### PR TITLE
Show diff when running black in CI

### DIFF
--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: psf/black@stable
         with:
-          options: "--check --verbose --target-version=py311 --line-length=120"
+          options: "--check --diff --verbose --target-version=py311 --line-length=120"
           src: "./"
           version: "~= 24.0"
 


### PR DESCRIPTION
Due to configuration (exact black version, Python version, etc.) differences, `black` in CI can propose slightly different formatting. Instead of merely saying that it would reformat a file, adding `--diff` actually displays the proposed reformat which makes it much easier for a developer to make the necessary edits in the follow-up commit.