### PR TITLE
Add PR workflow commands

### DIFF
--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -3,6 +3,7 @@ on:
     pull_request:
       branches:
         - '**'
+    workflow_dispatch:
 
 # Allow subsequent pushes to the same PR or REF to cancel any previous jobs.
 concurrency:

--- a/.github/workflows/cu128.yml
+++ b/.github/workflows/cu128.yml
@@ -11,6 +11,7 @@ on:
         - 'examples/**'
         - 'notebooks/**'
         - 'scripts/**'
+  workflow_dispatch:
 
 # Allow subsequent pushes to the same PR or REF to cancel any previous jobs.
 concurrency:

--- a/.github/workflows/cu130.yml
+++ b/.github/workflows/cu130.yml
@@ -11,6 +11,7 @@ on:
         - 'examples/**'
         - 'notebooks/**'
         - 'scripts/**'
+  workflow_dispatch:
 
 # Allow subsequent pushes to the same PR or REF to cancel any previous jobs.
 concurrency:

--- a/.github/workflows/pr-commands.yml
+++ b/.github/workflows/pr-commands.yml
@@ -37,128 +37,12 @@ jobs:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           comment_id: ${{ github.event.comment.id }}
 
-  run-all-workflows:
-    name: Run All Workflows
-    if: >
-      github.event.issue.pull_request &&
-      contains(github.event.comment.body, '/run-all') &&
-      (
-        github.event.comment.author_association == 'OWNER' ||
-        github.event.comment.author_association == 'MEMBER' ||
-        github.event.comment.author_association == 'COLLABORATOR'
-      )
-    runs-on: ubuntu-latest
-    permissions:
-      actions: write
-      pull-requests: write
-    steps:
-      - name: Add reaction to comment
-        uses: actions/github-script@v7
-        with:
-          script: |
-            await github.rest.reactions.createForIssueComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              comment_id: context.payload.comment.id,
-              content: 'rocket'
-            });
-
-      - name: Get PR info
-        id: pr-info
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const pr = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.issue.number
-            });
-            core.setOutput('ref', pr.data.head.ref);
-            console.log(`PR branch: ${pr.data.head.ref}`);
-
-      - name: Trigger all workflows
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const ref = '${{ steps.pr-info.outputs.ref }}';
-            const workflows = [
-              'tests.yml',
-              'codestyle.yml',
-              'cu128.yml',
-              'cu130.yml'
-            ];
-
-            // Helper to find the triggered run with retries
-            async function findWorkflowRun(workflowId, beforeTime) {
-              const maxRetries = 5;
-              const delayMs = 3000;
-
-              for (let attempt = 1; attempt <= maxRetries; attempt++) {
-                await new Promise(resolve => setTimeout(resolve, delayMs));
-                console.log(`Looking for ${workflowId} run (attempt ${attempt}/${maxRetries})...`);
-
-                const runs = await github.rest.actions.listWorkflowRuns({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  workflow_id: workflowId,
-                  branch: ref,
-                  per_page: 10,
-                  event: 'workflow_dispatch'
-                });
-
-                // Find a run created after we triggered it
-                const run = runs.data.workflow_runs.find(r =>
-                  new Date(r.created_at) >= beforeTime
-                );
-
-                if (run) {
-                  console.log(`Found run: ${run.html_url}`);
-                  return run;
-                }
-              }
-              return null;
-            }
-
-            const results = [];
-            for (const workflow of workflows) {
-              const beforeTime = new Date();
-              try {
-                console.log(`Triggering ${workflow} on ref ${ref}`);
-                await github.rest.actions.createWorkflowDispatch({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  workflow_id: workflow,
-                  ref: ref
-                });
-                console.log(`Successfully triggered ${workflow}`);
-
-                // Try to find the run and get its URL
-                const run = await findWorkflowRun(workflow, beforeTime);
-                if (run) {
-                  results.push(`* [\`${workflow}\`](${run.html_url})`);
-                } else {
-                  results.push(`* \`${workflow}\` (run pending)`);
-                }
-              } catch (error) {
-                console.log(`Failed to trigger ${workflow}: ${error.message}`);
-                results.push(`* \`${workflow}\`: ${error.message}`);
-              }
-            }
-
-            // Post summary comment
-            const body = `### Triggered workflows on branch \`${ref}\`\n\n${results.join('\n')}`;
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              body: body
-            });
-
-  run-single-workflow:
-    name: Run Single Workflow
+  run-workflows:
+    name: Run Workflows
     if: >
       github.event.issue.pull_request &&
       (
+        contains(github.event.comment.body, '/run-all') ||
         contains(github.event.comment.body, '/run-tests') ||
         contains(github.event.comment.body, '/run-codestyle') ||
         contains(github.event.comment.body, '/run-cu128') ||
@@ -198,7 +82,7 @@ jobs:
             core.setOutput('ref', pr.data.head.ref);
             console.log(`PR branch: ${pr.data.head.ref}`);
 
-      - name: Trigger requested workflow
+      - name: Trigger workflows
         uses: actions/github-script@v7
         with:
           script: |
@@ -211,6 +95,18 @@ jobs:
               '/run-cu128': 'cu128.yml',
               '/run-cu130': 'cu130.yml'
             };
