### PR TITLE
Optimize joffsets construction via pinned memory

### DIFF
--- a/src/fvdb/JaggedTensor.cpp
+++ b/src/fvdb/JaggedTensor.cpp
@@ -79,9 +79,11 @@ JaggedTensor::JaggedTensor(const std::vector<torch::Tensor> &tensors) {
                     "assigned data must have shape [N, ...], but got data.dim() = 0");
         mBatchIdx =
             torch::empty({0}, torch::TensorOptions().dtype(JIdxScalarType).device(mData.device()));
-        mOffsets =
-            torch::tensor({JOffsetsType(0), mData.size(0)},
-                          torch::TensorOptions().dtype(JOffsetsScalarType).device(mData.device()));
+        mOffsets = torch::tensor({JOffsetsType(0), mData.size(0)},
+                                 torch::TensorOptions()
+                                     .dtype(JOffsetsScalarType)
+                                     .device(mData.device())
+                                     .pinned_memory(true));
         mListIdx = torch::empty(
             {0, 1}, torch::TensorOptions().dtype(JLIdxScalarType).device(mData.device()));
         mNumOuterLists = 1;

--- a/src/fvdb/detail/ops/JOffsetsFromJIdx.cu
+++ b/src/fvdb/detail/ops/JOffsetsFromJIdx.cu
@@ -23,10 +23,11 @@ joffsetsFromJIdx(torch::Tensor jidx, torch::Tensor jdata, int64_t numTensors) {
     TORCH_CHECK_VALUE(jidx.dim() == 1, "jidx must be a 1D tensor");
 
     if (jidx.size(0) == 0 && numTensors == 1) {
-        torch::Tensor ret = torch::empty({2}, JOffsetsScalarType);
-        auto acc          = ret.accessor<JOffsetsType, 1>();
-        acc[0]            = 0;
-        acc[1]            = jdata.size(0);
+        torch::Tensor ret =
+            torch::empty({2}, torch::TensorOptions().dtype(JOffsetsScalarType).pinned_memory(true));
+        auto acc = ret.accessor<JOffsetsType, 1>();
+        acc[0]   = 0;
+        acc[1]   = jdata.size(0);
         return ret.to(jdata.device());
     }
 


### PR DESCRIPTION
During Gaussian splat training, we construct several JaggedTensor instances where the small joffsets tensor is initialized on the host and then copied over to the device. Page-locking these small tensors on the host enables them to be read at a higher bandwidth by the device which accelerates the subsequent host to device transfer. Furthermore, with the Unified Memory backend, this reduces the amount of host <-> device synchronization required enabling the the subsequent small kernels to be launched with lower latency.

NB: The `torch::tensor(...)` call with the initialization list performs the initialization on the host before copying the contents to the device.