### PR TITLE
Docker workdir fixes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,70 @@
+# Ignore everything that should not be sent to the Docker build context
+# Keeps builds fast and prevents host artifacts from leaking into the image
+
+# Python
+__pycache__/
+*.py[cod]
+*.pyo
+*.pyd
+*.so
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+.pytest_cache/
+.hypothesis/
+.coverage
+coverage.xml
+.nox/
+.tox/
+
+# Virtual envs
+venv/
+.venv/
+ENV/
+
+# Jupyter
+.ipynb_checkpoints/
+
+# Build systems: scikit-build, CMake, wheels, sdist
+build/
+dist/
+*.egg-info/
+*.egg
+*.whl
+*.tar.gz
+compile_commands.json
+
+# CMake & caches
+CMakeFiles/
+CMakeCache.txt
+cmake-build*/
+_skbuild/
+
+# Editors/OS
+.DS_Store
+*.swp
+*.swo
+.idea/
+.vscode/
+
+# Logs
+*.log
+
+# Docker (do not ignore Dockerfile or compose; needed for build)
+# .dockerignore itself is harmless to include; leave it
+
+# Git (context excludes .git by default via CLI, but keep explicit)
+.git/
+.gitignore
+
+# Data and artifacts
+**/.cache/
+cache/
+tmp/
+temp/
+*.tmp
+
+# Project specifics
+notebooks/.local/
+docs/_build/
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,13 +6,16 @@ RUN echo "Building fVDB container in $MODE mode"
 # used for cross-compilation in docker build
 ENV FORCE_CUDA=1
 
-WORKDIR /openvdb
+# Create and use a consistent workspace directory
+RUN mkdir -p /workspace
+WORKDIR /workspace
 
+# Conda setup
 # force this CUDA version to be used to build the docker container because `docker build` does not
 # expose the GPU to the docker build process for it to be detected
-ENV CONDA_OVERRIDE_CUDA=12.0
-# copy env/dev_environment.yml to /tmp/
-COPY fvdb/env/dev_environment.yml /tmp/
+# fVDB team NOTE!!! We've tried removing this ENV line and it doesn't work, container build fails.
+ENV CONDA_OVERRIDE_CUDA=12.8
+COPY env/dev_environment.yml /tmp/
 RUN  conda env create -f /tmp/dev_environment.yml
 
 RUN conda init

--- a/README.md
+++ b/README.md
@@ -35,34 +35,19 @@ During the project's initial development stages, it is necessary to [run the bui
 ## Building *f*VDB from Source
 
 ### Environment Management
