### PR TITLE
Update CUDA 13 nightly test image

### DIFF
--- a/.github/workflows/cu130-nightly.yml
+++ b/.github/workflows/cu130-nightly.yml
@@ -1,4 +1,4 @@
-name: fVDB Nightly Build and Tests -- CUDA 13.0.1
+name: fVDB Nightly Build and Tests -- CUDA 13.0.2
 
 on:
 #   schedule:
@@ -19,7 +19,7 @@ jobs:
     runs-on:
       - self-hosted
     container:
-      image: nvidia/cuda:13.0.1-cudnn-devel-ubuntu22.04
+      image: nvidia/cuda:13.0.2-cudnn-devel-ubuntu22.04
       env:
         PYTHONPATH: ""
         CPM_SOURCE_CACHE: "/__w/cpm_cache"
@@ -164,7 +164,7 @@ jobs:
     runs-on:
       - self-hosted
     container:
-      image: nvidia/cuda:13.0.1-cudnn-devel-ubuntu22.04
+      image: nvidia/cuda:13.0.2-cudnn-devel-ubuntu22.04
       env:
         PYTHONPATH: ""
       options: --rm


### PR DESCRIPTION
Image upgrade required to match PyTorch 2.10 upgrade introduced in #424 and #425 .