### PR TITLE
Remove unnecessary linking to Python in libfvdb

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ set(FVDB_BINDINGS_CPP_FILES
     src/python/ViewerBinding.cpp)
 
 # Build library
-Python3_add_library(_Cpp ${FVDB_BINDINGS_CPP_FILES})
+Python3_add_library(_Cpp ${FVDB_BINDINGS_CPP_FILES} MODULE)
 if (DEFINED TORCH_PYBIND11_INCLUDE_DIR)
     target_link_libraries(_Cpp PUBLIC torch_pybind11_headers)
 else()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -172,7 +172,6 @@ target_include_directories(fvdb PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${nanovdb_SOURCE_DIR}/nanovdb
     ${TORCH_INCLUDE_DIRS}
-    ${Python3_INCLUDE_DIRS}
     ${nvtx3_SOURCE_DIR}/include
     ${NANOVDB_EDITOR_INCLUDE_DIR})
 target_include_directories(fvdb PRIVATE
@@ -211,8 +210,6 @@ target_compile_options(fvdb PRIVATE
 
 target_link_libraries(fvdb PRIVATE
     ${TORCH_LIBRARIES} tinyply cudnn_frontend cudnn cutlass blosc::blosc)
-target_link_libraries(fvdb PUBLIC
-    ${Python3_LIBRARIES})
 
 # Install rules
 install(TARGETS fvdb


### PR DESCRIPTION
libfvdb.so is unnecessarily linked against libpython3.x.so which results in an unnecessary and unconventional dependency to the Python shared library at runtime.