### PR TITLE
Fix CI checks showing 'waiting for status' when paths-ignore skips workflows

### DIFF
--- a/.github/workflows/check-changes.yml
+++ b/.github/workflows/check-changes.yml
@@ -1,0 +1,43 @@
+# Copyright Contributors to the OpenVDB Project
+# SPDX-License-Identifier: Apache-2.0
+#
+# Reusable workflow: detect whether a PR touches source files or only
+# documentation / non-code paths. Callers gate their real jobs on the
+# `should_test` output so that docs-only PRs are marked as passed
+# (not perpetually "waiting for status").
+
+name: Check for relevant changes
+
+on:
+  workflow_call:
+    outputs:
+      should_test:
+        description: "'true' when the change includes source files, 'false' for docs-only"
+        value: ${{ jobs.check-changes.outputs.should_test }}
+
+# Permissions are inherited from the calling workflow; do not set them here.
+
+jobs:
+  check-changes:
+    name: Check for relevant changes
+    runs-on: ubuntu-latest
+    outputs:
+      should_test: ${{ github.event_name != 'pull_request_target' || steps.filter.outputs.src == 'true' }}
+    steps:
+      # predicate-quantifier is supported in code but missing from action.yml in v3;
+      # produces a non-blocking "Invalid action input" warning. Upstream fix: PR #226.
+      - uses: dorny/paths-filter@v3
+        id: filter
+        if: github.event_name == 'pull_request_target'
+        with:
+          predicate-quantifier: 'every'
+          filters: |
+            src:
+              - '**'
+              - '!**/*.md'
+              - '!CODEOWNERS'
+              - '!debug/**'
+              - '!examples/**'
+              - '!notebooks/**'
+              - '!devtools/**'
+              - '!scripts/**'

--- a/.github/workflows/cu128.yml
+++ b/.github/workflows/cu128.yml
@@ -23,28 +23,7 @@ jobs:
   # CHECK FOR RELEVANT CHANGES
   ##############################################################################
   check-changes:
-    name: Check for relevant changes
-    runs-on: ubuntu-latest
-    outputs:
-      should_test: ${{ github.event_name != 'pull_request_target' || steps.filter.outputs.src == 'true' }}
-    steps:
-      # predicate-quantifier is supported in code but missing from action.yml in v3;
-      # produces a non-blocking "Invalid action input" warning. Upstream fix: PR #226.
-      - uses: dorny/paths-filter@v3
-        id: filter
-        if: github.event_name == 'pull_request_target'
-        with:
-          predicate-quantifier: 'every'
-          filters: |
-              src:
-                - '**'
-                - '!**/*.md'
-                - '!CODEOWNERS'
-                - '!debug/**'
-                - '!examples/**'
-                - '!notebooks/**'
-                - '!devtools/**'
-                - '!scripts/**'
+    uses: ./.github/workflows/check-changes.yml
 
   ##############################################################################
   # START FVDB BUILD RUNNER

--- a/.github/workflows/cu130.yml
+++ b/.github/workflows/cu130.yml
@@ -23,28 +23,7 @@ jobs:
   # CHECK FOR RELEVANT CHANGES
   ##############################################################################
   check-changes:
-    name: Check for relevant changes
-    runs-on: ubuntu-latest
-    outputs:
-      should_test: ${{ github.event_name != 'pull_request_target' || steps.filter.outputs.src == 'true' }}
-    steps:
-      # predicate-quantifier is supported in code but missing from action.yml in v3;
-      # produces a non-blocking "Invalid action input" warning. Upstream fix: PR #226.
-      - uses: dorny/paths-filter@v3
-        id: filter
-        if: github.event_name == 'pull_request_target'
-        with:
-          predicate-quantifier: 'every'
-          filters: |
-            src:
-              - '**'
-              - '!**/*.md'
-              - '!CODEOWNERS'
-              - '!debug/**'
-              - '!examples/**'
-              - '!notebooks/**'
-              - '!devtools/**'
-              - '!scripts/**'
+    uses: ./.github/workflows/check-changes.yml
 
   ##############################################################################
   # START FVDB BUILD RUNNER

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,28 +29,7 @@ jobs:
   # CHECK FOR RELEVANT CHANGES
   ##############################################################################
   check-changes:
-    name: Check for relevant changes
-    runs-on: ubuntu-latest
-    outputs:
-      should_test: ${{ github.event_name != 'pull_request_target' || steps.filter.outputs.src == 'true' }}
-    steps:
-      # predicate-quantifier is supported in code but missing from action.yml in v3;
-      # produces a non-blocking "Invalid action input" warning. Upstream fix: PR #226.
-      - uses: dorny/paths-filter@v3
-        id: filter
-        if: github.event_name == 'pull_request_target'
-        with:
-          predicate-quantifier: 'every'
-          filters: |
-            src:
-              - '**'
-              - '!**/*.md'
-              - '!CODEOWNERS'
-              - '!debug/**'
-              - '!examples/**'
-              - '!notebooks/**'
-              - '!devtools/**'
-              - '!scripts/**'
+    uses: ./.github/workflows/check-changes.yml
 
   ##############################################################################
   # BUILD FVDB


### PR DESCRIPTION
## Summary

Fixes #456

- Replaces `paths-ignore` trigger filters with a `check-changes` gate job in `tests.yml`, `cu128.yml`, and `cu130.yml`
- When a PR only touches ignored paths (markdown, scripts, notebooks, etc.), the `check-changes` job detects no relevant changes and all downstream jobs are skipped -- GitHub marks these as "passed" for branch protection instead of "waiting for status"
- Uses `dorny/paths-filter@v3` with negation patterns and `predicate-quantifier: 'every'` to mirror the existing `paths-ignore` lists exactly
- `workflow_dispatch` triggers default to `should_test: 'true'` so manual runs are unaffected

## Changes

Three workflow files modified with identical pattern:

1. **Removed `paths-ignore`** from `pull_request_target` triggers so workflows always fire
2. **Added `check-changes` job** (runs on `ubuntu-latest`, ~10s) that uses `dorny/paths-filter@v3` to detect relevant file changes
3. **Gated `start-build-runner`** on `needs.check-changes.outputs.should_test == 'true'`, preserving the existing draft-PR guard

No EC2 runners are started when `should_test` is false, so there is zero cost for docs-only PRs.

## Test plan

- [ ] After merging, open a docs-only PR (touching only `.md` files) and confirm all check names appear as "passed" (skipped) rather than "waiting for status"
- [ ] Open a code PR and confirm all tests still run normally
- [ ] Trigger `tests.yml` via `workflow_dispatch` and confirm it runs all tests (the fallback defaults to `true` for non-PR events)

> **Note:** Since these workflows use `pull_request_target`, the changes only take effect after merging to main. The PR itself will still run the old workflow from the base branch.


Made with [Cursor](https://cursor.com)