### PR TITLE
Add bfloat16 support to JaggedTensor reduce operators

### DIFF
--- a/src/fvdb/detail/ops/jagged/JaggedReduce.cu
+++ b/src/fvdb/detail/ops/jagged/JaggedReduce.cu
@@ -184,7 +184,8 @@ JaggedReduce(const torch::Tensor &jdataRaw,
             }
         }),
         AT_EXPAND(AT_ALL_TYPES),
-        c10::kHalf);
+        c10::kHalf,
+        c10::kBFloat16);
 
     torch::Tensor rOut                   = out.reshape(spliceShape({out.size(0)}, jdataRaw));
     std::optional<torch::Tensor> rArgOut = std::nullopt;

--- a/tests/unit/test_jagged_tensor.py
+++ b/tests/unit/test_jagged_tensor.py
@@ -30,6 +30,8 @@ import fvdb
 
 all_device_dtype_combos = [
     ["cuda", torch.float16],
+    ["cuda", torch.bfloat16],
+    ["cpu", torch.bfloat16],
     ["cpu", torch.float32],
     ["cuda", torch.float32],
     ["cpu", torch.float64],
@@ -622,6 +624,8 @@ class TestJaggedTensor(unittest.TestCase):
 
     @parameterized.expand(all_device_dtype_combos)
     def test_jagged_tensor_one_element(self, device, dtype):
+        if dtype == torch.bfloat16:
+            self.skipTest("GridBatch.from_points does not support bfloat16")
         # Make sure we can pass in JaggedTensors with a single thing explicitly
         pts_list = []
         while len(pts_list) == 0:
@@ -645,6 +649,8 @@ class TestJaggedTensor(unittest.TestCase):
 
     @parameterized.expand(all_device_dtype_combos)
     def test_indexing(self, device, dtype):
+        if dtype == torch.bfloat16:
+            self.skipTest("GridBatch.from_points does not support bfloat16")
         pts_list: List[torch.Tensor] = []
         ijk_list: List[torch.Tensor] = []
         while len(pts_list) == 0:
@@ -878,7 +884,10 @@ class TestJaggedTensor(unittest.TestCase):
         self.check_lshape(res, pts_list)
 
         res2 = randpts_b % randpts_c
-        if dtype != torch.float16:  # Not stable in float 16, but not important for this test
+        if dtype not in (
+            torch.float16,
+            torch.bfloat16,
+        ):  # Not stable in reduced precision, but not important for this test
             self.assertTrue(torch.allclose(res2.jdata, randpts_b.jdata % randpts_c.jdata))
             self.check_lshape(res2, pts_list)
             fvdb.config.pedantic_error_checking = True
@@ -1144,7 +1153,10 @@ class TestJaggedTensor(unittest.TestCase):
         self.assertTrue(torch.allclose(res.jdata, randpts.jdata / randpts_b.jdata))
         self.check_lshape(res, pts_list)
 
-        if dtype != torch.float16:  # Not stable in float 16, but not important for this test
+        if dtype not in (
+            torch.float16,
+            torch.bfloat16,
+        ):  # Not stable in reduced precision, but not important for this test
             res2 = randpts / randpts_c
             self.assertTrue(torch.allclose(res2.jdata, randpts.jdata / randpts_c.jdata))
             self.check_lshape(res2, pts_list)
@@ -1161,7 +1173,10 @@ class TestJaggedTensor(unittest.TestCase):
         self.assertTrue(torch.allclose(res.jdata, randpts.jdata // randpts_b.jdata))
         self.check_lshape(res, pts_list)
 
-        if dtype != torch.float16:  # Not stable in float 16, but not important for this test
+        if dtype not in (
+            torch.float16,
+            torch.bfloat16,
+        ):  # Not stable in reduced precision, but not important for this test
             res2 = randpts // randpts_c
             self.assertTrue(torch.allclose(res2.jdata, randpts.jdata // randpts_c.jdata))
             self.check_lshape(res2, pts_list)
@@ -1332,13 +1347,15 @@ class TestJaggedTensor(unittest.TestCase):
         pass_percentage=80,
         conditional_args=[
             ["cuda"],
-            [torch.float16, torch.float32],
+            [torch.float16, torch.bfloat16, torch.float32],
         ],
     )
     def test_jsum(self, device, dtype):
         torch.random.manual_seed(111)
         np.random.seed(111)
-        if dtype == torch.float16:
+        if dtype == torch.bfloat16:
+            min_num = 50
+        elif dtype == torch.float16:
             min_num = 100
         else:
             min_num = 1000
@@ -1375,7 +1392,10 @@ class TestJaggedTensor(unittest.TestCase):
             grad_ptscatter = jt.jdata.grad.clone()
 
             tol = {}
-            if dtype == torch.float16:
+            if dtype == torch.bfloat16:
+                tol["rtol"] = 2e-1
+                tol["atol"] = 2e-1
+            elif dtype == torch.float16:
                 tol["rtol"] = 1e-1
                 tol["atol"] = 1e-1
             elif dtype == torch.float32:
@@ -1396,7 +1416,7 @@ class TestJaggedTensor(unittest.TestCase):
 
     @parameterized.expand(all_device_dtype_combos)
     def test_jmin(self, device, dtype):
-        if dtype == torch.float16:
+        if dtype in (torch.float16, torch.bfloat16):
             min_num = 100
         else:
             min_num = 1000
@@ -1451,7 +1471,7 @@ class TestJaggedTensor(unittest.TestCase):
 
     @parameterized.expand(all_device_dtype_combos)
     def test_jmax(self, device, dtype):
-        if dtype == torch.float16:
+        if dtype in (torch.float16, torch.bfloat16):
             min_num = 100
         else:
             min_num = 1000
@@ -1503,7 +1523,7 @@ class TestJaggedTensor(unittest.TestCase):
 
     @parameterized.expand(all_device_dtype_combos)
     def test_jmin_list_of_lists(self, device, dtype):
-        if dtype == torch.float16:
+        if dtype in (torch.float16, torch.bfloat16):
             min_num = 100
         else:
             min_num = 1000
@@ -1581,7 +1601,7 @@ class TestJaggedTensor(unittest.TestCase):
 
     @parameterized.expand(all_device_dtype_combos)
     def test_jmax_list_of_lists(self, device, dtype):
-        if dtype == torch.float16:
+        if dtype in (torch.float16, torch.bfloat16):
             min_num = 100
         else:
             min_num = 1000
@@ -1649,14 +1669,19 @@ class TestJaggedTensor(unittest.TestCase):
     @parameterized.expand(all_device_dtype_combos)
     def test_jsum_list_of_lists(self, device, dtype):
         tol = {}
-        if dtype == torch.float16:
+        if dtype == torch.bfloat16:
+            tol["rtol"] = 2e-1
+            tol["atol"] = 2e-1
+        elif dtype == torch.float16:
             tol["rtol"] = 1e-1
             tol["atol"] = 1e-1
         elif dtype == torch.float32:
             tol["rtol"] = 1e-3
             tol["atol"] = 1e-4
 
-        if dtype == torch.float16:
+        if dtype == torch.bfloat16:
+            min_num = 50
+        elif dtype == torch.float16:
             min_num = 100
         else:
             min_num = 1000
@@ -1700,7 +1725,7 @@ class TestJaggedTensor(unittest.TestCase):
         self.assertTrue(torch.allclose(sum_ours_jdata, sum_res_ptscatter, **tol))
         self.assertTrue(torch.allclose(grad_ours, grad_ptscatter, **tol))
 
-    @parameterized.expand([(torch.float16,), (torch.float32,), (torch.float64,)])
+    @parameterized.expand([(torch.float16,), (torch.bfloat16,), (torch.float32,), (torch.float64,)])
     def test_sdpa(self, dtype):
         torch.random.manual_seed(0)
 
@@ -1748,7 +1773,10 @@ class TestJaggedTensor(unittest.TestCase):
 
         atol = 1e-8
         rtol = 1e-5
-        if dtype == torch.float16:
+        if dtype == torch.bfloat16:
+            atol = 1e-2
+            rtol = 1e-2
+        elif dtype == torch.float16:
             atol = 1e-3
             rtol = 1e-3
         self.assertTrue(torch.allclose(out_jagged_torch_forloop.jdata, out_jagged_fvdb.jdata, atol=atol, rtol=rtol))
@@ -2382,6 +2410,8 @@ class TestJaggedTensor(unittest.TestCase):
 
     @parameterized.expand(all_device_dtype_combos)
     def test_assignment(self, device, dtype):
+        if dtype == torch.bfloat16 and device == "cpu":
+            self.skipTest("PyTorch in-place division not truly in-place for bfloat16 on CPU")
         jt1 = fvdb.JaggedTensor.from_randn(
             [[10, 20, 30], [40, 50, 60, 70], [80, 90]], (3, 4), device=device, dtype=dtype
         )


### PR DESCRIPTION
Add bfloat16 support to JaggedTensor reduce operators: add c10::kBFloat16 to the AT_DISPATCH_V2 type list in JaggedReduce.cu, enabling jsum/jmin/jmax to accept bfloat16 tensors. JaggedSort already supported bfloat16; JaggedReduce was the only jagged kernel missing it.

Expand test_jagged_tensor.py to cover bfloat16 on both CUDA and CPU, with appropriately wider tolerances and smaller dataset sizes to account for bfloat16's 7-bit mantissa. Skip tests that depend on grid-building ops (GridBatch.from_points) which do not yet support bfloat16.

fixes #395 