### PR TITLE
Remove torchmetrics from conda environments

### DIFF
--- a/env/dev_environment.yml
+++ b/env/dev_environment.yml
@@ -64,7 +64,6 @@ dependencies:
   - pyyaml
   - scikit-learn
   - srt
-  - torchmetrics
   - torchvision
   - tyro
   - utm

--- a/env/learn_environment.yml
+++ b/env/learn_environment.yml
@@ -28,14 +28,11 @@ dependencies:
   - tensorboard
   - tqdm
   ## 3dgs
-  - torchmetrics
-  - fastai::opencv-python-headless
   - tyro
   - pillow
   - py-opencv>=4.10[build=headless*]
   - pyyaml
   - scikit-learn
-  - torchmetrics
   - torchvision
   - tyro
   - viser

--- a/env/test_environment.yml
+++ b/env/test_environment.yml
@@ -35,7 +35,6 @@ dependencies:
   ## 3dgs
   - pyproj
   - scikit-image
-  - torchmetrics
   - torchvision
   - viser
   - pip:


### PR DESCRIPTION
We no longer use torchmetrics in fvdb, and after [openvdb/fvdb-realitycapture#](https://github.com/openvdb/fvdb-realitycapture/pull/29) we no longer use it in `fvdb-realitycapture`. This PR removes it from all conda environments.

Also fixes a fastai::pyopencv-headless dependency that got left in the learning_environment.yml.