### PR TITLE
Fix/improve radix sort synchronization

### DIFF
--- a/src/fvdb/detail/ops/gsplat/GaussianTileIntersection.cu
+++ b/src/fvdb/detail/ops/gsplat/GaussianTileIntersection.cu
@@ -639,7 +639,7 @@ mergePathKernel(KeyIteratorIn keys1,
     mergePath(keys1, keys1Count, keys2, keys2Count, key1Intervals, key2Intervals, intervalIndex);
 }
 
-template <typename KeyT, typename ValueT, typename NumItemsT, typename OffsetT, typename CountT>
+template <typename KeyT, typename ValueT, typename NumItemsT>
 void
 radixSortAsync(KeyT *keysIn,
                KeyT *keysOut,
@@ -648,15 +648,30 @@ radixSortAsync(KeyT *keysIn,
                NumItemsT numItems,
                int beginBit,
                int endBit,
-               OffsetT *mergeIntervals,
-               const OffsetT *offsets,
-               const CountT *counts,
                cudaEvent_t *events) {
+    using OffsetT = int64_t;
+    using CountT  = int64_t;
+
+    auto hostOptions = torch::TensorOptions().dtype(torch::kInt64).device(torch::kCPU);
+    auto itemOffsets = torch::empty({c10::cuda::device_count()}, hostOptions);
+    auto itemCounts  = torch::empty({c10::cuda::device_count()}, hostOptions);
+    for (const auto deviceId: c10::irange(c10::cuda::device_count())) {
+        std::tie(itemOffsets.data_ptr<OffsetT>()[deviceId],
+                 itemCounts.data_ptr<CountT>()[deviceId]) = deviceChunk(numItems, deviceId);
+    }
+    const auto *offsets = itemOffsets.const_data_ptr<OffsetT>();
+    const auto *counts  = itemCounts.const_data_ptr<CountT>();
+
+    torch::Tensor deviceMergeIntervals =
+        torch::empty({2 * c10::cuda::device_count()},
+                     torch::TensorOptions().dtype(torch::kInt64).device(torch::kPrivateUse1));
+    auto mergeIntervals = deviceMergeIntervals.data_ptr<OffsetT>();
+
     // Radix sort the subset of keys assigned to each device in parallel
     for (const auto deviceId: c10::irange(c10::cuda::device_count())) {
         C10_CUDA_CHECK(cudaSetDevice(deviceId));
         auto stream = c10::cuda::getCurrentCUDAStream(deviceId);
-        C10_CUDA_CHECK(cudaEventSynchronize(events[deviceId]));
+        // C10_CUDA_CHECK(cudaEventSynchronize(events[deviceId]));
 
         const KeyT *deviceKeysIn     = keysIn + offsets[deviceId];
         const ValueT *deviceValuesIn = valuesIn + offsets[deviceId];
@@ -1037,13 +1052,6 @@ gaussianTileIntersectionPrivateUse1Impl(
         torch::Tensor keysSorted = torch::empty_like(intersectionKeys);
         torch::Tensor valsSorted = torch::empty_like(intersectionValues);
 
-        torch::Tensor deviceIntersectionOffsets =
-            torch::empty({c10::cuda::device_count()}, means2d.options().dtype(torch::kInt64));
-        torch::Tensor deviceIntersectionCounts =
-            torch::empty({c10::cuda::device_count()}, means2d.options().dtype(torch::kInt64));
-        torch::Tensor mergeIntervals =
-            torch::empty({2 * c10::cuda::device_count()}, means2d.options().dtype(torch::kInt64));
-
         std::vector<cudaEvent_t> events(c10::cuda::device_count());
 
         // Compute a joffsets tensor that stores the offsets into the sorted Gaussian
@@ -1100,9 +1108,6 @@ gaussianTileIntersectionPrivateUse1Impl(
             C10_CUDA_CHECK(cudaSetDevice(deviceId));
             auto stream = c10::cuda::getCurrentCUDAStream(deviceId);
             C10_CUDA_CHECK(cudaStreamWaitEvent(stream, events[0]));
-            std::tie(deviceIntersectionOffsets.data_ptr<int64_t>()[deviceId],
-                     deviceIntersectionCounts.data_ptr<int64_t>()[deviceId]) =
-                deviceChunk(totalIntersections, deviceId);
         }
 
         const int32_t numBits = 32 + numCamIdBits + numTileIdBits;
@@ -1113,9 +1118,6 @@ gaussianTileIntersectionPrivateUse1Impl(
                        totalIntersections,
                        0,
                        numBits,
-                       mergeIntervals.data_ptr<int64_t>(),
-                       deviceIntersectionOffsets.const_data_ptr<int64_t>(),
-                       deviceIntersectionCounts.const_data_ptr<int64_t>(),
                        events.data());
 
         {
@@ -1134,12 +1136,14 @@ gaussianTileIntersectionPrivateUse1Impl(
             auto stream = c10::cuda::getCurrentCUDAStream(deviceId);
             C10_CUDA_CHECK(cudaStreamWaitEvent(stream, events[0]));
 
-            const int NUM_BLOCKS_2 =
-                (deviceIntersectionCounts.const_data_ptr<int64_t>()[deviceId] + NUM_THREADS - 1) /
-                NUM_THREADS;
+            int64_t deviceIntersectionOffset, deviceIntersectionCount;
+            std::tie(deviceIntersectionOffset, deviceIntersectionCount) =
+                deviceChunk(totalIntersections, deviceId);
+
+            const int NUM_BLOCKS_2 = (deviceIntersectionCount + NUM_THREADS - 1) / NUM_THREADS;
             computeTileOffsets<<<NUM_BLOCKS_2, NUM_THREADS, 0, stream>>>(
-                deviceIntersectionOffsets.const_data_ptr<int64_t>()[deviceId],
-                deviceIntersectionCounts.const_data_ptr<int64_t>()[deviceId],
+                deviceIntersectionOffset,
+                deviceIntersectionCount,
                 totalIntersections,
                 numCameras,
                 totalTiles,


### PR DESCRIPTION
The item offsets and counts arrays are only accessed on the host. Prior to this PR, these were allocated in Unified Memory without the appropriate synchronization. This leads to a rare race condition and also necessitates additional host-device synchronization at the beginning of the radix sort loop. Migrating these arrays to the host fixes the race condition and removes the need to synchronize.