### PR TITLE
Pin CI checkout refs to immutable commit SHAs to fix build/test skew

### DIFF
--- a/.github/workflows/cu128.yml
+++ b/.github/workflows/cu128.yml
@@ -81,7 +81,7 @@ jobs:
           fetch-depth: 0 # Fetch all history for all branches
           # For pull requests, this automatically checks out the merge commit
           # For pushes, this checks out the pushed commit
-          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.ref || github.ref }}
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha }}
       - name: Fetch PR branch
         if: github.event_name == 'pull_request_target'
         run: |
@@ -90,7 +90,8 @@ jobs:
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
           git config --global --add safe.directory "$(pwd)"
-          git fetch origin pull/${{ github.event.pull_request.number }}/head:pr_branch
+          git fetch origin ${{ github.event.pull_request.head.sha }}
+          git branch pr_branch FETCH_HEAD
 
       - name: Merge PR branch into base
         if: github.event_name == 'pull_request_target'
@@ -250,7 +251,7 @@ jobs:
           fetch-depth: 0 # Fetch all history for all branches
           # For pull requests, this automatically checks out the merge commit
           # For pushes, this checks out the pushed commit
-          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.ref || github.ref }}
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha }}
       - name: Fetch PR branch
         if: github.event_name == 'pull_request_target'
         run: |
@@ -259,7 +260,8 @@ jobs:
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
           git config --global --add safe.directory "$(pwd)"
-          git fetch origin pull/${{ github.event.pull_request.number }}/head:pr_branch
+          git fetch origin ${{ github.event.pull_request.head.sha }}
+          git branch pr_branch FETCH_HEAD
 
       - name: Merge PR branch into base
         if: github.event_name == 'pull_request_target'
@@ -352,7 +354,7 @@ jobs:
           fetch-depth: 0 # Fetch all history for all branches
           # For pull requests, this automatically checks out the merge commit
           # For pushes, this checks out the pushed commit
-          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.ref || github.ref }}
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha }}
 
       - name: Fetch PR branch
         if: github.event_name == 'pull_request_target'
@@ -362,7 +364,8 @@ jobs:
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
           git config --global --add safe.directory "$(pwd)"
-          git fetch origin pull/${{ github.event.pull_request.number }}/head:pr_branch
+          git fetch origin ${{ github.event.pull_request.head.sha }}
+          git branch pr_branch FETCH_HEAD
 
       - name: Merge PR branch into base
         if: github.event_name == 'pull_request_target'
@@ -441,7 +444,7 @@ jobs:
           fetch-depth: 0 # Fetch all history for all branches
           # For pull requests, this automatically checks out the merge commit
           # For pushes, this checks out the pushed commit
-          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.ref || github.ref }}
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha }}
 
       - name: Fetch PR branch
         if: github.event_name == 'pull_request_target'
@@ -451,7 +454,8 @@ jobs:
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
           git config --global --add safe.directory "$(pwd)"
-          git fetch origin pull/${{ github.event.pull_request.number }}/head:pr_branch
+          git fetch origin ${{ github.event.pull_request.head.sha }}
+          git branch pr_branch FETCH_HEAD
 
       - name: Merge PR branch into base
         if: github.event_name == 'pull_request_target'

--- a/.github/workflows/cu130.yml
+++ b/.github/workflows/cu130.yml
@@ -81,7 +81,7 @@ jobs:
           fetch-depth: 0 # Fetch all history for all branches
           # For pull requests, this automatically checks out the merge commit
           # For pushes, this checks out the pushed commit
-          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.ref || github.ref }}
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha }}
       - name: Fetch PR branch
         if: github.event_name == 'pull_request_target'
         run: |
@@ -90,7 +90,8 @@ jobs:
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
           git config --global --add safe.directory "$(pwd)"
-          git fetch origin pull/${{ github.event.pull_request.number }}/head:pr_branch
+          git fetch origin ${{ github.event.pull_request.head.sha }}
+          git branch pr_branch FETCH_HEAD
 
       - name: Merge PR branch into base
         if: github.event_name == 'pull_request_target'
@@ -250,7 +251,7 @@ jobs:
           fetch-depth: 0 # Fetch all history for all branches
           # For pull requests, this automatically checks out the merge commit
           # For pushes, this checks out the pushed commit
-          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.ref || github.ref }}
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha }}
       - name: Fetch PR branch
         if: github.event_name == 'pull_request_target'
         run: |
@@ -259,7 +260,8 @@ jobs:
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
           git config --global --add safe.directory "$(pwd)"
