### PR TITLE
Match gridbatch and grid API

### DIFF
--- a/examples/wip/structure_prediction_net.py
+++ b/examples/wip/structure_prediction_net.py
@@ -4,18 +4,16 @@
 
 import os
 
+import fvdb.nn as fvnn
 import numpy as np
+import point_cloud_utils as pcu
+import polyscope as ps
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-
-import point_cloud_utils as pcu
-import polyscope as ps
-
 import torch_cudamanaged
 
 import fvdb
-import fvdb.nn as fvnn
 
 torch.backends.cudnn.deterministic = True
 np.random.seed(42)
@@ -125,7 +123,7 @@ def normalize_pts(xyz: np.ndarray):
 
 def visualize_grid(grid: fvdb.GridBatch):
     ps.init()
-    xyz = grid.grid_to_world(grid.ijk.float())
+    xyz = grid.voxel_to_world(grid.ijk.float())
     for batch_idx in range(grid.grid_count):
         pts = xyz[batch_idx].jdata.cpu().numpy()
         ps.register_point_cloud(f"grid_{batch_idx}", pts, radius=0.0025)

--- a/fvdb/__init__.py
+++ b/fvdb/__init__.py
@@ -75,14 +75,8 @@ from .jagged_tensor import (
     jempty,
 )
 
-# Import GridBatch and gridbatch_from_* functions from grid_batch.py
-from .grid_batch import (
-    GridBatch,
-    load_gridbatch,
-    save_gridbatch,
-)
-
-
+# Import GridBatch and Grid
+from .grid_batch import GridBatch
 from .grid import Grid
 
 

--- a/tests/unit/test_accessors.py
+++ b/tests/unit/test_accessors.py
@@ -30,7 +30,7 @@ class TestAccessors(unittest.TestCase):
         sparse_points = torch.tensor([[0, 0, 0], [1, 1, 1]], dtype=torch.float16, device=device)
         grid_batch = GridBatch.from_points(JaggedTensor(sparse_points), voxel_sizes=0.1, origins=0.0)
 
-        read_jagged_data = grid_batch.read_from_dense_cminor(dense_grid, dense_origin)
+        read_jagged_data = grid_batch.inject_from_dense_cminor(dense_grid, dense_origin)
         self.assertIsInstance(read_jagged_data, JaggedTensor)
 
         grid = Grid.from_points(sparse_points, voxel_size=0.1, origin=0.0)
@@ -45,7 +45,7 @@ class TestAccessors(unittest.TestCase):
         grid_batch = GridBatch.from_points(JaggedTensor(zero_points), voxel_sizes=0.1, origins=0.0)
 
         sparse_data = torch.tensor([[0], [0]], dtype=torch.float16, device=device)
-        grid_batch.write_to_dense_cminor(JaggedTensor(sparse_data), dense_origin, (RESOLUTION, RESOLUTION, RESOLUTION))
+        grid_batch.inject_to_dense_cminor(JaggedTensor(sparse_data), dense_origin, (RESOLUTION, RESOLUTION, RESOLUTION))
 
         grid = Grid.from_points(zero_points, voxel_size=0.1, origin=0.0)
         grid.inject_to_dense_cminor(sparse_data, dense_origin, (RESOLUTION, RESOLUTION, RESOLUTION))

--- a/tests/unit/test_basic_ops.py
+++ b/tests/unit/test_basic_ops.py
@@ -323,7 +323,7 @@ class TestBasicOps(unittest.TestCase):
         grid = grid.dual_grid()
 
         target_dual_coordinates = ((pts - vox_origin) / vox_size) + 0.5
