### PR TITLE
Pin PyTorch version in CI to 2.9.1

### DIFF
--- a/env/build_requirements.txt
+++ b/env/build_requirements.txt
@@ -3,4 +3,4 @@ scikit_build_core
 wheel
 ninja
 numpy
-torch
+torch==2.9.1

--- a/env/test_requirements.txt
+++ b/env/test_requirements.txt
@@ -4,7 +4,7 @@ wheel
 ninja
 tqdm
 numpy
-torch
+torch==2.9.1
 GitPython
 pandas
 pytest


### PR DESCRIPTION
PyTorch 2.10 was released today which introduces an API change which breaks compilation. Even with the relevant fixes, it still leads to a `CUBLAS_STATUS_INVALID_VALUE` mismatch on the unit tests. Pin the PyTorch version to 2.9.1 to workaround these issues for now.

For more information, refer to #423 and https://github.com/pytorch/pytorch/issues/170676