### PR TITLE
Fix version macro and PyTorch 2.10 build error

### DIFF
--- a/.github/workflows/cu130.yml
+++ b/.github/workflows/cu130.yml
@@ -386,8 +386,8 @@ jobs:
           uv venv
           uv pip install --no-cache-dir -r env/test_requirements.txt --extra-index-url https://download.pytorch.org/whl/cu130 --index-strategy unsafe-best-match
           uv pip install --no-cache-dir setuptools
-          # TORCH_CUDA_ARCH_LIST="8.9+PTX" uv pip install -v --no-build-isolation git+https://github.com/rusty1s/pytorch_scatter.git
-          # TORCH_CUDA_ARCH_LIST="8.9+PTX" uv pip install -v --no-build-isolation git+https://github.com/heiwang1997/torchsparse.git
+          TORCH_CUDA_ARCH_LIST="8.9+PTX" uv pip install -v --no-build-isolation git+https://github.com/rusty1s/pytorch_scatter.git
+          TORCH_CUDA_ARCH_LIST="8.9+PTX" uv pip install -v --no-build-isolation git+https://github.com/heiwang1997/torchsparse.git
 
       - name: Download package
         uses: actions/download-artifact@v4
@@ -404,8 +404,7 @@ jobs:
         run: |
           source .venv/bin/activate
           cd tests;
-          python -m torch.utils.collect_env
-          pytest -v unit/test_gaussian_splat_3d.py
+          pytest -v unit
 
       - name: Cleanup
         if: always()

--- a/.github/workflows/cu130.yml
+++ b/.github/workflows/cu130.yml
@@ -386,8 +386,8 @@ jobs:
           uv venv
           uv pip install --no-cache-dir -r env/test_requirements.txt --extra-index-url https://download.pytorch.org/whl/cu130 --index-strategy unsafe-best-match
           uv pip install --no-cache-dir setuptools
-          TORCH_CUDA_ARCH_LIST="8.9+PTX" uv pip install -v --no-build-isolation git+https://github.com/rusty1s/pytorch_scatter.git
-          TORCH_CUDA_ARCH_LIST="8.9+PTX" uv pip install -v --no-build-isolation git+https://github.com/heiwang1997/torchsparse.git
+          # TORCH_CUDA_ARCH_LIST="8.9+PTX" uv pip install -v --no-build-isolation git+https://github.com/rusty1s/pytorch_scatter.git
+          # TORCH_CUDA_ARCH_LIST="8.9+PTX" uv pip install -v --no-build-isolation git+https://github.com/heiwang1997/torchsparse.git
 
       - name: Download package
         uses: actions/download-artifact@v4
@@ -405,7 +405,7 @@ jobs:
           source .venv/bin/activate
           cd tests;
           python -m torch.utils.collect_env
-          pytest -v unit
+          pytest -v unit/test_gaussian_splat_3d.py
 
       - name: Cleanup
         if: always()

--- a/.github/workflows/cu130.yml
+++ b/.github/workflows/cu130.yml
@@ -1,7 +1,7 @@
 name: fVDB CUDA 13.0.1 Build and Test
 
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - '**'
     paths-ignore:
@@ -32,7 +32,7 @@ jobs:
   start-build-runner:
     name: Start CPU-only EC2 runner for build
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false || github.event_name != 'pull_request_target'
+    if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     outputs:
       label: ${{ steps.start-build-runner.outputs.label }}
       ec2-instance-id: ${{ steps.start-build-runner.outputs.ec2-instance-id }}
@@ -79,9 +79,9 @@ jobs:
           fetch-depth: 0 # Fetch all history for all branches
           # For pull requests, this automatically checks out the merge commit
           # For pushes, this checks out the pushed commit
-          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.ref || github.ref }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref || github.ref }}
       - name: Fetch PR branch
-        if: github.event_name == 'pull_request_target'
+        if: github.event_name == 'pull_request'
         run: |
           cd $GITHUB_WORKSPACE
           git config --global user.name "github-actions[bot]"
@@ -91,7 +91,7 @@ jobs:
           git fetch origin pull/${{ github.event.pull_request.number }}/head:pr_branch
 
       - name: Merge PR branch into base
-        if: github.event_name == 'pull_request_target'
+        if: github.event_name == 'pull_request'
         run: |
           cd $GITHUB_WORKSPACE
           git merge pr_branch
@@ -246,9 +246,9 @@ jobs:
           fetch-depth: 0 # Fetch all history for all branches
           # For pull requests, this automatically checks out the merge commit
           # For pushes, this checks out the pushed commit
-          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.ref || github.ref }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref || github.ref }}
       - name: Fetch PR branch
