### PR TITLE
Docs tests work in Dev environment

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -12,6 +12,7 @@ usage() {
   echo "                   install    - Build and install the package (default)."
   echo "                   wheel      - Build the Python wheel."
   echo "                   ctest      - Run tests (requires tests to be built)."
+  echo "                   docstest   - Run pytest markdown documentation tests."
   echo ""
   echo "Options:"
   echo "  -h, --help     Display this help message and exit."
@@ -124,7 +125,7 @@ _first_arg_val="$1"
 BUILD_TYPE="install" # Default build type
 
 if [[ -n "$_first_arg_val" ]]; then
-  if [[ "$_first_arg_val" == "install" || "$_first_arg_val" == "wheel" || "$_first_arg_val" == "ctest" ]]; then
+  if [[ "$_first_arg_val" == "install" || "$_first_arg_val" == "wheel" || "$_first_arg_val" == "ctest" || "$_first_arg_val" == "docstest" ]]; then
     BUILD_TYPE="$_first_arg_val"
     shift # Consume the build_type argument
   else
@@ -201,7 +202,7 @@ export PIP_ARGS="--no-build-isolation$CONFIG_SETTINGS$PASS_THROUGH_ARGS"
 # Detect and export CUDA architectures early so builds pick it up
 set_cuda_arch_list "$CUDA_ARCH_LIST_ARG"
 
-if [ "$BUILD_TYPE" != "ctest" ]; then
+if [ "$BUILD_TYPE" != "ctest" ] && [ "$BUILD_TYPE" != "docstest" ]; then
     setup_parallel_build_jobs
 fi
 
@@ -276,8 +277,15 @@ elif [ "$BUILD_TYPE" == "ctest" ]; then
     echo "ctest finished with exit code $CTEST_EXIT_CODE."
     exit $CTEST_EXIT_CODE
 
+elif [ "$BUILD_TYPE" == "docstest" ]; then
+    echo "Running pytest markdown documentation tests..."
+    pytest --markdown-docs ./docs --ignore-glob="**/wip/**"
+    PYTEST_EXIT_CODE=$?
+    echo "pytest markdown tests finished with exit code $PYTEST_EXIT_CODE."
+    exit $PYTEST_EXIT_CODE
+
 else
     echo "Invalid build/run type: $BUILD_TYPE"
-    echo "Valid build/run types are: wheel, install, ctest"
+    echo "Valid build/run types are: wheel, install, ctest, docstest"
     exit 1
 fi

--- a/env/dev_environment.yml
+++ b/env/dev_environment.yml
@@ -71,6 +71,7 @@ dependencies:
   - viser
   - pip:
     - point-cloud-utils
+    - pytest-markdown-docs
     - https://nksr.s3.ap-northeast-1.amazonaws.com/dev-whls/pt27cu128/torchsparse-2.1.0-cp312-cp312-linux_x86_64.whl
     - https://nksr.s3.ap-northeast-1.amazonaws.com/dev-whls/pt27cu128/torchsparse_20-2.0.0b0-cp312-cp312-linux_x86_64.whl
     - https://nksr.s3.ap-northeast-1.amazonaws.com/dev-whls/pt27cu128/torch_scatter-2.1.2-cp312-cp312-linux_x86_64.whl

--- a/fvdb/utils/examples/__init__.py
+++ b/fvdb/utils/examples/__init__.py
@@ -3,78 +3,17 @@
 #
 import hashlib
 import logging
-import site
-import tempfile
 import timeit
 from pathlib import Path
 from typing import List, Tuple, Union
 
-import git
-import git.repo
 import numpy as np
 import point_cloud_utils as pcu
 import torch
 from fvdb.types import NumericMaxRank1, NumericMaxRank2
-from git.exc import InvalidGitRepositoryError
+from fvdb.utils.tests import get_fvdb_example_data_path as _get_fvdb_example_data_path
 
 from fvdb import Grid, GridBatch, JaggedTensor
-
-
-def _is_editable_install() -> bool:
-    # check we're not in a site package
-    module_path = Path(__file__).resolve()
-    for site_path in site.getsitepackages():
-        if str(module_path).startswith(site_path):
-            return False
-    # check if we're in the source directory
-    module_dir = module_path.parent.parent.parent.parent
-    return (module_dir / "setup.py").is_file()
-
-
-def _get_local_repo_path() -> Path:
-    if _is_editable_install():
-        external_dir = Path(__file__).resolve().parent.parent.parent.parent / "external"
-        if not external_dir.exists():
-            external_dir.mkdir()
-        local_repo_path = external_dir
-    else:
-        local_repo_path = Path(tempfile.gettempdir())
-
-    local_repo_path = local_repo_path / "fvdb_example_data"
-    return local_repo_path
-
-
-def _clone_fvdb_example_data():
-    def is_git_repo(repo_path: str):
-        is_repo = False
-        try:
-            _ = git.repo.Repo(repo_path)
-            is_repo = True
-        except InvalidGitRepositoryError:
-            is_repo = False
-
-        return is_repo
-
-    git_tag = "613c3a4e220eb45b9ae0271dca4808ab484ee134"
-    git_url = "https://github.com/voxel-foundation/fvdb-example-data.git"
-
-    repo_path = _get_local_repo_path()
-    if repo_path.exists() and repo_path.is_dir():
-        if is_git_repo(str(repo_path)):
-            repo = git.repo.Repo(repo_path)
-            repo.git.checkout(git_tag)
-        else:
-            raise ValueError(f"A path {repo_path} exists but is not a git repo")
-    else:
-        repo = git.repo.Repo.clone_from(git_url, repo_path)
-        repo.git.checkout(git_tag)
-
-    return repo_path, repo
-
-
-def _get_fvdb_example_data_path():
-    repo_path, _ = _clone_fvdb_example_data()
-    return repo_path
 
 
 def _get_md5_checksum(file_path: Path):


### PR DESCRIPTION
"fvdb" conda environment now has everything it needs to do docs testing.

The build.sh file now also has a "docstest" target which will run the documentation tests. You can run them manually like so:

```
pytest --markdown-docs ./docs
```

The example/test data was failing in some cases because if the directory `/tmp/fvdb_example_data` already existed, one of the functions which did git commands to clone that data would skip it, but then fail on subsequent attempts to check out a particular hash. We had duplicate functions for cloning test and example data, so I've combined them and added the required "fetch" if the repo already existed. 