### PR TITLE
`JaggedTensor::unbind*`:  Reduce number of blocking GPU->CPU copies by reusing cached lsizes

### DIFF
--- a/src/fvdb/JaggedTensor.cpp
+++ b/src/fvdb/JaggedTensor.cpp
@@ -395,7 +395,7 @@ JaggedTensor::unbind2() const {
         std::vector<torch::Tensor> inner_tensors;
         inner_tensors.reserve(inner_sizes.size());
 
-        for (int64_t size: inner_sizes) {
+        for (JOffsetsType size: inner_sizes) {
             inner_tensors.push_back(mData.narrow(0, offset, size));
             offset += size;
         }


### PR DESCRIPTION
`JaggedTensor::unbind1()` and `JaggedTensor::unbind2()` perform blocking GPU->CPU copies.  We can amortize these by reusing the cached `lsizes1()` and `lsizes2()` calls.  If these functions were previously called, their values are cached, or they were cached on construction (which some of our constructors do), then no sync is needed. 