### PR TITLE
Fix the derivation of the number of cameras in the rasterization kernels that would be incorrect when in packed mode.

### DIFF
--- a/src/fvdb/detail/ops/gsplat/GaussianRasterizeBackward.cu
+++ b/src/fvdb/detail/ops/gsplat/GaussianRasterizeBackward.cu
@@ -924,7 +924,11 @@ callRasterizeBackwardWithTemplatedSharedChannels(
                                outDLossDOpacities);
     }
 
-    const uint32_t C = means2d.size(0);
+    // tileOffsets can be 3D (dense) or 1D (sparse)
+    const bool tileOffsetsAreSparse = tileOffsets.dim() == 1;
+    // Get C from tileOffsets for dense mode
+    // For sparse mode, C is unused, only used for output sizing for dense mode
+    const uint32_t C = tileOffsetsAreSparse ? 0 : tileOffsets.size(0);
     const uint32_t H = imageHeight;
     const uint32_t W = imageWidth;
 
@@ -1210,7 +1214,11 @@ callRasterizeBackwardPrivateUse1(
                                outDLossDOpacities);
     }
 
-    const uint32_t C = means2d.size(0);
+    // tileOffsets can be 3D (dense) or 1D (sparse)
+    const bool tileOffsetsAreSparse = tileOffsets.dim() == 1;
+    // Get C from tileOffsets for dense mode
+    // For sparse mode, C is unused, only used for output sizing for dense mode
+    const uint32_t C = tileOffsetsAreSparse ? 0 : tileOffsets.size(0);
     const uint32_t H = imageHeight;
     const uint32_t W = imageWidth;
 


### PR DESCRIPTION
I noticed that the value for the number of cameras was being incorrectly taken from the batch dimension of `means2d` but when in packed mode, this would be the number of gaussians, not the number of cameras.  Fixed up this logic, made comments about dimensions more complete and added some tests.

Signed-off-by: Jonathan Swartz <jonathan@jswartz.info>