-        pred_dual_coordinates = grid.world_to_grid(fvdb.JaggedTensor(pts)).jdata
+        pred_dual_coordinates = grid.world_to_voxel(fvdb.JaggedTensor(pts)).jdata
 
         self.assertTrue(
             torch.allclose(pred_dual_coordinates, target_dual_coordinates, atol=dtype_to_atol(dtype)),
@@ -341,7 +341,7 @@ class TestBasicOps(unittest.TestCase):
         grid = grid.dilated_grid(1)
 
         target_primal_coordinates = (pts - vox_origin) / vox_size
-        pred_primal_coordinates = grid.world_to_grid(fvdb.JaggedTensor(pts)).jdata
+        pred_primal_coordinates = grid.world_to_voxel(fvdb.JaggedTensor(pts)).jdata
 
         self.assertTrue(torch.allclose(target_primal_coordinates, pred_primal_coordinates, atol=dtype_to_atol(dtype)))
 
@@ -357,7 +357,7 @@ class TestBasicOps(unittest.TestCase):
         grid = grid.dilated_grid(1)
         grid = grid.dual_grid()
 
-        pred_dual_coordinates = grid.world_to_grid(fvdb.JaggedTensor(pts)).jdata
+        pred_dual_coordinates = grid.world_to_voxel(fvdb.JaggedTensor(pts)).jdata
         grad_out = torch.rand_like(pred_dual_coordinates)
         pred_dual_coordinates.backward(grad_out)
 
@@ -385,7 +385,7 @@ class TestBasicOps(unittest.TestCase):
         grid = GridBatch.from_points(fvdb.JaggedTensor(pts), voxel_sizes=vox_size, origins=vox_origin)
         grid = grid.dilated_grid(1)
 
-        pred_primal_coordinates = grid.world_to_grid(fvdb.JaggedTensor(pts)).jdata
+        pred_primal_coordinates = grid.world_to_voxel(fvdb.JaggedTensor(pts)).jdata
         grad_out = torch.rand_like(pred_primal_coordinates)
         pred_primal_coordinates.backward(grad_out)
 
@@ -415,7 +415,7 @@ class TestBasicOps(unittest.TestCase):
         grid = grid.dilated_grid(1)
 
         target_world_pts = (grid_pts * vox_size) + vox_origin
-        pred_world_pts = grid.grid_to_world(fvdb.JaggedTensor(grid_pts)).jdata
+        pred_world_pts = grid.voxel_to_world(fvdb.JaggedTensor(grid_pts)).jdata
 
         self.assertTrue(torch.allclose(target_world_pts, pred_world_pts, atol=dtype_to_atol(dtype)))
 
@@ -432,7 +432,7 @@ class TestBasicOps(unittest.TestCase):
         grid = grid.dual_grid()
 
         target_world_pts = ((grid_pts - 0.5) * vox_size) + vox_origin
-        pred_world_pts = grid.grid_to_world(fvdb.JaggedTensor(grid_pts)).jdata
+        pred_world_pts = grid.voxel_to_world(fvdb.JaggedTensor(grid_pts)).jdata
 
         self.assertTrue(torch.allclose(target_world_pts, pred_world_pts, atol=dtype_to_atol(dtype)))
 
@@ -448,7 +448,7 @@ class TestBasicOps(unittest.TestCase):
         grid = GridBatch.from_points(fvdb.JaggedTensor(pts), voxel_sizes=vox_size, origins=vox_origin)
         grid = grid.dilated_grid(1)
 
-        pred_world_pts = grid.grid_to_world(fvdb.JaggedTensor(grid_pts)).jdata
+        pred_world_pts = grid.voxel_to_world(fvdb.JaggedTensor(grid_pts)).jdata
         grad_out = torch.rand_like(pred_world_pts)
         pred_world_pts.backward(grad_out)
 
@@ -478,7 +478,7 @@ class TestBasicOps(unittest.TestCase):
         grid = grid.dilated_grid(1)
         grid = grid.dual_grid()
 
-        pred_world_pts = grid.grid_to_world(fvdb.JaggedTensor(grid_pts)).jdata
+        pred_world_pts = grid.voxel_to_world(fvdb.JaggedTensor(grid_pts)).jdata
         grad_out = torch.rand_like(pred_world_pts)
         pred_world_pts.backward(grad_out)
 
@@ -516,7 +516,7 @@ class TestBasicOps(unittest.TestCase):
         self.assertTrue(torch.all(dual_origin == grid_dd.dual_grid().origins[0]))
 
         target_primal_coordinates = (pts - vox_origin) / vox_size
-        pred_primal_coordinates = grid.world_to_grid(fvdb.JaggedTensor(pts)).jdata
+        pred_primal_coordinates = grid.world_to_voxel(fvdb.JaggedTensor(pts)).jdata
 
         self.assertTrue(
             torch.allclose(target_primal_coordinates, pred_primal_coordinates, atol=dtype_to_atol(dtype)),
@@ -524,10 +524,10 @@ class TestBasicOps(unittest.TestCase):
         )
 
         target_dual_coordinates = ((pts - vox_origin) / vox_size) + 0.5
-        pred_dual_coordinates = grid_d.world_to_grid(fvdb.JaggedTensor(pts)).jdata
+        pred_dual_coordinates = grid_d.world_to_voxel(fvdb.JaggedTensor(pts)).jdata
         self.assertTrue(torch.allclose(pred_dual_coordinates, target_dual_coordinates, atol=dtype_to_atol(dtype)))
 
-        pred_primal_coordinates_dd = grid_dd.world_to_grid(fvdb.JaggedTensor(pts)).jdata
+        pred_primal_coordinates_dd = grid_dd.world_to_voxel(fvdb.JaggedTensor(pts)).jdata
         self.assertTrue(
             torch.allclose(target_primal_coordinates, pred_primal_coordinates_dd, atol=dtype_to_atol(dtype))
         )
@@ -640,7 +640,7 @@ class TestBasicOps(unittest.TestCase):
 
         all_coords = torch.cat([outside_random_coords, inside_coords])
 
-        all_world_points = grid.grid_to_world(fvdb.JaggedTensor(all_coords.to(dtype))).jdata
+        all_world_points = grid.voxel_to_world(fvdb.JaggedTensor(all_coords.to(dtype))).jdata
 
         pred_mask = grid.points_in_grid(fvdb.JaggedTensor(all_world_points)).jdata
         target_mask = torch.ones(all_coords.shape[0], dtype=torch.bool).to(device)
@@ -734,7 +734,7 @@ class TestBasicOps(unittest.TestCase):
         if p.dtype == torch.half:
             p = p.float()
 
-        expected_ijk = torch.floor(grid.world_to_grid(fvdb.JaggedTensor(p)).jdata)
+        expected_ijk = torch.floor(grid.world_to_voxel(fvdb.JaggedTensor(p)).jdata)
         offsets = torch.tensor(
             [
                 [0, 0, 0],
@@ -1275,7 +1275,7 @@ class TestBasicOps(unittest.TestCase):
         grid = grid.dual_grid()
 
         target_dual_coordinates = ((pts - vox_origin) / vox_size) + 0.5
-        pred_dual_coordinates = grid.world_to_grid(fvdb.JaggedTensor(pts)).jdata
+        pred_dual_coordinates = grid.world_to_voxel(fvdb.JaggedTensor(pts)).jdata
         self.assertTrue(torch.allclose(pred_dual_coordinates, target_dual_coordinates, atol=dtype_to_atol(dtype)))
         self.assertEqual(grid.device.type, torch.device(device).type)
 
@@ -1284,8 +1284,8 @@ class TestBasicOps(unittest.TestCase):
         target_dual_coordinates = ((pts - vox_origin) / vox_size) + 0.5
         if torch.device(device).type != to_device.type:
             with self.assertRaises(Exception):
-                pred_dual_coordinates = grid2.world_to_grid(fvdb.JaggedTensor(pts)).jdata
-        pred_dual_coordinates = grid2.world_to_grid(fvdb.JaggedTensor(pts.to(to_device))).jdata
+                pred_dual_coordinates = grid2.world_to_voxel(fvdb.JaggedTensor(pts)).jdata
+        pred_dual_coordinates = grid2.world_to_voxel(fvdb.JaggedTensor(pts.to(to_device))).jdata
         self.assertTrue(
             torch.allclose(pred_dual_coordinates, target_dual_coordinates.to(to_device), atol=dtype_to_atol(dtype))
         )
@@ -1296,8 +1296,8 @@ class TestBasicOps(unittest.TestCase):
         target_dual_coordinates = ((pts - vox_origin) / vox_size) + 0.5
         if torch.device(device).type != to_device.type:
             with self.assertRaises(Exception):
-                pred_dual_coordinates = grid2.world_to_grid(fvdb.JaggedTensor(pts)).jdata
-        pred_dual_coordinates = grid2.world_to_grid(fvdb.JaggedTensor(pts.to(to_device))).jdata
+                pred_dual_coordinates = grid2.world_to_voxel(fvdb.JaggedTensor(pts)).jdata
+        pred_dual_coordinates = grid2.world_to_voxel(fvdb.JaggedTensor(pts.to(to_device))).jdata
         self.assertTrue(
             torch.allclose(pred_dual_coordinates, target_dual_coordinates.to(to_device), atol=dtype_to_atol(dtype))
         )
@@ -1580,7 +1580,7 @@ class TestBasicOps(unittest.TestCase):
         grid = GridBatch.from_dense(
             1, [sphere_sdf.shape[i] for i in range(3)], [0] * 3, voxel_sizes=1.0 / N, origins=[0] * 3, device=device
         )
-        sdf_p = grid.read_from_dense_cminor(
+        sdf_p = grid.inject_from_dense_cminor(
             sphere_sdf.unsqueeze(-1).unsqueeze(0)
         ).jdata.squeeze()  # permuted sdf values
 
@@ -1641,7 +1641,7 @@ class TestBasicOps(unittest.TestCase):
                 origins=[0] * 3,
                 device=device,
             )
-            sdf_p = grid.read_from_dense_cminor(sphere_sdf)  # permuted sdf values
+            sdf_p = grid.inject_from_dense_cminor(sphere_sdf)  # permuted sdf values
 
             for level in [0.0, 0.2, -0.2]:
                 v, f, _ = grid.marching_cubes(sdf_p, level)

--- a/tests/unit/test_dense_interface.py
+++ b/tests/unit/test_dense_interface.py
@@ -37,12 +37,12 @@ class TestDenseInterfaceBatch(unittest.TestCase):
         )
         self.assertTrue(dense_vdb.total_voxels == 10 * 11 * 12)
 
-        vdb_coords = dense_vdb.grid_to_world(dense_vdb.ijk.float()).jdata
+        vdb_coords = dense_vdb.voxel_to_world(dense_vdb.ijk.float()).jdata
         self.assertAlmostEqual(torch.min(vdb_coords).item(), -2.0 + 3 / 12 * 0.5, places=6)
         self.assertAlmostEqual(torch.max(vdb_coords).item(), 1.0 - 3 / 12 * 0.5, places=6)
 
         vdb_feature = torch.randn((dense_vdb.total_voxels, 4), device=device, dtype=dtype)
-        dense_feature = dense_vdb.write_to_dense_cminor(JaggedTensor(vdb_feature)).squeeze(0)
+        dense_feature = dense_vdb.inject_to_dense_cminor(JaggedTensor(vdb_feature)).squeeze(0)
         for i in range(10):
             for j in range(11):
                 for k in range(12):
@@ -51,7 +51,7 @@ class TestDenseInterfaceBatch(unittest.TestCase):
                     ]
                     dense_f = dense_feature[i, j, k, :]
                     self.assertTrue(torch.allclose(vdb_f, dense_f))
-        vdb_feature2 = dense_vdb.read_from_dense_cminor(dense_feature.unsqueeze(0)).jdata
+        vdb_feature2 = dense_vdb.inject_from_dense_cminor(dense_feature.unsqueeze(0)).jdata
         self.assertTrue(torch.allclose(vdb_feature, vdb_feature2))
 
     @parameterized.expand(all_device_dtype_combos)
@@ -88,7 +88,7 @@ class TestDenseInterfaceBatch(unittest.TestCase):
             target_sparse = torch.zeros(grid.total_voxels, *feat_shape, device=device, dtype=dtype)
             target_sparse[grid_index] = random_grid.view(-1, *feat_shape)[offset]
 
-            pred_sparse = grid.read_from_dense_cminor(random_grid.unsqueeze(0), dense_origin).jdata
+            pred_sparse = grid.inject_from_dense_cminor(random_grid.unsqueeze(0), dense_origin).jdata
 
             self.assertEqual(torch.abs(target_sparse - pred_sparse).max().item(), 0.0)
             self.assertTrue(torch.all(target_sparse == pred_sparse))
@@ -127,7 +127,7 @@ class TestDenseInterfaceBatch(unittest.TestCase):
             target_sparse = torch.zeros(grid.total_voxels, *feat_shape, device=device, dtype=dtype)
             target_sparse[grid_index] = random_grid.view(-1, *feat_shape)[offset]
 
-            pred_sparse = grid.read_from_dense_cminor(random_grid.unsqueeze(0), dense_origin).jdata
+            pred_sparse = grid.inject_from_dense_cminor(random_grid.unsqueeze(0), dense_origin).jdata
 
             self.assertEqual(torch.abs(target_sparse - pred_sparse).max().item(), 0.0)
             self.assertTrue(torch.all(target_sparse == pred_sparse))
@@ -172,7 +172,7 @@ class TestDenseInterfaceBatch(unittest.TestCase):
             loss_copy = target_sparse.sum()
             loss_copy.backward()
 
-            pred_sparse = grid.read_from_dense_cminor(random_grid.unsqueeze(0), dense_origin).jdata
+            pred_sparse = grid.inject_from_dense_cminor(random_grid.unsqueeze(0), dense_origin).jdata
             loss = pred_sparse.sum()
             loss.backward()
 
@@ -221,7 +221,7 @@ class TestDenseInterfaceBatch(unittest.TestCase):
             idx = write_ijk[:, 0] * crop_size[1] * crop_size[2] + write_ijk[:, 1] * crop_size[2] + write_ijk[:, 2]
             target_crop.view(-1, sparse_data.shape[-1])[idx] = sparse_data[keep_mask]
 
-            pred_crop = grid.write_to_dense_cminor(JaggedTensor(sparse_data), crop_min, crop_size).squeeze(0)
+            pred_crop = grid.inject_to_dense_cminor(JaggedTensor(sparse_data), crop_min, crop_size).squeeze(0)
 
             self.assertTrue(torch.all(pred_crop == target_crop))
 
@@ -263,7 +263,7 @@ class TestDenseInterfaceBatch(unittest.TestCase):
             idx = write_ijk[:, 0] * crop_size[1] * crop_size[2] + write_ijk[:, 1] * crop_size[2] + write_ijk[:, 2]
             target_crop.view(-1, *sparse_data.shape[1:])[idx] = sparse_data[keep_mask]
 
-            pred_crop = grid.write_to_dense_cminor(JaggedTensor(sparse_data), crop_min, crop_size).squeeze(0)
+            pred_crop = grid.inject_to_dense_cminor(JaggedTensor(sparse_data), crop_min, crop_size).squeeze(0)
 
             self.assertTrue(torch.all(pred_crop == target_crop))
 
@@ -311,7 +311,7 @@ class TestDenseInterfaceBatch(unittest.TestCase):
             loss_copy = target_crop.sum()
             loss_copy.backward()
 
-            pred_crop = grid.write_to_dense_cminor(JaggedTensor(sparse_data), crop_min, crop_size).squeeze(0)
+            pred_crop = grid.inject_to_dense_cminor(JaggedTensor(sparse_data), crop_min, crop_size).squeeze(0)
             loss = pred_crop.sum()
             loss.backward()
 
@@ -334,8 +334,8 @@ class TestDenseInterfaceBatch(unittest.TestCase):
         for eshape in [(3,), (5, 7)]:
             sparse_data = torch.randn((total_voxels, *eshape), device=device, dtype=dtype)
 
-            dense_default = grid.write_to_dense_cminor(JaggedTensor(sparse_data), min_coord, dense_size)
-            dense_conv = grid.write_to_dense_cmajor(JaggedTensor(sparse_data), min_coord, dense_size)
+            dense_default = grid.inject_to_dense_cminor(JaggedTensor(sparse_data), min_coord, dense_size)
+            dense_conv = grid.inject_to_dense_cmajor(JaggedTensor(sparse_data), min_coord, dense_size)
 
             self.assertEqual(dense_default.shape, (1, dims[0], dims[1], dims[2], *eshape))
             self.assertEqual(dense_conv.shape, (1, *eshape, dims[0], dims[1], dims[2]))
@@ -373,8 +373,8 @@ class TestDenseInterfaceBatch(unittest.TestCase):
         for eshape in [(3,), (5, 7)]:
             sparse_data = torch.randn((total_voxels, *eshape), device=device, dtype=dtype)
 
-            dense_default = grid.write_to_dense_cminor(JaggedTensor(sparse_data), min_coord, dense_size)
-            dense_conv = grid.write_to_dense_cmajor(JaggedTensor(sparse_data), min_coord, dense_size)
+            dense_default = grid.inject_to_dense_cminor(JaggedTensor(sparse_data), min_coord, dense_size)
+            dense_conv = grid.inject_to_dense_cmajor(JaggedTensor(sparse_data), min_coord, dense_size)
 
             self.assertEqual(dense_default.shape, (1, dims[0], dims[1], dims[2], *eshape))
             self.assertEqual(dense_conv.shape, (1, *eshape, dims[0], dims[1], dims[2]))
@@ -413,8 +413,8 @@ class TestDenseInterfaceBatch(unittest.TestCase):
                 assert conv_to_default_permute_order == (0, 2, 3, 4, 1)
             dense_default = dense_conv.permute(*conv_to_default_permute_order).contiguous()
 
-            sparse_conv = grid.read_from_dense_cmajor(dense_conv, min_coord)
-            sparse_default = grid.read_from_dense_cminor(dense_default, min_coord)
+            sparse_conv = grid.inject_from_dense_cmajor(dense_conv, min_coord)
+            sparse_default = grid.inject_from_dense_cminor(dense_default, min_coord)
 
             self.assertEqual(sparse_conv.jdata.shape, (total_voxels, *eshape))
             self.assertEqual(sparse_default.jdata.shape, (total_voxels, *eshape))

--- a/tests/unit/test_empty_grids.py
+++ b/tests/unit/test_empty_grids.py
@@ -46,7 +46,7 @@ class TestBasicOps(unittest.TestCase):
         self.assertEqual(grids.cum_voxels.shape, (0,))
         self.assertEqual(grids.dual_bboxes.shape, (0, 2, 3))
         self.assertEqual(grids.grid_count, 0)
-        self.assertEqual(grids.grid_to_world_matrices.shape, (0, 4, 4))
+        self.assertEqual(grids.voxel_to_world_matrices.shape, (0, 4, 4))
         self.assertTrue(grids.has_zero_grids)
         self.assertEqual(grids.ijk.jdata.shape, (0, 3))
         self.assertEqual(grids.jidx.shape, (0,))
@@ -60,7 +60,7 @@ class TestBasicOps(unittest.TestCase):
         self.assertEqual(grids.total_leaf_nodes, 0)
         self.assertEqual(grids.total_voxels, 0)
         self.assertEqual(grids.voxel_sizes.shape, (0, 3))
-        self.assertEqual(grids.world_to_grid_matrices.shape, (0, 4, 4))
+        self.assertEqual(grids.world_to_voxel_matrices.shape, (0, 4, 4))
 
     @parameterized.expand(["cuda", "cpu"])
     def test_building_zero_voxels_constructor(self, device):
@@ -74,7 +74,7 @@ class TestBasicOps(unittest.TestCase):
         self.assertEqual(grids.cum_voxels.shape, (1,))
         self.assertEqual(grids.dual_bboxes.shape, (1, 2, 3))
         self.assertEqual(grids.grid_count, 1)
-        self.assertEqual(grids.grid_to_world_matrices.shape, (1, 4, 4))
+        self.assertEqual(grids.voxel_to_world_matrices.shape, (1, 4, 4))
         self.assertFalse(grids.has_zero_grids)
         self.assertEqual(grids.ijk.jdata.shape, (0, 3))
         self.assertEqual(grids.jidx.shape, (0,))
@@ -87,7 +87,7 @@ class TestBasicOps(unittest.TestCase):
         self.assertEqual(grids.total_leaf_nodes, 0)
         self.assertEqual(grids.total_voxels, 0)
         self.assertEqual(grids.voxel_sizes.shape, (1, 3))
-        self.assertEqual(grids.world_to_grid_matrices.shape, (1, 4, 4))
+        self.assertEqual(grids.world_to_voxel_matrices.shape, (1, 4, 4))
         self.assertTrue(torch.allclose(grids.voxel_sizes, expected_voxel_sizes))
         self.assertTrue(torch.allclose(grids.origins, expected_origins))
 

--- a/tests/unit/test_io.py
+++ b/tests/unit/test_io.py
@@ -81,10 +81,10 @@ class TestIO(unittest.TestCase):
 
         with tempfile.NamedTemporaryFile() as temp:
             if name:
-                fvdb.save_gridbatch(temp.name, grid, data, name=name, compressed=compressed)
+                grid.save_nanovdb(temp.name, data, name=name, compressed=compressed)
             else:
-                fvdb.save_gridbatch(temp.name, grid, data, names=names, compressed=compressed)
-            grid2, data2, names2 = fvdb.load_gridbatch(temp.name, device=device)
+                grid.save_nanovdb(temp.name, data, names=names, compressed=compressed)
+            grid2, data2, names2 = fvdb.GridBatch.from_nanovdb(temp.name, device=device)
 
             if name:
                 names = [name] * batch_size
@@ -138,8 +138,8 @@ class TestIO(unittest.TestCase):
         grid = fvdb.GridBatch.from_ijk(grid_ijk)
 
         with tempfile.NamedTemporaryFile() as temp:
-            fvdb.save_gridbatch(temp.name, grid, names=names, compressed=True)
-            grid2, data2, names2 = fvdb.load_gridbatch(temp.name, device=device)
+            grid.save_nanovdb(temp.name, names=names, compressed=True)
+            grid2, data2, names2 = fvdb.GridBatch.from_nanovdb(temp.name, device=device)
 
             names = [""] * batch_size
 
@@ -173,9 +173,9 @@ class TestIO(unittest.TestCase):
     def test_load_gridbatch_basic(self):
         datadir = get_fvdb_test_data_path()
         # Load an uncompressed gridbatch
-        grids, data, names = fvdb.load_gridbatch(str(datadir / "io" / "batch.nvdb"))
+        grids, data, names = fvdb.GridBatch.from_nanovdb(str(datadir / "io" / "batch.nvdb"))
         # Load a blosc-compressed gridbatch
-        grids, data, names = fvdb.load_gridbatch(str(datadir / "io" / "smoke-blosc.nvdb"))
+        grids, data, names = fvdb.GridBatch.from_nanovdb(str(datadir / "io" / "smoke-blosc.nvdb"))
 
     @parameterized.expand(["cpu", "cuda"])
     def test_name_too_long_raises(self, device):
@@ -186,7 +186,7 @@ class TestIO(unittest.TestCase):
             )
             grid = fvdb.GridBatch.from_ijk(grid_ijk)
             with self.assertRaises(ValueError):
