### PR TITLE
[ci] Fix torch/pytorch 2.9/2.8 conflict in test environment

### DIFF
--- a/env/dev_environment.yml
+++ b/env/dev_environment.yml
@@ -78,4 +78,4 @@ dependencies:
     - dlnr_lite
     - einops
     - oiio-static-python
-    - torchvision --index-url https://download.pytorch.org/whl/cu129 # NOTE: torchvision is not available on conda-forge for pytorch 2.8.0 yet
+    - torchvision==0.23.0 --index-url https://download.pytorch.org/whl/cu129 # NOTE: torchvision is not available on conda-forge for pytorch 2.8.0 yet

--- a/env/learn_environment.yml
+++ b/env/learn_environment.yml
@@ -41,4 +41,4 @@ dependencies:
     - https://nksr.s3.ap-northeast-1.amazonaws.com/dev-whls/pt28cu129/torchsparse-2.1.0-cp312-cp312-linux_x86_64.whl
     - https://nksr.s3.ap-northeast-1.amazonaws.com/dev-whls/pt28cu129/torchsparse_20-2.0.0b0-cp312-cp312-linux_x86_64.whl
     - https://nksr.s3.ap-northeast-1.amazonaws.com/dev-whls/pt28cu129/torch_scatter-2.1.2-cp312-cp312-linux_x86_64.whl
-    - torchvision --index-url https://download.pytorch.org/whl/cu129 # NOTE: torchvision is not available on conda-forge for pytorch 2.8.0 yet
+    - torchvision==0.23.0 --index-url https://download.pytorch.org/whl/cu129 # NOTE: torchvision is not available on conda-forge for pytorch 2.8.0 yet

--- a/env/test_environment.yml
+++ b/env/test_environment.yml
@@ -44,6 +44,7 @@ dependencies:
     - torchsparse @ https://nksr.s3.ap-northeast-1.amazonaws.com/dev-whls/pt28cu129/torchsparse-2.1.0-cp312-cp312-linux_x86_64.whl
     - torchsparse_20 @ https://nksr.s3.ap-northeast-1.amazonaws.com/dev-whls/pt28cu129/torchsparse_20-2.0.0b0-cp312-cp312-linux_x86_64.whl
     - torch_scatter @ https://nksr.s3.ap-northeast-1.amazonaws.com/dev-whls/pt28cu129/torch_scatter-2.1.2-cp312-cp312-linux_x86_64.whl
+    - torchvision==0.23.0 --index-url https://download.pytorch.org/whl/cu129 # NOTE: torchvision is not available on conda-forge for pytorch 2.8.0 yet
     ## 3dgs tests
     - oiio-static-python
 platforms:


### PR DESCRIPTION
Added explicit torchvision 0.23.0 to pip requirements in our test/learn/dev environments so that 0.24.0 is not picked up and bring in 'torch' 2.9.0 from pypi which conflicts with our desired pytorch 2.8.0 version.