### PR TITLE
Don't use cudnn for SDPA

### DIFF
--- a/src/fvdb/FVDB.cpp
+++ b/src/fvdb/FVDB.cpp
@@ -40,47 +40,33 @@ scaledDotProductAttention(const JaggedTensor &query,
                           const JaggedTensor &key,
                           const JaggedTensor &value,
                           float scale) {
-    cudaDeviceProp *p           = at::cuda::getDeviceProperties(query.device().index());
-    const int computeCapability = p->major * 10 + p->minor;
+    // https://pytorch.org/docs/stable/generated/torch.nn.functional.scaled_dot_product_attention.html
+    // - query: (N, ..., L, E)
+    // - key: (N, ..., S, E)
+    // - value: (N, ..., S, V)
+    std::vector<torch::Tensor> outList;
+    torch::Tensor qOffsets  = query.joffsets().cpu();
+    torch::Tensor kvOffsets = key.joffsets().cpu();
 
-    if (computeCapability < 90) {
-        // https://pytorch.org/docs/stable/generated/torch.nn.functional.scaled_dot_product_attention.html
-        // - query: (N, ..., L, E)
-        // - key: (N, ..., S, E)
-        // - value: (N, ..., S, V)
-        std::vector<torch::Tensor> outList;
-        torch::Tensor qOffsets  = query.joffsets().cpu();
-        torch::Tensor kvOffsets = key.joffsets().cpu();
+    for (int64_t b = 0; b < query.num_tensors(); ++b) {
+        int64_t qStart  = qOffsets[b].item<int64_t>();
+        int64_t qEnd    = qOffsets[b + 1].item<int64_t>();
+        int64_t kvStart = kvOffsets[b].item<int64_t>();
+        int64_t kvEnd   = kvOffsets[b + 1].item<int64_t>();
 
-        for (int64_t b = 0; b < query.num_tensors(); ++b) {
-            int64_t qStart  = qOffsets[b].item<int64_t>();
-            int64_t qEnd    = qOffsets[b + 1].item<int64_t>();
-            int64_t kvStart = kvOffsets[b].item<int64_t>();
-            int64_t kvEnd   = kvOffsets[b + 1].item<int64_t>();
+        torch::Tensor q =
+            query.jdata().index({torch::indexing::Slice(qStart, qEnd)}).permute({1, 0, 2});
+        torch::Tensor k =
+            key.jdata().index({torch::indexing::Slice(kvStart, kvEnd)}).permute({1, 0, 2});
+        torch::Tensor v =
+            value.jdata().index({torch::indexing::Slice(kvStart, kvEnd)}).permute({1, 0, 2});
 
-            torch::Tensor q =
-                query.jdata().index({torch::indexing::Slice(qStart, qEnd)}).permute({1, 0, 2});
-            torch::Tensor k =
-                key.jdata().index({torch::indexing::Slice(kvStart, kvEnd)}).permute({1, 0, 2});
-            torch::Tensor v =
-                value.jdata().index({torch::indexing::Slice(kvStart, kvEnd)}).permute({1, 0, 2});
-
-            torch::Tensor out =
-                at::native::scaled_dot_product_attention(q, k, v, {}, 0.0, false, scale);
-            outList.push_back(out.permute({1, 0, 2}));
-        }
-
-        return JaggedTensor(outList);
+        torch::Tensor out =
+            at::native::scaled_dot_product_attention(q, k, v, {}, 0.0, false, scale);
+        outList.push_back(out.permute({1, 0, 2}));
     }
 
-    // Custom implementation with CUDNN is only available for Hopper.
-    torch::Tensor qLengths =
-        query.joffsets().index({torch::indexing::Slice(1, query.num_tensors())});
-    torch::Tensor kvLengths =
-        key.joffsets().index({torch::indexing::Slice(1, query.num_tensors())});
-    torch::Tensor res = detail::autograd::Attention::apply(
-        query.jdata(), key.jdata(), value.jdata(), qLengths, kvLengths, scale)[0];
-    return query.jagged_like(res);
+    return JaggedTensor(outList);
 }
 
 std::tuple<GridBatch, JaggedTensor, std::vector<std::string>>


### PR DESCRIPTION
We previously used cuDNN for Scaled Dot Product Attention on GPUs with CC ?> 9.0. However we only test on CC 8.9 in CI so this path was untested, and I found that it fails on blackwell. Since PyTorch implementation works on all GPUs we care about now, let's remove that code path.

Signed-off-by: Mark Harris <mharris@nvidia.com>