### PR TITLE
Refactor CameraIntrinsics constructor and add missing include

### DIFF
--- a/src/fvdb/detail/ops/gsplat/GaussianCameraIntrinsics.cuh
+++ b/src/fvdb/detail/ops/gsplat/GaussianCameraIntrinsics.cuh
@@ -5,6 +5,7 @@
 #define FVDB_DETAIL_OPS_GSPLAT_GAUSSIANCAMERAINTRINSICS_CUH
 
 #include <nanovdb/math/Math.h>
+#include <nanovdb/util/Util.h>
 
 namespace fvdb::detail::ops {
 
@@ -15,13 +16,13 @@ namespace fvdb::detail::ops {
 /// loading from a row-major 3x3 pointer.
 template <typename T> struct CameraIntrinsics {
     T fx, fy, cx, cy;
-    inline __host__ __device__ CameraIntrinsics() = default;
-    inline __host__ __device__
+    CameraIntrinsics() = default;
+    __hostdev__
     CameraIntrinsics(T fx_, T fy_, T cx_, T cy_)
         : fx(fx_), fy(fy_), cx(cx_), cy(cy_) {}
-    inline __host__ __device__ explicit CameraIntrinsics(const nanovdb::math::Mat3<T> &K)
+    __hostdev__ explicit CameraIntrinsics(const nanovdb::math::Mat3<T> &K)
         : fx(K[0][0]), fy(K[1][1]), cx(K[0][2]), cy(K[1][2]) {}
-    inline __host__ __device__ explicit CameraIntrinsics(const T *rowMajorK9)
+    __hostdev__ explicit CameraIntrinsics(const T *rowMajorK9)
         : fx(rowMajorK9[0]), fy(rowMajorK9[4]), cx(rowMajorK9[2]), cy(rowMajorK9[5]) {}
 };
 


### PR DESCRIPTION
- Updated CameraIntrinsics constructors to remove inline specifiers and replace them with __hostdev__.
- Added missing include for nanovdb::util::Util.h to ensure proper functionality.