### PR TITLE
Remove the paths-ignore form the codestyle check

### DIFF
--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -3,12 +3,6 @@ on:
     pull_request:
       branches:
         - '**'
-      paths-ignore:
-          - 'CODEOWNERS'
-          - '**.md'
-          - 'docs/**'
-          - 'env/**'
-          - 'notebooks/**'
 
 # Allow subsequent pushes to the same PR or REF to cancel any previous jobs.
 concurrency:


### PR DESCRIPTION
Remove the paths-ignore form the codestyle check because when they don't run, you cannot merge the PR and that's quite annoying.

Signed-off-by: Jonathan Swartz <jonathan@jswartz.info>