### PR TITLE
Fix smoke test Python setup and open release PR as draft

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -514,11 +514,15 @@ jobs:
         shell: bash -el {0}
     strategy: *matrix-strategy
     steps:
-      - name: Install Python and pip
-        run: |
-          apt update && apt install -y python${{ matrix.python-version }} python3-pip wget
-          update-alternatives --install /usr/bin/python3 python3 /usr/bin/python${{ matrix.python-version }} 1
-          python3 --version
+      - name: Install prerequisites
+        run: apt update && apt install -y git wget
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '${{ matrix.python-version }}'
+        env:
+          AGENT_TOOLSDIRECTORY: "/opt/hostedtoolcache"
 
       - name: Download wheel artifact
         uses: actions/download-artifact@v4

--- a/devtools/finish-release.sh
+++ b/devtools/finish-release.sh
@@ -173,6 +173,9 @@ else
         die "aborted -- get the PR approved first"
     fi
 
+    log "Marking PR #${PR_NUMBER} as ready for review..."
+    gh pr ready "$PR_NUMBER" --repo "$REPO_SLUG"
+
     log "Merging PR #${PR_NUMBER} with merge commit"
     log "NOTE: The merge will conflict on the version line in pyproject.toml."
     log "      Resolve by keeping the main branch version (the .dev0 version)."

--- a/devtools/start-release.sh
+++ b/devtools/start-release.sh
@@ -191,7 +191,8 @@ EOF
         --base main \
         --head "$RELEASE_BRANCH" \
         --title "Release v${VERSION}" \
-        --body "$PR_BODY"
+        --body "$PR_BODY" \
+        --draft
 fi
 
 echo ""

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -70,7 +70,7 @@ This will:
 2. Set the version to `0.4.0` on the release branch
 3. Bump `main` to `0.5.0.dev0`
 4. Push both branches to `upstream`
-5. Open a PR from `release/v0.4` into `main`
+5. Open a **draft** PR from `release/v0.4` into `main`
 
 Use `--remote origin` to push to a different remote.
 Use `--dry-run` to preview without making changes.


### PR DESCRIPTION
## Summary

- Use `actions/setup-python@v5` in smoke test validation containers instead of
  bare `apt install`. The `nvidia/cuda` Ubuntu 22.04 containers only have
  Python 3.10 in their default apt repos; Python 3.12 and 3.13 require the
  deadsnakes PPA. This matches the approach already used by the build job.

- Open the release PR as a draft to avoid CI failures from the expected
  `pyproject.toml` version conflict between the release branch and `main`.
  `finish-release.sh` marks it ready before merging.

## Test plan

- [ ] Re-run `start-release.sh` after merge; verify smoke tests pass for all
  Python versions (3.10-3.13)
- [ ] Verify the release PR is created as a draft
- [ ] Verify `finish-release.sh` marks the PR ready before merging