### PR TITLE
Switch from host to device synchronization for mGPU operators

### DIFF
--- a/src/fvdb/detail/ops/gsplat/FusedSSIM.cu
+++ b/src/fvdb/detail/ops/gsplat/FusedSSIM.cu
@@ -660,9 +660,7 @@ fusedSSIMPrivateUse1(
         }
     }
 
-    for (const auto deviceId: c10::irange(c10::cuda::device_count())) {
-        c10::cuda::getCurrentCUDAStream(deviceId).synchronize();
-    }
+    mergeStreams();
 
     return std::make_tuple(ssim_map, dm_dmu1, dm_dsigma1_sq, dm_dsigma12);
 }
@@ -774,9 +772,7 @@ fusedSSIMBackwardPrivateUse1(double C1,
         }
     }
 
-    for (const auto deviceId: c10::irange(c10::cuda::device_count())) {
-        c10::cuda::getCurrentCUDAStream(deviceId).synchronize();
-    }
+    mergeStreams();
 
     return dL_dimg1;
 }

--- a/src/fvdb/detail/ops/gsplat/GaussianComputeNanInfMask.cu
+++ b/src/fvdb/detail/ops/gsplat/GaussianComputeNanInfMask.cu
@@ -199,9 +199,7 @@ dispatchGaussianNanInfMask<torch::kPrivateUse1>(const fvdb::JaggedTensor &means,
         C10_CUDA_KERNEL_LAUNCH_CHECK();
     }
 
-    for (const auto deviceId: c10::irange(c10::cuda::device_count())) {
-        c10::cuda::getCurrentCUDAStream(deviceId).synchronize();
-    }
+    mergeStreams();
 
     return means.jagged_like(outValid);
 }

--- a/src/fvdb/detail/ops/gsplat/GaussianProjectionBackward.cu
+++ b/src/fvdb/detail/ops/gsplat/GaussianProjectionBackward.cu
@@ -594,9 +594,7 @@ dispatchGaussianProjectionBackward<torch::kPrivateUse1>(
             C10_CUDA_KERNEL_LAUNCH_CHECK();
         }
 
-        for (const auto deviceId: c10::irange(c10::cuda::device_count())) {
-            c10::cuda::getCurrentCUDAStream(deviceId).synchronize();
-        }
+        mergeStreams();
 
         if (outNormalizeddLossdMeans2dNormAccum.has_value()) {
             float *outNormalizeddLossdMeans2dNormAccumPtr =
@@ -629,9 +627,7 @@ dispatchGaussianProjectionBackward<torch::kPrivateUse1>(
                     C10_CUDA_KERNEL_LAUNCH_CHECK();
                 }
 
-                for (const auto deviceId: c10::irange(c10::cuda::device_count())) {
-                    c10::cuda::getCurrentCUDAStream(deviceId).synchronize();
-                }
+                mergeStreams();
 
             } else {
                 for (const auto deviceId: c10::irange(c10::cuda::device_count())) {
@@ -658,9 +654,7 @@ dispatchGaussianProjectionBackward<torch::kPrivateUse1>(
                     C10_CUDA_KERNEL_LAUNCH_CHECK();
                 }
 
-                for (const auto deviceId: c10::irange(c10::cuda::device_count())) {
-                    c10::cuda::getCurrentCUDAStream(deviceId).synchronize();
-                }
+                mergeStreams();
             }
         }
     }

--- a/src/fvdb/detail/ops/gsplat/GaussianProjectionForward.cu
+++ b/src/fvdb/detail/ops/gsplat/GaussianProjectionForward.cu
@@ -445,9 +445,7 @@ dispatchGaussianProjectionForward<torch::kPrivateUse1>(
         }
     }
 
-    for (const auto deviceId: c10::irange(c10::cuda::device_count())) {
-        c10::cuda::getCurrentCUDAStream(deviceId).synchronize();
-    }
+    mergeStreams();
     return std::make_tuple(outRadii, outMeans2d, outDepths, outConics, outCompensations);
 }
 

--- a/src/fvdb/detail/ops/gsplat/GaussianRasterizeForward.cu
+++ b/src/fvdb/detail/ops/gsplat/GaussianRasterizeForward.cu
@@ -555,9 +555,7 @@ launchRasterizeForwardKernels(
         }
     }
 
-    for (const auto device_index: c10::irange(c10::cuda::device_count())) {
-        c10::cuda::getCurrentCUDAStream(device_index).synchronize();
-    }
+    mergeStreams();
 
     // In dense mode, we need to reshape the output tensors to the original image size
     // because they are packed into a single JaggedTensor so that the output code is the same

--- a/src/fvdb/detail/ops/gsplat/GaussianSphericalHarmonicsBackward.cu
+++ b/src/fvdb/detail/ops/gsplat/GaussianSphericalHarmonicsBackward.cu
@@ -582,9 +582,7 @@ dispatchSphericalHarmonicsBackward<torch::kPrivateUse1>(
                 computeDLossDViewDirs ? dLossDViewDirs.data_ptr<scalar_t>() : nullptr);
             C10_CUDA_KERNEL_LAUNCH_CHECK();
         }
-        for (const auto deviceId: c10::irange(c10::cuda::device_count())) {
-            c10::cuda::getCurrentCUDAStream(deviceId).synchronize();
-        }
+        mergeStreams();
 
         return std::make_tuple(dLossDSh0Coeffs, dLossDShNCoeffs, dLossDViewDirs);
     } else {
@@ -617,9 +615,7 @@ dispatchSphericalHarmonicsBackward<torch::kPrivateUse1>(
                 dLossDSh0Coeffs.packed_accessor32<scalar_t, 3, torch::RestrictPtrTraits>());
             C10_CUDA_KERNEL_LAUNCH_CHECK();
         }
