### PR TITLE
Minimal conda environment with cuda

### DIFF
--- a/env/mininal_environment.yml
+++ b/env/mininal_environment.yml
@@ -1,0 +1,29 @@
+name: fvdb_min
+channels:
+  - conda-forge
+  - nodefaults
+dependencies:
+  - blas=*=mkl
+  - ca-certificates
+  - certifi
+  - cmake
+  - cuda-command-line-tools
+  - cuda-compiler
+  - cuda-nvrtc-dev
+  - cuda-nvtx-dev
+  - cuda-version=12.8
+  - cudnn>=9.12.0
+  - cxx-compiler
+  - gcc_linux-64=13
+  - git
+  - gxx_linux-64=13
+  - libcublas-dev
+  - libcusolver-dev
+  - libcusparse-dev
+  - libpng
+  - make
+  - openssl
+  - pip
+  - pybind11=2.13.6
+  - python=3.12
+  - zlib


### PR DESCRIPTION
This PR adds a minimal conda environment with system packages for cuda and compiler tools which can be used as a starting point for building fvdb (pip install -r env/build_requirements.txt). This acts as a good transition as we move over to pip-only for the release.