-        if: github.event_name == 'pull_request_target'
+        if: github.event_name == 'pull_request'
         run: |
           cd $GITHUB_WORKSPACE
           git config --global user.name "github-actions[bot]"
@@ -258,7 +258,7 @@ jobs:
           git fetch origin pull/${{ github.event.pull_request.number }}/head:pr_branch
 
       - name: Merge PR branch into base
-        if: github.event_name == 'pull_request_target'
+        if: github.event_name == 'pull_request'
         run: |
           cd $GITHUB_WORKSPACE
           git merge pr_branch
@@ -348,10 +348,10 @@ jobs:
           fetch-depth: 0 # Fetch all history for all branches
           # For pull requests, this automatically checks out the merge commit
           # For pushes, this checks out the pushed commit
-          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.ref || github.ref }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref || github.ref }}
 
       - name: Fetch PR branch
-        if: github.event_name == 'pull_request_target'
+        if: github.event_name == 'pull_request'
         run: |
           cd $GITHUB_WORKSPACE
           git config --global user.name "github-actions[bot]"
@@ -361,7 +361,7 @@ jobs:
           git fetch origin pull/${{ github.event.pull_request.number }}/head:pr_branch
 
       - name: Merge PR branch into base
-        if: github.event_name == 'pull_request_target'
+        if: github.event_name == 'pull_request'
         run: |
           cd $GITHUB_WORKSPACE
           git merge pr_branch
@@ -404,6 +404,7 @@ jobs:
         run: |
           source .venv/bin/activate
           cd tests;
+          python -m torch.utils.collect_env
           pytest -v unit
 
       - name: Cleanup
@@ -437,10 +438,10 @@ jobs:
           fetch-depth: 0 # Fetch all history for all branches
           # For pull requests, this automatically checks out the merge commit
           # For pushes, this checks out the pushed commit
-          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.ref || github.ref }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref || github.ref }}
 
       - name: Fetch PR branch
-        if: github.event_name == 'pull_request_target'
+        if: github.event_name == 'pull_request'
         run: |
           cd $GITHUB_WORKSPACE
           git config --global user.name "github-actions[bot]"
@@ -450,7 +451,7 @@ jobs:
           git fetch origin pull/${{ github.event.pull_request.number }}/head:pr_branch
 
       - name: Merge PR branch into base
-        if: github.event_name == 'pull_request_target'
+        if: github.event_name == 'pull_request'
         run: |
           cd $GITHUB_WORKSPACE
           git merge pr_branch

--- a/.github/workflows/cu130.yml
+++ b/.github/workflows/cu130.yml
@@ -1,4 +1,4 @@
-name: fVDB CUDA 13.0.1 Build and Test
+name: fVDB CUDA 13.0.2 Build and Test
 
 on:
   pull_request:
@@ -61,7 +61,7 @@ jobs:
     needs: start-build-runner
     runs-on: ${{ needs.start-build-runner.outputs.label }}
     container:
-      image: nvidia/cuda:13.0.1-cudnn-devel-ubuntu22.04
+      image: nvidia/cuda:13.0.2-cudnn-devel-ubuntu22.04
       env:
         PYTHONPATH: ""
         CPM_SOURCE_CACHE: "/__w/cpm_cache"
@@ -229,7 +229,7 @@ jobs:
     name: fVDB GTests
     runs-on: ${{ needs.start-tests-gpu-runner.outputs.label }} # run the job on the newly created runner
     container:
-      image: nvidia/cuda:13.0.1-cudnn-runtime-ubuntu22.04
+      image: nvidia/cuda:13.0.2-cudnn-runtime-ubuntu22.04
       env:
         PYTHONPATH: ""
         CPM_SOURCE_CACHE: "/__w/cpm_cache"
@@ -332,7 +332,7 @@ jobs:
     name: fVDB PyTests
     runs-on: ${{ needs.start-tests-gpu-runner.outputs.label }} # run the job on the newly created runner
     container:
-      image: nvidia/cuda:13.0.1-cudnn-devel-ubuntu22.04
+      image: nvidia/cuda:13.0.2-cudnn-devel-ubuntu22.04
       env:
         PYTHONPATH: ""
       options: --rm
@@ -422,7 +422,7 @@ jobs:
     name: fVDB Documentation Tests
     runs-on: ${{ needs.start-tests-gpu-runner.outputs.label }} # run the job on the newly created runner
     container:
-      image: nvidia/cuda:13.0.1-cudnn-runtime-ubuntu22.04
+      image: nvidia/cuda:13.0.2-cudnn-runtime-ubuntu22.04
       env:
         PYTHONPATH: ""
       options: --rm

