### PR TITLE
Fix multibatch mGPU race condition in SH backwards op

### DIFF
--- a/src/fvdb/detail/ops/gsplat/GaussianSphericalHarmonicsBackward.cu
+++ b/src/fvdb/detail/ops/gsplat/GaussianSphericalHarmonicsBackward.cu
@@ -47,7 +47,8 @@ evalShFunctionVJP(const int64_t degree,                     // degree of SH to b
 ) {
     T dLossDRenderQuantitiesLocal = dLossDRenderQuantities[c];
 
-    gpuAtomicAdd(&dLossDSh0Coeffs[gi][0][c], T(0.2820947917738781) * dLossDRenderQuantitiesLocal);
+    atomicAdd_system(&dLossDSh0Coeffs[gi][0][c],
+                     T(0.2820947917738781) * dLossDRenderQuantitiesLocal);
 
     if (degree < 1) {
         return;
@@ -58,11 +59,12 @@ evalShFunctionVJP(const int64_t degree,                     // degree of SH to b
     const T z     = dir.z * inorm;
     T vX = 0.f, vY = 0.f, vZ = 0.f;
 
-    gpuAtomicAdd(&dLossDShNCoeffs[gi][0][c],
-                 T(-0.48860251190292) * y * dLossDRenderQuantitiesLocal);
-    gpuAtomicAdd(&dLossDShNCoeffs[gi][1][c], T(0.48860251190292) * z * dLossDRenderQuantitiesLocal);
-    gpuAtomicAdd(&dLossDShNCoeffs[gi][2][c],
-                 T(-0.48860251190292) * x * dLossDRenderQuantitiesLocal);
+    atomicAdd_system(&dLossDShNCoeffs[gi][0][c],
+                     T(-0.48860251190292) * y * dLossDRenderQuantitiesLocal);
+    atomicAdd_system(&dLossDShNCoeffs[gi][1][c],
+                     T(0.48860251190292) * z * dLossDRenderQuantitiesLocal);
+    atomicAdd_system(&dLossDShNCoeffs[gi][2][c],
+                     T(-0.48860251190292) * x * dLossDRenderQuantitiesLocal);
 
     if (dLossDViewDir != nullptr) {
         vX += T(-0.48860251190292) * coeffsN[gi][2][c] * dLossDRenderQuantitiesLocal;
@@ -85,11 +87,11 @@ evalShFunctionVJP(const int64_t degree,                     // degree of SH to b
     const T pSH5   = fTmp0B * y;
     const T pSH8   = T(0.5462742152960395) * fC1;
     const T pSH4   = T(0.5462742152960395) * fS1;
-    gpuAtomicAdd(&dLossDShNCoeffs[gi][3][c], pSH4 * dLossDRenderQuantitiesLocal);
-    gpuAtomicAdd(&dLossDShNCoeffs[gi][4][c], pSH5 * dLossDRenderQuantitiesLocal);
-    gpuAtomicAdd(&dLossDShNCoeffs[gi][5][c], pSH6 * dLossDRenderQuantitiesLocal);
-    gpuAtomicAdd(&dLossDShNCoeffs[gi][6][c], pSH7 * dLossDRenderQuantitiesLocal);
-    gpuAtomicAdd(&dLossDShNCoeffs[gi][7][c], pSH8 * dLossDRenderQuantitiesLocal);
+    atomicAdd_system(&dLossDShNCoeffs[gi][3][c], pSH4 * dLossDRenderQuantitiesLocal);
+    atomicAdd_system(&dLossDShNCoeffs[gi][4][c], pSH5 * dLossDRenderQuantitiesLocal);
+    atomicAdd_system(&dLossDShNCoeffs[gi][5][c], pSH6 * dLossDRenderQuantitiesLocal);
+    atomicAdd_system(&dLossDShNCoeffs[gi][6][c], pSH7 * dLossDRenderQuantitiesLocal);
+    atomicAdd_system(&dLossDShNCoeffs[gi][7][c], pSH8 * dLossDRenderQuantitiesLocal);
 
     T fTmp0B_z, fC1_x, fC1_y, fS1_x, fS1_y, pSH6_z, pSH7_x, pSH7_z, pSH5_y, pSH5_z, pSH8_x, pSH8_y,
         pSH4_x, pSH4_y;
@@ -139,13 +141,13 @@ evalShFunctionVJP(const int64_t degree,                     // degree of SH to b
     const T pSH15  = T(-0.5900435899266435) * fC2;
     const T pSH9   = T(-0.5900435899266435) * fS2;
 
-    gpuAtomicAdd(&dLossDShNCoeffs[gi][8][c], pSH9 * dLossDRenderQuantitiesLocal);
-    gpuAtomicAdd(&dLossDShNCoeffs[gi][9][c], pSH10 * dLossDRenderQuantitiesLocal);
-    gpuAtomicAdd(&dLossDShNCoeffs[gi][10][c], pSH11 * dLossDRenderQuantitiesLocal);
-    gpuAtomicAdd(&dLossDShNCoeffs[gi][11][c], pSH12 * dLossDRenderQuantitiesLocal);
-    gpuAtomicAdd(&dLossDShNCoeffs[gi][12][c], pSH13 * dLossDRenderQuantitiesLocal);
-    gpuAtomicAdd(&dLossDShNCoeffs[gi][13][c], pSH14 * dLossDRenderQuantitiesLocal);
-    gpuAtomicAdd(&dLossDShNCoeffs[gi][14][c], pSH15 * dLossDRenderQuantitiesLocal);
+    atomicAdd_system(&dLossDShNCoeffs[gi][8][c], pSH9 * dLossDRenderQuantitiesLocal);
+    atomicAdd_system(&dLossDShNCoeffs[gi][9][c], pSH10 * dLossDRenderQuantitiesLocal);
+    atomicAdd_system(&dLossDShNCoeffs[gi][10][c], pSH11 * dLossDRenderQuantitiesLocal);
+    atomicAdd_system(&dLossDShNCoeffs[gi][11][c], pSH12 * dLossDRenderQuantitiesLocal);
+    atomicAdd_system(&dLossDShNCoeffs[gi][12][c], pSH13 * dLossDRenderQuantitiesLocal);
+    atomicAdd_system(&dLossDShNCoeffs[gi][13][c], pSH14 * dLossDRenderQuantitiesLocal);
+    atomicAdd_system(&dLossDShNCoeffs[gi][14][c], pSH15 * dLossDRenderQuantitiesLocal);
 
     T fTmp0C_z, fTmp1B_z, fC2_x, fC2_y, fS2_x, fS2_y, pSH12_z, pSH13_x, pSH13_z, pSH11_y, pSH11_z,
         pSH14_x, pSH14_y, pSH14_z, pSH10_x, pSH10_y, pSH10_z, pSH15_x, pSH15_y, pSH9_x, pSH9_y;
@@ -212,15 +214,15 @@ evalShFunctionVJP(const int64_t degree,                     // degree of SH to b
     const T pSH24  = T(0.6258357354491763) * fC3;
     const T pSH16  = T(0.6258357354491763) * fS3;
 
-    gpuAtomicAdd(&dLossDShNCoeffs[gi][15][c], pSH16 * dLossDRenderQuantitiesLocal);
-    gpuAtomicAdd(&dLossDShNCoeffs[gi][16][c], pSH17 * dLossDRenderQuantitiesLocal);
-    gpuAtomicAdd(&dLossDShNCoeffs[gi][17][c], pSH18 * dLossDRenderQuantitiesLocal);
-    gpuAtomicAdd(&dLossDShNCoeffs[gi][18][c], pSH19 * dLossDRenderQuantitiesLocal);
-    gpuAtomicAdd(&dLossDShNCoeffs[gi][19][c], pSH20 * dLossDRenderQuantitiesLocal);
-    gpuAtomicAdd(&dLossDShNCoeffs[gi][20][c], pSH21 * dLossDRenderQuantitiesLocal);
-    gpuAtomicAdd(&dLossDShNCoeffs[gi][21][c], pSH22 * dLossDRenderQuantitiesLocal);
-    gpuAtomicAdd(&dLossDShNCoeffs[gi][22][c], pSH23 * dLossDRenderQuantitiesLocal);
-    gpuAtomicAdd(&dLossDShNCoeffs[gi][23][c], pSH24 * dLossDRenderQuantitiesLocal);
+    atomicAdd_system(&dLossDShNCoeffs[gi][15][c], pSH16 * dLossDRenderQuantitiesLocal);
+    atomicAdd_system(&dLossDShNCoeffs[gi][16][c], pSH17 * dLossDRenderQuantitiesLocal);
+    atomicAdd_system(&dLossDShNCoeffs[gi][17][c], pSH18 * dLossDRenderQuantitiesLocal);
+    atomicAdd_system(&dLossDShNCoeffs[gi][18][c], pSH19 * dLossDRenderQuantitiesLocal);
+    atomicAdd_system(&dLossDShNCoeffs[gi][19][c], pSH20 * dLossDRenderQuantitiesLocal);
+    atomicAdd_system(&dLossDShNCoeffs[gi][20][c], pSH21 * dLossDRenderQuantitiesLocal);
+    atomicAdd_system(&dLossDShNCoeffs[gi][21][c], pSH22 * dLossDRenderQuantitiesLocal);
+    atomicAdd_system(&dLossDShNCoeffs[gi][22][c], pSH23 * dLossDRenderQuantitiesLocal);
+    atomicAdd_system(&dLossDShNCoeffs[gi][23][c], pSH24 * dLossDRenderQuantitiesLocal);
 
     T fTmp0D_z, fTmp1C_z, fTmp2B_z, fC3_x, fC3_y, fS3_x, fS3_y, pSH20_z, pSH21_x, pSH21_z, pSH19_y,
         pSH19_z, pSH22_x, pSH22_y, pSH22_z, pSH18_x, pSH18_y, pSH18_z, pSH23_x, pSH23_y, pSH23_z,
@@ -367,8 +369,8 @@ computeShDiffuseOnlyBackward(
         return;
     }
 
-    gpuAtomicAdd(&outDLossDSh0Coeffs[gid][0][c],
-                 T(0.2820947917738781) * dLossDRenderQuantities[cid][gid][c]);
+    atomicAdd_system(&outDLossDSh0Coeffs[gid][0][c],
+                     T(0.2820947917738781) * dLossDRenderQuantities[cid][gid][c]);
 }
 
 } // namespace


### PR DESCRIPTION
Follow up to #434 . In the mGPU case, different batches can be processed on different GPUs so we need `atomicAdd_system` instead of `gpuAtomicAdd` aka `atomicAdd`.