+
+            // Determine which workflows to run
+            let workflowsToRun = [];
+            if (comment.includes('/run-all')) {
+              workflowsToRun = Object.values(workflowMap);
+            } else {
+              for (const [command, workflow] of Object.entries(workflowMap)) {
+                if (comment.includes(command)) {
+                  workflowsToRun.push(workflow);
+                }
+              }
+            }
 
             // Helper to find the triggered run with retries
             async function findWorkflowRun(workflowId, beforeTime) {
@@ -242,34 +138,36 @@ jobs:
               return null;
             }
 
-            for (const [command, workflow] of Object.entries(workflowMap)) {
-              if (comment.includes(command)) {
-                const beforeTime = new Date();
-                try {
-                  console.log(`Triggering ${workflow} on ref ${ref}`);
-                  await github.rest.actions.createWorkflowDispatch({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    workflow_id: workflow,
-                    ref: ref
-                  });
+            const results = [];
+            for (const workflow of workflowsToRun) {
+              const beforeTime = new Date();
+              try {
+                console.log(`Triggering ${workflow} on ref ${ref}`);
+                await github.rest.actions.createWorkflowDispatch({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  workflow_id: workflow,
+                  ref: ref
+                });
+                console.log(`Successfully triggered ${workflow}`);
 
-                  const run = await findWorkflowRun(workflow, beforeTime);
-                  const link = run ? `[\`${workflow}\`](${run.html_url})` : `\`${workflow}\``;
-
-                  await github.rest.issues.createComment({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    issue_number: context.issue.number,
-                    body: `* Triggered ${link} on branch \`${ref}\``
-                  });
-                } catch (error) {
-                  await github.rest.issues.createComment({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    issue_number: context.issue.number,
-                    body: `* Failed to trigger \`${workflow}\`: ${error.message}`
-                  });
+                const run = await findWorkflowRun(workflow, beforeTime);
+                if (run) {
+                  results.push(`* [\`${workflow}\`](${run.html_url})`);
+                } else {
+                  results.push(`* \`${workflow}\` (run pending)`);
                 }
+              } catch (error) {
+                console.log(`Failed to trigger ${workflow}: ${error.message}`);
+                results.push(`* \`${workflow}\`: ${error.message}`);
               }
             }
+
+            // Post summary comment
+            const body = `### Triggered workflows on branch \`${ref}\`\n\n${results.join('\n')}`;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: body
+            });

--- a/.github/workflows/pr-commands.yml
+++ b/.github/workflows/pr-commands.yml
@@ -1,0 +1,275 @@
+name: PR Workflow Commands
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  rerun-failed-workflows:
+    name: Rerun Failed Workflows
+    if: >
+      github.event.issue.pull_request &&
+      contains(github.event.comment.body, '/rerun-all') &&
+      (
+        github.event.comment.author_association == 'OWNER' ||
+        github.event.comment.author_association == 'MEMBER' ||
+        github.event.comment.author_association == 'COLLABORATOR'
+      )
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      pull-requests: write
+      checks: write
+    steps:
+      - name: Add reaction to comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: 'rocket'
+            });
+
+      - uses: estroz/rerun-actions@v0.3.0
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          comment_id: ${{ github.event.comment.id }}
+
+  run-all-workflows:
+    name: Run All Workflows
+    if: >
+      github.event.issue.pull_request &&
+      contains(github.event.comment.body, '/run-all') &&
+      (
+        github.event.comment.author_association == 'OWNER' ||
+        github.event.comment.author_association == 'MEMBER' ||
+        github.event.comment.author_association == 'COLLABORATOR'
+      )
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      pull-requests: write
+    steps:
+      - name: Add reaction to comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: 'rocket'
+            });
+
+      - name: Get PR info
+        id: pr-info
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number
+            });
+            core.setOutput('ref', pr.data.head.ref);
+            console.log(`PR branch: ${pr.data.head.ref}`);
+
+      - name: Trigger all workflows
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const ref = '${{ steps.pr-info.outputs.ref }}';
+            const workflows = [
+              'tests.yml',
+              'codestyle.yml',
+              'cu128.yml',
+              'cu130.yml'
+            ];
+
+            // Helper to find the triggered run with retries
+            async function findWorkflowRun(workflowId, beforeTime) {
+              const maxRetries = 5;
+              const delayMs = 3000;
+
+              for (let attempt = 1; attempt <= maxRetries; attempt++) {
+                await new Promise(resolve => setTimeout(resolve, delayMs));
+                console.log(`Looking for ${workflowId} run (attempt ${attempt}/${maxRetries})...`);
+
+                const runs = await github.rest.actions.listWorkflowRuns({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  workflow_id: workflowId,
+                  branch: ref,
+                  per_page: 10,
+                  event: 'workflow_dispatch'
+                });
+
+                // Find a run created after we triggered it
+                const run = runs.data.workflow_runs.find(r =>
+                  new Date(r.created_at) >= beforeTime
+                );
+
+                if (run) {
+                  console.log(`Found run: ${run.html_url}`);
+                  return run;
+                }
+              }
+              return null;
+            }
+
+            const results = [];
+            for (const workflow of workflows) {
+              const beforeTime = new Date();
+              try {
+                console.log(`Triggering ${workflow} on ref ${ref}`);
+                await github.rest.actions.createWorkflowDispatch({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  workflow_id: workflow,
+                  ref: ref
+                });
+                console.log(`Successfully triggered ${workflow}`);
+
+                // Try to find the run and get its URL
+                const run = await findWorkflowRun(workflow, beforeTime);
+                if (run) {
+                  results.push(`* [\`${workflow}\`](${run.html_url})`);
+                } else {
+                  results.push(`* \`${workflow}\` (run pending)`);
+                }
+              } catch (error) {
+                console.log(`Failed to trigger ${workflow}: ${error.message}`);
+                results.push(`* \`${workflow}\`: ${error.message}`);
+              }
+            }
+
+            // Post summary comment
+            const body = `### Triggered workflows on branch \`${ref}\`\n\n${results.join('\n')}`;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: body
+            });
+
+  run-single-workflow:
+    name: Run Single Workflow
+    if: >
+      github.event.issue.pull_request &&
+      (
+        contains(github.event.comment.body, '/run-tests') ||
+        contains(github.event.comment.body, '/run-codestyle') ||
+        contains(github.event.comment.body, '/run-cu128') ||
+        contains(github.event.comment.body, '/run-cu130')
+      ) &&
+      (
+        github.event.comment.author_association == 'OWNER' ||
+        github.event.comment.author_association == 'MEMBER' ||
+        github.event.comment.author_association == 'COLLABORATOR'
+      )
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      pull-requests: write
+    steps:
+      - name: Add reaction to comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: 'rocket'
+            });
+
+      - name: Get PR info
+        id: pr-info
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number
+            });
+            core.setOutput('ref', pr.data.head.ref);
+            console.log(`PR branch: ${pr.data.head.ref}`);
+
+      - name: Trigger requested workflow
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const ref = '${{ steps.pr-info.outputs.ref }}';
+            const comment = context.payload.comment.body;
+
+            const workflowMap = {
+              '/run-tests': 'tests.yml',
+              '/run-codestyle': 'codestyle.yml',
+              '/run-cu128': 'cu128.yml',
+              '/run-cu130': 'cu130.yml'
+            };
+
+            // Helper to find the triggered run with retries
+            async function findWorkflowRun(workflowId, beforeTime) {
+              const maxRetries = 5;
+              const delayMs = 3000;
+
+              for (let attempt = 1; attempt <= maxRetries; attempt++) {
+                await new Promise(resolve => setTimeout(resolve, delayMs));
+                console.log(`Looking for ${workflowId} run (attempt ${attempt}/${maxRetries})...`);
+
+                const runs = await github.rest.actions.listWorkflowRuns({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  workflow_id: workflowId,
+                  branch: ref,
+                  per_page: 10,
+                  event: 'workflow_dispatch'
+                });
+
+                const run = runs.data.workflow_runs.find(r =>
+                  new Date(r.created_at) >= beforeTime
+                );
+
+                if (run) {
+                  console.log(`Found run: ${run.html_url}`);
+                  return run;
+                }
+              }
+              return null;
+            }
+
+            for (const [command, workflow] of Object.entries(workflowMap)) {
+              if (comment.includes(command)) {
+                const beforeTime = new Date();
+                try {
+                  console.log(`Triggering ${workflow} on ref ${ref}`);
+                  await github.rest.actions.createWorkflowDispatch({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    workflow_id: workflow,
+                    ref: ref
+                  });
+
+                  const run = await findWorkflowRun(workflow, beforeTime);
+                  const link = run ? `[\`${workflow}\`](${run.html_url})` : `\`${workflow}\``;
+
+                  await github.rest.issues.createComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: context.issue.number,
+                    body: `* Triggered ${link} on branch \`${ref}\``
+                  });
+                } catch (error) {
+                  await github.rest.issues.createComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: context.issue.number,
+                    body: `* Failed to trigger \`${workflow}\`: ${error.message}`
+                  });
+                }
+              }
+            }

