### PR TITLE
Fix GHA error in (currently unused) nightly workflows

### DIFF
--- a/.github/workflows/cu128-nightly.yml
+++ b/.github/workflows/cu128-nightly.yml
@@ -1,9 +1,9 @@
 name: fVDB Nightly Build and Tests -- CUDA 12.8
 
-# on:
+on:
 #   schedule:
 #     - cron: "01 15 * * *"  # Runs every day at 4am pacific/11am UTC
-#   workflow_dispatch:
+  workflow_dispatch:
 
 
 permissions:

--- a/.github/workflows/cu130-nightly.yml
+++ b/.github/workflows/cu130-nightly.yml
@@ -1,9 +1,9 @@
 name: fVDB Nightly Build and Tests -- CUDA 13.0.1
 
-# on:
+on:
 #   schedule:
 #     - cron: "01 15 * * *"  # Runs every day at 4am pacific/11am UTC
-#   workflow_dispatch:
+  workflow_dispatch:
 
 
 permissions:


### PR DESCRIPTION
To disable these two nightly workflows, the entire "on:" section was commented out. That is an error since a GHA workflow must have an "on:". This PR just uncomments "on:" and "workflow_dispatch".

(I was seeing daily errors from these on my fork because I had actions enabled. Not sure why they don't cause errors on the main repo.)

Signed-off-by: Mark Harris <mharris@nvidia.com>