### PR TITLE
Add missing setuptools dependency (due to PyTorch 2.9.0 release)

### DIFF
--- a/.github/workflows/cu128.yml
+++ b/.github/workflows/cu128.yml
@@ -386,6 +386,7 @@ jobs:
           uv venv
           uv pip install --no-cache-dir -r env/test_requirements.txt --extra-index-url https://download.pytorch.org/whl/cu128
           uv pip install torch-scatter -f https://data.pyg.org/whl/torch-2.8.0+cu128.html
+          uv pip install --no-cache-dir setuptools
           TORCH_CUDA_ARCH_LIST="8.9+PTX" uv pip install -v --no-build-isolation git+https://github.com/heiwang1997/torchsparse.git
 
       - name: Download package


### PR DESCRIPTION
PyTorch 2.9.0 doesn't specify setuptools as a dependency anymore so we need to install it explicitly in order to build torchsparse.