### PR TITLE
Fix host-device synchronization in tile intersection radix sort

### DIFF
--- a/src/fvdb/detail/ops/gsplat/GaussianTileIntersection.cu
+++ b/src/fvdb/detail/ops/gsplat/GaussianTileIntersection.cu
@@ -511,6 +511,7 @@ gaussianTileIntersectionCUDAImpl(
                         0,
                         num_bits,
                         stream);
+            C10_CUDA_CHECK(cudaStreamSynchronize(stream));
             // DoubleBuffer swaps the pointers if the keys were sorted in the input buffer
             // so we need to grab the right buffer.
             if (d_keys.selector == 1) {


### PR DESCRIPTION
The `DoubleBuffer` selector variable is not valid until the radix sort call has completed on the device. Thus, we need to synchronize the stream before querying it.