### PR TITLE
Fuse log into projection

### DIFF
--- a/fvdb/gaussian_splatting.py
+++ b/fvdb/gaussian_splatting.py
@@ -441,7 +441,7 @@ class GaussianSplat3d:
         Note: To read the opacities, see the `opacities` property (which is read-only).
 
         Returns:
-            torch.Tensor: A tensor of shape (N, 3) where N is the number
+            torch.Tensor: A tensor of shape (N,) where N is the number
                 of Gaussians (see `num_gaussians`). Each row represents the logit of the opacity of a Gaussian in 3D space.
         """
         return self._impl.logit_opacities

--- a/src/fvdb/GaussianSplat3d.cpp
+++ b/src/fvdb/GaussianSplat3d.cpp
@@ -319,7 +319,7 @@ GaussianSplat3d::projectGaussiansImpl(const torch::Tensor &worldToCameraMatrices
     const auto projectionResults =
         detail::autograd::ProjectGaussians::apply(mMeans,
                                                   mQuats,
-                                                  scales(),
+                                                  mLogScales,
                                                   worldToCameraMatrices,
                                                   projectionMatrices,
                                                   settings.imageWidth,

--- a/src/fvdb/detail/autograd/GaussianRender.cpp
+++ b/src/fvdb/detail/autograd/GaussianRender.cpp
@@ -19,7 +19,7 @@ ProjectGaussians::VariableList
 ProjectGaussians::forward(ProjectGaussians::AutogradContext *ctx,
                           const ProjectGaussians::Variable &means,
                           const ProjectGaussians::Variable &quats,
-                          const ProjectGaussians::Variable &scales,
+                          const ProjectGaussians::Variable &logScales,
                           const ProjectGaussians::Variable &worldToCamMatrices,
                           const ProjectGaussians::Variable &projectionMatrices,
                           const uint32_t imageWidth,
@@ -41,7 +41,7 @@ ProjectGaussians::forward(ProjectGaussians::AutogradContext *ctx,
     auto variables   = FVDB_DISPATCH_KERNEL_DEVICE(means.device(), [&]() {
         return ops::dispatchGaussianProjectionForward<DeviceTag>(means,
                                                                  quats,
-                                                                 scales,
+                                                                 logScales,
                                                                  worldToCamMatrices,
                                                                  projectionMatrices,
                                                                  imageWidth,
@@ -81,7 +81,7 @@ ProjectGaussians::forward(ProjectGaussians::AutogradContext *ctx,
         Variable compensations = std::get<4>(variables);
         ctx->save_for_backward({means,
                                 quats,
-                                scales,
+                                logScales,
                                 worldToCamMatrices,
                                 projectionMatrices,
                                 radii,
@@ -90,7 +90,7 @@ ProjectGaussians::forward(ProjectGaussians::AutogradContext *ctx,
         return {radii, means2d, depths, conics, compensations};
     } else {
         ctx->save_for_backward(
-            {means, quats, scales, worldToCamMatrices, projectionMatrices, radii, conics});
+            {means, quats, logScales, worldToCamMatrices, projectionMatrices, radii, conics});
         return {radii, means2d, depths, conics};
     }
 }
@@ -121,7 +121,7 @@ ProjectGaussians::backward(ProjectGaussians::AutogradContext *ctx,
     VariableList saved          = ctx->get_saved_variables();
     Variable means              = saved.at(0);
     Variable quats              = saved.at(1);
-    Variable scales             = saved.at(2);
+    Variable logScales          = saved.at(2);
     Variable worldToCamMatrices = saved.at(3);
     Variable projectionMatrices = saved.at(4);
     Variable radii              = saved.at(5);
@@ -161,7 +161,7 @@ ProjectGaussians::backward(ProjectGaussians::AutogradContext *ctx,
     auto variables = FVDB_DISPATCH_KERNEL_DEVICE(means.device(), [&]() {
         return ops::dispatchGaussianProjectionBackward<DeviceTag>(means,
                                                                   quats,
-                                                                  scales,
+                                                                  logScales,
                                                                   worldToCamMatrices,
                                                                   projectionMatrices,
                                                                   compensations,

--- a/src/fvdb/detail/ops/gsplat/GaussianProjectionBackward.cu
+++ b/src/fvdb/detail/ops/gsplat/GaussianProjectionBackward.cu
@@ -74,7 +74,7 @@ projectionBackwardKernel(
     const T *__restrict__ means,              // [N, 3]
     const T *__restrict__ covars,             // [N, 6] optional
     const T *__restrict__ quats,              // [N, 4] optional
-    const T *__restrict__ scales,             // [N, 3] optional
+    const T *__restrict__ logScales,          // [N, 3] optional
     const T *__restrict__ worldToCamMatrices, // [C, 4, 4]
     const T *__restrict__ projectionMatrices, // [C, 3, 3]
     const int32_t imageWidth,
@@ -158,11 +158,13 @@ projectionBackwardKernel(
                                        covars[5]  // 3rd row
         );
     } else {
-        // compute from quaternions and scales
+        // compute from quaternions and logScales
         quats += gId * 4;
-        scales += gId * 3;
+        logScales += gId * 3;
         quat  = nanovdb::math::Vec4<T>(quats[0], quats[1], quats[2], quats[3]);
-        scale = nanovdb::math::Vec3<T>(scales[0], scales[1], scales[2]);
+        scale = nanovdb::math::Vec3<T>(::cuda::std::exp(logScales[0]),
+                                       ::cuda::std::exp(logScales[1]),
+                                       ::cuda::std::exp(logScales[2]));
 
         covar = quaternionAndScaleToCovariance<T>(quat, scale);
     }
@@ -285,7 +287,7 @@ dispatchGaussianProjectionBackward<torch::kCUDA>(
     // fwd inputs
     const torch::Tensor &means,                       // [N, 3]
     const torch::Tensor &quats,                       // [N, 4]
-    const torch::Tensor &scales,                      // [N, 3]
+    const torch::Tensor &logScales,                   // [N, 3]
     const torch::Tensor &worldToCamMatrices,          // [C, 4, 4]
     const torch::Tensor &projectionMatrices,          // [C, 3, 3]
     const at::optional<torch::Tensor> &compensations, // [N, 6] optional
@@ -318,7 +320,7 @@ dispatchGaussianProjectionBackward<torch::kCUDA>(
         GSPLAT_CHECK_INPUT(covars.value());
     } else {
         GSPLAT_CHECK_INPUT(quats);
-        GSPLAT_CHECK_INPUT(scales);
+        GSPLAT_CHECK_INPUT(logScales);
     }
     GSPLAT_CHECK_INPUT(worldToCamMatrices);
     GSPLAT_CHECK_INPUT(projectionMatrices);
@@ -345,7 +347,7 @@ dispatchGaussianProjectionBackward<torch::kCUDA>(
         dLossDCovars = torch::zeros_like(covars.value());
     } else {
         dLossDQuats  = torch::zeros_like(quats);
-        dLossDScales = torch::zeros_like(scales);
+        dLossDScales = torch::zeros_like(logScales);
     }
     torch::Tensor dLossDWorldToCamMatrices;
     if (worldToCamMatricesRequiresGrad) {
@@ -360,7 +362,7 @@ dispatchGaussianProjectionBackward<torch::kCUDA>(
                     means.data_ptr<float>(),
                     covars.has_value() ? covars.value().data_ptr<float>() : nullptr,
                     covars.has_value() ? nullptr : quats.data_ptr<float>(),
-                    covars.has_value() ? nullptr : scales.data_ptr<float>(),
+                    covars.has_value() ? nullptr : logScales.data_ptr<float>(),
                     worldToCamMatrices.data_ptr<float>(),
                     projectionMatrices.data_ptr<float>(),
                     imageWidth,
@@ -388,7 +390,7 @@ dispatchGaussianProjectionBackward<torch::kCUDA>(
                     means.data_ptr<float>(),
                     covars.has_value() ? covars.value().data_ptr<float>() : nullptr,
                     covars.has_value() ? nullptr : quats.data_ptr<float>(),
-                    covars.has_value() ? nullptr : scales.data_ptr<float>(),
+                    covars.has_value() ? nullptr : logScales.data_ptr<float>(),
                     worldToCamMatrices.data_ptr<float>(),
                     projectionMatrices.data_ptr<float>(),
                     imageWidth,


### PR DESCRIPTION
Our previous kernels took in scales directly, but we store log(scales) to ensure the parameter is always valid. This change makes the projection kernel accept logScales instead, avoiding an extra operation (and derivative). 

This change requires us to update the gtests to use higher tolerances since the original test data was computed using scales as input rather than logScales. While the tolerances are larger, they are still a tiny fraction of the actual range of the data, so probably fine. 

I've also trained several splats in reality capture with this change. The only difference is a slight speedup.

Thanks @matthewdcong for the original code (I just fixed up the tests). 