-                fvdb.save_gridbatch("temp.nvdb", grid, grid_ijk, compressed=True, names=["a" * 1000] * batch_size)
+                grid.save_nanovdb("temp.nvdb", grid_ijk, compressed=True, names=["a" * 1000] * batch_size)
 
     @parameterized.expand(["cpu", "cuda"])
     def test_bad_length_raises(self, device):
@@ -203,7 +203,7 @@ class TestIO(unittest.TestCase):
                 self.assertEqual(grid_data.jdata.shape[0], grid.total_voxels)
             with tempfile.NamedTemporaryFile() as temp:
                 with self.assertRaises(ValueError):
-                    fvdb.save_gridbatch(temp.name, grid, grid_data, compressed=True, names=["a"] * batch_size)
+                    grid.save_nanovdb(temp.name, grid_data, compressed=True, names=["a"] * batch_size)
 
             sizes = [np.random.randint(100, 200) for _ in range(batch_size)]
             grid_ijk = fvdb.JaggedTensor([torch.randint(-512, 512, (sizes[i], 3)) for i in range(batch_size)]).to(
@@ -220,7 +220,7 @@ class TestIO(unittest.TestCase):
                 self.assertEqual(grid_data.jdata.shape[0], grid.total_voxels)
             with tempfile.NamedTemporaryFile() as temp:
                 with self.assertRaises(ValueError):
-                    fvdb.save_gridbatch(temp.name, grid, grid_data, compressed=True, names=["a"] * batch_size)
+                    grid.save_nanovdb(temp.name, grid_data, compressed=True, names=["a"] * batch_size)
 
     @parameterized.expand(["cpu", "cuda"])
     def test_bad_device_raises(self, device):
@@ -235,7 +235,7 @@ class TestIO(unittest.TestCase):
                 [torch.rand(int(grid.num_voxels[i].item())).to(bad_device) for i in range(batch_size)]
             )
             with self.assertRaises(ValueError):
