### PR TITLE
Fix the docstrings of  `fvdb.viz.Scene.camera_orbit_direction`

### DIFF
--- a/fvdb/viz/_scene.py
+++ b/fvdb/viz/_scene.py
@@ -351,7 +351,7 @@ class Scene:
             The camera itself is positioned at: ``camera_position = orbit_center - orbit_radius * orbit_direction``
 
         Returns:
-            direction (torch.Tensor): A tensor of shape ``(3,)`` representing the direction pointing from the orbit
+            direction (torch.Tensor): A tensor of shape ``(3,)`` representing the direction pointing from the
                 camera position toward the orbit center.
         """
         server = _get_viewer_server_cpp()
@@ -370,7 +370,7 @@ class Scene:
             The camera itself is positioned at: ``camera_position = orbit_center - orbit_radius * orbit_direction``
 
         Args:
-            direction (NumericMaxRank1): A tensor-like object of shape ``(3,)`` representing the direction pointing from the orbit
+            direction (NumericMaxRank1): A tensor-like object of shape ``(3,)`` representing the direction pointing from the
                 camera position toward the orbit center.
         """
         server = _get_viewer_server_cpp()


### PR DESCRIPTION
Fixed the docstring for `fvdb.viz.Scene.camera_orbit_direction` which mentions that this is the direction pointing from the center to the camera but the values being returned are instead the direction from the camera to the center.  These values are the `eye_direction` in the nanovdb-editor which can be seen as being the opposite of what we describe in the `viz.Scene` docstrings here:

https://github.com/openvdb/nanovdb-editor/blob/main/nanovdb_editor/putil/Camera.h#L381

Perhaps, for future discussion, we should use the same terminology and call these attrs `camera_eye_direction`, `camera_eye_distance`, and so on; I think that language is more standard and correct.  I'm not sure why we use the word 'orbit' except for perhaps legacy reasons when these APIs related to specifically to parameters of the orbits of drones, visualization rendering, or nomenclature in viser?