### PR TITLE
Add ORSB tracking info for Fused SSIM

### DIFF
--- a/fvdb/utils/metrics/ssim.py
+++ b/fvdb/utils/metrics/ssim.py
@@ -1,6 +1,6 @@
-# Copyright Contributors to the OpenVDB Project
-# SPDX-License-Identifier: Apache-2.0
-#
+# This file contains source code from the fused-ssim library obtained from
+# https://github.com/rahul-goel/fused-ssim. The fused-ssim library is licensed under the MIT
+# License. Refer to ORSB 5512107 for more. Original license text follows.
 
 # Copyright (c) 2024 Rahul Goel
 
@@ -21,6 +21,10 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
+
+# Copyright Contributors to the OpenVDB Project
+# SPDX-License-Identifier: Apache-2.0
+#
 
 
 from typing import NamedTuple

--- a/src/fvdb/detail/ops/gsplat/FusedSSIM.cu
+++ b/src/fvdb/detail/ops/gsplat/FusedSSIM.cu
@@ -1,3 +1,7 @@
+// This file contains source code from the fused-ssim library obtained from
+// https://github.com/rahul-goel/fused-ssim. The fused-ssim library is licensed under the MIT
+// License. Refer to ORSB 5512107 for more. Original license text follows.
+
 // Copyright (c) 2024 Rahul Goel
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/src/fvdb/detail/ops/gsplat/FusedSSIM.h
+++ b/src/fvdb/detail/ops/gsplat/FusedSSIM.h
@@ -1,3 +1,7 @@
+// This file contains source code from the fused-ssim library obtained from
+// https://github.com/rahul-goel/fused-ssim. The fused-ssim library is licensed under the MIT
+// License. Refer to ORSB 5512107 for more. Original license text follows.
+
 // Copyright (c) 2024 Rahul Goel
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy


### PR DESCRIPTION
This is for NVIDIA-internal tracking of OSS license for vendored-in software.