-                fvdb.save_gridbatch("temp.nvdb", grid, grid_data, compressed=True, names=["a"] * batch_size)
+                grid.save_nanovdb("temp.nvdb", grid_data, compressed=True, names=["a"] * batch_size)
 
     @parameterized.expand(["cpu", "cuda"])
     def test_bad_names_raises(self, device):
@@ -251,7 +251,7 @@ class TestIO(unittest.TestCase):
             names = ["aaa"] * (batch_size + 1)
             with tempfile.NamedTemporaryFile() as temp:
                 with self.assertRaises(ValueError):
-                    fvdb.save_gridbatch(temp.name, grid, grid_data, compressed=True, names=names)
+                    grid.save_nanovdb(temp.name, grid_data, compressed=True, names=names)
 
     @parameterized.expand(["cpu", "cuda"])
     def test_nonexistent_name_raises(self, device):
@@ -263,13 +263,13 @@ class TestIO(unittest.TestCase):
             grid = fvdb.GridBatch.from_ijk(grid_ijk)
             # data = fvdb.JaggedTensor([torch.rand(grid.num_voxels[i].item()).to(device) for i in range(batch_size)])
             with tempfile.NamedTemporaryFile() as temp:
-                fvdb.save_gridbatch(temp.name, grid, compressed=True, names=[f"a_{i}" for i in range(batch_size)])
+                grid.save_nanovdb(temp.name, compressed=True, names=[f"a_{i}" for i in range(batch_size)])
 
                 with self.assertRaises(IndexError):
