### PR TITLE
Switch to device-centric synchronization for forEach mGPU

### DIFF
--- a/src/fvdb/detail/utils/cuda/ForEachPrivateUse1.cuh
+++ b/src/fvdb/detail/utils/cuda/ForEachPrivateUse1.cuh
@@ -149,9 +149,7 @@ forEachLeafPrivateUse1(int64_t numChannels,
         }
     }
 
-    for (const auto deviceId: c10::irange(c10::cuda::device_count())) {
-        c10::cuda::getCurrentCUDAStream(deviceId).synchronize();
-    }
+    fvdb::detail::mergeStreams();
 }
 
 template <typename Func, typename... Args>
@@ -197,9 +195,7 @@ forEachVoxelPrivateUse1(int64_t numChannels,
         }
     }
 
-    for (const auto deviceId: c10::irange(c10::cuda::device_count())) {
-        c10::cuda::getCurrentCUDAStream(deviceId).synchronize();
-    }
+    fvdb::detail::mergeStreams();
 }
 
 template <typename ScalarT, int32_t NDIMS, typename Func, typename... Args>
@@ -233,9 +229,7 @@ forEachJaggedElementChannelPrivateUse1(int64_t numChannels,
         }
     }
 
-    for (const auto deviceId: c10::irange(c10::cuda::device_count())) {
-        c10::cuda::getCurrentCUDAStream(deviceId).synchronize();
-    }
+    fvdb::detail::mergeStreams();
 }
 
 template <typename ScalarT, int32_t NDIMS, typename Func, typename... Args>
@@ -268,9 +262,7 @@ forEachTensorElementChannelPrivateUse1(int64_t numChannels,
         }
     }
 
-    for (const auto deviceId: c10::irange(c10::cuda::device_count())) {
-        c10::cuda::getCurrentCUDAStream(deviceId).synchronize();
-    }
+    fvdb::detail::mergeStreams();
 }
 
 } // namespace fvdb


### PR DESCRIPTION
Before device-centric synchronization was introduced for mGPU we needed to sync all of the device streams with the host. Now, we can just call `mergeStreams` instead (just like we do in the Gaussian splatting code) in order to perform this synchronization fully on the device side.