### PR TITLE
Disable unreliable rasterization deadlock test

### DIFF
--- a/tests/unit/test_rasterize_from_world.py
+++ b/tests/unit/test_rasterize_from_world.py
@@ -667,6 +667,7 @@ def test_gaussiansplat3d_render_images_from_world_masks_write_background_and_zer
     )
 
 
+@pytest.mark.skip(reason="Disabled: deadlock test is unreliable in CI; see PR for details")
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
 def test_gaussiansplat3d_render_images_from_world_masks_edge_tile_does_not_deadlock():
     """


### PR DESCRIPTION
## Summary

- Disables `test_gaussiansplat3d_render_images_from_world_masks_edge_tile_does_not_deadlock` with `pytest.mark.skip` because the subprocess-timeout approach is unreliable in CI, causing spurious failures.
- The underlying kernel fix from #480 remains in place; only the flaky test detection mechanism is skipped.

## Test plan

- Verify the test is skipped when running the test suite:
  ```
  python -m pytest tests/unit/test_rasterize_from_world.py -v -k deadlock
  ```
  Expected: the test shows as `SKIPPED`.
- Confirm no other tests are affected:
  ```
  python -m pytest tests/unit/test_rasterize_from_world.py -v
  ```

Made with [Cursor](https://cursor.com)