### PR TITLE
Run unit tests only for matching test_environment.yml config

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,6 +42,8 @@ jobs:
     outputs:
       s3: ${{ steps.flags.outputs.s3 }}
       release_push: ${{ steps.flags.outputs.release_push }}
+      test_python_version: ${{ steps.test-env.outputs.python_version }}
+      test_cuda_version: ${{ steps.test-env.outputs.cuda_version }}
     steps:
       - name: Compute publish routing flags
         id: flags
@@ -64,6 +66,18 @@ jobs:
             }
             core.setOutput('s3', s3 ? 'true' : 'false');
             core.setOutput('release_push', releasePush ? 'true' : 'false');
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: env/test_environment.yml
+          sparse-checkout-cone-mode: false
+      - name: Parse test environment versions
+        id: test-env
+        run: |
+          PY_VER=$(grep -oP '^\s*-\s*python=\K[0-9]+\.[0-9]+' env/test_environment.yml)
+          CUDA_VER=$(grep -oP '^\s*-\s*cuda-version=\K[0-9]+\.[0-9]+' env/test_environment.yml)
+          echo "python_version=$PY_VER" >> $GITHUB_OUTPUT
+          echo "cuda_version=$CUDA_VER" >> $GITHUB_OUTPUT
+          echo "Test env: python=$PY_VER cuda=$CUDA_VER"
   start-build-runner:
     name: Start CPU-only EC2 runner for build
     runs-on: ubuntu-latest
@@ -555,7 +569,13 @@ jobs:
   validate-unit-tests:
     name: Full unit tests on built wheel
     needs: [start-validation-runner, validate-smoke-test, pr-flags]
-    if: ${{ !cancelled() && needs.validate-smoke-test.result == 'success' && (needs.pr-flags.outputs.release_push == 'true' || inputs.run_validation == true) }}
+    # Only run for the matrix entry matching env/test_environment.yml (python + cuda pinned there)
+    if: >-
+      ${{ !cancelled()
+          && needs.validate-smoke-test.result == 'success'
+          && (needs.pr-flags.outputs.release_push == 'true' || inputs.run_validation == true)
+          && matrix.python-version == needs.pr-flags.outputs.test_python_version
+          && matrix.cuda-version == needs.pr-flags.outputs.test_cuda_version }}
     runs-on: val-${{ matrix.python-version }}-pt${{ matrix.torch-version }}-cu${{ matrix.cuda-version }}-${{ github.run_id }}
     container:
       image: aswf/ci-openvdb:2024-clang17.2

--- a/devtools/start-release.sh
+++ b/devtools/start-release.sh
@@ -193,13 +193,17 @@ else
 
 Merge release branch \`${RELEASE_BRANCH}\` into \`main\` at release time.
 
+**Note:** This PR is intentionally a draft. The PR CI will show a version
+conflict because \`${RELEASE_BRANCH}\` has \`${VERSION}\` while \`main\` has the
+next dev version. This is expected. Use \`finish-release.sh\` to merge, which
+resolves the conflict by keeping the \`main\` version.
+
 ### Checklist
 
+- [ ] Publish workflow passing on \`${RELEASE_BRANCH}\` (builds + smoke tests)
 - [ ] All planned fixes merged into \`${RELEASE_BRANCH}\`
 - [ ] Code freeze applied (branch protection tightened)
 - [ ] Release notes drafted
-- [ ] Tag \`v${VERSION}\` created on release branch HEAD
-- [ ] CI passing on release branch
 
 ### Release command
 


### PR DESCRIPTION
## Summary

- **Fix unit test failures in publish workflow**: The `validate-unit-tests` job
  uses a conda env (`env/test_environment.yml`) pinned to Python 3.12 + CUDA 13.0,
  but the matrix builds wheels for all 8 Python/CUDA combinations. Only the matching
  entry can install successfully; the others fail with "not a supported wheel on this
  platform".

- **Dynamic discovery**: The `pr-flags` job now parses `test_environment.yml` to
  extract the pinned `python` and `cuda-version` values. The unit test job's `if`
  condition gates it to run only for the matching matrix entry. No hardcoded values --
  if the env file is updated, the filter adjusts automatically.

- **Smoke tests unaffected**: All 8 matrix combinations still run smoke tests to
  validate basic import and GPU operation across all Python/CUDA variants.

- **Release PR template**: Updated to explain the expected CI version conflict on
  draft release PRs.

## Test plan

- [ ] Merge and re-run publish workflow on `release/v0.4`
- [ ] Verify unit tests run only for `(3.12, 13.0)` and pass
- [ ] Verify the other 7 unit test matrix entries are skipped
- [ ] Verify smoke tests still run for all 8 entries