-                    fvdb.load_gridbatch(temp.name, device=device, names=["a_0", "b", "a_1", "a_0"])
+                    fvdb.GridBatch.from_nanovdb(temp.name, device=device, names=["a_0", "b", "a_1", "a_0"])
 
                 with self.assertRaises(IndexError):
-                    fvdb.load_gridbatch(temp.name, device=device, name="c")
+                    fvdb.GridBatch.from_nanovdb(temp.name, device=device, name="c")
 
     @parameterized.expand(["cpu", "cuda"])
     def test_one_voxel_grids(self, device):
@@ -281,8 +281,8 @@ class TestIO(unittest.TestCase):
             grid = fvdb.GridBatch.from_ijk(grid_ijk)
             data = fvdb.JaggedTensor([torch.rand(1).squeeze().to(device)] * batch_size)
             with tempfile.NamedTemporaryFile() as temp:
-                fvdb.save_gridbatch(temp.name, grid, data, compressed=False)
-                grid2, data2, names = fvdb.load_gridbatch(temp.name, device=device)
+                grid.save_nanovdb(temp.name, data, compressed=False)
+                grid2, data2, names = fvdb.GridBatch.from_nanovdb(temp.name, device=device)
                 self.assertTrue(torch.all(grid2.ijk.jdata == grid.ijk.jdata))
                 self.assertTrue(torch.all(data2.jdata == data.jdata))
 
