### PR TITLE
Fix gtest build for CUDA 13

### DIFF
--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -71,6 +71,7 @@ function(ConfigureTest CMAKE_TEST_NAME)
     $<TARGET_PROPERTY:GTest::gtest,INTERFACE_INCLUDE_DIRECTORIES> # Get includes exposed by GTest::gtest
     $<TARGET_PROPERTY:GTest::gtest_main,INTERFACE_INCLUDE_DIRECTORIES> # Get includes exposed by GTest::gtest_main
     ${CUDAToolkit_INCLUDE_DIRS}
+    ${CUDAToolkit_INCLUDE_DIRS}/cccl
     ${NANOVDB_EDITOR_INCLUDE_DIR}
   )
 


### PR DESCRIPTION
CCCL has been moved to the cccl subdirectory in CUDA 13 so we need to include it as well for the gtests in order to use thrust/sort.h