### PR TITLE
Morton Order for supporting point transformer v3

### DIFF
--- a/fvdb/grid.py
+++ b/fvdb/grid.py
@@ -1835,6 +1835,40 @@ class Grid:
     def ijk(self) -> torch.Tensor:
         return self._impl.ijk.jdata
 
+    def serialize_encode(self, order_type: str = "z") -> torch.Tensor:
+        """
+        Return the Morton codes for active voxels in this grid.
+        
+        Morton codes provide a space-filling curve that maps 3D coordinates to 1D integers,
+        preserving spatial locality. This is useful for serialization, sorting, and 
+        spatial data structures.
+
+        Returns:
+            torch.Tensor: A tensor of shape `[num_voxels, 1]` containing
+                the Morton codes for each active voxel.
+        """
+        return self._impl.serialize_encode(order_type).jdata
+
+    def permute(self, order_type: str = "z") -> torch.Tensor:
+        """
+        Get permutation indices to sort voxels by spatial order.
+        
+        This method computes Morton codes for all active voxels and returns the indices
+        that would sort them according to the specified ordering. This is useful for
+        spatially coherent data access patterns and cache optimization.
+
+        Args:
+            order_type (str): The type of spatial ordering to use:
+                - "morton": Morton Z-order curve (default, ascending)
+                - "ascending": Sort Morton codes in ascending order (same as "morton")
+                - "descending": Sort Morton codes in descending order
+
+        Returns:
+            torch.Tensor: A tensor of shape `[num_voxels, 1]` containing
+                the permutation indices. Use these indices to reorder voxel data for spatial coherence.
+        """
+        return self._impl.permute(order_type).jdata
+
     @property
     def num_bytes(self) -> int:
         return self._impl.total_bytes

--- a/fvdb/grid_batch.py
+++ b/fvdb/grid_batch.py
@@ -1956,6 +1956,48 @@ class GridBatch:
     def ijk(self) -> JaggedTensor:
         return self._impl.ijk
 
