### PR TITLE
GaussianProjectionForward: fix camera data loading that exceeds blockDim

### DIFF
--- a/src/fvdb/detail/ops/gsplat/GaussianProjectionForward.cu
+++ b/src/fvdb/detail/ops/gsplat/GaussianProjectionForward.cu
@@ -198,7 +198,7 @@ template <typename T, bool Ortho> struct ProjectionForward {
     inline __device__ void
     loadCamerasIntoSharedMemory() {
         // Load projection matrices and world-to-camera matrices into shared memory
-        extern __shared__ char sharedMemory[];
+        alignas(Mat3) extern __shared__ char sharedMemory[];
 
         projectionMatsShared    = reinterpret_cast<Mat3 *>(sharedMemory);
         worldToCamRotMatsShared = reinterpret_cast<Mat3 *>(sharedMemory + C * sizeof(Mat3));


### PR DESCRIPTION
In `loadCamerasIntoSharedMemory`, each thread loaded an element of camera data into shared memory.  However, if the amount of camera data exceeds the number of threads, all of the camera data would fail to be loaded.  This happens around camera 13 (256 / 21 elements-per-camera).  Changed this loading into a strided loop so all camera data will be loaded.

Also I changed the calculation of shared memory from a manual calculation to using `sizeof()` the appropriate `nanovdb::math` structs for safety's sake.