### PR TITLE
Release v0.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "fvdb-core"
-version = "0.5.0.dev0"
+version = "0.4.0"
 license = { text = "Apache-2.0" }
 requires-python = ">=3.10"
 readme = "README.md"


### PR DESCRIPTION
## Release v0.4.0

Merge release branch `release/v0.4` into `main` at release time.

**Note:** This PR is intentionally a draft. The PR CI will show a version
conflict because `release/v0.4` has `0.4.0` while `main` has the
next dev version. This is expected. Use `finish-release.sh` to merge, which
resolves the conflict by keeping the `main` version.

### Checklist

- [ ] Publish workflow passing on `release/v0.4` (builds + smoke tests)
- [ ] All planned fixes merged into `release/v0.4`
- [ ] Code freeze applied (branch protection tightened)
- [ ] Release notes drafted

### Release command

```bash
./devtools/finish-release.sh 0.4.0
```