### PR TITLE
More PyTorch header optimizations

### DIFF
--- a/src/benchmarks/simple/simple.cpp
+++ b/src/benchmarks/simple/simple.cpp
@@ -4,7 +4,7 @@
 
 // A simple minimal benchmark to serve as a starting point for fVDB benchmarks.
 
-#include <torch/all.h>
+#include <torch/types.h>
 
 #include <benchmark/benchmark.h>
 

--- a/src/fvdb/GridBatch.cpp
+++ b/src/fvdb/GridBatch.cpp
@@ -38,7 +38,7 @@
 #include <fvdb/detail/ops/convolution/pack_info/IGEMMBitOperations.h>
 #include <fvdb/detail/utils/Utils.h>
 
-#include <torch/all.h>
+#include <torch/types.h>
 
 namespace fvdb {
 

--- a/src/fvdb/detail/autograd/SparseConvolutionHalo.cpp
+++ b/src/fvdb/detail/autograd/SparseConvolutionHalo.cpp
@@ -6,7 +6,7 @@
 #include <fvdb/detail/ops/convolution/backend/SparseConvolutionHaloGrad.h>
 #include <fvdb/detail/utils/Utils.h>
 
-#include <torch/all.h>
+#include <torch/autograd.h>
 
 #include <string>
 

--- a/src/fvdb/detail/autograd/SparseConvolutionImplicitGEMM.cpp
+++ b/src/fvdb/detail/autograd/SparseConvolutionImplicitGEMM.cpp
@@ -7,7 +7,7 @@
 #include <fvdb/detail/ops/convolution/backend/SparseConvolutionImplicitGEMMGradSorted.h>
 #include <fvdb/detail/ops/convolution/backend/SparseConvolutionImplicitGEMMSorted.h>
 
-#include <torch/all.h>
+#include <torch/autograd.h>
 
 namespace fvdb {
 namespace detail {

--- a/src/fvdb/detail/autograd/SparseConvolutionKernelMap.cpp
+++ b/src/fvdb/detail/autograd/SparseConvolutionKernelMap.cpp
@@ -6,7 +6,7 @@
 #include <fvdb/detail/ops/convolution/backend/MESparseConvolution.h>
 #include <fvdb/detail/ops/convolution/backend/SparseConvolutionKernelMap.h>
 
-#include <torch/all.h>
+#include <torch/autograd.h>
 
 #include <string>
 #include <vector>

--- a/src/fvdb/detail/io/LoadNanovdb.cpp
+++ b/src/fvdb/detail/io/LoadNanovdb.cpp
@@ -11,7 +11,7 @@
 #include <nanovdb/tools/CreateNanoGrid.h>
 #include <nanovdb/tools/GridBuilder.h>
 
-#include <torch/all.h>
+#include <torch/types.h>
 
 namespace fvdb {
 namespace detail {

--- a/src/fvdb/detail/io/SaveNanoVDB.cpp
+++ b/src/fvdb/detail/io/SaveNanoVDB.cpp
@@ -11,7 +11,7 @@
 
 #include <c10/cuda/CUDACachingAllocator.h>
 #include <c10/cuda/CUDAGuard.h>
-#include <torch/all.h>
+#include <torch/types.h>
 
 #include <cuda.h>
 #include <cuda_runtime_api.h>

--- a/src/fvdb/detail/ops/ActiveVoxelsInBoundsMask.cu
+++ b/src/fvdb/detail/ops/ActiveVoxelsInBoundsMask.cu
@@ -8,7 +8,7 @@
 #include <fvdb/detail/utils/cuda/ForEachCUDA.cuh>
 
 #include <c10/cuda/CUDAException.h>
-#include <torch/all.h>
+#include <torch/types.h>
 
 namespace fvdb {
 namespace detail {

--- a/src/fvdb/detail/ops/BuildCoarseGridFromFine.cu
+++ b/src/fvdb/detail/ops/BuildCoarseGridFromFine.cu
@@ -15,7 +15,7 @@
 #include <c10/cuda/CUDACachingAllocator.h>
 #include <c10/cuda/CUDAGuard.h>
 #include <c10/cuda/CUDAMathCompat.h>
-#include <torch/all.h>
+#include <torch/types.h>
 
 namespace fvdb::detail::ops {
 

--- a/src/fvdb/detail/ops/BuildDenseGrid.cu
+++ b/src/fvdb/detail/ops/BuildDenseGrid.cu
@@ -18,7 +18,7 @@
 #include <c10/cuda/CUDACachingAllocator.h>
 #include <c10/cuda/CUDAGuard.h>
 #include <c10/cuda/CUDAMathCompat.h>
-#include <torch/all.h>
+#include <torch/types.h>
 
 namespace fvdb {
 namespace detail {

--- a/src/fvdb/detail/ops/BuildDilatedGrid.cu
+++ b/src/fvdb/detail/ops/BuildDilatedGrid.cu
@@ -11,7 +11,7 @@
 #include <nanovdb/util/MorphologyHelpers.h>
 
 #include <c10/cuda/CUDAGuard.h>
-#include <torch/all.h>
+#include <torch/types.h>
 
 namespace fvdb::detail::ops {
 

--- a/src/fvdb/detail/ops/BuildFineGridFromCoarse.cu
+++ b/src/fvdb/detail/ops/BuildFineGridFromCoarse.cu
@@ -17,7 +17,7 @@
 #include <c10/cuda/CUDACachingAllocator.h>
 #include <c10/cuda/CUDAGuard.h>
 #include <c10/cuda/CUDAMathCompat.h>
-#include <torch/all.h>
+#include <torch/types.h>
 
 #include <cub/cub.cuh>
 

--- a/src/fvdb/detail/ops/BuildGridForConv.cu
+++ b/src/fvdb/detail/ops/BuildGridForConv.cu
@@ -16,7 +16,7 @@
 #include <c10/cuda/CUDACachingAllocator.h>
 #include <c10/cuda/CUDAGuard.h>
 #include <c10/cuda/CUDAMathCompat.h>
-#include <torch/all.h>
+#include <torch/types.h>
 
 namespace fvdb {
 namespace detail {

--- a/src/fvdb/detail/ops/BuildGridFromIjk.cu
+++ b/src/fvdb/detail/ops/BuildGridFromIjk.cu
@@ -17,7 +17,7 @@
 #include <c10/cuda/CUDACachingAllocator.h>
 #include <c10/cuda/CUDAGuard.h>
 #include <c10/cuda/CUDAMathCompat.h>
-#include <torch/all.h>
+#include <torch/types.h>
 
 namespace fvdb {
 namespace detail {

--- a/src/fvdb/detail/ops/BuildGridFromMesh.cu
+++ b/src/fvdb/detail/ops/BuildGridFromMesh.cu
@@ -14,7 +14,7 @@
 #include <c10/cuda/CUDACachingAllocator.h>
 #include <c10/cuda/CUDAGuard.h>
 #include <c10/cuda/CUDAMathCompat.h>
-#include <torch/all.h>
+#include <torch/types.h>
 
 namespace fvdb {
 namespace detail {

--- a/src/fvdb/detail/ops/BuildGridFromNearestVoxelsToPoints.cu
+++ b/src/fvdb/detail/ops/BuildGridFromNearestVoxelsToPoints.cu
@@ -14,7 +14,7 @@
 #include <c10/cuda/CUDACachingAllocator.h>
 #include <c10/cuda/CUDAGuard.h>
 #include <c10/cuda/CUDAMathCompat.h>
-#include <torch/all.h>
+#include <torch/types.h>
 
 namespace fvdb {
 namespace detail {

--- a/src/fvdb/detail/ops/convolution/backend/MESparseConvolution.cu
+++ b/src/fvdb/detail/ops/convolution/backend/MESparseConvolution.cu
@@ -9,7 +9,7 @@
 #include <ATen/cuda/Atomic.cuh>
 #include <ATen/cuda/CUDAContext.h>
 #include <c10/cuda/CUDACachingAllocator.h>
-#include <torch/all.h>
+#include <torch/types.h>
 
 #include <cublas_v2.h>
 

--- a/src/fvdb/detail/ops/convolution/backend/SparseConvolutionImplicitGEMM.cu
+++ b/src/fvdb/detail/ops/convolution/backend/SparseConvolutionImplicitGEMM.cu
@@ -4,7 +4,7 @@
 #include <fvdb/detail/ops/convolution/backend/ConvPragmaMessage.h>
 #include <fvdb/detail/ops/convolution/backend/SparseConvolutionImplicitGEMM.h>
 
-#include <torch/all.h>
+#include <torch/types.h>
 
 #include <cuda_fp16.h>
 

--- a/src/fvdb/detail/ops/convolution/backend/SparseConvolutionImplicitGEMMGrad.cu
+++ b/src/fvdb/detail/ops/convolution/backend/SparseConvolutionImplicitGEMMGrad.cu
@@ -4,7 +4,7 @@
 #include <fvdb/detail/ops/convolution/backend/ConvPragmaMessage.h>
 #include <fvdb/detail/ops/convolution/backend/SparseConvolutionImplicitGEMMGrad.h>
 
-#include <torch/all.h>
+#include <torch/types.h>
 
 #include <cuda_fp16.h>
 

--- a/src/fvdb/detail/ops/convolution/backend/SparseConvolutionImplicitGEMMGradSorted.cu
+++ b/src/fvdb/detail/ops/convolution/backend/SparseConvolutionImplicitGEMMGradSorted.cu
@@ -4,7 +4,7 @@
 #include <fvdb/detail/ops/convolution/backend/ConvPragmaMessage.h>
 #include <fvdb/detail/ops/convolution/backend/SparseConvolutionImplicitGEMMGradSorted.h>
 
-#include <torch/all.h>
+#include <torch/types.h>
 
 #include <cuda_fp16.h>
 

--- a/src/fvdb/detail/ops/convolution/backend/SparseConvolutionImplicitGEMMSorted.cu
+++ b/src/fvdb/detail/ops/convolution/backend/SparseConvolutionImplicitGEMMSorted.cu
@@ -4,7 +4,7 @@
 #include <fvdb/detail/ops/convolution/backend/ConvPragmaMessage.h>
 #include <fvdb/detail/ops/convolution/backend/SparseConvolutionImplicitGEMMSorted.h>
 
-#include <torch/all.h>
+#include <torch/types.h>
 
 #include <cuda_fp16.h>
 

--- a/src/fvdb/detail/ops/convolution/backend/SparseConvolutionKernelMap.cu
+++ b/src/fvdb/detail/ops/convolution/backend/SparseConvolutionKernelMap.cu
@@ -9,7 +9,7 @@
 #include <ATen/Dispatch_v2.h>
 #include <ATen/cuda/CUDAContext.h>
 #include <c10/cuda/CUDAGuard.h>
-#include <torch/all.h>
+#include <torch/types.h>
 
 #include <algorithm>
 

--- a/src/fvdb/detail/ops/convolution/pack_info/IGEMMBitOperations.cu
+++ b/src/fvdb/detail/ops/convolution/pack_info/IGEMMBitOperations.cu
@@ -5,7 +5,7 @@
 #include <fvdb/detail/utils/AccessorHelpers.cuh>
 
 #include <c10/cuda/CUDAException.h>
-#include <torch/all.h>
+#include <torch/types.h>
 
 namespace fvdb {
 namespace detail {

--- a/src/fvdb/detail/ops/jagged/JaggedReduce.cu
+++ b/src/fvdb/detail/ops/jagged/JaggedReduce.cu
@@ -8,7 +8,7 @@
 #include <fvdb/detail/utils/cuda/ForEachCUDA.cuh>
 
 #include <c10/cuda/CUDAException.h>
-#include <torch/all.h>
+#include <torch/types.h>
 
 namespace fvdb {
 namespace detail {

--- a/src/fvdb/detail/ops/jagged/JaggedSort.cu
+++ b/src/fvdb/detail/ops/jagged/JaggedSort.cu
@@ -7,7 +7,7 @@
 #include <fvdb/detail/utils/cuda/ForEachCUDA.cuh>
 
 #include <c10/cuda/CUDAException.h>
-#include <torch/all.h>
+#include <torch/types.h>
 
 namespace fvdb {
 namespace detail {

--- a/src/tests/ExampleTest.cpp
+++ b/src/tests/ExampleTest.cpp
@@ -3,7 +3,7 @@
 
 // A simple minimal unit test to serve as a starting point for fVDB unit tests.
 
-#include <torch/all.h>
+#include <torch/types.h>
 
 #include <gtest/gtest.h>
 

--- a/src/tests/GaussianComputeNanInfMaskTest.cpp
+++ b/src/tests/GaussianComputeNanInfMaskTest.cpp
@@ -5,7 +5,7 @@
 
 #include <fvdb/detail/ops/gsplat/GaussianComputeNanInfMask.h>
 
-#include <torch/all.h>
+#include <torch/types.h>
 
 #include <gtest/gtest.h>
 

--- a/src/tests/GaussianProjectionBackwardTest.cpp
+++ b/src/tests/GaussianProjectionBackwardTest.cpp
@@ -6,8 +6,8 @@
 #include <fvdb/detail/ops/gsplat/GaussianProjectionBackward.h>
 #include <fvdb/detail/ops/gsplat/GaussianProjectionForward.h>
 
-#include <torch/all.h>
 #include <torch/script.h>
+#include <torch/types.h>
 
 #include <cuda_runtime_api.h>
 

--- a/src/tests/GaussianProjectionForwardTest.cpp
+++ b/src/tests/GaussianProjectionForwardTest.cpp
@@ -5,8 +5,8 @@
 
 #include <fvdb/detail/ops/gsplat/GaussianProjectionForward.h>
 
-#include <torch/all.h>
 #include <torch/script.h>
+#include <torch/types.h>
 
 #include <gtest/gtest.h>
 

--- a/src/tests/GaussianRasterizeBackwardTest.cpp
+++ b/src/tests/GaussianRasterizeBackwardTest.cpp
@@ -7,7 +7,7 @@
 #include <fvdb/detail/ops/gsplat/GaussianRasterizeForward.h>
 #include <fvdb/detail/ops/gsplat/GaussianSplatSparse.h>
 
-#include <torch/all.h>
+#include <torch/types.h>
 
 #include <gtest/gtest.h>
 

--- a/src/tests/GaussianRasterizeForwardTest.cpp
+++ b/src/tests/GaussianRasterizeForwardTest.cpp
@@ -7,8 +7,8 @@
 #include <fvdb/detail/ops/gsplat/GaussianRasterizeForward.h>
 #include <fvdb/detail/ops/gsplat/GaussianSplatSparse.h>
 
-#include <torch/all.h>
 #include <torch/script.h>
+#include <torch/types.h>
 
 #include <gtest/gtest.h>
 

--- a/src/tests/GaussianRasterizeTopContributorsTest.cpp
+++ b/src/tests/GaussianRasterizeTopContributorsTest.cpp
@@ -6,8 +6,8 @@
 #include <fvdb/detail/ops/gsplat/GaussianRasterizeTopContributingGaussianIds.h>
 #include <fvdb/detail/ops/gsplat/GaussianSplatSparse.h>
 
-#include <torch/all.h>
 #include <torch/script.h>
+#include <torch/types.h>
 
 #include <gtest/gtest.h>
 

--- a/src/tests/GaussianSphericalHarmonicsBackwardTest.cpp
+++ b/src/tests/GaussianSphericalHarmonicsBackwardTest.cpp
@@ -5,7 +5,7 @@
 
 #include <fvdb/detail/ops/gsplat/GaussianSphericalHarmonicsBackward.h>
 
-#include <torch/all.h>
+#include <torch/types.h>
 
 #include <gtest/gtest.h>
 

--- a/src/tests/GaussianSphericalHarmonicsForwardTest.cpp
+++ b/src/tests/GaussianSphericalHarmonicsForwardTest.cpp
@@ -5,7 +5,7 @@
 
 #include <fvdb/detail/ops/gsplat/GaussianSphericalHarmonicsForward.h>
 
-#include <torch/all.h>
+#include <torch/types.h>
 
 #include <gtest/gtest.h>
 

--- a/src/tests/GaussianTileIntersectionTest.cpp
+++ b/src/tests/GaussianTileIntersectionTest.cpp
@@ -4,7 +4,7 @@
 #include <fvdb/detail/ops/gsplat/GaussianSplatSparse.h>
 #include <fvdb/detail/ops/gsplat/GaussianTileIntersection.h>
 
-#include <torch/all.h>
+#include <torch/types.h>
 
 #include <gtest/gtest.h>
 

--- a/src/tests/JaggedTensorTest.cpp
+++ b/src/tests/JaggedTensorTest.cpp
@@ -3,7 +3,7 @@
 
 #include <fvdb/JaggedTensor.h>
 
-#include <torch/all.h>
+#include <torch/types.h>
 
 #include <gtest/gtest.h>
 

--- a/src/tests/PackedJaggedAccessorTest.cu
+++ b/src/tests/PackedJaggedAccessorTest.cu
@@ -3,7 +3,7 @@
 
 #include <fvdb/JaggedTensor.h>
 
-#include <torch/all.h>
+#include <torch/types.h>
 
 #include <gtest/gtest.h>
 

--- a/src/tests/utils/ImageUtils.cpp
+++ b/src/tests/utils/ImageUtils.cpp
@@ -3,7 +3,7 @@
 
 #include "ImageUtils.h"
 
-#include <torch/all.h>
+#include <torch/types.h>
 
 #include <png.h>
 

--- a/src/tests/utils/ImageUtils.h
+++ b/src/tests/utils/ImageUtils.h
@@ -4,7 +4,7 @@
 #ifndef TESTS_UTILS_IMAGEUTILS_H
 #define TESTS_UTILS_IMAGEUTILS_H
 
-#include <torch/all.h>
+#include <torch/types.h>
 
 #include <string>
 

--- a/src/tests/utils/Tensor.cpp
+++ b/src/tests/utils/Tensor.cpp
@@ -3,6 +3,9 @@
 
 #include "Tensor.h"
 
+#include <torch/script.h>
+#include <torch/serialize.h>
+
 namespace fvdb::test {
 
 std::vector<torch::Tensor>

--- a/src/tests/utils/Tensor.h
+++ b/src/tests/utils/Tensor.h
@@ -4,8 +4,7 @@
 #ifndef TESTS_UTILS_TENSOR_H
 #define TESTS_UTILS_TENSOR_H
 
-#include <torch/all.h>
-#include <torch/script.h>
+#include <torch/types.h>
 
 #include <vector>
 


### PR DESCRIPTION
In most cases where we're including torch/all.h, we really only need the fundamental ATen types which can be obtained by including torch/types.h.

Improve CUDA 12.8 CI build times by another 30 or so seconds.