### PR TITLE
Fix package name for pypi

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [
 build-backend = "scikit_build_core.build"
 
 [project]
-name = "fvdb"
+name = "fvdb-core"
 version = "0.2.1"
 license = { text = "Apache-2.0" }
 


### PR DESCRIPTION
Our pyproject.toml file specified the package name as fvdb but to upload to pypi, we need the name to be fvdb-core. The module name will still be fvdb. 