### PR TITLE
Update NanoVDB to v32.9.1

### DIFF
--- a/src/cmake/get_nanovdb.cmake
+++ b/src/cmake/get_nanovdb.cmake
@@ -4,7 +4,7 @@
 CPMAddPackage(
     NAME nanovdb
     GITHUB_REPOSITORY AcademySoftwareFoundation/openvdb
-    GIT_TAG cfba6dff785629c9f02583fde6e38bf845b3509b
+    GIT_TAG fec59777b768eae283659c5b87e377ac31653e41
     SOURCE_SUBDIR nanovdb/nanovdb
     DOWNLOAD_ONLY YES
 )


### PR DESCRIPTION
This pull request updates the version of the `nanovdb` dependency in the build configuration.  This is primarily to pickup an optimization in grid building.

Dependency update:

* Updated the `nanovdb` package in `src/cmake/get_nanovdb.cmake` to use the newer commit `fec59777b768eae283659c5b87e377ac31653e41` instead of `cfba6dff785629c9f02583fde6e38bf845b3509b`.