### PR TITLE
Make start-release.sh idempotent for safe re-runs

### DIFF
--- a/devtools/start-release.sh
+++ b/devtools/start-release.sh
@@ -116,37 +116,53 @@ echo ""
 
 if ! $DRY_RUN; then
     CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
-    [[ "$CURRENT_BRANCH" == "main" ]] || die "must be on main (currently on $CURRENT_BRANCH)"
+    [[ "$CURRENT_BRANCH" == "main" || "$CURRENT_BRANCH" == "$RELEASE_BRANCH" ]] \
+        || die "must be on main or $RELEASE_BRANCH (currently on $CURRENT_BRANCH)"
 
     if ! git diff --quiet || ! git diff --cached --quiet; then
         die "working tree is not clean; commit or stash changes first"
     fi
 
-    if git show-ref --verify --quiet "refs/heads/$RELEASE_BRANCH"; then
-        die "branch $RELEASE_BRANCH already exists locally"
+    if [[ "$CURRENT_BRANCH" != "main" ]]; then
+        git checkout main
     fi
 fi
 
 # --- create release branch and set version ------------------------------------
-log "Creating branch $RELEASE_BRANCH from main..."
-run git checkout -b "$RELEASE_BRANCH"
+if ! $DRY_RUN && git show-ref --verify --quiet "refs/heads/$RELEASE_BRANCH"; then
+    log "Branch $RELEASE_BRANCH already exists locally, checking out..."
+    run git checkout "$RELEASE_BRANCH"
+else
+    log "Creating branch $RELEASE_BRANCH from main..."
+    run git checkout -b "$RELEASE_BRANCH"
+fi
 
-log "Setting version to $VERSION on $RELEASE_BRANCH..."
 if ! $DRY_RUN; then
-    set_version "$VERSION"
-    git add pyproject.toml
-    git commit -s -S -m "Set version to $VERSION for release"
+    CURRENT_VER="$(get_version)"
+    if [[ "$CURRENT_VER" == "$VERSION" ]]; then
+        log "Version already set to $VERSION on $RELEASE_BRANCH"
+    else
+        log "Setting version to $VERSION on $RELEASE_BRANCH..."
+        set_version "$VERSION"
+        git add pyproject.toml
+        git commit -s -S -m "Set version to $VERSION for release"
+    fi
 fi
 
 # --- switch back to main and bump to next dev version -------------------------
 log "Switching back to main..."
 run git checkout main
 
-log "Bumping main version to $NEXT_DEV..."
 if ! $DRY_RUN; then
-    set_version "$NEXT_DEV"
-    git add pyproject.toml
-    git commit -s -S -m "Bump version to $NEXT_DEV after $RELEASE_BRANCH branch"
+    CURRENT_VER="$(get_version)"
+    if [[ "$CURRENT_VER" == "$NEXT_DEV" ]]; then
+        log "Main already at $NEXT_DEV"
+    else
+        log "Bumping main version to $NEXT_DEV..."
+        set_version "$NEXT_DEV"
+        git add pyproject.toml
+        git commit -s -S -m "Bump version to $NEXT_DEV after $RELEASE_BRANCH branch"
+    fi
 fi
 
 # --- push ---------------------------------------------------------------------
@@ -164,9 +180,15 @@ fi
 if $NO_PR || $DRY_RUN; then
     log "Skipping PR creation"
 else
-    log "Creating PR from $RELEASE_BRANCH to main..."
+    REPO_SLUG="$(gh repo view --json nameWithOwner -q .nameWithOwner)"
+    EXISTING_PR="$(gh pr list --repo "$REPO_SLUG" --head "$RELEASE_BRANCH" --base main --state open --json number -q '.[0].number' 2>/dev/null || true)"
 
-    PR_BODY="$(cat <<EOF
+    if [[ -n "$EXISTING_PR" ]]; then
+        log "Release PR #${EXISTING_PR} already exists"
+    else
+        log "Creating draft PR from $RELEASE_BRANCH to main..."
+
+        PR_BODY="$(cat <<EOF
 ## Release v${VERSION}
 
 Merge release branch \`${RELEASE_BRANCH}\` into \`main\` at release time.
@@ -186,13 +208,14 @@ Merge release branch \`${RELEASE_BRANCH}\` into \`main\` at release time.
 \`\`\`
 EOF
 )"
-    gh pr create \
-        --repo "$(gh repo view --json nameWithOwner -q .nameWithOwner)" \
-        --base main \
-        --head "$RELEASE_BRANCH" \
-        --title "Release v${VERSION}" \
-        --body "$PR_BODY" \
-        --draft
+        gh pr create \
+            --repo "$REPO_SLUG" \
+            --base main \
+            --head "$RELEASE_BRANCH" \
+            --title "Release v${VERSION}" \
+            --body "$PR_BODY" \
+            --draft
+    fi
 fi
 
 echo ""

--- a/devtools/test-release-scripts.sh
+++ b/devtools/test-release-scripts.sh
@@ -156,14 +156,21 @@ git checkout main >/dev/null 2>&1
 
 echo ""
 echo "============================================="
-echo " Test: start-release.sh rejects duplicate"
+echo " Test: start-release.sh is idempotent"
 echo "============================================="
 
-if "$START_RELEASE" 0.4.0 --no-push --no-pr 2>&1; then
-    fail "should reject when release branch already exists"
-else
-    pass "rejects duplicate release branch"
-fi
+RERUN_OUTPUT="$("$START_RELEASE" 0.4.0 --no-push --no-pr 2>&1)"
+pass "re-running start-release succeeds"
+assert_contains "re-run detects existing branch" "$RERUN_OUTPUT" "already exists"
+assert_contains "re-run detects version already set" "$RERUN_OUTPUT" "already"
+
+MAIN_VERSION_RERUN="$(get_version)"
+assert_eq "main still at 0.5.0.dev0 after re-run" "0.5.0.dev0" "$MAIN_VERSION_RERUN"
+
+git checkout release/v0.4 >/dev/null 2>&1
+RELEASE_VERSION_RERUN="$(get_version)"
+assert_eq "release branch still at 0.4.0 after re-run" "0.4.0" "$RELEASE_VERSION_RERUN"
+git checkout main >/dev/null 2>&1
 
 echo ""
 echo "============================================="


### PR DESCRIPTION
## Summary

- Make `start-release.sh` idempotent so it can be safely re-run after a partial
  failure or after fixing an issue discovered during the release process
- Each step checks whether it has already been completed:
  - Release branch: reuse if it already exists locally
  - Version on release branch: skip commit if already correct
  - Dev version bump on main: skip commit if already correct
  - PR creation: skip if an open release PR already exists
- Updated test script to verify idempotent behavior (re-run succeeds with
  correct state preserved)

## Test plan

- [x] `./devtools/test-release-scripts.sh` passes (28/28)
- [ ] Manual: run `start-release.sh` twice in a row -- second run should
  succeed and detect existing state