### PR TITLE
Add CONDA_OVERRIDE_CUDA 12.9 to the tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,7 +1,7 @@
 name: fVDB Unit Tests
 
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - '**'
     paths-ignore:


### PR DESCRIPTION
Needed for #191 to see the CONDA_CUDA_VERSION in the job definition when using the `pull_request_target` trigger