### PR TITLE
[CI] Fix git install before checkout action

### DIFF
--- a/.github/workflows/cu128.yml
+++ b/.github/workflows/cu128.yml
@@ -71,15 +71,15 @@ jobs:
       run:
         shell: bash -el {0}
     steps:
+      - name: Apt update and install git and wget
+        run: apt update && apt install -y git wget
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Fetch all history for all branches
           # For pull requests, this automatically checks out the merge commit
           # For pushes, this checks out the pushed commit
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.ref || github.ref }}
-
-      - name: Apt update and install git and wget
-        run: apt update && apt install -y git wget
       - name: Fetch PR branch
         if: github.event_name == 'pull_request_target'
         run: |
@@ -238,15 +238,15 @@ jobs:
       run:
         shell: bash -el {0}
     steps:
+      - name: Apt update and install git and wget
+        run: apt update && apt install -y git wget
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Fetch all history for all branches
           # For pull requests, this automatically checks out the merge commit
           # For pushes, this checks out the pushed commit
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.ref || github.ref }}
-
-      - name: Apt update and install git and wget
-        run: apt update && apt install -y git wget
       - name: Fetch PR branch
         if: github.event_name == 'pull_request_target'
         run: |
@@ -340,14 +340,16 @@ jobs:
       run:
         shell: bash -el {0}
     steps:
+      - name: Apt update and install git and wget
+        run: apt update && apt install -y git wget
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Fetch all history for all branches
           # For pull requests, this automatically checks out the merge commit
           # For pushes, this checks out the pushed commit
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.ref || github.ref }}
-      - name: Apt update and install git and wget
-        run: apt update && apt install -y git wget
+
       - name: Fetch PR branch
         if: github.event_name == 'pull_request_target'
         run: |
@@ -429,15 +431,15 @@ jobs:
       run:
         shell: bash -el {0}
     steps:
+      - name: Apt update and install git and wget
+        run: apt update && apt install -y git wget
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Fetch all history for all branches
           # For pull requests, this automatically checks out the merge commit
           # For pushes, this checks out the pushed commit
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.ref || github.ref }}
-
-      - name: Apt update and install git and wget
-        run: apt update && apt install -y git wget
 
       - name: Fetch PR branch
         if: github.event_name == 'pull_request_target'

--- a/.github/workflows/cu129.yml
+++ b/.github/workflows/cu129.yml
@@ -64,15 +64,15 @@ jobs:
       run:
         shell: bash -el {0}
     steps:
+      - name: Apt update and install git and wget
+        run: apt update && apt install -y git wget
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Fetch all history for all branches
           # For pull requests, this automatically checks out the merge commit
           # For pushes, this checks out the pushed commit
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.ref || github.ref }}
-
-      - name: Apt update and install git and wget
-        run: apt update && apt install -y git wget
       - name: Fetch PR branch
         if: github.event_name == 'pull_request_target'
         run: |
@@ -229,15 +229,15 @@ jobs:
       run:
         shell: bash -el {0}
     steps:
+      - name: Apt update and install git and wget
+        run: apt update && apt install -y git wget
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Fetch all history for all branches
           # For pull requests, this automatically checks out the merge commit
           # For pushes, this checks out the pushed commit
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.ref || github.ref }}
-
-      - name: Apt update and install git and wget
-        run: apt update && apt install -y git wget
       - name: Fetch PR branch
         if: github.event_name == 'pull_request_target'
         run: |
@@ -331,15 +331,15 @@ jobs:
       run:
         shell: bash -el {0}
     steps:
+      - name: Apt update and install git and wget
+        run: apt update && apt install -y git wget
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Fetch all history for all branches
           # For pull requests, this automatically checks out the merge commit
           # For pushes, this checks out the pushed commit
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.ref || github.ref }}
-
-      - name: Apt update and install git and wget
-        run: apt update && apt install -y git wget
       - name: Fetch PR branch
         if: github.event_name == 'pull_request_target'
         run: |
@@ -418,15 +418,15 @@ jobs:
       run:
         shell: bash -el {0}
     steps:
+      - name: Apt update and install git and wget
+        run: apt update && apt install -y git wget
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Fetch all history for all branches
           # For pull requests, this automatically checks out the merge commit
           # For pushes, this checks out the pushed commit
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.ref || github.ref }}
-
-      - name: Apt update and install git and wget
-        run: apt update && apt install -y git wget
       - name: Fetch PR branch
         if: github.event_name == 'pull_request_target'
         run: |


### PR DESCRIPTION
In the `cu*` actions, git needs to be installed on the image before checkout happens