### PR TITLE
Added the github CLI to the conda dev environment

### DIFF
--- a/env/dev_environment.yml
+++ b/env/dev_environment.yml
@@ -17,6 +17,7 @@ dependencies:
   - cuda-version=12.9
   - cxx-compiler
   - gcc_linux-64=13
+  - gh
   - git
   - gitpython
   - gxx_linux-64=13


### PR DESCRIPTION
Does what it says on the tin! The conda environment in dev_environment.yml now includes gh.