@@ -293,8 +293,8 @@ class TestIO(unittest.TestCase):
             grid = fvdb.GridBatch.from_ijk(grid_ijk)
             data = fvdb.JaggedTensor([torch.rand(1).unsqueeze(-1).unsqueeze(-1).to(device)] * batch_size)
             with tempfile.NamedTemporaryFile() as temp:
-                fvdb.save_gridbatch(temp.name, grid, data, compressed=False)
-                grid2, data2, names = fvdb.load_gridbatch(temp.name, device=device)
+                grid.save_nanovdb(temp.name, data, compressed=False)
+                grid2, data2, names = fvdb.GridBatch.from_nanovdb(temp.name, device=device)
                 self.assertTrue(torch.all(grid2.ijk.jdata == grid.ijk.jdata))
                 self.assertTrue(torch.all(data2.jdata == data.jdata))
 
@@ -313,16 +313,16 @@ class TestIO(unittest.TestCase):
 
         with tempfile.NamedTemporaryFile() as temp:
             # test saving index grids by themselves which will be written as a NanoVDB index grid
-            fvdb.save_gridbatch(temp.name, test_grid)
-            test_grid_from_file, _, _ = fvdb.load_gridbatch(temp.name, device=device)
+            test_grid.save_nanovdb(temp.name)
+            test_grid_from_file, _, _ = fvdb.GridBatch.from_nanovdb(temp.name, device=device)
 
             self.assertTrue(torch.all(test_grid.voxel_sizes == test_grid_from_file.voxel_sizes))
             self.assertTrue(torch.all(test_grid.origins == test_grid_from_file.origins))
 
             # test saving index grids with data of a channel size which will be written as a NanoVDB data grid
             data = test_grid.jagged_like(torch.rand(test_grid.total_voxels, 3, device=device))
