### PR TITLE
Fix namespace for GaussianTileIntersection

### DIFF
--- a/src/fvdb/detail/ops/gsplat/GaussianTileIntersection.cu
+++ b/src/fvdb/detail/ops/gsplat/GaussianTileIntersection.cu
@@ -11,6 +11,10 @@
 #include <cub/cub.cuh>
 #include <thrust/binary_search.h>
 
+namespace fvdb {
+namespace detail {
+namespace ops {
+
 namespace {
 
 #define NUM_THREADS 256
@@ -560,10 +564,6 @@ gaussianTileIntersectionCUDAImpl(
 }
 
 } // namespace
-
-namespace fvdb {
-namespace detail {
-namespace ops {
 
 template <>
 std::tuple<torch::Tensor, torch::Tensor>


### PR DESCRIPTION
In our other files, the anonymous namespace is located within `fvdb::detail::ops` so that we can access utility functions without additional qualification. This changes GaussianTileIntersection to match those other files.