### PR TITLE
Remove unnecessary stream sync in GaussianTileIntersection

### DIFF
--- a/src/fvdb/detail/ops/gsplat/GaussianTileIntersection.cu
+++ b/src/fvdb/detail/ops/gsplat/GaussianTileIntersection.cu
@@ -519,7 +519,7 @@ gaussianTileIntersectionCUDAImpl(
                         0,
                         numBits,
                         stream);
-            C10_CUDA_CHECK(cudaStreamSynchronize(stream));
+
             // DoubleBuffer swaps the pointers if the keys were sorted in the input buffer
             // so we need to grab the right buffer.
             if (d_keys.selector == 1) {


### PR DESCRIPTION
This removes an unnecessary call to  `cudaDeviceSynchronize()`. The stream was added due to uncertainty about whether the `cub::DoubleBuffer` pointers are valid to access immediately after `cub::DeviceRadixSort::SortPairs`. 

The CUB implementation updates the selector in host code (with an xor flip), after launching the kernel. Indeed the kernel may not be done, but we can flip the selector before it's done, and we can choose a pointer to pass to the next kernel on the same stream. The next kernel that accesses these device pointers is launched on the same stream.

Note I approved adding this sync back in #155. My mistake!

Signed-off-by: Mark Harris <mharris@nvidia.com>