--- a/.github/workflows/cu130.yml
+++ b/.github/workflows/cu130.yml
@@ -1,7 +1,7 @@
 name: fVDB CUDA 13.0.2 Build and Test
 
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - '**'
     paths-ignore:
@@ -32,7 +32,7 @@ jobs:
   start-build-runner:
     name: Start CPU-only EC2 runner for build
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
+    if: github.event.pull_request.draft == false || github.event_name != 'pull_request_target'
     outputs:
       label: ${{ steps.start-build-runner.outputs.label }}
       ec2-instance-id: ${{ steps.start-build-runner.outputs.ec2-instance-id }}
@@ -79,9 +79,9 @@ jobs:
           fetch-depth: 0 # Fetch all history for all branches
           # For pull requests, this automatically checks out the merge commit
           # For pushes, this checks out the pushed commit
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref || github.ref }}
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.ref || github.ref }}
       - name: Fetch PR branch
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request_target'
         run: |
           cd $GITHUB_WORKSPACE
           git config --global user.name "github-actions[bot]"
@@ -91,7 +91,7 @@ jobs:
           git fetch origin pull/${{ github.event.pull_request.number }}/head:pr_branch
 
       - name: Merge PR branch into base
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request_target'
         run: |
           cd $GITHUB_WORKSPACE
           git merge pr_branch
@@ -246,9 +246,9 @@ jobs:
           fetch-depth: 0 # Fetch all history for all branches
           # For pull requests, this automatically checks out the merge commit
           # For pushes, this checks out the pushed commit
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref || github.ref }}
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.ref || github.ref }}
       - name: Fetch PR branch
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request_target'
         run: |
           cd $GITHUB_WORKSPACE
           git config --global user.name "github-actions[bot]"
@@ -258,7 +258,7 @@ jobs:
           git fetch origin pull/${{ github.event.pull_request.number }}/head:pr_branch
 
       - name: Merge PR branch into base
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request_target'
         run: |
           cd $GITHUB_WORKSPACE
           git merge pr_branch
@@ -348,10 +348,10 @@ jobs:
           fetch-depth: 0 # Fetch all history for all branches
           # For pull requests, this automatically checks out the merge commit
           # For pushes, this checks out the pushed commit
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref || github.ref }}
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.ref || github.ref }}
 
       - name: Fetch PR branch
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request_target'
         run: |
           cd $GITHUB_WORKSPACE
           git config --global user.name "github-actions[bot]"
@@ -361,7 +361,7 @@ jobs:
           git fetch origin pull/${{ github.event.pull_request.number }}/head:pr_branch
 
       - name: Merge PR branch into base
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request_target'
         run: |
           cd $GITHUB_WORKSPACE
           git merge pr_branch
@@ -437,10 +437,10 @@ jobs:
           fetch-depth: 0 # Fetch all history for all branches
           # For pull requests, this automatically checks out the merge commit
           # For pushes, this checks out the pushed commit
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref || github.ref }}
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.ref || github.ref }}
 
       - name: Fetch PR branch
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request_target'
         run: |
           cd $GITHUB_WORKSPACE
           git config --global user.name "github-actions[bot]"
@@ -450,7 +450,7 @@ jobs:
           git fetch origin pull/${{ github.event.pull_request.number }}/head:pr_branch
 
       - name: Merge PR branch into base
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request_target'
         run: |
           cd $GITHUB_WORKSPACE
           git merge pr_branch

--- a/env/build_requirements.txt
+++ b/env/build_requirements.txt
@@ -3,4 +3,4 @@ scikit_build_core
 wheel
 ninja
 numpy
-torch==2.9.1
+torch

--- a/env/test_requirements.txt
+++ b/env/test_requirements.txt
@@ -4,7 +4,7 @@ wheel
 ninja
 tqdm
 numpy
-torch==2.9.1
+torch
 GitPython
 pandas
 pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ requires-python = ">=3.10"
 readme = "README.md"
 dependencies = [
     # Require torch; users will choose the correct CUDA build from PyTorch's index
-    "torch>=2.8,<2.10",
+    "torch>=2.8,<2.11",
     "numpy",
 ]
 classifiers = [

--- a/src/fvdb/detail/io/SaveNanoVDB.cpp
+++ b/src/fvdb/detail/io/SaveNanoVDB.cpp
@@ -335,8 +335,11 @@ getIndexGrid(const GridBatch &gridBatch, const std::vector<std::string> names = 
                               "Grid name " + name + " exceeds maximum character length of " +
                                   std::to_string(nanovdb::GridData::MaxNameSize) + ".");
             nanovdb::GridData *retGridData = (nanovdb::GridData *)(retHandle.gridData(bi));
+#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wstringop-truncation"
+#pragma GCC diagnostic ignored "-Warray-bounds"
             strncpy(retGridData->mGridName, names[bi].c_str(), nanovdb::GridData::MaxNameSize);
+#pragma GCC diagnostic pop
         }
     }
 