+    def serialize_encode(self, order_type: str = "z") -> JaggedTensor:
+        """
+        Return the Morton codes for active voxels in this grid batch.
+        
+        Morton codes provide a space-filling curve that maps 3D coordinates to 1D integers,
+        preserving spatial locality. This is useful for serialization, sorting, and 
+        spatial data structures.
+
+        Returns:
+            JaggedTensor: A JaggedTensor of shape `[num_grids, -1, 1]` containing
+                the Morton codes for each active voxel in the batch.
+        """
+        return self._impl.serialize_encode(order_type)
+
+    def permute(self, order_type: str = "z") -> JaggedTensor:
+        """
+        Get permutation indices to sort voxels by spatial order.
+        
+        This method computes Morton codes for all active voxels and returns the indices
+        that would sort them according to the specified ordering. This is useful for
+        spatially coherent data access patterns and cache optimization.
+
+        Args:
+            order_type (str): The type of spatial ordering to use:
+                - "z": Regular Z-order curve (xyz bit interleaving, default)
+                - "z-trans": Transposed Z-order curve (zyx bit interleaving)
+                - "morton": Alias for "z" (for backward compatibility)
+                - "ascending": Alias for "z"
+                - "descending": Sort Morton codes in descending order
+
+        Returns:
+            JaggedTensor: A JaggedTensor of shape `[num_grids, -1, 1]` containing
+                the permutation indices. Use these indices to reorder voxel data for spatial coherence.
+                
+        Example:
+            >>> z_indices = grid_batch.permute("z")  # Regular xyz z-order
+            >>> z_trans_indices = grid_batch.permute("z-trans")  # Transposed zyx z-order
+            >>> # Use indices to reorder some voxel data
+            >>> reordered_data = voxel_data.jdata[z_indices.jdata.squeeze(-1)]
+        """
+        return self._impl.permute(order_type)
+
     @property
     def jidx(self) -> torch.Tensor:
         if self.has_zero_grids:

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -118,6 +118,7 @@ set(FVDB_CU_FILES
     fvdb/detail/ops/PointsInGrid.cu
     fvdb/detail/ops/IjkToIndex.cu
     fvdb/detail/ops/ActiveGridGoords.cu
+    fvdb/detail/ops/SerializeEncode.cu
     fvdb/detail/ops/IjkToInvIndex.cu
     fvdb/detail/ops/ReadFromDense.cu
     fvdb/detail/ops/NearestIjkForPoints.cu

--- a/src/fvdb/GridBatch.h
+++ b/src/fvdb/GridBatch.h
@@ -472,6 +472,21 @@ struct GridBatch : torch::CustomClassHolder {
     /// @return A JaggedTensor of voxel coordinates indexed by this grid batch (shape [B, -1, 3])
     JaggedTensor ijk() const;
 
+    /// @brief Return the Morton codes for active voxels in this grid batch with specific order type
+    /// @param order_type The type of z-order to use ("z" for xyz, "z-trans" for zyx)
+    /// @return A JaggedTensor of Morton codes for active voxels (shape [B, -1, 1])
+    JaggedTensor serialize_encode(const std::string &order_type) const;
+
+    /// @brief Get permutation indices to sort voxels by spatial order
+    /// @param order_type The type of spatial ordering to use:
+    ///                   - "z": Regular Z-order curve (xyz bit interleaving, default)
+    ///                   - "z-trans": Transposed Z-order curve (zyx bit interleaving)
+    ///                   - "morton": Alias for "z" (for backward compatibility)
+    ///                   - "ascending": Alias for "z" 
+    ///                   - "descending": Sort Morton codes in descending order
+    /// @return A JaggedTensor of permutation indices (shape [B, -1])
+    JaggedTensor permute(const std::string &order_type) const;
+
     /// @brief Find the intersection between a collection of rays and the zero level set of a scalar
     /// field
     ///        at each voxel in the grid batch

--- a/src/fvdb/detail/ops/SerializeEncode.cu
+++ b/src/fvdb/detail/ops/SerializeEncode.cu
@@ -1,0 +1,190 @@
+// Copyright Contributors to the OpenVDB Project
+// SPDX-License-Identifier: Apache-2.0
+//
+#include <fvdb/detail/GridBatchImpl.h>
+#include <fvdb/detail/ops/SerializeEncode.h>
+#include <fvdb/detail/utils/AccessorHelpers.cuh>
+#include <fvdb/detail/utils/ForEachCPU.h>
+#include <fvdb/detail/utils/cuda/ForEachCUDA.cuh>
+#include <fvdb/detail/utils/cuda/ForEachPrivateUse1.cuh>
+#include <fvdb/detail/utils/MortonCode.h>
+
+#include <c10/cuda/CUDAException.h>
+#include <cuda_runtime.h>
+#include <vector>
+
+namespace fvdb {
+namespace detail {
+namespace ops {
+
+/// @brief Per-voxel callback which computes the Morton code for each active voxel in a batch of grids
+template <template <typename T, int32_t D> typename TorchAccessor>
+__hostdev__ inline void
+serializeEncodeVoxelCallback(int64_t batchIdx,
+                             int64_t leafIdx,
+                             int64_t voxelIdx,
+                             GridBatchImpl::Accessor gridAccessor,
+                             TorchAccessor<int64_t, 2> outMortonCodes,
+                             const nanovdb::Coord* bboxMinCoords,
+                             int order_type) {
+    const nanovdb::OnIndexGrid *grid = gridAccessor.grid(batchIdx);
+    const typename nanovdb::OnIndexGrid::LeafNodeType &leaf =
+        grid->tree().template getFirstNode<0>()[leafIdx];
+    const int64_t baseOffset = gridAccessor.voxelOffset(batchIdx);
+
+    const nanovdb::Coord &ijk = leaf.offsetToGlobalCoord(voxelIdx);
+    if (leaf.isActive(voxelIdx)) {
+        const int64_t idx = baseOffset + (int64_t)leaf.getValue(voxelIdx) - 1;
+        
+        // Get bounding box minimum for this batch to use as offset
+        const nanovdb::Coord &bboxMin = bboxMinCoords[batchIdx];
+        int32_t offset_i = bboxMin[0];
+        int32_t offset_j = bboxMin[1];
+        int32_t offset_k = bboxMin[2];
+        
+        // Compute Morton code with offset to ensure non-negative coordinates
+        uint64_t morton_code;
+        if (order_type == 1) {  // ORDER_TYPE_Z_TRANS
+            // Transposed z-order: swap coordinates zyx
+            morton_code = utils::morton_with_offset(
+                ijk[2], ijk[1], ijk[0],
+                static_cast<uint32_t>(-offset_k), 
+                static_cast<uint32_t>(-offset_j), 
+                static_cast<uint32_t>(-offset_i)
+            );
+        } else {  // ORDER_TYPE_Z (default)
+            // Regular z-order: xyz
+            morton_code = utils::morton_with_offset(
+                ijk[0], ijk[1], ijk[2],
+                static_cast<uint32_t>(-offset_i), 
+                static_cast<uint32_t>(-offset_j), 
+                static_cast<uint32_t>(-offset_k)
+            );
+        }
+        
+        outMortonCodes[idx][0] = static_cast<int64_t>(morton_code);
+    }
+}
+
+/// @brief Get the Morton codes for active voxels in a batch of grids
+/// @param gridBatch The batch of grids
+/// @param outMortonCodes Tensor which will contain the output Morton codes
+/// @param bboxMinCoords Array of bounding box minimum coordinates for each grid
+/// @param order_type Integer representing the order type (0=z, 1=z-trans, etc.)
+template <torch::DeviceType DeviceTag>
+void
+GetSerializeEncode(const GridBatchImpl &gridBatch, 
+                   torch::Tensor &outMortonCodes,
+                   const nanovdb::Coord* bboxMinCoords,
+                   int order_type) {
+    auto outCodesAcc = tensorAccessor<DeviceTag, int64_t, 2>(outMortonCodes);
+
+    if constexpr (DeviceTag == torch::kCUDA) {
+        auto cb = [=] __device__(int64_t batchIdx,
+                                 int64_t leafIdx,
+                                 int64_t voxelIdx,
+                                 int64_t,
+                                 GridBatchImpl::Accessor gridAccessor) {
+            serializeEncodeVoxelCallback<TorchRAcc32>(
+                batchIdx, leafIdx, voxelIdx, gridAccessor, outCodesAcc, bboxMinCoords, order_type);
+        };
+        forEachVoxelCUDA(1024, 1, gridBatch, cb);
+    } else if constexpr (DeviceTag == torch::kPrivateUse1) {
+        auto cb = [=] __device__(int64_t batchIdx,
+                                 int64_t leafIdx,
+                                 int64_t voxelIdx,
+                                 int64_t,
+                                 GridBatchImpl::Accessor gridAccessor) {
+            serializeEncodeVoxelCallback<TorchRAcc32>(
+                batchIdx, leafIdx, voxelIdx, gridAccessor, outCodesAcc, bboxMinCoords, order_type);
+        };
+        forEachVoxelPrivateUse1(1, gridBatch, cb);
+    } else {
+        auto cb = [=](int64_t batchIdx,
+                      int64_t leafIdx,
+                      int64_t voxelIdx,
+                      int64_t,
+                      GridBatchImpl::Accessor gridAccessor) {
+            serializeEncodeVoxelCallback<TorchAcc>(
+                batchIdx, leafIdx, voxelIdx, gridAccessor, outCodesAcc, bboxMinCoords, order_type);
+        };
+        forEachVoxelCPU(1, gridBatch, cb);
+    }
+}
+
+/// @brief Get the Morton codes for active voxels in a batch of grids
+/// @tparam DeviceTag Which device to run on
+/// @param gridBatch The batch of grids to get the Morton codes for
+/// @param order_type The type of z-order to use ("z" for xyz, "z-trans" for zyx)
+/// @return A JaggedTensor of shape [B, -1, 1] of Morton codes for active voxels
+template <torch::DeviceType DeviceTag>
+JaggedTensor
+SerializeEncode(const GridBatchImpl &gridBatch, const std::string &order_type) {
+    gridBatch.checkNonEmptyGrid();
+    auto opts = torch::TensorOptions().dtype(torch::kInt64).device(gridBatch.device());
+    torch::Tensor outMortonCodes = torch::empty({gridBatch.totalVoxels(), 1}, opts);
+    
+    // Parse order type string to integer
+    int order_type_int;
+    if (order_type == "z") {
+        order_type_int = ORDER_TYPE_Z;  // Regular xyz z-order
+    } else if (order_type == "z-trans") {
+        order_type_int = ORDER_TYPE_Z_TRANS;  // Transposed zyx z-order
+    } else {
+        // raise an error
+        throw std::runtime_error("Invalid order_type: " + order_type + ". Valid options are 'z' or 'z-trans'.");
+    }
+    
+    // Get bounding box minimum coordinates for offset calculation
+    // We need to extract the minimum coordinates from each grid's bounding box
+    std::vector<nanovdb::Coord> bboxMinCoords;
+    bboxMinCoords.reserve(gridBatch.batchSize());
+    
+    for (int64_t i = 0; i < gridBatch.batchSize(); ++i) {
+        nanovdb::CoordBBox bbox = gridBatch.bboxAt(i);
+        bboxMinCoords.push_back(bbox.min());
+    }
+    
+    // For GPU execution, we need to copy the data to device
+    nanovdb::Coord* bboxMinPtr = nullptr;
+    if constexpr (DeviceTag == torch::kCUDA || DeviceTag == torch::kPrivateUse1) {
+        // Allocate device memory and copy
+        cudaMalloc(&bboxMinPtr, bboxMinCoords.size() * sizeof(nanovdb::Coord));
+        cudaMemcpy(bboxMinPtr, bboxMinCoords.data(), 
+                   bboxMinCoords.size() * sizeof(nanovdb::Coord), 
+                   cudaMemcpyHostToDevice);
+    } else {
+        bboxMinPtr = bboxMinCoords.data();
+    }
+    
+    GetSerializeEncode<DeviceTag>(gridBatch, outMortonCodes, bboxMinPtr, order_type_int);
+    
+    // Clean up device memory if allocated
+    if constexpr (DeviceTag == torch::kCUDA || DeviceTag == torch::kPrivateUse1) {
+        cudaFree(bboxMinPtr);
+    }
+    
+    return gridBatch.jaggedTensor(outMortonCodes);
+}
+
+template <>
+JaggedTensor
+dispatchSerializeEncode<torch::kCUDA>(const GridBatchImpl &gridBatch, const std::string &order_type) {
+    return SerializeEncode<torch::kCUDA>(gridBatch, order_type);
+}
+
+template <>
+JaggedTensor
+dispatchSerializeEncode<torch::kCPU>(const GridBatchImpl &gridBatch, const std::string &order_type) {
+    return SerializeEncode<torch::kCPU>(gridBatch, order_type);
+}
+
+template <>
+JaggedTensor
+dispatchSerializeEncode<torch::kPrivateUse1>(const GridBatchImpl &gridBatch, const std::string &order_type) {
+    return SerializeEncode<torch::kPrivateUse1>(gridBatch, order_type);
+}
+
+} // namespace ops
+} // namespace detail
+} // namespace fvdb

--- a/src/fvdb/detail/ops/SerializeEncode.h
+++ b/src/fvdb/detail/ops/SerializeEncode.h
@@ -1,0 +1,27 @@
+// Copyright Contributors to the OpenVDB Project
+// SPDX-License-Identifier: Apache-2.0
+//
+#ifndef FVDB_DETAIL_OPS_SERIALIZEENCODE_H
+#define FVDB_DETAIL_OPS_SERIALIZEENCODE_H
+
+#include <fvdb/JaggedTensor.h>
+#include <fvdb/detail/GridBatchImpl.h>
+
+#include <torch/types.h>
+
+namespace fvdb {
+namespace detail {
+namespace ops {
+
+// Order type constants for serialize encode
+constexpr int ORDER_TYPE_Z = 0;        // Regular z-order (xyz)
+constexpr int ORDER_TYPE_Z_TRANS = 1;  // Transposed z-order (zyx)
+
+template <torch::DeviceType>
+JaggedTensor dispatchSerializeEncode(const GridBatchImpl &gridBatch, const std::string &order_type = "z");
+
+} // namespace ops
+} // namespace detail
+} // namespace fvdb
+
+#endif // FVDB_DETAIL_OPS_SERIALIZEENCODE_H

--- a/src/fvdb/detail/utils/MortonCode.h
+++ b/src/fvdb/detail/utils/MortonCode.h
@@ -1,0 +1,79 @@
+// Copyright Contributors to the OpenVDB Project
+// SPDX-License-Identifier: Apache-2.0
+//
+#ifndef FVDB_DETAIL_UTILS_MORTONCODE_H
+#define FVDB_DETAIL_UTILS_MORTONCODE_H
+
+#include <cstdint>
+#include <nanovdb/util/Util.h>  // For __hostdev__ definition
+
+namespace fvdb {
+namespace detail {
+namespace utils {
+
+//-----------------------------------------------------------------------------
+// This strange bit-shifting thing comes from here:
+// http://programming.sirrida.de/calcperm.php
+//-----------------------------------------------------------------------------
+
+template <uint32_t mask, int shift>
+__hostdev__ inline uint32_t
+bit_permute_step(uint32_t x) {
+    return ((x & mask) << shift) | ((x >> shift) & mask);
+}
+
+//-----------------------------------------------------------------------------
+// 3D case
+__hostdev__ inline uint32_t
+expand_lower_10_bits_by_3(uint32_t x) {
+    x = bit_permute_step<0x000007c0, 16>(x);  // Butterfly, stage 4
+    x = bit_permute_step<0x00000038, 8>(x);   // Butterfly, stage 3
+    x = bit_permute_step<0x04040004, 4>(x);   // Butterfly, stage 2
+    x = bit_permute_step<0x02202202, 2>(x);   // Butterfly, stage 1
+    return x & 0b01001001001001001001001001001u;
+}
+
+__hostdev__ inline uint64_t
+expand_lower_21_bits_by_3(uint32_t const x) {
+    static constexpr uint32_t bit_21 = 0x1 << 20;
+    return static_cast<uint64_t>(expand_lower_10_bits_by_3(x)) |
+           (static_cast<uint64_t>(expand_lower_10_bits_by_3(x >> 10)) << 30) |
+           (static_cast<uint64_t>(x & bit_21) << 40);
+}
+
+/// @brief Compute Morton code for 3D coordinates
+/// @param x X coordinate (must be <= 2^21-1)
+/// @param y Y coordinate (must be <= 2^21-1)  
+/// @param z Z coordinate (must be <= 2^21-1)
+/// @return 64-bit Morton code
+__hostdev__ inline uint64_t
+morton(uint32_t const x, uint32_t const y, uint32_t const z) {
+    return expand_lower_21_bits_by_3(x) |
+           (expand_lower_21_bits_by_3(y) << 1) |
+           (expand_lower_21_bits_by_3(z) << 2);
+}
+
+/// @brief Compute Morton code for 3D coordinates with offset handling
+/// @param i I coordinate (can be negative)
+/// @param j J coordinate (can be negative)
+/// @param k K coordinate (can be negative)
+/// @param offset_i Offset to make i non-negative
+/// @param offset_j Offset to make j non-negative
+/// @param offset_k Offset to make k non-negative
+/// @return 64-bit Morton code
+__hostdev__ inline uint64_t
+morton_with_offset(int32_t const i, int32_t const j, int32_t const k,
+                   uint32_t const offset_i, uint32_t const offset_j, uint32_t const offset_k) {
+    // Add offsets to ensure non-negative coordinates
+    uint32_t x = static_cast<uint32_t>(i + static_cast<int32_t>(offset_i));
+    uint32_t y = static_cast<uint32_t>(j + static_cast<int32_t>(offset_j));
+    uint32_t z = static_cast<uint32_t>(k + static_cast<int32_t>(offset_k));
+    
+    return morton(x, y, z);
+}
+
+} // namespace utils
+} // namespace detail
+} // namespace fvdb
+
+#endif // FVDB_DETAIL_UTILS_MORTONCODE_H


### PR DESCRIPTION
Point transformer v3 requires attention along the different serialization orders. This PR supports different z-order and transposed z-order. Next, I will implement hilbert order and transposed hilbert order to match with original ptv3 faithfully. 