### PR TITLE
Improve const-correctness for fused SSIM

### DIFF
--- a/src/fvdb/detail/ops/gsplat/FusedSSIM.h
+++ b/src/fvdb/detail/ops/gsplat/FusedSSIM.h
@@ -43,10 +43,10 @@ torch::Tensor fusedSSIMBackwardCUDA(double C1,
                                     double C2,
                                     const torch::Tensor &img1,
                                     const torch::Tensor &img2,
-                                    torch::Tensor &dL_dmap,
-                                    torch::Tensor &dm_dmu1,
-                                    torch::Tensor &dm_dsigma1_sq,
-                                    torch::Tensor &dm_dsigma12);
+                                    const torch::Tensor &dL_dmap,
+                                    const torch::Tensor &dm_dmu1,
+                                    const torch::Tensor &dm_dsigma1_sq,
+                                    const torch::Tensor &dm_dsigma12);
 
 std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor> fusedSSIMPrivateUse1(
     double C1, double C2, const torch::Tensor &img1, const torch::Tensor &img2, bool train);
@@ -55,10 +55,10 @@ torch::Tensor fusedSSIMBackwardPrivateUse1(double C1,
                                            double C2,
                                            const torch::Tensor &img1,
                                            const torch::Tensor &img2,
-                                           torch::Tensor &dL_dmap,
-                                           torch::Tensor &dm_dmu1,
-                                           torch::Tensor &dm_dsigma1_sq,
-                                           torch::Tensor &dm_dsigma12);
+                                           const torch::Tensor &dL_dmap,
+                                           const torch::Tensor &dm_dmu1,
+                                           const torch::Tensor &dm_dsigma1_sq,
+                                           const torch::Tensor &dm_dsigma12);
 
 } // namespace ops
 

--- a/src/python/Bindings.cpp
+++ b/src/python/Bindings.cpp
@@ -469,5 +469,5 @@ TORCH_LIBRARY(fvdb, m) {
     m.def(
         "_fused_ssim(float C1, float C2, Tensor img1, Tensor img2, bool train) -> (Tensor, Tensor, Tensor, Tensor)");
     m.def(
-        "_fused_ssim_backward(float C1, float C2, Tensor img1, Tensor img2, Tensor(a!) dL_dmap, Tensor(b!) dm_dmu1, Tensor(c!) dm_dsigma1_sq, Tensor(d!) dm_dsigma12) -> Tensor");
+        "_fused_ssim_backward(float C1, float C2, Tensor img1, Tensor img2, Tensor dL_dmap, Tensor dm_dmu1, Tensor dm_dsigma1_sq, Tensor dm_dsigma12) -> Tensor");
 }


### PR DESCRIPTION
This PR improves const-correctness for fused SSIM at both the C++ and PyTorch schema level.