### PR TITLE
Fix flaky test_jsum_list_of_lists bfloat16 test

### DIFF
--- a/tests/unit/test_jagged_tensor.py
+++ b/tests/unit/test_jagged_tensor.py
@@ -1667,6 +1667,14 @@ class TestJaggedTensor(unittest.TestCase):
             self.assertTrue(torch.allclose(zgours, zgcmp))
 
     @parameterized.expand(all_device_dtype_combos)
+    @probabilistic_test(
+        iterations=20,
+        pass_percentage=80,
+        conditional_args=[
+            ["cuda"],
+            [torch.float16, torch.bfloat16, torch.float32],
+        ],
+    )
     def test_jsum_list_of_lists(self, device, dtype):
         torch.random.manual_seed(111)
         np.random.seed(111)


### PR DESCRIPTION
## Summary

- Add `@probabilistic_test` decorator to `test_jsum_list_of_lists`, matching the pattern already used by `test_jsum`
- The bfloat16 numerical precision causes non-deterministic `allclose` failures when comparing `jsum` against `scatter_sum`
- The decorator runs 20 iterations and passes if >= 80% succeed, which is the same strategy used for the flat-list variant

This was observed as a transient CI failure on the V0.4 release branch (PR #515).

## Test plan

- [ ] CI passes (codestyle + unit tests)
- [ ] Verify `test_jsum_list_of_lists_1_cuda` (bfloat16) no longer flakes


Made with [Cursor](https://cursor.com)