### PR TITLE
Restore fix for dLossDQuat missing warpSum

### DIFF
--- a/src/fvdb/detail/ops/gsplat/GaussianProjectionBackward.cu
+++ b/src/fvdb/detail/ops/gsplat/GaussianProjectionBackward.cu
@@ -193,6 +193,7 @@ projectionBackwardKernel(const int32_t offset,
             quaternionAndScaleToCovarianceVectorJacobianProduct<T, true>(
                 quat, scale, rotmat, dLossDCovar);
 
+        warpSum(dLossDQuat, warp_group_g);
         warpSum(dLossDLogScale, warp_group_g);
         if (warp_group_g.thread_rank() == 0) {
             outDLossDQuats += gId * 4;


### PR DESCRIPTION
Originally added in #435 but accidentally clobbered in #444 