### PR TITLE
Switch SH accessors from 32-bit to 64-bit

### DIFF
--- a/src/fvdb/detail/ops/gsplat/GaussianSphericalHarmonicsBackward.cu
+++ b/src/fvdb/detail/ops/gsplat/GaussianSphericalHarmonicsBackward.cu
@@ -39,10 +39,10 @@ evalShFunctionVJP(const int64_t degree,                     // degree of SH to b
                   const int64_t gi,                         // gaussian index
                   const int64_t c,                          // render channel
                   const typename Vec3Type<T>::type &dir,    // [3]
-                  const torch::PackedTensorAccessor32<T, 3, torch::RestrictPtrTraits> coeffsN,
+                  const torch::PackedTensorAccessor64<T, 3, torch::RestrictPtrTraits> coeffsN,
                   const T *dLossDRenderQuantities,          // [D]
-                  torch::PackedTensorAccessor32<T, 3, torch::RestrictPtrTraits> dLossDSh0Coeffs,
-                  torch::PackedTensorAccessor32<T, 3, torch::RestrictPtrTraits> dLossDShNCoeffs,
+                  torch::PackedTensorAccessor64<T, 3, torch::RestrictPtrTraits> dLossDSh0Coeffs,
+                  torch::PackedTensorAccessor64<T, 3, torch::RestrictPtrTraits> dLossDShNCoeffs,
                   typename Vec3Type<T>::type *dLossDViewDir // [3] optional
 ) {
     T dLossDRenderQuantitiesLocal = dLossDRenderQuantities[c];
@@ -287,13 +287,13 @@ computeShBackward(
     const int64_t K,
     const int64_t D,
     const int64_t shDegreeToUse,
-    const torch::PackedTensorAccessor32<T, 3, torch::RestrictPtrTraits> viewDirs,     // [C, N, 3]
-    const torch::PackedTensorAccessor32<T, 3, torch::RestrictPtrTraits> shNCoeffs,    // [K-1, N, D]
+    const torch::PackedTensorAccessor64<T, 3, torch::RestrictPtrTraits> viewDirs,     // [C, N, 3]
+    const torch::PackedTensorAccessor64<T, 3, torch::RestrictPtrTraits> shNCoeffs,    // [K-1, N, D]
     const int *__restrict__ radii,                                                    // [C, N]
-    const torch::PackedTensorAccessor32<T, 3, torch::RestrictPtrTraits>
+    const torch::PackedTensorAccessor64<T, 3, torch::RestrictPtrTraits>
         dLossDRenderQuantities,                                                       // [C, N, D]
-    torch::PackedTensorAccessor32<T, 3, torch::RestrictPtrTraits> outDLossDSh0Coeffs, // [N, 1, D]
-    torch::PackedTensorAccessor32<T, 3, torch::RestrictPtrTraits> outDLossDShNCoeffs, // [N, K-1, D]
+    torch::PackedTensorAccessor64<T, 3, torch::RestrictPtrTraits> outDLossDSh0Coeffs, // [N, 1, D]
+    torch::PackedTensorAccessor64<T, 3, torch::RestrictPtrTraits> outDLossDShNCoeffs, // [N, K-1, D]
     T *__restrict__ outDLossDViewDirs // [C, N, 3] optiondl
 ) {
     // parallelize over C * N * D
@@ -345,10 +345,10 @@ computeShDiffuseOnlyBackward(
     const int64_t C,
     const int64_t N,
     const int64_t D,
-    const torch::PackedTensorAccessor32<T, 3, torch::RestrictPtrTraits>
+    const torch::PackedTensorAccessor64<T, 3, torch::RestrictPtrTraits>
         dLossDRenderQuantities,                                                      // [C, N, D]
     const int *__restrict__ radii,                                                   // [C, N]
-    torch::PackedTensorAccessor32<T, 3, torch::RestrictPtrTraits> outDLossDSh0Coeffs // [N, 1, D]
+    torch::PackedTensorAccessor64<T, 3, torch::RestrictPtrTraits> outDLossDSh0Coeffs // [N, 1, D]
 ) {
     // parallelize over C * N * D
     auto idx = blockIdx.x * blockDim.x + threadIdx.x; // cidx * N * D + gidx * D + c
@@ -453,12 +453,12 @@ dispatchSphericalHarmonicsBackward<torch::kCUDA>(
             K,
             D,
             shDegreeToUse,
-            viewDirs.packed_accessor32<scalar_t, 3, torch::RestrictPtrTraits>(),
-            shNCoeffs.packed_accessor32<scalar_t, 3, torch::RestrictPtrTraits>(),
+            viewDirs.packed_accessor64<scalar_t, 3, torch::RestrictPtrTraits>(),
+            shNCoeffs.packed_accessor64<scalar_t, 3, torch::RestrictPtrTraits>(),
             radiiPtr,
-            dLossDRenderQuantities.packed_accessor32<scalar_t, 3, torch::RestrictPtrTraits>(),
-            dLossDSh0Coeffs.packed_accessor32<scalar_t, 3, torch::RestrictPtrTraits>(),
-            dLossDShNCoeffs.packed_accessor32<scalar_t, 3, torch::RestrictPtrTraits>(),
+            dLossDRenderQuantities.packed_accessor64<scalar_t, 3, torch::RestrictPtrTraits>(),
+            dLossDSh0Coeffs.packed_accessor64<scalar_t, 3, torch::RestrictPtrTraits>(),
+            dLossDShNCoeffs.packed_accessor64<scalar_t, 3, torch::RestrictPtrTraits>(),
             computeDLossDViewDirs ? dLossDViewDirs.data_ptr<scalar_t>() : nullptr);
         C10_CUDA_KERNEL_LAUNCH_CHECK();
 
@@ -477,9 +477,9 @@ dispatchSphericalHarmonicsBackward<torch::kCUDA>(
             C,
             N,
             D,
-            dLossDRenderQuantities.packed_accessor32<scalar_t, 3, torch::RestrictPtrTraits>(),
+            dLossDRenderQuantities.packed_accessor64<scalar_t, 3, torch::RestrictPtrTraits>(),
             radiiPtr,
-            dLossDSh0Coeffs.packed_accessor32<scalar_t, 3, torch::RestrictPtrTraits>());
+            dLossDSh0Coeffs.packed_accessor64<scalar_t, 3, torch::RestrictPtrTraits>());
         C10_CUDA_KERNEL_LAUNCH_CHECK();
         return std::make_tuple(dLossDSh0Coeffs, dLossDShNCoeffs, dLossDViewDirs);
     }
@@ -573,12 +573,12 @@ dispatchSphericalHarmonicsBackward<torch::kPrivateUse1>(
                 K,
                 D,
                 shDegreeToUse,
-                viewDirs.packed_accessor32<scalar_t, 3, torch::RestrictPtrTraits>(),
-                shNCoeffs.packed_accessor32<scalar_t, 3, torch::RestrictPtrTraits>(),
+                viewDirs.packed_accessor64<scalar_t, 3, torch::RestrictPtrTraits>(),
+                shNCoeffs.packed_accessor64<scalar_t, 3, torch::RestrictPtrTraits>(),
                 radiiPtr,
-                dLossDRenderQuantities.packed_accessor32<scalar_t, 3, torch::RestrictPtrTraits>(),
-                dLossDSh0Coeffs.packed_accessor32<scalar_t, 3, torch::RestrictPtrTraits>(),
-                dLossDShNCoeffs.packed_accessor32<scalar_t, 3, torch::RestrictPtrTraits>(),
+                dLossDRenderQuantities.packed_accessor64<scalar_t, 3, torch::RestrictPtrTraits>(),
+                dLossDSh0Coeffs.packed_accessor64<scalar_t, 3, torch::RestrictPtrTraits>(),
+                dLossDShNCoeffs.packed_accessor64<scalar_t, 3, torch::RestrictPtrTraits>(),
                 computeDLossDViewDirs ? dLossDViewDirs.data_ptr<scalar_t>() : nullptr);
             C10_CUDA_KERNEL_LAUNCH_CHECK();
         }
