### PR TITLE
Templatize helper function for calculating strided array bounds

### DIFF
--- a/src/fvdb/detail/ops/convolution/backend/SparseConvolutionHalo.cu
+++ b/src/fvdb/detail/ops/convolution/backend/SparseConvolutionHalo.cu
@@ -518,8 +518,8 @@ dispatchSparseConvolutionHalo<torch::kPrivateUse1>(const GridBatchImpl &batchHdl
             paddedKernel.data_ptr<float>(), paddedKernel.numel() * sizeof(float), deviceId, stream);
 
         auto hostGridAccessor = batchHdl.hostAccessor();
-        size_t deviceNumLeaves, deviceLeafOffset;
-        std::tie(deviceNumLeaves, deviceLeafOffset) = deviceCountAndOffset(numLeaves, deviceId);
+        size_t deviceLeafOffset, deviceNumLeaves;
+        std::tie(deviceLeafOffset, deviceNumLeaves) = deviceOffsetAndCount(numLeaves, deviceId);
         if (deviceNumLeaves) {
             // Query the first and last leaf processed by each GPU. The start index of the first
             // leaf and end index of the last leaf provides us with a very good heuristic for the
@@ -554,8 +554,8 @@ dispatchSparseConvolutionHalo<torch::kPrivateUse1>(const GridBatchImpl &batchHdl
         C10_CUDA_CHECK(cudaSetDevice(deviceId));
         cudaStream_t stream = c10::cuda::getCurrentCUDAStream(deviceId).stream();
 
-        size_t deviceNumLeaves, deviceLeafOffset;
-        std::tie(deviceNumLeaves, deviceLeafOffset) = deviceCountAndOffset(numLeaves, deviceId);
+        size_t deviceLeafOffset, deviceNumLeaves;
+        std::tie(deviceLeafOffset, deviceNumLeaves) = deviceOffsetAndCount(numLeaves, deviceId);
         if (deviceNumLeaves) {
             if (variant == 8) {
                 stencilConvHaloKernel<<<M * N * deviceNumLeaves, 1024, 0, stream>>>(

--- a/src/fvdb/detail/utils/cuda/Utils.cuh
+++ b/src/fvdb/detail/utils/cuda/Utils.cuh
@@ -10,12 +10,13 @@
 
 #include <c10/cuda/CUDAFunctions.h>
 
-inline std::tuple<size_t, size_t>
-deviceCountAndOffset(size_t count, c10::DeviceIndex deviceId) {
+template <typename index_t>
+inline std::tuple<index_t, index_t>
+deviceOffsetAndCount(index_t count, c10::DeviceIndex deviceId) {
     auto deviceCount        = (count + c10::cuda::device_count() - 1) / c10::cuda::device_count();
     const auto deviceOffset = deviceCount * deviceId;
     deviceCount             = std::min(deviceCount, count - deviceOffset);
-    return std::make_tuple(deviceCount, deviceOffset);
+    return std::make_tuple(deviceOffset, deviceCount);
 }
 
 #endif // FVDB_DETAIL_UTILS_CUDA_UTILS_CUH


### PR DESCRIPTION
Enables the use of the function for narrower index types, i.e. `uint32_t`