### PR TITLE
Don't keep reference to splats in viewer

### DIFF
--- a/src/cmake/get_nanovdb_editor.cmake
+++ b/src/cmake/get_nanovdb_editor.cmake
@@ -15,7 +15,7 @@ option(NANOVDB_EDITOR_SKIP "Skip nanovdb_editor wheel build" OFF)
 CPMAddPackage(
     NAME nanovdb_editor
     GITHUB_REPOSITORY openvdb/nanovdb-editor
-    GIT_TAG 482bd60f4263629c12d3218c615908ac77bd55de
+    GIT_TAG b6dc88421484c126fe398a74b1536627a1b8d636
     VERSION 0.0.2
     DOWNLOAD_ONLY YES
 )

--- a/src/fvdb/detail/viewer/GaussianSplat3dView.cpp
+++ b/src/fvdb/detail/viewer/GaussianSplat3dView.cpp
@@ -10,10 +10,8 @@
 
 namespace fvdb::detail::viewer {
 
-GaussianSplat3dView::GaussianSplat3dView(const std::string &name,
-                                         const GaussianSplat3d &splats,
-                                         const Viewer &viewer)
-    : mSplats(splats), mViewName(name) {
+GaussianSplat3dView::GaussianSplat3dView(const std::string &name, const Viewer &viewer)
+    : mViewName(name) {
     mParams.near_plane_override = 0;
     mParams.far_plane_override  = 0;
     mParams.eps2d               = 0.3f;

--- a/src/fvdb/detail/viewer/GaussianSplat3dView.h
+++ b/src/fvdb/detail/viewer/GaussianSplat3dView.h
@@ -22,7 +22,6 @@ class GaussianSplat3dView {
     GaussianSplat3dView(const GaussianSplat3dView &)            = delete;
     GaussianSplat3dView &operator=(const GaussianSplat3dView &) = delete;
 
-    GaussianSplat3d mSplats;
     std::string mViewName;
 
   protected:
@@ -30,9 +29,7 @@ class GaussianSplat3dView {
     std::function<void(bool)> mSyncCallback;
 
   public:
-    GaussianSplat3dView(const std::string &name,
-                        const GaussianSplat3d &splats,
-                        const Viewer &viewer);
+    GaussianSplat3dView(const std::string &name, const Viewer &viewer);
 
     const float
     getNear() const {

--- a/src/fvdb/detail/viewer/Viewer.cpp
+++ b/src/fvdb/detail/viewer/Viewer.cpp
@@ -102,9 +102,8 @@ Viewer::~Viewer() {
 
 fvdb::detail::viewer::GaussianSplat3dView &
 Viewer::addGaussianSplat3d(const std::string &name, const GaussianSplat3d &splats) {
-    auto [it, inserted] = mSplat3dViews.emplace(std::piecewise_construct,
-                                                std::forward_as_tuple(name),
-                                                std::forward_as_tuple(name, splats, *this));
+    auto [it, inserted] = mSplat3dViews.emplace(
+        std::piecewise_construct, std::forward_as_tuple(name), std::forward_as_tuple(name, *this));
     // Load splats into viewer
 
     // Get the various tensors to pass to the viewer


### PR DESCRIPTION
The GaussianSplat3dView keeps a reference to a `GaussianSplat3d` which is not needed for rendering and can lead to extra GPU memory usage. 