@@ -610,9 +610,9 @@ dispatchSphericalHarmonicsBackward<torch::kPrivateUse1>(
                 C,
                 N,
                 D,
-                dLossDRenderQuantities.packed_accessor32<scalar_t, 3, torch::RestrictPtrTraits>(),
+                dLossDRenderQuantities.packed_accessor64<scalar_t, 3, torch::RestrictPtrTraits>(),
                 radiiPtr,
-                dLossDSh0Coeffs.packed_accessor32<scalar_t, 3, torch::RestrictPtrTraits>());
+                dLossDSh0Coeffs.packed_accessor64<scalar_t, 3, torch::RestrictPtrTraits>());
             C10_CUDA_KERNEL_LAUNCH_CHECK();
         }
         mergeStreams();

--- a/src/fvdb/detail/ops/gsplat/GaussianSphericalHarmonicsForward.cu
+++ b/src/fvdb/detail/ops/gsplat/GaussianSphericalHarmonicsForward.cu
@@ -27,8 +27,8 @@ evalShFunction(const int64_t degree,                      // degree of SH to be 
                const int64_t gi,                          // gaussian index
                const int64_t c,                           // render channel
                const typename Vec3Type<T>::type &viewDir, // [D]
-               const torch::PackedTensorAccessor32<T, 3, torch::RestrictPtrTraits> sh0Coeffs,
-               const torch::PackedTensorAccessor32<T, 3, torch::RestrictPtrTraits> shNCoeffs) {
+               const torch::PackedTensorAccessor64<T, 3, torch::RestrictPtrTraits> sh0Coeffs,
+               const torch::PackedTensorAccessor64<T, 3, torch::RestrictPtrTraits> shNCoeffs) {
     const T cSH0 = sh0Coeffs[gi][0][c];
 
     T result = T(0.2820947917738781) * cSH0;
@@ -141,9 +141,9 @@ computeSh(
     const int64_t N,
     const int64_t D,
     const int64_t shDegreeToUse,
-    const torch::PackedTensorAccessor32<T, 3, torch::RestrictPtrTraits> viewDirs,  // [C, N, 3]
-    const torch::PackedTensorAccessor32<T, 3, torch::RestrictPtrTraits> sh0Coeffs, // [1, N, D]
-    const torch::PackedTensorAccessor32<T, 3, torch::RestrictPtrTraits> shNCoeffs, // [K-1, N, D]
+    const torch::PackedTensorAccessor64<T, 3, torch::RestrictPtrTraits> viewDirs,  // [C, N, 3]
+    const torch::PackedTensorAccessor64<T, 3, torch::RestrictPtrTraits> sh0Coeffs, // [1, N, D]
+    const torch::PackedTensorAccessor64<T, 3, torch::RestrictPtrTraits> shNCoeffs, // [K-1, N, D]
     const int *__restrict__ radii,                                                 // [C, N]
     T *__restrict__ outRenderQuantities                                            // [C, N, D]
 ) {
@@ -177,7 +177,7 @@ computeShDiffuseOnly(const int64_t offset,
                      const int64_t C,
                      const int64_t N,
                      const int64_t D,
-                     const torch::PackedTensorAccessor32<T, 3, torch::RestrictPtrTraits> sh0Coeffs,
+                     const torch::PackedTensorAccessor64<T, 3, torch::RestrictPtrTraits> sh0Coeffs,
                      const int *__restrict__ radii, // [C, N]
                      T *__restrict__ outRenderQuantities) {
     // parallelize over C * N * D
@@ -279,9 +279,9 @@ dispatchSphericalHarmonicsForward<torch::kCUDA>(const int64_t shDegreeToUse,
             N,
             D,
             shDegreeToUse,
-            viewDirs.packed_accessor32<scalar_t, 3, torch::RestrictPtrTraits>(),
-            sh0Coeffs.packed_accessor32<scalar_t, 3, torch::RestrictPtrTraits>(),
-            shNCoeffs.packed_accessor32<scalar_t, 3, torch::RestrictPtrTraits>(),
+            viewDirs.packed_accessor64<scalar_t, 3, torch::RestrictPtrTraits>(),
+            sh0Coeffs.packed_accessor64<scalar_t, 3, torch::RestrictPtrTraits>(),
+            shNCoeffs.packed_accessor64<scalar_t, 3, torch::RestrictPtrTraits>(),
             radiiPtr,
             renderQuantities.data_ptr<scalar_t>());
         C10_CUDA_KERNEL_LAUNCH_CHECK();
@@ -292,7 +292,7 @@ dispatchSphericalHarmonicsForward<torch::kCUDA>(const int64_t shDegreeToUse,
             C,
             N,
             D,
-            sh0Coeffs.packed_accessor32<scalar_t, 3, torch::RestrictPtrTraits>(),
+            sh0Coeffs.packed_accessor64<scalar_t, 3, torch::RestrictPtrTraits>(),
             radiiPtr,
             renderQuantities.data_ptr<scalar_t>());
         C10_CUDA_KERNEL_LAUNCH_CHECK();
@@ -387,9 +387,9 @@ dispatchSphericalHarmonicsForward<torch::kPrivateUse1>(
                 N,
                 D,
                 shDegreeToUse,
-                viewDirs.packed_accessor32<scalar_t, 3, torch::RestrictPtrTraits>(),
-                sh0Coeffs.packed_accessor32<scalar_t, 3, torch::RestrictPtrTraits>(),
-                shNCoeffs.packed_accessor32<scalar_t, 3, torch::RestrictPtrTraits>(),
+                viewDirs.packed_accessor64<scalar_t, 3, torch::RestrictPtrTraits>(),
+                sh0Coeffs.packed_accessor64<scalar_t, 3, torch::RestrictPtrTraits>(),
+                shNCoeffs.packed_accessor64<scalar_t, 3, torch::RestrictPtrTraits>(),
                 radiiPtr,
                 renderQuantities.data_ptr<scalar_t>());
             C10_CUDA_KERNEL_LAUNCH_CHECK();
@@ -400,7 +400,7 @@ dispatchSphericalHarmonicsForward<torch::kPrivateUse1>(
                 C,
                 N,
                 D,
-                sh0Coeffs.packed_accessor32<scalar_t, 3, torch::RestrictPtrTraits>(),
+                sh0Coeffs.packed_accessor64<scalar_t, 3, torch::RestrictPtrTraits>(),
                 radiiPtr,
                 renderQuantities.data_ptr<scalar_t>());
             C10_CUDA_KERNEL_LAUNCH_CHECK();


### PR DESCRIPTION
As the number of Gaussian splats becomes large (55M+ in my case with degree 3) , the 32-bit accessor becomes insufficient and throws the following error in the SH evaluation code. Switch to 64-bit accessors to address the issue.

`RuntimeError: numel needs to be smaller than int32_t max; otherwise, please use packed_accessor64`

2^32 / (55M * sizeof(float) * 16 SH DOFs) is very close to 1