### PR TITLE
Add AGENTS.md for AI agent guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,11 @@ Codex, etc.) working on this codebase. Human contributors should also refer to
 - All commits **must** be SSH-signed (`git commit --gpg-sign` / `-S`).
 - **Never** skip hooks or signing: do not use `--no-verify` or `--no-gpg-sign`.
 
+## General Style
+
+- Avoid excessive use of emoji and non-ascii characters in code and documentation except
+  where it is helpful to user experience or user interfaces.
+
 ## Python Code Style
 
 - Format Python code with **black** using the exact flags from CI:
@@ -81,3 +86,8 @@ C++ files:
 - Include a test plan with specific commands to verify the change.
 - Ensure all CI checks pass before requesting review (DCO, codestyle, tests).
 - Keep PRs focused on a single concern.
+
+**Do not commit unless directed:**
+- `.vscode/settings.json` - local IDE settings
+- `.cursor/` - local Cursor config
+- Test-specific matrices or configs with hardcoded paths


### PR DESCRIPTION
## Summary

- Adds a new `AGENTS.md` file to the repository root providing persistent instructions for AI coding agents (Cursor, Copilot, Codex, etc.)
- Covers git commit conventions (DCO sign-off, SSH signing), Python code style (black with project-specific flags), C++ code style (clang-format 18), license headers (Apache-2.0 SPDX), whitespace rules, testing, and PR/issue workflows
- All instructions are derived from existing CI configuration (`.github/workflows/codestyle.yml`) and project conventions (`CONTRIBUTING.md`, `pyproject.toml`)

Fixes #453

## Test plan

- [x] Verify `AGENTS.md` renders correctly on GitHub
- [x] Confirm black flags match `.github/workflows/codestyle.yml` (`--target-version=py311 --line-length=120 --extend-exclude='wip/'`)
- [x] Confirm clang-format version and extensions match CI config (v18, `h,cpp,cc,cu,cuh`)
- [x] Confirm pytest command aligns with `pyproject.toml` `[tool.pytest.ini_options]`
- [x] Confirm SPDX header examples match existing source files

Made with [Cursor](https://cursor.com)