### PR TITLE
conda environment files: switch to conda-forge torchvision

### DIFF
--- a/env/dev_environment.yml
+++ b/env/dev_environment.yml
@@ -66,6 +66,7 @@ dependencies:
   - pyyaml
   - scikit-learn
   - srt
+  - torchvision
   - tyro
   - utm
   - viser
@@ -79,4 +80,3 @@ dependencies:
     - dlnr_lite
     - einops
     - oiio-static-python
-    - torchvision==0.23.0 --index-url https://download.pytorch.org/whl/cu129 # NOTE: torchvision is not available on conda-forge for pytorch 2.8.0 yet

--- a/env/learn_environment.yml
+++ b/env/learn_environment.yml
@@ -34,6 +34,7 @@ dependencies:
   - py-opencv>=4.10[build=headless*]
   - pyyaml
   - scikit-learn
+  - torchvision
   - tyro
   - viser
   - pip:
@@ -41,4 +42,3 @@ dependencies:
     - https://nksr.s3.ap-northeast-1.amazonaws.com/dev-whls/pt28cu129/torchsparse-2.1.0-cp312-cp312-linux_x86_64.whl
     - https://nksr.s3.ap-northeast-1.amazonaws.com/dev-whls/pt28cu129/torchsparse_20-2.0.0b0-cp312-cp312-linux_x86_64.whl
     - https://nksr.s3.ap-northeast-1.amazonaws.com/dev-whls/pt28cu129/torch_scatter-2.1.2-cp312-cp312-linux_x86_64.whl
-    - torchvision==0.23.0 --index-url https://download.pytorch.org/whl/cu129 # NOTE: torchvision is not available on conda-forge for pytorch 2.8.0 yet

--- a/env/test_environment.yml
+++ b/env/test_environment.yml
@@ -36,6 +36,7 @@ dependencies:
   ## 3dgs
   - pyproj
   - scikit-image
+  - torchvision
   - viser
   - pip:
     - gsplat
@@ -44,7 +45,6 @@ dependencies:
     - torchsparse @ https://nksr.s3.ap-northeast-1.amazonaws.com/dev-whls/pt28cu129/torchsparse-2.1.0-cp312-cp312-linux_x86_64.whl
     - torchsparse_20 @ https://nksr.s3.ap-northeast-1.amazonaws.com/dev-whls/pt28cu129/torchsparse_20-2.0.0b0-cp312-cp312-linux_x86_64.whl
     - torch_scatter @ https://nksr.s3.ap-northeast-1.amazonaws.com/dev-whls/pt28cu129/torch_scatter-2.1.2-cp312-cp312-linux_x86_64.whl
-    - torchvision==0.23.0 --index-url https://download.pytorch.org/whl/cu129 # NOTE: torchvision is not available on conda-forge for pytorch 2.8.0 yet
     ## 3dgs tests
     - oiio-static-python
 platforms:


### PR DESCRIPTION
torchvision is now available on conda-forge for pytorch 2.8.0; switching to conda-forge package in relevant env yml files