### PR TITLE
Add missing pybind11 to dev_environment

### DIFF
--- a/env/dev_environment.yml
+++ b/env/dev_environment.yml
@@ -41,6 +41,7 @@ dependencies:
   - polyscope
   - psutil
   - py-opencv>=4.10[build=headless*]
+  - pybind11=2.13.6
   - pyrender
   - pytest-benchmark
   - python=3.12


### PR DESCRIPTION
Added missing, specific version of pybind11 so that pybind11 >=3 doesn't resolve into the environment