### PR TITLE
Fix: `ProjectionForward` initializes accessors in both the initializer list and constructor body

### DIFF
--- a/src/fvdb/detail/ops/gsplat/GaussianProjectionForward.cu
+++ b/src/fvdb/detail/ops/gsplat/GaussianProjectionForward.cu
@@ -91,15 +91,7 @@ template <typename T, bool Ortho> struct ProjectionForward {
           mOutDepthsAcc(outDepths.packed_accessor64<T, 2, torch::RestrictPtrTraits>()),
           mOutConicsAcc(outConics.packed_accessor64<T, 3, torch::RestrictPtrTraits>()),
           mOutCompensationsAcc(outCompensations.defined() ? outCompensations.data_ptr<T>()
-                                                          : nullptr) {
-        mMeansAcc     = means.packed_accessor64<T, 2, torch::RestrictPtrTraits>();
-        mQuatsAcc     = quats.packed_accessor64<T, 2, torch::RestrictPtrTraits>();
-        mLogScalesAcc = logScales.packed_accessor64<T, 2, torch::RestrictPtrTraits>();
-        mWorldToCamMatricesAcc =
-            worldToCamMatrices.packed_accessor32<T, 3, torch::RestrictPtrTraits>();
-        mProjectionMatricesAcc =
-            projectionMatrices.packed_accessor32<T, 3, torch::RestrictPtrTraits>();
-    }
+                                                          : nullptr) {}
 
     inline __device__ Mat3
     computeCovarianceMatrix(int64_t gid) const {


### PR DESCRIPTION
Fix initializing the means, quats, scales, etc. accessors initialized in both the initializer list and the body of the constructor