### PR TITLE
Fix semantics of GaussianTileIntersection's torch::cumsum

### DIFF
--- a/src/fvdb/detail/ops/gsplat/GaussianTileIntersection.cu
+++ b/src/fvdb/detail/ops/gsplat/GaussianTileIntersection.cu
@@ -459,12 +459,8 @@ gaussianTileIntersectionCUDAImpl(
                                                  tilesPerGaussianCumsum.data_ptr<int32_t>());
     C10_CUDA_KERNEL_LAUNCH_CHECK();
 
-    // In place cumulative sum to get the total number of intersections
-    CUB_WRAPPER(cub::DeviceScan::InclusiveSum,
-                tilesPerGaussianCumsum.data_ptr<int32_t>(),
-                tilesPerGaussianCumsum.data_ptr<int32_t>(),
-                totalGaussians,
-                stream);
+    // cumulative sum to get the total number of intersections
+    tilesPerGaussianCumsum = torch::cumsum(tilesPerGaussianCumsum, 0, torch::kInt32);
 
     // Allocate tensors to store the intersections
     const int64_t totalIntersections = tilesPerGaussianCumsum[-1].item<int64_t>();
@@ -1038,16 +1034,8 @@ gaussianTileIntersectionPrivateUse1Impl(
 
     mergeStreams();
 
-    // In place cumulative sum to get the total number of intersections
-    {
-        const auto deviceGuard = at::cuda::OptionalCUDAGuard(at::device_of(means2d));
-        auto stream            = at::cuda::getCurrentCUDAStream(means2d.device().index());
-        CUB_WRAPPER(cub::DeviceScan::InclusiveSum,
-                    tilesPerGaussianCumsum.data_ptr<int32_t>(),
-                    tilesPerGaussianCumsum.data_ptr<int32_t>(),
-                    totalGaussians,
-                    stream);
-    }
+    // cumulative sum to get the total number of intersections
+    tilesPerGaussianCumsum = torch::cumsum(tilesPerGaussianCumsum, 0, torch::kInt32);
 
     // Allocate tensors to store the intersections
     const int64_t totalIntersections = tilesPerGaussianCumsum[-1].item<int64_t>();


### PR DESCRIPTION
In `GaussianTileIntersection` we use `torch::cumsum_out` in two places using the `tilesPerGaussian` tensor as both the input and output arguments.  `cumsum_out` does not provide a guarantee that aliasing the storage of the in/out tensors like this will produce a correct result.  Specifically the schema (from Torch's RegistrationDeclarations.h) is:

`aten::cumsum.out(Tensor self, int dim, *, ScalarType? dtype=None, Tensor(a!) out) -> Tensor(a!)`

Even though this does seem to work today in the current version of PyTorch we test against, to be correct we should use a separate tensor as the output tensor for use with `torch::cumsum_out`.

Instead, I have changed the semantics to just use `torch::cumsum`.  I have measured the difference in runtime to be a few 1/1000ths of a ms (out of 7.621ms) between the two when running a benchmark on just the projection part of the rasterization pipeline.

Signed-off-by: Jonathan Swartz <jonathan@jswartz.info>