--- a/src/fvdb/detail/io/SaveNanoVDB.cpp
+++ b/src/fvdb/detail/io/SaveNanoVDB.cpp
@@ -337,6 +337,7 @@ getIndexGrid(const GridBatch &gridBatch, const std::vector<std::string> names = 
             nanovdb::GridData *retGridData = (nanovdb::GridData *)(retHandle.gridData(bi));
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wstringop-truncation"
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
 #pragma GCC diagnostic ignored "-Warray-bounds"
             strncpy(retGridData->mGridName, names[bi].c_str(), nanovdb::GridData::MaxNameSize);
 #pragma GCC diagnostic pop

--- a/src/fvdb/detail/ops/convolution/backend/MESparseConvolution.cu
+++ b/src/fvdb/detail/ops/convolution/backend/MESparseConvolution.cu
@@ -128,6 +128,7 @@ gpu_gemm<at::Half>(const cublasOperation_t transA,
                               N,
                               CUDA_R_32F,
                               CUBLAS_GEMM_DEFAULT_TENSOR_OP));
+    CUBLAS_CHECK(cublasSetMathMode(handle, CUBLAS_DEFAULT_MATH));
 }
 
 template <>

--- a/src/fvdb/detail/ops/convolution/backend/MESparseConvolution.cu
+++ b/src/fvdb/detail/ops/convolution/backend/MESparseConvolution.cu
@@ -10,6 +10,7 @@
 #include <ATen/cuda/CUDAContext.h>
 #include <c10/cuda/CUDACachingAllocator.h>
 #include <torch/types.h>
+#include <torch/version.h>
 
 #include <cublas_v2.h>
 
@@ -95,7 +96,14 @@ gpu_gemm<at::Half>(const cublasOperation_t transA,
     int lda                   = (transA == CUBLAS_OP_N) ? K : M;
     int ldb                   = (transB == CUBLAS_OP_N) ? N : K;
     cublasMath_t cublas_flags = CUBLAS_DEFAULT_MATH;
+
+#if (!defined(TORCH_VERSION_MAJOR) || (TORCH_VERSION_MAJOR < 2) || \
+     (TORCH_VERSION_MAJOR >= 2 && TORCH_VERSION_MINOR < 10))
     if (!at::globalContext().allowFP16ReductionCuBLAS()) {
+#else
+    if (at::globalContext().allowFP16ReductionCuBLAS() !=
+        at::CuBLASReductionOption::AllowReducedPrecisionWithSplitK) {
+#endif
         cublas_flags = static_cast<cublasMath_t>(cublas_flags |
                                                  CUBLAS_MATH_DISALLOW_REDUCED_PRECISION_REDUCTION);
     }

--- a/src/fvdb/detail/utils/Utils.h
+++ b/src/fvdb/detail/utils/Utils.h
@@ -11,6 +11,7 @@
 #include <ATen/Dispatch_v2.h>
 #include <c10/util/Half.h>
 #include <torch/types.h>
+#include <torch/version.h>
 
 #include <iostream>
 #include <memory>

--- a/src/python/TypeCasters.h
+++ b/src/python/TypeCasters.h
@@ -10,6 +10,7 @@
 #include <fvdb/Types.h>
 
 #include <torch/extension.h>
+#include <torch/version.h>
 
 namespace pybind11 {
 namespace detail {


### PR DESCRIPTION
The return value of `allowFP16ReductionCuBLAS` has been changed to an enum in PyTorch 2.10. Unfortunately, the return value of the enum when reinterpreted as a boolean/integer has also been changed so we need to `#ifdef` it using a version macro. Prior to PyTorch 2.10, allowing reduced precision returned `true` but now allowing reduced precision returns the enum value `AllowReducedPrecisionWithSplitK` which equals `0`.

Furthermore, the other places in fVDB where we were relying on PyTorch version macros were not correctly including the header that defines the macros. While this still yields correct behavior for most recent PyTorch versions (>= 2.7), this should still be fixed up. This also silences two warnings that are showing up in the Conda CI as a result of these includes. These are likely due to GCC bugs and incorrect based on silencing of a similar error (and prior experience with NanoVDB).

Finally, certain cuBLAS calls in the PyTests fail with PyTorch 2.1.0 and the `cuda:13.0.1` image. Upgrading to `cuda:13.0.2` fixes the issues. We haven't been able to reproduce these errors outside of Docker or in other Docker containers so it's unlikely worth additional investigation at least for now.