-            fvdb.save_gridbatch(temp.name, test_grid, data)
-            test_grid_from_file, data_from_file, _ = fvdb.load_gridbatch(temp.name, device=device)
+            test_grid.save_nanovdb(temp.name, data)
+            test_grid_from_file, data_from_file, _ = fvdb.GridBatch.from_nanovdb(temp.name, device=device)
 
             self.assertTrue(torch.all(test_grid.voxel_sizes == test_grid_from_file.voxel_sizes))
             self.assertTrue(torch.all(test_grid.origins == test_grid_from_file.origins))

--- a/tests/unit/test_ray_marching.py
+++ b/tests/unit/test_ray_marching.py
@@ -477,7 +477,7 @@ class TestRayMarching(unittest.TestCase):
         gsize = 8
         grid, _, _ = make_dense_grid_batch_and_jagged_point_data(gsize, device, dtype)
 
-        grid_centers = grid.grid_to_world(grid.ijk.float()).jdata
+        grid_centers = grid.voxel_to_world(grid.ijk.float()).jdata
         camera_origin_inside = torch.mean(grid_centers, dim=0)
         camera_origin_outside = camera_origin_inside - torch.tensor([0.0, 0.0, 4.0]).to(grid.device)
 

--- a/tests/wip/unit/test_conv.py
+++ b/tests/wip/unit/test_conv.py
@@ -137,7 +137,7 @@ class TestConv(unittest.TestCase):
         vdb_kernels.grad.zero_()
 
         # # Dense convolution & backward
