### PR TITLE
Fix radix sort prefetch for disjoint sorts

### DIFF
--- a/src/fvdb/detail/ops/gsplat/GaussianTileIntersection.cu
+++ b/src/fvdb/detail/ops/gsplat/GaussianTileIntersection.cu
@@ -782,24 +782,29 @@ radixSortAsync(KeyT *keysIn,
                 OffsetT outputOffset = offsets[leftDeviceId] + leftIntervals[leftDeviceId] +
                                        rightIntervals[leftDeviceId];
 
-                C10_CUDA_CHECK(nanovdb::util::cuda::memPrefetchAsync(
-                    leftKeysIn, leftCount * sizeof(KeyT), leftDeviceId, leftStream));
-                C10_CUDA_CHECK(nanovdb::util::cuda::memPrefetchAsync(
-                    leftValuesIn, leftCount * sizeof(ValueT), leftDeviceId, leftStream));
-                C10_CUDA_CHECK(nanovdb::util::cuda::memPrefetchAsync(
-                    rightKeysIn, rightCount * sizeof(KeyT), leftDeviceId, leftStream));
-                C10_CUDA_CHECK(nanovdb::util::cuda::memPrefetchAsync(
-                    rightValuesIn, rightCount * sizeof(ValueT), leftDeviceId, leftStream));
-                C10_CUDA_CHECK(
-                    nanovdb::util::cuda::memPrefetchAsync(keysOut + outputOffset,
-                                                          (leftCount + rightCount) * sizeof(KeyT),
-                                                          leftDeviceId,
-                                                          leftStream));
-                C10_CUDA_CHECK(
-                    nanovdb::util::cuda::memPrefetchAsync(valuesOut + outputOffset,
-                                                          (leftCount + rightCount) * sizeof(ValueT),
-                                                          leftDeviceId,
-                                                          leftStream));
+                if (leftCount) {
+                    C10_CUDA_CHECK(nanovdb::util::cuda::memPrefetchAsync(
+                        leftKeysIn, leftCount * sizeof(KeyT), leftDeviceId, leftStream));
+                    C10_CUDA_CHECK(nanovdb::util::cuda::memPrefetchAsync(
+                        leftValuesIn, leftCount * sizeof(ValueT), leftDeviceId, leftStream));
+                }
+                if (rightCount) {
+                    C10_CUDA_CHECK(nanovdb::util::cuda::memPrefetchAsync(
+                        rightKeysIn, rightCount * sizeof(KeyT), leftDeviceId, leftStream));
+                    C10_CUDA_CHECK(nanovdb::util::cuda::memPrefetchAsync(
+                        rightValuesIn, rightCount * sizeof(ValueT), leftDeviceId, leftStream));
+                }
+                if (auto outputCount = leftCount + rightCount) {
+                    C10_CUDA_CHECK(nanovdb::util::cuda::memPrefetchAsync(keysOut + outputOffset,
+                                                                         outputCount * sizeof(KeyT),
+                                                                         leftDeviceId,
+                                                                         leftStream));
+                    C10_CUDA_CHECK(
+                        nanovdb::util::cuda::memPrefetchAsync(valuesOut + outputOffset,
+                                                              outputCount * sizeof(ValueT),
+                                                              leftDeviceId,
+                                                              leftStream));
+                }
 
                 CUB_WRAPPER(cub::DeviceMerge::MergePairs,
                             leftKeysIn,
@@ -831,24 +836,29 @@ radixSortAsync(KeyT *keysIn,
                 OffsetT outputOffset = offsets[leftDeviceId] + leftIntervals[rightDeviceId] +
                                        rightIntervals[rightDeviceId];
 
-                C10_CUDA_CHECK(nanovdb::util::cuda::memPrefetchAsync(
-                    leftKeysIn, leftCount * sizeof(KeyT), rightDeviceId, rightStream));
-                C10_CUDA_CHECK(nanovdb::util::cuda::memPrefetchAsync(
-                    leftValuesIn, leftCount * sizeof(ValueT), rightDeviceId, rightStream));
-                C10_CUDA_CHECK(nanovdb::util::cuda::memPrefetchAsync(
-                    rightKeysIn, rightCount * sizeof(KeyT), rightDeviceId, rightStream));
-                C10_CUDA_CHECK(nanovdb::util::cuda::memPrefetchAsync(
-                    rightValuesIn, rightCount * sizeof(ValueT), rightDeviceId, rightStream));
-                C10_CUDA_CHECK(
-                    nanovdb::util::cuda::memPrefetchAsync(keysOut + outputOffset,
-                                                          (leftCount + rightCount) * sizeof(KeyT),
-                                                          rightDeviceId,
-                                                          rightStream));
-                C10_CUDA_CHECK(
-                    nanovdb::util::cuda::memPrefetchAsync(valuesOut + outputOffset,
-                                                          (leftCount + rightCount) * sizeof(ValueT),
-                                                          rightDeviceId,
-                                                          rightStream));
+                if (leftCount) {
+                    C10_CUDA_CHECK(nanovdb::util::cuda::memPrefetchAsync(
+                        leftKeysIn, leftCount * sizeof(KeyT), rightDeviceId, rightStream));
+                    C10_CUDA_CHECK(nanovdb::util::cuda::memPrefetchAsync(
+                        leftValuesIn, leftCount * sizeof(ValueT), rightDeviceId, rightStream));
+                }
+                if (rightCount) {
+                    C10_CUDA_CHECK(nanovdb::util::cuda::memPrefetchAsync(
+                        rightKeysIn, rightCount * sizeof(KeyT), rightDeviceId, rightStream));
+                    C10_CUDA_CHECK(nanovdb::util::cuda::memPrefetchAsync(
+                        rightValuesIn, rightCount * sizeof(ValueT), rightDeviceId, rightStream));
+                }
+                if (auto outputCount = leftCount + rightCount) {
+                    C10_CUDA_CHECK(nanovdb::util::cuda::memPrefetchAsync(keysOut + outputOffset,
+                                                                         outputCount * sizeof(KeyT),
+                                                                         rightDeviceId,
+                                                                         rightStream));
+                    C10_CUDA_CHECK(
+                        nanovdb::util::cuda::memPrefetchAsync(valuesOut + outputOffset,
+                                                              outputCount * sizeof(ValueT),
+                                                              rightDeviceId,
+                                                              rightStream));
+                }
 
                 CUB_WRAPPER(cub::DeviceMerge::MergePairs,
                             leftKeysIn,


### PR DESCRIPTION
When merging sorted arrays across GPUs, it's possible that all of the elements on the first device are less than all of the elements on the second device. This means that the second GPU needs to prefetch no elements from the first device and the first GPU needs to prefetch no elements from the second device. In this case, `rightCount` and `leftCount` are zero for the left and right device respectively and we need to check for that before calling `memPrefetchAsync` to avoid a `cudaErrorInvalidValue` failure.