### PR TITLE
Fix inverted logic on computing abs(gradient) in backward Gaussian rasterization

### DIFF
--- a/src/fvdb/detail/ops/gsplat/GaussianRasterizeBackward.cu
+++ b/src/fvdb/detail/ops/gsplat/GaussianRasterizeBackward.cu
@@ -504,7 +504,7 @@ struct RasterizeBackwardArgs {
         outMean2dGradientContribution = {
             sigmaGradientContribution * (conic[0] * delta[0] + conic[1] * delta[1]),
             sigmaGradientContribution * (conic[1] * delta[0] + conic[2] * delta[1])};
-        if (!mAbsGrad) {
+        if (mAbsGrad) {
             outMean2dAbsGradientContribution = {abs(outMean2dGradientContribution[0]),
                                                 abs(outMean2dGradientContribution[1])};
         }


### PR DESCRIPTION
Fixes #354

Fixes inverted logic on AbsGrad computation. 

Signed-off-by: Mark Harris <mharris@nvidia.com>