-        dense_features = grid.write_to_dense_cminor(JaggedTensor(vdb_features)).squeeze(0).permute(3, 2, 1, 0)
+        dense_features = grid.inject_to_dense_cminor(JaggedTensor(vdb_features)).squeeze(0).permute(3, 2, 1, 0)
         out_dense_features_ref = torch.nn.functional.conv3d(
             dense_features, vdb_kernels, padding=(kernel_size - 1) // 2, stride=stride
         )
@@ -427,7 +427,7 @@ class TestConv(unittest.TestCase):
         vdb_kernels.requires_grad = True
 
         # Dense convolution & backward
-        dense_features = grid.write_to_dense_cminor(JaggedTensor(vdb_features)).squeeze(0).permute(3, 2, 1, 0)
+        dense_features = grid.inject_to_dense_cminor(JaggedTensor(vdb_features)).squeeze(0).permute(3, 2, 1, 0)
         out_dense_features_ref = torch.nn.functional.conv3d(
             dense_features, vdb_kernels, padding=(kernel_size - 1) // 2, stride=stride
         )
@@ -534,7 +534,7 @@ class TestConv(unittest.TestCase):
         vdb_kernels.requires_grad = True
 
         # Dense convolution & backward
-        dense_features = grid.write_to_dense_cminor(JaggedTensor(vdb_features)).squeeze(0).permute(3, 2, 1, 0)
+        dense_features = grid.inject_to_dense_cminor(JaggedTensor(vdb_features)).squeeze(0).permute(3, 2, 1, 0)
         out_dense_features_ref = torch.nn.functional.conv3d(
             dense_features,
             vdb_kernels,
@@ -657,7 +657,7 @@ class TestConv(unittest.TestCase):
 
         # Sparse convolution & backward
         out_vdb_features = kmap.sparse_transpose_conv_3d(vdb_features, vdb_kernels, symbol)
-        out_dense_features = source_grid.write_to_dense_cminor(out_vdb_features).squeeze(0).permute(3, 2, 1, 0)
+        out_dense_features = source_grid.inject_to_dense_cminor(out_vdb_features).squeeze(0).permute(3, 2, 1, 0)
         out_grad = torch.rand_like(out_dense_features)
         # TODO: Hack to compare with PyTorch with even filter size
         # out_dense_features = out_dense_features[:, :31, :31, :31]


### PR DESCRIPTION
Changed some things in grid, now changing them in gridbatch too.

 1. Rigorous naming of coordinates spaces (world means world, voxel means ijk, index means linear offset). Updated methods to reflect this.
 2. Moved load/save functions to from_nanovdb, save_nanovdb which conforms with `Grid` and `GaussianSplat3d` (`from_ply`/`save_ply`). 
 3. Renamed `read/write_to/from_dense_cmajor/minor` to `inject_to/from_dense_cmajor/minor` because these are just injection functions over dense grids and it conforms with `inject_from_ijk`.