### PR TITLE
Fix NaNs in `rasterizeTopContributingGaussianIdsForward` weights

### DIFF
--- a/src/fvdb/detail/ops/gsplat/GaussianRasterizeTopContributingGaussianIds.cu
+++ b/src/fvdb/detail/ops/gsplat/GaussianRasterizeTopContributingGaussianIds.cu
@@ -387,7 +387,7 @@ launchRasterizeTopContributingGaussianIdsForwardKernel(
         idsToRenderVec.push_back(
             torch::empty({size, settings.numDepthSamples}, means2d.options().dtype(torch::kInt32)));
         weightsToRenderVec.push_back(
-            torch::empty({size, settings.numDepthSamples},
+            torch::zeros({size, settings.numDepthSamples},
                          means2d.options().dtype(c10::CppTypeToScalarType<ScalarType>::value)));
     }
 


### PR DESCRIPTION
I was finding that `rasterizeTopContributingGaussianIdsForward` during training could occasionally produce NaNs in its returned weights.  Logically I don't understand how a condition like this could be reached, but initializing the output weights to zeros (instead of `torch::empty`), mitigates this issue.