### PR TITLE
Upgrade clang-tools to 21 to fix clangd SIGSEGV on CUDA files

### DIFF
--- a/env/dev_environment.yml
+++ b/env/dev_environment.yml
@@ -6,9 +6,9 @@ dependencies:
   - blas=*=mkl
   - ca-certificates
   - certifi
-  - clang-format=18
-  - clang-tools=18
-  - clang=18
+  - clang-format-18
+  - clang-tools=21
+  - clang-18
   - cmake
   - cuda-command-line-tools
   - cuda-compiler


### PR DESCRIPTION
## Summary

- **Upgrades `clang-tools` from 18 to 21** in the dev conda environment to fix a `clangd` crash (SIGSEGV) that occurs when building ASTs for `.cuh` files.
- The crash is a known clang 18 bug in CUDA host/device `operator delete` resolution, triggered by `delete this;` in GCC 13.4.0's `locale_classes.h` (`std::locale::facet::_M_remove_reference`). It is fixed in clang 21.
- Switches `clang-format` and `clang` specs to versioned package names (`clang-format-18`, `clang-18`) so they coexist with the `clang-tools=21` dependency on `clang-format=21`. The `clang-format-18` binary remains available as required by CI.

## Motivation

`clangd` (shipped via `clang-tools`) crashes with a segmentation fault every time it tries to parse CUDA files that transitively include GCC's `<locale>` header (e.g. via PyTorch or standard library headers). This makes C++/CUDA language intelligence completely non-functional for affected files like `GaussianCameras.cuh`.

The crash stack trace:

```
Signalled during AST worker action: Build AST
Signal: SIGSEGV
clang::Sema::ActOnCXXDelete(...)
clang::Sema::MarkFunctionReferenced(...)
```

Upgrading to clang-tools 21 (which bundles clangd 21) resolves the crash since the underlying CUDA `operator delete` resolution bug was fixed upstream.

## Test plan

- [x] Verified `clangd --check=src/fvdb/detail/ops/gsplat/GaussianCameras.cuh` completes without crash on clangd 21
- [x] Verified `clang-format-18 --version` still reports 18.1.8 after the environment rebuild
- [x] Rebuild the conda environment from `env/dev_environment.yml` and confirm clangd no longer crashes on CUDA files
- [x] Confirm CI passes (codestyle checks still use clang-format 18)


Made with [Cursor](https://cursor.com)