### PR TITLE
Fix ODR violation introduced by viewer bindings

### DIFF
--- a/src/python/TypeCasters.h
+++ b/src/python/TypeCasters.h
@@ -158,35 +158,29 @@ INBOUND_TYPE_CASTER(fvdb::Vec3dBatchOrScalar, loadVecBatch)
 INBOUND_TYPE_CASTER(fvdb::Vec3dBatch, loadVecBatch)
 INBOUND_TYPE_CASTER(fvdb::Vec3iBatch, loadVecBatch)
 
-template <>
-struct type_caster<fvdb::GaussianSplat3d::ProjectionType>
-    : public type_caster_base<fvdb::GaussianSplat3d::ProjectionType> {
-    using base = type_caster_base<fvdb::GaussianSplat3d::ProjectionType>;
-
+template <> struct type_caster<fvdb::GaussianSplat3d::ProjectionType> {
   public:
-    fvdb::GaussianSplat3d::ProjectionType projection_type_value;
+    PYBIND11_TYPE_CASTER(fvdb::GaussianSplat3d::ProjectionType, const_name("ProjectionType"));
 
     bool
-    load(handle src, bool convert) {
+    load(handle src, bool) {
         std::string strvalue = src.cast<std::string>();
         std::transform(strvalue.begin(), strvalue.end(), strvalue.begin(), [](unsigned char c) {
             return std::tolower(c);
         });
         if (strvalue == "perspective") {
-            projection_type_value = fvdb::GaussianSplat3d::ProjectionType::PERSPECTIVE;
+            value = fvdb::GaussianSplat3d::ProjectionType::PERSPECTIVE;
+            return true;
         } else if (strvalue == "orthographic") {
-            projection_type_value = fvdb::GaussianSplat3d::ProjectionType::ORTHOGRAPHIC;
+            value = fvdb::GaussianSplat3d::ProjectionType::ORTHOGRAPHIC;
+            return true;
         } else {
             return false;
         }
-        value = &projection_type_value;
-        return true;
     }
 
     static handle
-    cast(const fvdb::GaussianSplat3d::ProjectionType &src,
-         return_value_policy policy,
-         handle parent) {
+    cast(const fvdb::GaussianSplat3d::ProjectionType &src, return_value_policy, handle) {
         switch (src) {
         case fvdb::GaussianSplat3d::ProjectionType::PERSPECTIVE:
             return pybind11::str("perspective").release();

--- a/src/python/ViewerBinding.cpp
+++ b/src/python/ViewerBinding.cpp
@@ -1,6 +1,9 @@
 // Copyright Contributors to the OpenVDB Project
 // SPDX-License-Identifier: Apache-2.0
 //
+
+#include "TypeCasters.h"
+
 #include <fvdb/GaussianSplat3d.h>
 #include <fvdb/detail/viewer/GaussianSplat3dView.h>
 #include <fvdb/detail/viewer/Viewer.h>


### PR DESCRIPTION
When compiling ToT main fVDB, we see the following warning:

```
fvdb/src/python/TypeCasters.h:161:20: warning: type ‘struct type_caster’ violates the C++ One Definition Rule [-Wodr]
    161 | template <> struct type_caster<fvdb::GaussianSplat3d::ProjectionType> : public type_caster_base<fvdb::GaussianSplat3d::ProjectionType> {
        |                    ^
lib/python3.10/site-packages/torch/include/pybind11/cast.h:38:7: note: a different type is defined in another translation unit
     38 | class type_caster : public type_caster_base<type> {};
        |       ^
fvdb/src/python/TypeCasters.h:163:5: note: the first difference of corresponding definitions is field ‘value’
    163 |     PYBIND11_TYPE_CASTER(fvdb::GaussianSplat3d::ProjectionType, const_name("ProjectionType"));
        |     ^
lib/python3.10/site-packages/torch/include/pybind11/cast.h:38:7: note: a type with different number of fields is defined in another translation unit
     38 | class type_caster : public type_caster_base<type> {};
        |  
```

ViewerBindings.cpp uses a `GaussianSplat3d::ProjectionType` as a default argument which means that it needs a type caster defined since default arguments are instantiated at import time. Since ViewerBindings.cpp wasn't including the header file for the `ProjectionType` typecaster, it was using the default no-op typecaster provided by pybind11 in it's translation unit hence the ODR violation warning.

The changes to the typecaster body itself are to make it more compliant with pybind11's recommendations, including the use of the `PYBIND11_TYPE_CASTER` macro. This fixes the second part of the ODR warning which says that the fields in the defined type caster are different from what pybind11 expects.