-          git fetch origin pull/${{ github.event.pull_request.number }}/head:pr_branch
+          git fetch origin ${{ github.event.pull_request.head.sha }}
+          git branch pr_branch FETCH_HEAD
 
       - name: Merge PR branch into base
         if: github.event_name == 'pull_request_target'
@@ -352,7 +354,7 @@ jobs:
           fetch-depth: 0 # Fetch all history for all branches
           # For pull requests, this automatically checks out the merge commit
           # For pushes, this checks out the pushed commit
-          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.ref || github.ref }}
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha }}
 
       - name: Fetch PR branch
         if: github.event_name == 'pull_request_target'
@@ -362,7 +364,8 @@ jobs:
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
           git config --global --add safe.directory "$(pwd)"
-          git fetch origin pull/${{ github.event.pull_request.number }}/head:pr_branch
+          git fetch origin ${{ github.event.pull_request.head.sha }}
+          git branch pr_branch FETCH_HEAD
 
       - name: Merge PR branch into base
         if: github.event_name == 'pull_request_target'
@@ -441,7 +444,7 @@ jobs:
           fetch-depth: 0 # Fetch all history for all branches
           # For pull requests, this automatically checks out the merge commit
           # For pushes, this checks out the pushed commit
-          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.ref || github.ref }}
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha }}
 
       - name: Fetch PR branch
         if: github.event_name == 'pull_request_target'
@@ -451,7 +454,8 @@ jobs:
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
           git config --global --add safe.directory "$(pwd)"
-          git fetch origin pull/${{ github.event.pull_request.number }}/head:pr_branch
+          git fetch origin ${{ github.event.pull_request.head.sha }}
+          git branch pr_branch FETCH_HEAD
 
       - name: Merge PR branch into base
         if: github.event_name == 'pull_request_target'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -78,7 +78,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Fetch all history for all branches
-          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.ref || github.ref }}
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha }}
 
       - name: Fetch PR branch
         if: github.event_name == 'pull_request_target'
@@ -88,7 +88,8 @@ jobs:
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
           git config --global --add safe.directory "$(pwd)"
-          git fetch origin pull/${{ github.event.pull_request.number }}/head:pr_branch
+          git fetch origin ${{ github.event.pull_request.head.sha }}
+          git branch pr_branch FETCH_HEAD
 
       - name: Merge PR branch into base
         if: github.event_name == 'pull_request_target'
@@ -215,7 +216,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Fetch all history for all branches
-          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.ref || github.ref }}
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha }}
 
       - name: Fetch PR branch
         if: github.event_name == 'pull_request_target'
@@ -225,7 +226,8 @@ jobs:
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
           git config --global --add safe.directory "$(pwd)"
-          git fetch origin pull/${{ github.event.pull_request.number }}/head:pr_branch
+          git fetch origin ${{ github.event.pull_request.head.sha }}
+          git branch pr_branch FETCH_HEAD
       - name: Merge PR branch into base
         if: github.event_name == 'pull_request_target'
         run: |
@@ -287,7 +289,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Fetch all history for all branches
-          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.ref || github.ref }}
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha }}
 
       - name: Fetch PR branch
         if: github.event_name == 'pull_request_target'
@@ -297,7 +299,8 @@ jobs:
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
           git config --global --add safe.directory "$(pwd)"
-          git fetch origin pull/${{ github.event.pull_request.number }}/head:pr_branch
+          git fetch origin ${{ github.event.pull_request.head.sha }}
+          git branch pr_branch FETCH_HEAD
 
       - name: Merge PR branch into base
         if: github.event_name == 'pull_request_target'
@@ -349,7 +352,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Fetch all history for all branches
-          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.ref || github.ref }}
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha }}
 
       - name: Fetch PR branch
         if: github.event_name == 'pull_request_target'
@@ -359,7 +362,8 @@ jobs:
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
           git config --global --add safe.directory "$(pwd)"
-          git fetch origin pull/${{ github.event.pull_request.number }}/head:pr_branch
+          git fetch origin ${{ github.event.pull_request.head.sha }}
+          git branch pr_branch FETCH_HEAD
 
       - name: Merge PR branch into base
         if: github.event_name == 'pull_request_target'


### PR DESCRIPTION
When the build and test jobs checked out the base branch by name (e.g. "main"), a PR merged between the build and test phases could advance the branch tip, causing test jobs to run newer tests against an older built package. Fix by using `github.event.pull_request.base.sha` and `github.sha` instead of branch refs, and fetching the PR head by its exact SHA rather than the mutable pull/N/head ref. All values are constants within a single workflow run, guaranteeing every job sees the same source tree.

Applied to tests.yml, cu128.yml, and cu130.yml.