### PR TITLE
Fix fvdb-issue clipboard crash in SSH sessions

### DIFF
--- a/devtools/worktree/fvdb-issue
+++ b/devtools/worktree/fvdb-issue
@@ -402,14 +402,13 @@ else
     STARTER_PROMPT="Please read the issue in .cursor/rules/current-issue.md and create a plan to implement it."
 
     # Try xclip (Linux), then xsel, then pbcopy (macOS)
-    if command -v xclip &> /dev/null; then
-        echo -n "$STARTER_PROMPT" | xclip -selection clipboard
+    # Combine existence check with actual clipboard write so that runtime failures
+    # (e.g., no X display in SSH) fall through gracefully instead of crashing under set -e
+    if command -v xclip &> /dev/null && echo -n "$STARTER_PROMPT" | xclip -selection clipboard 2>/dev/null; then
         echo -e "${GREEN}Starter prompt copied to clipboard - just paste and send!${NC}"
-    elif command -v xsel &> /dev/null; then
-        echo -n "$STARTER_PROMPT" | xsel --clipboard --input
+    elif command -v xsel &> /dev/null && echo -n "$STARTER_PROMPT" | xsel --clipboard --input 2>/dev/null; then
         echo -e "${GREEN}Starter prompt copied to clipboard - just paste and send!${NC}"
-    elif command -v pbcopy &> /dev/null; then
-        echo -n "$STARTER_PROMPT" | pbcopy
+    elif command -v pbcopy &> /dev/null && echo -n "$STARTER_PROMPT" | pbcopy 2>/dev/null; then
         echo -e "${GREEN}Starter prompt copied to clipboard - just paste and send!${NC}"
     else
         echo -e "${YELLOW}Clipboard not available. Start with:${NC}"


### PR DESCRIPTION
## Summary

- Fixes the `fvdb-issue` script crashing with `xsel: Can't open display: (null)` when run in SSH sessions without X11 forwarding
- Combines the clipboard tool existence check (`command -v`) with the actual clipboard write into a single `&&` conditional, with stderr suppressed via `2>/dev/null`
- Runtime clipboard failures now gracefully fall through to the next option instead of terminating the script under `set -e`

Fixes #460

## Test plan

- [x] Run `fvdb-issue <issue-number>` in a local session with a display — verify clipboard copy still works and the editor launches
- [x] Run `fvdb-issue <issue-number>` in an SSH session without X11 forwarding — verify the script prints the starter prompt to the terminal ("Clipboard not available. Start with: ...") and launches the editor instead of crashing
- [x] Run `bash -n devtools/worktree/fvdb-issue` to verify syntax is valid

Made with [Cursor](https://cursor.com)