### PR TITLE
Fix hardcoded float dtype

### DIFF
--- a/src/fvdb/detail/ops/gsplat/GaussianRasterizeForward.cu
+++ b/src/fvdb/detail/ops/gsplat/GaussianRasterizeForward.cu
@@ -346,10 +346,8 @@ launchRasterizeForwardKernel(
     std::vector<torch::Tensor> lastIdsToRenderVec;
 
     for (const auto &size: sizes) {
-        featuresToRenderVec.push_back(
-            torch::empty({size, channels}, features.options().dtype(torch::kFloat32)));
-        alphasToRenderVec.push_back(
-            torch::empty({size, 1}, features.options().dtype(torch::kFloat32)));
+        featuresToRenderVec.push_back(torch::empty({size, channels}, features.options()));
+        alphasToRenderVec.push_back(torch::empty({size, 1}, features.options()));
         lastIdsToRenderVec.push_back(torch::empty({size}, features.options().dtype(torch::kInt32)));
     }
 
@@ -468,10 +466,8 @@ launchRasterizeForwardKernels(
     std::vector<torch::Tensor> lastIdsToRenderVec;
 
     for (const auto &size: sizes) {
-        featuresToRenderVec.push_back(
-            torch::empty({size, channels}, features.options().dtype(torch::kFloat32)));
-        alphasToRenderVec.push_back(
-            torch::empty({size, 1}, features.options().dtype(torch::kFloat32)));
+        featuresToRenderVec.push_back(torch::empty({size, channels}, features.options()));
+        alphasToRenderVec.push_back(torch::empty({size, 1}, features.options()));
         lastIdsToRenderVec.push_back(torch::empty({size}, features.options().dtype(torch::kInt32)));
     }
 


### PR DESCRIPTION
`featuresToRender` is assumed to have `ScalarType` data in the rasterization kernel. In most cases, this will be `ScalarType` will be `float` and this code will work without errors, but if `ScalarType` equals `double` or `half` this will fail with an accessor type mismatch.