--- a/.github/workflows/pr-commands.yml
+++ b/.github/workflows/pr-commands.yml
@@ -69,24 +69,19 @@ jobs:
               content: 'rocket'
             });
 
-      - name: Get PR info
-        id: pr-info
+      - name: Trigger workflows
         uses: actions/github-script@v7
         with:
           script: |
+            // Get PR branch
             const pr = await github.rest.pulls.get({
               owner: context.repo.owner,
               repo: context.repo.repo,
               pull_number: context.issue.number
             });
-            core.setOutput('ref', pr.data.head.ref);
-            console.log(`PR branch: ${pr.data.head.ref}`);
+            const ref = pr.data.head.ref;
+            console.log(`PR branch: ${ref}`);
 
-      - name: Trigger workflows
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const ref = '${{ steps.pr-info.outputs.ref }}';
             const comment = context.payload.comment.body;
 
             const workflowMap = {
@@ -96,13 +91,16 @@ jobs:
               '/run-cu130': 'cu130.yml'
             };
 
+            // Helper to check if command is present (with word boundary)
+            const hasCommand = (cmd) => new RegExp(`${cmd}(?:\\s|$)`).test(comment);
+
             // Determine which workflows to run
             let workflowsToRun = [];
-            if (comment.includes('/run-all')) {
+            if (hasCommand('/run-all')) {
               workflowsToRun = Object.values(workflowMap);
             } else {
               for (const [command, workflow] of Object.entries(workflowMap)) {
-                if (comment.includes(command)) {
+                if (hasCommand(command)) {
                   workflowsToRun.push(workflow);
                 }
               }


### PR DESCRIPTION
Adds a new GitHub Actions workflow that allows maintainers to trigger CI workflows via PR comments. This is useful when workflows need to be re-run manually or when the automatic triggers didn't fire due to PR draft state.

| Command | Description |
|---------|-------------|
| `/run-all` | Trigger all PR workflows (tests, codestyle, cu128, cu130) |
| `/run-tests` | Trigger `tests.yml` only |
| `/run-codestyle` | Trigger `codestyle.yml` only |
| `/run-cu128` | Trigger `cu128.yml` only |
| `/run-cu130` | Trigger `cu130.yml` only |
| `/rerun-all` | Rerun all failed workflows |