### PR TITLE
Add lineinfo option to build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -26,6 +26,7 @@ usage() {
   echo "  editor_skip    Skip building and installing the nanovdb_editor dependency (sets NANOVDB_EDITOR_SKIP=ON)."
   echo "  editor_force   Force rebuild of the nanovdb_editor dependency (sets NANOVDB_EDITOR_FORCE=ON)."
   echo "  debug          Build in debug mode with full debug symbols and no optimizations."
+  echo "  lineinfo       Enable CUDA lineinfo (sets FVDB_LINEINFO=ON)."
   echo "  strip_symbols  Strip symbols from the build (will be ignored if debug is enabled)."
   echo "  verbose        Enable verbose build output for pip and CMake."
   echo ""
@@ -190,6 +191,10 @@ while (( "$#" )); do
     elif [[ "$1" == "debug" ]]; then
       echo "Enabling debug build"
       CONFIG_SETTINGS+=" --config-settings=cmake.build-type=Debug  -C cmake.define.CMAKE_BUILD_TYPE=Debug"
+      is_config_arg_handled=true
+    elif [[ "$1" == "lineinfo" ]]; then
+      echo "Enabling CUDA lineinfo"
+      CONFIG_SETTINGS+=" --config-settings=cmake.define.FVDB_LINEINFO=ON"
       is_config_arg_handled=true
     elif [[ "$1" == "strip_symbols" ]]; then
       echo "Enabling strip symbols build"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,6 +18,7 @@ include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/get_blosc.cmake)
 option(FVDB_BUILD_TESTS "Configure CMake to build tests" ON)
 option(FVDB_BUILD_BENCHMARKS "Configure CMake to build (google & nvbench) benchmarks" OFF)
 option(FVDB_STRIP_SYMBOLS "Strip symbols from the build" OFF)
+option(FVDB_LINEINFO "Enable lineinfo in the build" OFF)
 
 message(STATUS "FVDB: Configure CMake to build tests: ${FVDB_BUILD_TESTS}")
 message(STATUS "FVDB: Configure CMake to build (google & nvbench) benchmarks: ${FVDB_BUILD_BENCHMARKS}")
@@ -212,7 +213,8 @@ target_compile_options(fvdb PRIVATE
     "--threads=$ENV{NVCC_THREADS}"
     "-Xcompiler=-Wall,-Werror"
     ${TORCH_CUDA_COMMON_FLAGS}
-    >)
+    >
+    $<$<AND:$<BOOL:${FVDB_LINEINFO}>,$<COMPILE_LANGUAGE:CUDA>>:-lineinfo>)
 
 target_link_libraries(fvdb PRIVATE
     ${TORCH_LIBRARIES} tinyply cutlass blosc::blosc)


### PR DESCRIPTION
Adds a cmake option FVDB_LINEINFO to the fvdb CMakeLists.txt. (default OFF). Adds a command line option lineinfo to build.sh.

This makes it easy to build with -lineinfo for CUDA code, which makes profiling with nsight compute and nsys much more informative, as performance problems can be correlated with specific lines of CUDA code (e.g. uncoalesced loads/stores).

Signed-off-by: Mark Harris [mharris@nvidia.com](mailto:mharris@nvidia.com)