-        for (const auto deviceId: c10::irange(c10::cuda::device_count())) {
-            c10::cuda::getCurrentCUDAStream(deviceId).synchronize();
-        }
+        mergeStreams();
 
         return std::make_tuple(dLossDSh0Coeffs, dLossDShNCoeffs, dLossDViewDirs);
     }

--- a/src/fvdb/detail/ops/gsplat/GaussianSphericalHarmonicsForward.cu
+++ b/src/fvdb/detail/ops/gsplat/GaussianSphericalHarmonicsForward.cu
@@ -407,9 +407,7 @@ dispatchSphericalHarmonicsForward<torch::kPrivateUse1>(
         }
     }
 
-    for (const auto deviceId: c10::irange(c10::cuda::device_count())) {
-        c10::cuda::getCurrentCUDAStream(deviceId).synchronize();
-    }
+    mergeStreams();
     return renderQuantities;
 }
 

--- a/src/fvdb/detail/ops/gsplat/GaussianTileIntersection.cu
+++ b/src/fvdb/detail/ops/gsplat/GaussianTileIntersection.cu
@@ -1018,9 +1018,7 @@ gaussianTileIntersectionPrivateUse1Impl(
         C10_CUDA_KERNEL_LAUNCH_CHECK();
     }
 
-    for (const auto deviceId: c10::irange(c10::cuda::device_count())) {
-        c10::cuda::getCurrentCUDAStream(deviceId).synchronize();
-    }
+    mergeStreams();
 
     // In place cumulative sum to get the total number of intersections
     torch::cumsum_out(tiles_per_gaussian_cumsum, tiles_per_gaussian_cumsum, 0, torch::kInt32);
@@ -1153,10 +1151,10 @@ gaussianTileIntersectionPrivateUse1Impl(
         }
 
         for (const auto deviceId: c10::irange(c10::cuda::device_count())) {
-            C10_CUDA_CHECK(cudaSetDevice(deviceId));
-            c10::cuda::getCurrentCUDAStream(deviceId).synchronize();
             cudaEventDestroy(events[deviceId]);
         }
+
+        mergeStreams();
 
         return std::make_tuple(tile_joffsets, vals_sorted);
     }

--- a/src/fvdb/detail/utils/cuda/Utils.cuh
+++ b/src/fvdb/detail/utils/cuda/Utils.cuh
@@ -8,7 +8,7 @@
 #define CCCL_DEVICE_MERGE_SUPPORTED (__CUDACC_VER_MAJOR__ >= 12 && __CUDACC_VER_MINOR__ >= 8)
 #endif
 
-#include <c10/cuda/CUDAFunctions.h>
+#include <c10/cuda/CUDAStream.h>
 
 namespace fvdb {
 
@@ -31,6 +31,49 @@ deviceAlignedChunk(size_t alignment, size_t size, c10::DeviceIndex device) {
 inline std::tuple<size_t, size_t>
 deviceChunk(size_t size, c10::DeviceIndex device) {
     return deviceAlignedChunk(1, size, device);
+}
+
+inline void mergeStreams()
+{
+    constexpr int mergeDeviceId = 0;
+    cudaEvent_t mergeEvent = 0;
+    std::vector<cudaEvent_t> events(c10::cuda::device_count());
+
+    // Create an event for each device and record it in their respective streams
+    for (const auto deviceId : c10::irange(c10::cuda::device_count()))
+    {
+        C10_CUDA_CHECK(cudaSetDevice(deviceId));
+        auto stream = c10::cuda::getCurrentCUDAStream(deviceId);
+        C10_CUDA_CHECK(cudaEventCreate(&events[deviceId], cudaEventDisableTiming));
+        C10_CUDA_CHECK(cudaEventRecord(events[deviceId], stream));
+    }
+
+    // Create an event on the merge device
+    C10_CUDA_CHECK(cudaSetDevice(mergeDeviceId));
+    C10_CUDA_CHECK(cudaEventCreate(&mergeEvent, cudaEventDisableTiming));
+    auto mergeStream = c10::cuda::getCurrentCUDAStream(mergeDeviceId);
+    // On the merge stream, wait until the per-device events have completed
+    for (const auto deviceId : c10::irange(c10::cuda::device_count()))
+    {
+        C10_CUDA_CHECK(cudaStreamWaitEvent(mergeStream, events[deviceId]));
+    }
+    // Record an event on the merge stream to signify that the per-device events have been merged
+    C10_CUDA_CHECK(cudaEventRecord(mergeEvent, mergeStream));
+
+    // On each per-device stream, wait on the merge event
+    for (const auto deviceId : c10::irange(c10::cuda::device_count()))
+    {
+        C10_CUDA_CHECK(cudaSetDevice(deviceId));
+        auto stream = c10::cuda::getCurrentCUDAStream(deviceId);
+        C10_CUDA_CHECK(cudaStreamWaitEvent(stream, mergeEvent));
+    }
+
+    // Destroy events
+    for (const auto deviceId : c10::irange(c10::cuda::device_count()))
+    {
+        C10_CUDA_CHECK(cudaEventDestroy(events[deviceId]));
+    }
+    C10_CUDA_CHECK(cudaEventDestroy(mergeEvent));
 }
 
 } // namespace detail


### PR DESCRIPTION
In the existing code, each GPU synchronizes with the host thread at the end of the mGPU operator. This conservatively ensures that the kernels launched on each GPU for a given operator would complete before the next set of kernels were launched for the subsequent operator.

This PR revises the synchronization to use inter-GPU synchronization via CUDA events and achieve the same synchronization guarantees while also bypassing the host. This enables mGPU operators to be queued up asynchronously wrt to the host and improves throughput.