### PR TITLE
Fix Gaussian rasterization shared memory alignment

### DIFF
--- a/src/fvdb/detail/ops/gsplat/GaussianRasterizeBackward.cu
+++ b/src/fvdb/detail/ops/gsplat/GaussianRasterizeBackward.cu
@@ -619,7 +619,7 @@ struct RasterizeBackwardArgs {
         const uint32_t blockSize,
         const bool pixelIsActive,
         const uint32_t activePixelIndex) {
-        extern __shared__ int s[];
+        alignas(Gaussian2D<ScalarType>) extern __shared__ char s[];
 
         Gaussian2D<ScalarType> *sharedGaussians =
             reinterpret_cast<Gaussian2D<ScalarType> *>(s);               // [blockSize]

--- a/src/fvdb/detail/ops/gsplat/GaussianRasterizeForward.cu
+++ b/src/fvdb/detail/ops/gsplat/GaussianRasterizeForward.cu
@@ -127,7 +127,7 @@ template <typename ScalarType, uint32_t NUM_CHANNELS, bool IS_PACKED> struct Ras
                             const uint32_t blockSize,
                             const bool pixelIsActive,
                             const uint32_t activePixelIndex) {
-        extern __shared__ int s[];
+        alignas(Gaussian2D<ScalarType>) extern __shared__ char s[];
         auto *sharedGaussians = reinterpret_cast<Gaussian2D<ScalarType> *>(s); // [blockSize]
 
         // NOTE: The accumulated transmittance is used in the backward pass, and


### PR DESCRIPTION
Gaussian2D is 32-byte aligned but when we declare the pointer to shared memory, we were not specifying an alignment (leaving us with 4 or 16 byte alignment).  Then casting the pointer with lower alignment to one requiring 32-byte alignment is undefined.  This fixes this potential issue.

Signed-off-by: Jonathan Swartz <jonathan@jswartz.info>