### PR TITLE
Debug build gtest fix

### DIFF
--- a/src/tests/GaussianProjectionForwardTest.cpp
+++ b/src/tests/GaussianProjectionForwardTest.cpp
@@ -182,7 +182,7 @@ TEST_F(GaussianProjectionForwardTestFixture, TestPerspectiveProjection) {
                                                                            false);
 
     // Use relaxed tolerances to account for minor numerical differences between debug and release
-    // builds The default rtol=1e-5, atol=1e-8 are too strict for operations involving exp, sqrt,
+    // builds. The default rtol=1e-5, atol=1e-8 are too strict for operations involving exp, sqrt,
     // and inverse
 #ifdef NDEBUG
     // Release build: stricter tolerances


### PR DESCRIPTION
Increase the tolerances in the GaussianProjectionForward gtest for debug builds to get around numerical differences between cached results built with release and debug build test outputs. fixes #86

Signed-off-by: Jonathan Swartz <jonathan@jswartz.info>