-ƒVDB is a Python library implemented as a C++ Pytorch extension.  Of course you can build ƒVDB in whatever environment suits you, but we provide three paths to constructing reliable environments for building and running ƒVDB:  using [docker](#setting-up-a-docker-container), [conda](#setting-up-a-conda-environment), or a Python virtual environment.
+ƒVDB is a Python library implemented as a C++ Pytorch extension.  Of course you can build ƒVDB in whatever environment suits you, but we provide three paths to constructing reliable environments for building and running ƒVDB. These are separate options,
+choose only one. They're not intended to be used together.
+
+1. **RECOMMENDED** [conda](#option-1-setting-up-a-conda-environment-recommended)
+2. Using [docker](#option-2-setting-up-a-docker-container)
+3. Python virtual environment. [venv](#option-3-setting-up-a-python-virtual-environment)
 
 `conda` tends to be more flexible since reconfiguring toolchains and modules to suit your larger project can be dynamic, but at the same time this can be a more brittle experience compared to using a virtualized `docker` container.  Using `conda` is generally recommended for development and testing, while using `docker` is recommended for CI/CD and deployment.
 
-#### Setting up a Docker Container
-
-Running a docker container is a great way to ensure that you have a consistent environment for building and running ƒVDB.
-
-Our provided [`Dockerfile`](Dockerfile) constructs a Docker image which is ready to build ƒVDB.  The docker image is configured to install miniforge and the `fvdb` conda environment with all the dependencies needed to build and run ƒVDB.
-
-Building and starting the docker image is done by running the following command from the fvdb directory:
-```shell
-docker compose run --rm fvdb-dev
-```
+---
 
 
-When you are ready to build ƒVDB, run the following command within the docker container.  `TORCH_CUDA_ARCH_LIST` specifies which CUDA architectures to build for.
-```shell
-conda activate fvdb;
-cd /openvdb/fvdb;
-TORCH_CUDA_ARCH_LIST="7.5;8.0;8.6+PTX" \
-./build.sh install
-```
-
-Additional information about the ƒVDB docker setup, with troubleshooting for common errors, can be found
-here: [`ƒVDB Docker`](docs/markdown/docker_readme.md)
-
-#### Setting up a Conda Environment
+#### **OPTION 1** Setting up a Conda Environment (Recommended)
 
 *f*VDB can be used with any Conda distribution installed on your system. Below is an installation guide using
 [miniforge](https://github.com/conda-forge/miniforge). You can skip steps 1-3 if you already have a Conda installation.
@@ -95,9 +80,46 @@ conda activate fvdb
 * `fvdb_test`: Use `env/test_environment.yml` for a runtime environment which has only the packages required to run the unit tests after building ƒVDB. This is the environment used by the CI pipeline to run the tests after building ƒVDB in the `fvdb_build` environment.
 * `fvdb_learn`: Use `env/learn_environment.yml` for additional runtime requirements and packages needed to run the [notebooks](notebooks) or [examples](examples) and view their visualizations.
 
-#### Setting up a Python virtual environment
+---
 
-After creating a Python virtual environment, proceed to install the exact version of PyTorch that corresponds to your CUDA version. Then, install the rest of the build requirements.
+#### **OPTION 2** Setting up a Docker Container
+
+Running a docker container is a great way to ensure that you have a consistent environment for building and running ƒVDB.
+
+Our provided [`Dockerfile`](Dockerfile) constructs a Docker image which is ready to build ƒVDB.  The docker image is configured to install miniforge and the `fvdb` conda environment with all the dependencies needed to build and run ƒVDB.
+
+Building and starting the docker image is done by running the following command from the fvdb directory:
+```shell
+docker compose run --rm fvdb-dev
+```
+
+
+When you are ready to build ƒVDB, run the following command within the docker container.  `TORCH_CUDA_ARCH_LIST` specifies which CUDA architectures to build for.
+```shell
+conda activate fvdb;
+cd /workspace;
+TORCH_CUDA_ARCH_LIST="7.5;8.0;8.6+PTX" \
+./build.sh install verbose
+```
+
+If you've built an artifact that you want to extract from the container, with "wheel" being the
+most useful... The built wheel can be extracted from the running docker image using `docker cp`, given the
+ID of the running image. For example:
+
+```shell
+docker cp fvdb-fvdb-dev-run-0123456789ab:/workspace/dist/fvdb-0.2.1-cp312-cp312-linux_x86_64.whl .
+```
+
+where `0123456789ab` is the ID of the running docker container, obtained via `docker ps`.
+
+Additional information about the ƒVDB docker setup, with troubleshooting for common errors, can be found
+here: [`ƒVDB Docker`](docs/markdown/docker_readme.md)
+
+---
+
+#### **OPTION 3** Setting up a Python virtual environment
+
+Create a python virtual environment and then proceed to install the exact version of PyTorch that corresponds to your CUDA version. Finally, install the rest of the build requirements.
 
 ```shell
 python -m venv fvdb
@@ -110,6 +132,8 @@ When you're ready to build fVDB, run the following command after activating the 
 ```shell
 TORCH_CUDA_ARCH_LIST="7.5;8.0;8.6+PTX" ./build.sh install
 ```
+
+---
 
 ### Building *f*VDB
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,12 +2,22 @@ version: '3'
 services:
   fvdb-dev:
     build:
-      context: ../
-      dockerfile: fvdb/Dockerfile
+      context: ./
+      dockerfile: Dockerfile
       args:
         MODE: dev
+    working_dir: /workspace
     volumes:
-      - ../:/openvdb
+      - type: bind
+        source: .
+        target: /workspace
+      # Keep build artifacts inside the container (not mirrored to host)
+      - type: volume
+        target: /workspace/build
+      - type: volume
+        target: /workspace/dist
+      - type: volume
+        target: /workspace/_skbuild
     # Uncomment and adjust the following as needed
     # ports:
     #   - "8888:8888"  # Example for Jupyter notebook

--- a/docs/markdown/docker_readme.md
+++ b/docs/markdown/docker_readme.md
@@ -14,9 +14,61 @@ docker compose run --rm fvdb-dev
 When you are ready to build ƒVDB, run the following command within the docker container.  `TORCH_CUDA_ARCH_LIST` specifies which CUDA architectures to build for.
 ```shell
 conda activate fvdb;
-cd /openvdb/fvdb;
+cd /workspace;
 TORCH_CUDA_ARCH_LIST="7.5;8.0;8.6+PTX" \
-./build.sh install
+./build.sh install verbose
+```
+
+If you've built an artifact inside the docker container using `./build.sh wheel`:
+After you've built, if you want to extract the wheel artifact, from a separate terminal
+(not running inside the container) you can use `docker cp` to extract the wheel. The wheel is
+created with a name (in the container filesystem) like:
+```
+/workspace/dist/fvdb-0.2.1-cp312-cp312-linux_x86_64.whl
+```
+So we can use docker cp to extract it to a local directory. Use `docker ps -a` to determine what
+the name of the running container is:
+```
+:~$ docker ps -a
+CONTAINER ID   IMAGE           COMMAND       CREATED          STATUS          PORTS     NAMES
+239232951e48   fvdb-fvdb-dev   "/bin/bash"   21 minutes ago   Up 21 minutes             fvdb-fvdb-dev-run-0615ba7e27fd
+```
+
+And then we can copy from that container to the local directory
+
+```shell
+docker cp fvdb-fvdb-dev-run-0615ba7e27fd:/workspace/dist/fvdb-0.2.1-cp312-cp312-linux_x86_64.whl .
+```
+
+### Workflow Examples
+
+Here are the common cases.
+
+### If you launched with `docker compose run --rm fvdb-dev`
+- Exit the interactive shell (Ctrl-D or `exit`). The container is automatically removed.
+- Rebuild image and relaunch:
+```bash
+cd ~/src/fvdb
+docker compose build --no-cache fvdb-dev
+docker compose run --rm fvdb-dev
+```
+
+### If you used `docker compose up -d fvdb-dev`
+- Stop and remove the running container(s):
+```bash
+cd ~/src/fvdb
+docker compose down
+```
+- Rebuild and start:
+```bash
+docker compose build --no-cache fvdb-dev
+docker compose up -d fvdb-dev
+```
+
+### Optional deeper clean
+- Also remove images and volumes:
+```bash
+docker compose down --rmi local --volumes
 ```
 
 ### Troubleshooting

--- a/env/build_environment.yml
+++ b/env/build_environment.yml
@@ -28,6 +28,7 @@ dependencies:
   - ninja
   - numpy
   - openssl
+  - pkg-config
   - psutil
   - pybind11=2.13.6
   - python=3.12

--- a/env/dev_environment.yml
+++ b/env/dev_environment.yml
@@ -39,6 +39,7 @@ dependencies:
   - pandas
   - parameterized
   - pip
+  - pkg-config
   - polyscope
   - psutil
   - pybind11=2.13.6

--- a/env/learn_environment.yml
+++ b/env/learn_environment.yml
@@ -18,6 +18,7 @@ dependencies:
   - pandas
   - parameterized
   - pip
+  - pkg-config
   - polyscope
   - pybind11=2.13.6
   - pyrender

--- a/env/test_environment.yml
+++ b/env/test_environment.yml
@@ -19,6 +19,7 @@ dependencies:
   - pandas
   - parameterized
   - pip>=23.3.1
+  - pkg-config
   - polyscope
   - pybind11=2.13.6
   - py-opencv>=4.10[build=headless*]


### PR DESCRIPTION
This change modifies the docker build so that it no longer uses the parent directory, which is a holdover from the 
previous OpenVDB repo.

It also uses a more tailored approach towards the mounting of local directories.

Builds within the container will not affect build directories in the local directory outside the container.