### PR TITLE
Cleanup so JaggedTensor tests are linter-clean

### DIFF
--- a/fvdb/_Cpp.pyi
+++ b/fvdb/_Cpp.pyi
@@ -7,6 +7,11 @@ from typing import ClassVar, overload
 import torch
 
 from .types import (
+    DeviceIdentifier,
+    ListOfListsOfTensors,
+    ListOfTensors,
+    LShapeSpec,
+    RShapeSpec,
     Vec3d,
     Vec3dBatch,
     Vec3dBatchOrScalar,
@@ -598,7 +603,7 @@ class JaggedTensor:
     def to(self, device: str) -> JaggedTensor: ...
     def type(self, arg0: torch.dtype) -> JaggedTensor: ...
     def type_as(self, arg0: JaggedTensor | torch.Tensor) -> JaggedTensor: ...
-    def unbind(self) -> list[torch.Tensor] | list[list[torch.Tensor]]: ...
+    def unbind(self) -> ListOfTensors | ListOfListsOfTensors: ...
     @overload
     def __add__(self, other: torch.Tensor) -> JaggedTensor: ...
     @overload
@@ -1034,183 +1039,43 @@ def gridbatch_from_points(
 def jcat(grid_batches: list[GridBatch]) -> GridBatch: ...
 @overload
 def jcat(jagged_tensors: list[JaggedTensor | torch.Tensor], dim: int | None = ...) -> JaggedTensor: ...
-@overload
 def jempty(
-    lshape: list[int],
-    rshape: list[int] | None = ...,
+    lshape: LShapeSpec,
+    rshape: RShapeSpec | None = ...,
     dtype: torch.dtype | None = ...,
-    device: torch.device | None = ...,
+    device: DeviceIdentifier | None = ...,
     requires_grad: bool = ...,
     pin_memory: bool = ...,
 ) -> JaggedTensor: ...
-@overload
-def jempty(
-    lshape: list[int],
-    rshape: list[int] | None = ...,
-    dtype: torch.dtype | None = ...,
-    device: str | None = ...,
-    requires_grad: bool = ...,
-    pin_memory: bool = ...,
-) -> JaggedTensor: ...
-@overload
-def jempty(
-    lshape: list[list[int]],
-    rshape: list[int] | None = ...,
-    dtype: torch.dtype | None = ...,
-    device: torch.device | None = ...,
-    requires_grad: bool = ...,
-    pin_memory: bool = ...,
-) -> JaggedTensor: ...
-@overload
-def jempty(
-    lshape: list[list[int]],
-    rshape: list[int] | None = ...,
-    dtype: torch.dtype | None = ...,
-    device: str | None = ...,
-    requires_grad: bool = ...,
-    pin_memory: bool = ...,
-) -> JaggedTensor: ...
-@overload
 def jones(
-    lshape: list[int],
-    rshape: list[int] | None = ...,
+    lshape: LShapeSpec,
+    rshape: RShapeSpec | None = ...,
     dtype: torch.dtype | None = ...,
-    device: torch.device | None = ...,
+    device: DeviceIdentifier | None = ...,
     requires_grad: bool = ...,
     pin_memory: bool = ...,
 ) -> JaggedTensor: ...
-@overload
-def jones(
-    lshape: list[int],
-    rshape: list[int] | None = ...,
-    dtype: torch.dtype | None = ...,
-    device: str | None = ...,
-    requires_grad: bool = ...,
-    pin_memory: bool = ...,
-) -> JaggedTensor: ...
-@overload
-def jones(
-    lshape: list[list[int]],
-    rshape: list[int] | None = ...,
-    dtype: torch.dtype | None = ...,
-    device: torch.device | None = ...,
-    requires_grad: bool = ...,
-    pin_memory: bool = ...,
-) -> JaggedTensor: ...
-@overload
-def jones(
-    lshape: list[list[int]],
-    rshape: list[int] | None = ...,
-    dtype: torch.dtype | None = ...,
-    device: str | None = ...,
-    requires_grad: bool = ...,
-    pin_memory: bool = ...,
-) -> JaggedTensor: ...
-@overload
 def jrand(
-    lshape: list[int],
-    rshape: list[int] | None = ...,
+    lshape: LShapeSpec,
+    rshape: RShapeSpec | None = ...,
     dtype: torch.dtype | None = ...,
-    device: torch.device | None = ...,
+    device: DeviceIdentifier | None = ...,
     requires_grad: bool = ...,
     pin_memory: bool = ...,
 ) -> JaggedTensor: ...
-@overload
-def jrand(
-    lshape: list[int],
-    rshape: list[int] | None = ...,
-    dtype: torch.dtype | None = ...,
-    device: str | None = ...,
-    requires_grad: bool = ...,
-    pin_memory: bool = ...,
-) -> JaggedTensor: ...
-@overload
-def jrand(
-    lshape: list[list[int]],
-    rshape: list[int] | None = ...,
-    dtype: torch.dtype | None = ...,
-    device: torch.device | None = ...,
-    requires_grad: bool = ...,
-    pin_memory: bool = ...,
-) -> JaggedTensor: ...
-@overload
-def jrand(
-    lshape: list[list[int]],
-    rshape: list[int] | None = ...,
-    dtype: torch.dtype | None = ...,
-    device: str | None = ...,
-    requires_grad: bool = ...,
-    pin_memory: bool = ...,
-) -> JaggedTensor: ...
-@overload
 def jrandn(
-    lshape: list[int],
-    rshape: list[int] | None = ...,
+    lshape: LShapeSpec,
+    rshape: RShapeSpec | None = ...,
     dtype: torch.dtype | None = ...,
-    device: torch.device | None = ...,
+    device: DeviceIdentifier | None = ...,
     requires_grad: bool = ...,
     pin_memory: bool = ...,
 ) -> JaggedTensor: ...
-@overload
-def jrandn(
-    lshape: list[int],
-    rshape: list[int] | None = ...,
-    dtype: torch.dtype | None = ...,
-    device: str | None = ...,
-    requires_grad: bool = ...,
-    pin_memory: bool = ...,
-) -> JaggedTensor: ...
-@overload
-def jrandn(
-    lshape: list[list[int]],
-    rshape: list[int] | None = ...,
-    dtype: torch.dtype | None = ...,
-    device: torch.device | None = ...,
-    requires_grad: bool = ...,
-    pin_memory: bool = ...,
-) -> JaggedTensor: ...
-@overload
-def jrandn(
-    lshape: list[list[int]],
-    rshape: list[int] | None = ...,
-    dtype: torch.dtype | None = ...,
-    device: str | None = ...,
-    requires_grad: bool = ...,
-    pin_memory: bool = ...,
-) -> JaggedTensor: ...
-@overload
 def jzeros(
-    lshape: list[int],
-    rshape: list[int] | None = ...,
+    lshape: LShapeSpec,
+    rshape: RShapeSpec | None = ...,
     dtype: torch.dtype | None = ...,
-    device: torch.device | None = ...,
-    requires_grad: bool = ...,
-    pin_memory: bool = ...,
-) -> JaggedTensor: ...
-@overload
-def jzeros(
-    lshape: list[int],
-    rshape: list[int] | None = ...,
-    dtype: torch.dtype | None = ...,
-    device: str | None = ...,
-    requires_grad: bool = ...,
-    pin_memory: bool = ...,
-) -> JaggedTensor: ...
-@overload
-def jzeros(
-    lshape: list[list[int]],
-    rshape: list[int] | None = ...,
-    dtype: torch.dtype | None = ...,
-    device: torch.device | None = ...,
-    requires_grad: bool = ...,
-    pin_memory: bool = ...,
-) -> JaggedTensor: ...
-@overload
-def jzeros(
-    lshape: list[list[int]],
-    rshape: list[int] | None = ...,
-    dtype: torch.dtype | None = ...,
-    device: str | None = ...,
+    device: DeviceIdentifier | None = ...,
     requires_grad: bool = ...,
     pin_memory: bool = ...,
 ) -> JaggedTensor: ...

--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -8,11 +8,15 @@ import numpy as np
 import torch
 from fvdb.types import (  # Type guard functions; Type definitions; Conversion functions; Helper function
     DeviceIdentifier,
+    ListOfListsOfTensors,
+    ListOfTensors,
     NumericMaxRank1,
     NumericMaxRank2,
     NumericScalar,
     NumericScalarNative,
     ValueConstraint,
+    is_ListOfListsOfTensors,
+    is_ListOfTensors,
     is_NumericMaxRank1,
     is_NumericMaxRank2,
     is_NumericScalar,
@@ -51,6 +55,31 @@ class TestTypesRedux(unittest.TestCase):
         else:
             b_device = torch.device("cpu")
         self.assertEqual(a_device, b_device)
+
+    # ========== List of Tensors Tests ==========
+
+    def test_is_ListOfTensors(self):
+        """Test is_ListOfTensors type guard"""
+        self.assertTrue(is_ListOfTensors([torch.tensor(1), torch.tensor(2), torch.tensor(3)]))
+        self.assertFalse(is_ListOfTensors(torch.tensor([1, 2, 3])))
+        self.assertFalse(is_ListOfTensors(np.array([1, 2, 3])))
+        self.assertFalse(is_ListOfTensors([[1, 2], [3, 4]]))
+        self.assertFalse(is_ListOfTensors(torch.tensor([[1, 2], [3, 4]])))
+
+    def test_is_ListOfListsOfTensors(self):
+        """Test is_ListOfListsOfTensors type guard"""
+        self.assertTrue(
+            is_ListOfListsOfTensors(
+                [
+                    [torch.tensor(1), torch.tensor(2), torch.tensor(3)],
+                    [torch.tensor(4), torch.tensor(5), torch.tensor(6)],
+                ]
+            )
+        )
+        self.assertFalse(is_ListOfListsOfTensors(torch.tensor([[1, 2, 3], [4, 5, 6]])))
+        self.assertFalse(is_ListOfListsOfTensors(np.array([[1, 2, 3], [4, 5, 6]])))
+        self.assertFalse(is_ListOfListsOfTensors([[1, 2], [3, 4]]))
+        self.assertFalse(is_ListOfListsOfTensors(torch.tensor([[1, 2], [3, 4]])))
 
     # ========== Type Guard Tests ==========
 


### PR DESCRIPTION
The unit test for JaggedTensor, `tests/unit/test_jagged_tensor.py` had many linter failures. This fixes them.