### PR TITLE
Remove tests.yml 'push' trigger

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,16 +11,6 @@ on:
         - 'examples/**'
         - 'notebooks/**'
         - 'scripts/**'
-  push:
-    branches:
-      - main
-    paths-ignore:
-        - 'CODEOWNERS'
-        - '**.md'
-        - 'debug/**'
-        - 'examples/**'
-        - 'notebooks/**'
-        - 'scripts/**'
   workflow_dispatch:
     inputs:
       branch:


### PR DESCRIPTION
Remove the push to main trigger from tests.yml; this is vestigal from the needs of the copy-pr-bot workflow and is now just creating test startup failure noise.

Signed-off-by: Jonathan Swartz <jonathan@jswartz.info>