### PR TITLE
Fix PyTorch index url for package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:12.8.1-cudnn-devel-ubuntu22.04
+FROM nvidia/cuda:12.9.1-cudnn-devel-ubuntu22.04
 
 # Set environment variables to prevent interactive prompts during installation.
 ENV DEBIAN_FRONTEND=noninteractive

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ are provided.
 Install fvdb_core using the following pip command.
 
 ```
-pip install fvdb_core==0.3.0+pt28.cu129 --extra-index-url="https://d36m13axqqhiit.cloudfront.net/simple" torch==2.8.0
+pip install fvdb_core==0.3.0+pt28.cu129 --extra-index-url="https://d36m13axqqhiit.cloudfront.net/simple" torch==2.8.0 --extra-index-url https://download.pytorch.org/whl/cu129
 ```
 
 ## Building *f*VDB from Source


### PR DESCRIPTION
The default PyTorch 2.8.0 package uses CUDA 12.8. We need to specify the PyTorch CUDA 12.9 index URL in order to pick up the right version.

This also switches the dev dockerfile to CUDA 12.9 in order to match the package.