### PR TITLE
Add optimizations for multibatch Gaussian projection

### DIFF
--- a/src/fvdb/detail/ops/gsplat/GaussianCameras.cuh
+++ b/src/fvdb/detail/ops/gsplat/GaussianCameras.cuh
@@ -194,28 +194,41 @@ template <typename T> struct PerspectiveCamera {
     T nearPlane         = T(kBackwardProjectionNearPlane);
     T farPlane          = T(kBackwardProjectionFarPlane);
 
-    Mat3 *__restrict__ projectionMatsShared        = nullptr; // [C,3,3], optional
-    Mat3 *__restrict__ worldToCamRotMatsShared     = nullptr; // [C,3,3], optional
-    Vec3 *__restrict__ worldToCamTranslationShared = nullptr; // [C,3], optional
+    Mat3 *__restrict__ projectionMatShared         = nullptr; // [3,3], optional
+    Mat3 *__restrict__ worldToCamRotMatShared      = nullptr; // [3,3], optional
+    Vec3 *__restrict__ worldToCamTranslationShared = nullptr; // [3], optional
 
   public:
     /// @brief Returns dynamic shared-memory bytes required to cache camera matrices.
-    inline __host__ __device__ size_t
+    constexpr __host__ __device__ size_t
     numSharedMemBytes() const {
-        return static_cast<size_t>(2 * numCameras) * sizeof(Mat3) +
-               static_cast<size_t>(numCameras) * sizeof(Vec3);
+        return 2 * sizeof(Mat3) + sizeof(Vec3);
     }
 
     /// @brief Loads per-camera intrinsics/extrinsics into dynamic shared memory.
     inline __device__ void
-    loadSharedMemory(void *sharedMemory) {
-        const int64_t C             = numCameras;
-        projectionMatsShared        = reinterpret_cast<Mat3 *>(sharedMemory);
-        worldToCamRotMatsShared     = projectionMatsShared + C;
-        worldToCamTranslationShared = reinterpret_cast<Vec3 *>(worldToCamRotMatsShared + C);
-        copyMat3Accessor<T>(C, projectionMatsShared, projectionMatricesAcc);
-        copyMat3Accessor<T>(C, worldToCamRotMatsShared, worldToCamMatricesAcc);
-        copyWorldToCamTranslation<T>(C, worldToCamTranslationShared, worldToCamMatricesAcc);
+    loadSharedMemory(const int64_t cid, void *sharedMemory) {
+        projectionMatShared         = reinterpret_cast<Mat3 *>(sharedMemory);
+        worldToCamRotMatShared      = projectionMatShared + 1;
+        worldToCamTranslationShared = reinterpret_cast<Vec3 *>(worldToCamRotMatShared + 1);
+
+        if (threadIdx.x < 9) {
+            const auto i     = threadIdx.x;
+            const auto rowId = i / 3;
+            const auto colId = i % 3;
+
+            (*projectionMatShared)[rowId][colId] = projectionMatricesAcc[cid][rowId][colId];
+        } else if (threadIdx.x < 18) {
+            const auto i     = threadIdx.x - 9;
+            const auto rowId = i / 3;
+            const auto colId = i % 3;
+
+            (*worldToCamRotMatShared)[rowId][colId] = worldToCamMatricesAcc[cid][rowId][colId];
+        } else if (threadIdx.x < 21) {
+            const auto i = threadIdx.x - 18;
+
+            (*worldToCamTranslationShared)[i] = worldToCamMatricesAcc[cid][i][3];
+        }
     }
 
     /// @brief Returns true if camera-space depth is within [nearPlane, farPlane].
@@ -243,8 +256,8 @@ template <typename T> struct PerspectiveCamera {
     /// `p_c = R * p_w + t`.
     inline __device__ std::tuple<Mat3, Vec3>
     worldToCamTransform(const int64_t cid) const {
-        if (worldToCamRotMatsShared != nullptr) {
-            return std::make_tuple(worldToCamRotMatsShared[cid], worldToCamTranslationShared[cid]);
+        if (worldToCamRotMatShared != nullptr) {
+            return std::make_tuple(*worldToCamRotMatShared, *worldToCamTranslationShared);
         }
         const auto W = worldToCamMatricesAcc[cid];
         return std::make_tuple(
@@ -265,8 +278,8 @@ template <typename T> struct PerspectiveCamera {
         using Vec2   = nanovdb::math::Vec2<T>;
 
         T fx, fy, cx, cy;
-        if (projectionMatsShared != nullptr) {
-            const Mat3 &K = projectionMatsShared[cid];
+        if (projectionMatShared != nullptr) {
+            const Mat3 &K = *projectionMatShared;
             fx            = K[0][0];
             fy            = K[1][1];
             cx            = K[0][2];
@@ -320,8 +333,8 @@ template <typename T> struct PerspectiveCamera {
         using Vec3   = nanovdb::math::Vec3<T>;
 
         T fx, fy, cx, cy;
-        if (projectionMatsShared != nullptr) {
-            const Mat3 &K = projectionMatsShared[cid];
+        if (projectionMatShared != nullptr) {
+            const Mat3 &K = *projectionMatShared;
             fx            = K[0][0];
             fy            = K[1][1];
             cx            = K[0][2];
@@ -459,28 +472,41 @@ template <typename T> struct OrthographicCamera {
     T nearPlane         = T(kBackwardProjectionNearPlane);
     T farPlane          = T(kBackwardProjectionFarPlane);
 
-    Mat3 *__restrict__ projectionMatsShared        = nullptr; // [C,3,3], optional
-    Mat3 *__restrict__ worldToCamRotMatsShared     = nullptr; // [C,3,3], optional
-    Vec3 *__restrict__ worldToCamTranslationShared = nullptr; // [C,3], optional
+    Mat3 *__restrict__ projectionMatShared         = nullptr; // [3,3], optional
+    Mat3 *__restrict__ worldToCamRotMatShared      = nullptr; // [3,3], optional
+    Vec3 *__restrict__ worldToCamTranslationShared = nullptr; // [3], optional
 
   public:
     /// @brief Returns dynamic shared-memory bytes required to cache camera matrices.
-    inline __host__ __device__ size_t
+    constexpr __host__ __device__ size_t
     numSharedMemBytes() const {
-        return static_cast<size_t>(2 * numCameras) * sizeof(Mat3) +
-               static_cast<size_t>(numCameras) * sizeof(Vec3);
+        return 2 * sizeof(Mat3) + sizeof(Vec3);
     }
 
     /// @brief Loads per-camera intrinsics/extrinsics into dynamic shared memory.
     inline __device__ void
-    loadSharedMemory(void *sharedMemory) {
-        const int64_t C             = numCameras;
-        projectionMatsShared        = reinterpret_cast<Mat3 *>(sharedMemory);
-        worldToCamRotMatsShared     = projectionMatsShared + C;
-        worldToCamTranslationShared = reinterpret_cast<Vec3 *>(worldToCamRotMatsShared + C);
-        copyMat3Accessor<T>(C, projectionMatsShared, projectionMatricesAcc);
-        copyMat3Accessor<T>(C, worldToCamRotMatsShared, worldToCamMatricesAcc);
-        copyWorldToCamTranslation<T>(C, worldToCamTranslationShared, worldToCamMatricesAcc);
+    loadSharedMemory(int64_t cid, void *sharedMemory) {
+        projectionMatShared         = reinterpret_cast<Mat3 *>(sharedMemory);
+        worldToCamRotMatShared      = projectionMatShared + 1;
+        worldToCamTranslationShared = reinterpret_cast<Vec3 *>(worldToCamRotMatShared + 1);
+
+        if (threadIdx.x < 9) {
+            const auto i     = threadIdx.x;
+            const auto rowId = i / 3;
+            const auto colId = i % 3;
+
+            (*projectionMatShared)[rowId][colId] = projectionMatricesAcc[cid][rowId][colId];
+        } else if (threadIdx.x < 18) {
+            const auto i     = threadIdx.x - 9;
+            const auto rowId = i / 3;
+            const auto colId = i % 3;
+
+            (*worldToCamRotMatShared)[rowId][colId] = worldToCamMatricesAcc[cid][rowId][colId];
+        } else if (threadIdx.x < 21) {
+            const auto i = threadIdx.x - 18;
+
+            (*worldToCamTranslationShared)[i] = worldToCamMatricesAcc[cid][i][3];
+        }
     }
 
     /// @brief Returns true if camera-space depth is within [nearPlane, farPlane].
@@ -508,8 +534,8 @@ template <typename T> struct OrthographicCamera {
     /// `p_c = R * p_w + t`.
     inline __device__ std::tuple<Mat3, Vec3>
     worldToCamTransform(const int64_t cid) const {
-        if (worldToCamRotMatsShared != nullptr) {
-            return std::make_tuple(worldToCamRotMatsShared[cid], worldToCamTranslationShared[cid]);
+        if (worldToCamRotMatShared != nullptr) {
+            return std::make_tuple(*worldToCamRotMatShared, *worldToCamTranslationShared);
         }
         const auto W = worldToCamMatricesAcc[cid];
         return std::make_tuple(
@@ -530,8 +556,8 @@ template <typename T> struct OrthographicCamera {
         using Vec2   = nanovdb::math::Vec2<T>;
 
         T fx, fy, cx, cy;
-        if (projectionMatsShared != nullptr) {
-            const Mat3 &K = projectionMatsShared[cid];
+        if (projectionMatShared != nullptr) {
+            const Mat3 &K = *projectionMatShared;
             fx            = K[0][0];
             fy            = K[1][1];
             cx            = K[0][2];
@@ -571,8 +597,8 @@ template <typename T> struct OrthographicCamera {
         using Vec3   = nanovdb::math::Vec3<T>;
 
         T fx, fy, cx, cy;
-        if (projectionMatsShared != nullptr) {
-            const Mat3 &K = projectionMatsShared[cid];
+        if (projectionMatShared != nullptr) {
+            const Mat3 &K = *projectionMatShared;
             fx            = K[0][0];
             fy            = K[1][1];
             cx            = K[0][2];

--- a/src/fvdb/detail/ops/gsplat/GaussianCameras.cuh
+++ b/src/fvdb/detail/ops/gsplat/GaussianCameras.cuh
@@ -237,6 +237,15 @@ template <typename T> struct PerspectiveCamera {
         return depth >= nearPlane && depth <= farPlane;
     }
 
+    /// @brief Returns true if camera-space depth computed from the world space mean is within
+    /// [nearPlane, farPlane].
+    inline __device__ bool
+    isVisible(const int64_t cid, const nanovdb::math::Vec3<T> &meansWorldSpace) const {
+        const auto [R, t]                         = worldToCamTransform(cid);
+        const nanovdb::math::Vec3<T> meanCamSpace = transformPointWorldToCam(R, t, meansWorldSpace);
+        return isDepthVisible(meanCamSpace[2]);
+    }
+
     /// @brief Returns true when the footprint AABB has no overlap with the image.
     ///
     /// A 2D Gaussian footprint is an ellipse, but this check uses the axis-aligned bounding box
@@ -513,6 +522,15 @@ template <typename T> struct OrthographicCamera {
     inline __device__ bool
     isDepthVisible(const T depth) const {
         return depth >= nearPlane && depth <= farPlane;
+    }
+
+    /// @brief Returns true if camera-space depth computed from the world space mean is within
+    /// [nearPlane, farPlane].
+    inline __device__ bool
+    isVisible(const int64_t cid, const nanovdb::math::Vec3<T> &meansWorldSpace) const {
+        const auto [R, t]                         = worldToCamTransform(cid);
+        const nanovdb::math::Vec3<T> meanCamSpace = transformPointWorldToCam(R, t, meansWorldSpace);
+        return isDepthVisible(meanCamSpace[2]);
     }
 
     /// @brief Returns true when the footprint AABB has no overlap with the image.

--- a/src/fvdb/detail/ops/gsplat/GaussianProjectionBackward.cu
+++ b/src/fvdb/detail/ops/gsplat/GaussianProjectionBackward.cu
@@ -25,7 +25,41 @@ namespace {
 
 namespace cg = cooperative_groups;
 
-template <typename T, bool TRACK_MAX_RADII>
+template <typename T>
+__global__ __launch_bounds__(DEFAULT_BLOCK_DIM) void
+computeGradientState(const int32_t offset,
+                     const int32_t count,
+                     const uint32_t C,
+                     const uint32_t N,
+                     const int32_t imageWidth,
+                     const int32_t imageHeight,
+                     const int32_t *__restrict__ radii,
+                     const T *__restrict__ dLossDMeans2d,
+                     T *__restrict__ outDLossDMeans2dNormAccum,
+                     int32_t *__restrict__ outGradientStepCounts) {
+    auto idx = cg::this_grid().thread_rank();
+    if (idx >= count) {
+        return;
+    }
+    idx += offset;
+
+    T normAccum       = T(0);
+    int32_t stepCount = 0;
+    for (auto i = 0; i < C * N; i += N) {
+        const int32_t ri = radii[idx + i];
+        if (ri <= 0) {
+            continue;
+        }
+        const T dldm2x = dLossDMeans2d[(idx + i) * 2] * (T(imageWidth) / T(2) * T(C));
+        const T dldm2y = dLossDMeans2d[(idx + i) * 2 + 1] * (T(imageHeight) / T(2) * T(C));
+        normAccum += nanovdb::math::Sqrt(dldm2x * dldm2x + dldm2y * dldm2y);
+        stepCount += 1;
+    }
+    outDLossDMeans2dNormAccum[idx] += normAccum;
+    outGradientStepCounts[idx] += stepCount;
+}
+
+template <typename T>
 __global__ __launch_bounds__(DEFAULT_BLOCK_DIM) void
 computeGradientState(const int32_t offset,
                      const int32_t count,
@@ -46,6 +80,7 @@ computeGradientState(const int32_t offset,
 
     T normAccum       = T(0);
     int32_t stepCount = 0;
+    int32_t maxRad    = 0;
     for (auto i = 0; i < C * N; i += N) {
         const int32_t ri = radii[idx + i];
         if (ri <= 0) {
@@ -55,18 +90,9 @@ computeGradientState(const int32_t offset,
         const T dldm2y = dLossDMeans2d[(idx + i) * 2 + 1] * (T(imageHeight) / T(2) * T(C));
         normAccum += nanovdb::math::Sqrt(dldm2x * dldm2x + dldm2y * dldm2y);
         stepCount += 1;
+        maxRad = nanovdb::math::Max(maxRad, ri);
     }
-    if constexpr (TRACK_MAX_RADII) {
-        int32_t maxRad = 0;
-        for (auto i = 0; i < C * N; i += N) {
-            const int32_t ri = radii[idx + i];
-            if (ri <= 0) {
-                continue;
-            }
-            maxRad = nanovdb::math::Max(maxRad, ri);
-        }
-        outMaxRadiiAccum[idx] = nanovdb::math::Max(outMaxRadiiAccum[idx], maxRad);
-    }
+    outMaxRadiiAccum[idx] = nanovdb::math::Max(outMaxRadiiAccum[idx], maxRad);
     outDLossDMeans2dNormAccum[idx] += normAccum;
     outGradientStepCounts[idx] += stepCount;
 }
@@ -101,16 +127,16 @@ projectionBackwardKernel(const int32_t offset,
                          T *__restrict__ outDLossDWorldToCamMatrices // [C, 4, 4] optional
 ) {
     // parallelize over C * N.
-    uint32_t idx = cg::this_grid().thread_rank();
-    if (idx >= count) {
+    uint32_t cId = blockIdx.y;
+    uint32_t gId = blockIdx.x * blockDim.x + threadIdx.x;
+    if (gId >= count) {
         return;
     }
-    idx += offset;
+    gId += offset;
+    auto idx = cId * N + gId;
     if (radii[idx] <= 0) {
         return;
     }
-    const uint32_t cId = idx / N; // camera id
-    const uint32_t gId = idx % N; // gaussian id
 
     // shift pointers to the current camera and gaussian
     means += gId * 3;
@@ -193,6 +219,7 @@ projectionBackwardKernel(const int32_t offset,
             quaternionAndScaleToCovarianceVectorJacobianProduct<T, true>(
                 quat, scale, rotmat, dLossDCovar);
 
+        warpSum(dLossDQuat, warp_group_g);
         warpSum(dLossDLogScale, warp_group_g);
         if (warp_group_g.thread_rank() == 0) {
             outDLossDQuats += gId * 4;
@@ -299,19 +326,19 @@ dispatchGaussianProjectionBackward<torch::kCUDA>(
         dLossDWorldToCamMatrices = torch::zeros_like(worldToCamMatrices);
     }
     if (C && N) {
+        const dim3 NUM_BLOCKS(GET_BLOCKS(N, DEFAULT_BLOCK_DIM), C);
         if (ortho) {
-            const size_t NUM_BLOCKS = GET_BLOCKS(C * N, DEFAULT_BLOCK_DIM);
-            const auto camera       = OrthographicCamera<float>{projectionMatrices,
-                                                                worldToCamMatrices,
-                                                                static_cast<int32_t>(C),
-                                                                static_cast<int32_t>(imageWidth),
-                                                                static_cast<int32_t>(imageHeight),
-                                                                kBackwardProjectionNearPlane,
-                                                                kBackwardProjectionFarPlane};
+            const auto camera = OrthographicCamera<float>{projectionMatrices,
+                                                          worldToCamMatrices,
+                                                          static_cast<int32_t>(C),
+                                                          static_cast<int32_t>(imageWidth),
+                                                          static_cast<int32_t>(imageHeight),
+                                                          kBackwardProjectionNearPlane,
+                                                          kBackwardProjectionFarPlane};
             projectionBackwardKernel<float, OrthographicCamera<float>>
                 <<<NUM_BLOCKS, DEFAULT_BLOCK_DIM, 0, stream>>>(
                     0,
-                    C * N,
+                    N,
                     C,
                     N,
                     means.data_ptr<float>(),
@@ -335,18 +362,17 @@ dispatchGaussianProjectionBackward<torch::kCUDA>(
                     worldToCamMatricesRequiresGrad ? dLossDWorldToCamMatrices.data_ptr<float>()
                                                    : nullptr);
         } else {
-            const size_t NUM_BLOCKS = GET_BLOCKS(C * N, DEFAULT_BLOCK_DIM);
-            const auto camera       = PerspectiveCamera<float>{projectionMatrices,
-                                                               worldToCamMatrices,
-                                                               static_cast<int32_t>(C),
-                                                               static_cast<int32_t>(imageWidth),
-                                                               static_cast<int32_t>(imageHeight),
-                                                               kBackwardProjectionNearPlane,
-                                                               kBackwardProjectionFarPlane};
+            const auto camera = PerspectiveCamera<float>{projectionMatrices,
+                                                         worldToCamMatrices,
+                                                         static_cast<int32_t>(C),
+                                                         static_cast<int32_t>(imageWidth),
+                                                         static_cast<int32_t>(imageHeight),
+                                                         kBackwardProjectionNearPlane,
+                                                         kBackwardProjectionFarPlane};
             projectionBackwardKernel<float, PerspectiveCamera<float>>
                 <<<NUM_BLOCKS, DEFAULT_BLOCK_DIM, 0, stream>>>(
                     0,
-                    C * N,
+                    N,
                     C,
                     N,
                     means.data_ptr<float>(),
@@ -382,7 +408,7 @@ dispatchGaussianProjectionBackward<torch::kCUDA>(
                     outNormalizedMaxRadiiAccum.value().data_ptr<int32_t>();
 
                 const size_t NUM_BLOCKS = GET_BLOCKS(N, DEFAULT_BLOCK_DIM);
-                computeGradientState<float, true><<<NUM_BLOCKS, DEFAULT_BLOCK_DIM, 0, stream>>>(
+                computeGradientState<float><<<NUM_BLOCKS, DEFAULT_BLOCK_DIM, 0, stream>>>(
                     0,
                     N,
                     C,
@@ -396,7 +422,7 @@ dispatchGaussianProjectionBackward<torch::kCUDA>(
                     outGradientStepCountsPtr);
             } else {
                 const size_t NUM_BLOCKS = GET_BLOCKS(N, DEFAULT_BLOCK_DIM);
-                computeGradientState<float, false><<<NUM_BLOCKS, DEFAULT_BLOCK_DIM, 0, stream>>>(
+                computeGradientState<float><<<NUM_BLOCKS, DEFAULT_BLOCK_DIM, 0, stream>>>(
                     0,
                     N,
                     C,
@@ -406,7 +432,6 @@ dispatchGaussianProjectionBackward<torch::kCUDA>(
                     radii.data_ptr<int32_t>(),
                     dLossDMeans2d.data_ptr<float>(),
                     outNormalizeddLossdMeans2dNormAccumPtr,
-                    nullptr,
                     outGradientStepCountsPtr);
             }
             C10_CUDA_KERNEL_LAUNCH_CHECK();
@@ -469,8 +494,8 @@ dispatchGaussianProjectionBackward<torch::kPrivateUse1>(
             auto stream = c10::cuda::getCurrentCUDAStream(deviceId);
 
             int64_t deviceProblemOffset, deviceProblemSize;
-            std::tie(deviceProblemOffset, deviceProblemSize) = deviceChunk(C * N, deviceId);
-            const size_t NUM_BLOCKS = GET_BLOCKS(deviceProblemSize, DEFAULT_BLOCK_DIM);
+            std::tie(deviceProblemOffset, deviceProblemSize) = deviceChunk(N, deviceId);
+            const dim3 NUM_BLOCKS(GET_BLOCKS(deviceProblemSize, DEFAULT_BLOCK_DIM), C);
 
             if (ortho) {
                 const auto camera = OrthographicCamera<float>{projectionMatrices,
@@ -566,7 +591,7 @@ dispatchGaussianProjectionBackward<torch::kPrivateUse1>(
                     std::tie(deviceProblemOffset, deviceProblemSize) = deviceChunk(N, deviceId);
                     const size_t NUM_BLOCKS = GET_BLOCKS(deviceProblemSize, DEFAULT_BLOCK_DIM);
 
-                    computeGradientState<float, true><<<NUM_BLOCKS, DEFAULT_BLOCK_DIM, 0, stream>>>(
+                    computeGradientState<float><<<NUM_BLOCKS, DEFAULT_BLOCK_DIM, 0, stream>>>(
                         deviceProblemOffset,
                         deviceProblemSize,
                         C,
@@ -592,19 +617,17 @@ dispatchGaussianProjectionBackward<torch::kPrivateUse1>(
                     std::tie(deviceProblemOffset, deviceProblemSize) = deviceChunk(N, deviceId);
                     const size_t NUM_BLOCKS = GET_BLOCKS(deviceProblemSize, DEFAULT_BLOCK_DIM);
 
-                    computeGradientState<float, false>
-                        <<<NUM_BLOCKS, DEFAULT_BLOCK_DIM, 0, stream>>>(
-                            deviceProblemOffset,
-                            deviceProblemSize,
-                            C,
-                            N,
-                            imageWidth,
-                            imageHeight,
-                            radii.data_ptr<int32_t>(),
-                            dLossDMeans2d.data_ptr<float>(),
-                            outNormalizeddLossdMeans2dNormAccumPtr,
-                            nullptr,
-                            outGradientStepCountsPtr);
+                    computeGradientState<float><<<NUM_BLOCKS, DEFAULT_BLOCK_DIM, 0, stream>>>(
+                        deviceProblemOffset,
+                        deviceProblemSize,
+                        C,
+                        N,
+                        imageWidth,
+                        imageHeight,
+                        radii.data_ptr<int32_t>(),
+                        dLossDMeans2d.data_ptr<float>(),
+                        outNormalizeddLossdMeans2dNormAccumPtr,
+                        outGradientStepCountsPtr);
                     C10_CUDA_KERNEL_LAUNCH_CHECK();
                 }
 

--- a/src/fvdb/detail/ops/gsplat/GaussianProjectionBackward.cu
+++ b/src/fvdb/detail/ops/gsplat/GaussianProjectionBackward.cu
@@ -126,8 +126,12 @@ projectionBackwardKernel(const int32_t offset,
                          T *__restrict__ outDLossDScales,            // [N, 3] optional
                          T *__restrict__ outDLossDWorldToCamMatrices // [C, 4, 4] optional
 ) {
-    // parallelize over C * N.
     uint32_t cId = blockIdx.y;
+    alignas(nanovdb::math::Mat3<T>) extern __shared__ char sharedMemory[];
+    camera.loadSharedMemory(cId, sharedMemory);
+    __syncthreads();
+
+    // parallelize over N.
     uint32_t gId = blockIdx.x * blockDim.x + threadIdx.x;
     if (gId >= count) {
         return;
@@ -336,7 +340,7 @@ dispatchGaussianProjectionBackward<torch::kCUDA>(
                                                           kBackwardProjectionNearPlane,
                                                           kBackwardProjectionFarPlane};
             projectionBackwardKernel<float, OrthographicCamera<float>>
-                <<<NUM_BLOCKS, DEFAULT_BLOCK_DIM, 0, stream>>>(
+                <<<NUM_BLOCKS, DEFAULT_BLOCK_DIM, camera.numSharedMemBytes(), stream>>>(
                     0,
                     N,
                     C,
@@ -370,7 +374,7 @@ dispatchGaussianProjectionBackward<torch::kCUDA>(
                                                          kBackwardProjectionNearPlane,
                                                          kBackwardProjectionFarPlane};
             projectionBackwardKernel<float, PerspectiveCamera<float>>
-                <<<NUM_BLOCKS, DEFAULT_BLOCK_DIM, 0, stream>>>(
+                <<<NUM_BLOCKS, DEFAULT_BLOCK_DIM, camera.numSharedMemBytes(), stream>>>(
                     0,
                     N,
                     C,
@@ -506,7 +510,7 @@ dispatchGaussianProjectionBackward<torch::kPrivateUse1>(
                                                               kBackwardProjectionNearPlane,
                                                               kBackwardProjectionFarPlane};
                 projectionBackwardKernel<float, OrthographicCamera<float>>
-                    <<<NUM_BLOCKS, DEFAULT_BLOCK_DIM, 0, stream>>>(
+                    <<<NUM_BLOCKS, DEFAULT_BLOCK_DIM, camera.numSharedMemBytes(), stream>>>(
                         deviceProblemOffset,
                         deviceProblemSize,
                         C,
@@ -542,7 +546,7 @@ dispatchGaussianProjectionBackward<torch::kPrivateUse1>(
                                                              kBackwardProjectionNearPlane,
                                                              kBackwardProjectionFarPlane};
                 projectionBackwardKernel<float, PerspectiveCamera<float>>
-                    <<<NUM_BLOCKS, DEFAULT_BLOCK_DIM, 0, stream>>>(
+                    <<<NUM_BLOCKS, DEFAULT_BLOCK_DIM, camera.numSharedMemBytes(), stream>>>(
                         deviceProblemOffset,
                         deviceProblemSize,
                         C,

--- a/src/fvdb/detail/ops/gsplat/GaussianProjectionForward.cu
+++ b/src/fvdb/detail/ops/gsplat/GaussianProjectionForward.cu
@@ -148,9 +148,9 @@ template <typename T, typename Camera> struct ProjectionForward {
 
     /// @brief Stage per-camera projection and pose matrices into shared memory.
     inline __device__ void
-    loadCamerasIntoSharedMemory() {
+    loadCameraIntoSharedMemory(unsigned int cid) {
         alignas(Mat3) extern __shared__ char sharedMemory[];
-        mCamera.loadSharedMemory(sharedMemory);
+        mCamera.loadSharedMemory(cid, sharedMemory);
     }
 };
 
@@ -159,11 +159,11 @@ __global__ __launch_bounds__(DEFAULT_BLOCK_DIM) void
 projectionForwardKernel(int64_t offset,
                         int64_t count,
                         ProjectionForward<T, Camera> projectionForward) {
-    projectionForward.loadCamerasIntoSharedMemory();
+    auto cid = blockIdx.y;
+    projectionForward.loadCameraIntoSharedMemory(cid);
     __syncthreads();
 
-    // parallelize over C * N.
-    auto cid = blockIdx.y;
+    // parallelize over N.
     for (auto gid = blockIdx.x * blockDim.x + threadIdx.x; gid < count;
          gid += blockDim.x * gridDim.x) {
         projectionForward.projectionForward(cid, gid + offset);
@@ -220,8 +220,6 @@ dispatchGaussianProjectionForward<torch::kCUDA>(
     using scalar_t = float;
 
     const dim3 NUM_BLOCKS(GET_BLOCKS(N, DEFAULT_BLOCK_DIM), C);
-    const size_t SHARD_MEM_SIZE =
-        C * (2 * sizeof(nanovdb::math::Mat3<scalar_t>) + sizeof(nanovdb::math::Vec3<scalar_t>));
 
     if (ortho) {
         const auto camera = OrthographicCamera<scalar_t>{projectionMatrices,
@@ -245,7 +243,7 @@ dispatchGaussianProjectionForward<torch::kCUDA>(
             outConics,
             outCompensations);
         projectionForwardKernel<scalar_t, OrthographicCamera<scalar_t>>
-            <<<NUM_BLOCKS, DEFAULT_BLOCK_DIM, SHARD_MEM_SIZE, stream>>>(
+            <<<NUM_BLOCKS, DEFAULT_BLOCK_DIM, camera.numSharedMemBytes(), stream>>>(
                 0, N, projectionForward);
         C10_CUDA_KERNEL_LAUNCH_CHECK();
     } else {
@@ -270,7 +268,7 @@ dispatchGaussianProjectionForward<torch::kCUDA>(
             outConics,
             outCompensations);
         projectionForwardKernel<scalar_t, PerspectiveCamera<scalar_t>>
-            <<<NUM_BLOCKS, DEFAULT_BLOCK_DIM, SHARD_MEM_SIZE, stream>>>(
+            <<<NUM_BLOCKS, DEFAULT_BLOCK_DIM, camera.numSharedMemBytes(), stream>>>(
                 0, N, projectionForward);
         C10_CUDA_KERNEL_LAUNCH_CHECK();
     }
@@ -329,8 +327,6 @@ dispatchGaussianProjectionForward<torch::kPrivateUse1>(
         std::tie(deviceProblemOffset, deviceProblemSize) = deviceChunk(N, deviceId);
 
         const dim3 NUM_BLOCKS(GET_BLOCKS(deviceProblemSize, DEFAULT_BLOCK_DIM), C);
-        const size_t SHARD_MEM_SIZE =
-            C * (2 * sizeof(nanovdb::math::Mat3<scalar_t>) + sizeof(nanovdb::math::Vec3<scalar_t>));
 
         if (ortho) {
             const auto camera = OrthographicCamera<scalar_t>{projectionMatrices,
@@ -354,7 +350,7 @@ dispatchGaussianProjectionForward<torch::kPrivateUse1>(
                 outConics,
                 outCompensations);
             projectionForwardKernel<scalar_t, OrthographicCamera<scalar_t>>
-                <<<NUM_BLOCKS, DEFAULT_BLOCK_DIM, SHARD_MEM_SIZE, stream>>>(
+                <<<NUM_BLOCKS, DEFAULT_BLOCK_DIM, camera.numSharedMemBytes(), stream>>>(
                     deviceProblemOffset, deviceProblemSize, projectionForward);
             C10_CUDA_KERNEL_LAUNCH_CHECK();
         } else {
@@ -379,7 +375,7 @@ dispatchGaussianProjectionForward<torch::kPrivateUse1>(
                 outConics,
                 outCompensations);
             projectionForwardKernel<scalar_t, PerspectiveCamera<scalar_t>>
-                <<<NUM_BLOCKS, DEFAULT_BLOCK_DIM, SHARD_MEM_SIZE, stream>>>(
+                <<<NUM_BLOCKS, DEFAULT_BLOCK_DIM, camera.numSharedMemBytes(), stream>>>(
                     deviceProblemOffset, deviceProblemSize, projectionForward);
             C10_CUDA_KERNEL_LAUNCH_CHECK();
         }

--- a/src/fvdb/detail/ops/gsplat/GaussianProjectionForward.cu
+++ b/src/fvdb/detail/ops/gsplat/GaussianProjectionForward.cu
@@ -219,7 +219,7 @@ dispatchGaussianProjectionForward<torch::kCUDA>(
 
     using scalar_t = float;
 
-    const dim3 NUM_BLOCKS(GET_BLOCKS(N, DEFAULT_BLOCK_DIM), C, 1);
+    const dim3 NUM_BLOCKS(GET_BLOCKS(N, DEFAULT_BLOCK_DIM), C);
     const size_t SHARD_MEM_SIZE =
         C * (2 * sizeof(nanovdb::math::Mat3<scalar_t>) + sizeof(nanovdb::math::Vec3<scalar_t>));
 
@@ -328,7 +328,7 @@ dispatchGaussianProjectionForward<torch::kPrivateUse1>(
         int64_t deviceProblemOffset, deviceProblemSize;
         std::tie(deviceProblemOffset, deviceProblemSize) = deviceChunk(N, deviceId);
 
-        const dim3 NUM_BLOCKS(GET_BLOCKS(deviceProblemSize, DEFAULT_BLOCK_DIM), C, 1);
+        const dim3 NUM_BLOCKS(GET_BLOCKS(deviceProblemSize, DEFAULT_BLOCK_DIM), C);
         const size_t SHARD_MEM_SIZE =
             C * (2 * sizeof(nanovdb::math::Mat3<scalar_t>) + sizeof(nanovdb::math::Vec3<scalar_t>));
 

--- a/src/fvdb/detail/ops/gsplat/GaussianProjectionForward.cu
+++ b/src/fvdb/detail/ops/gsplat/GaussianProjectionForward.cu
@@ -95,12 +95,10 @@ template <typename T, typename Camera> struct ProjectionForward {
 
     /// @brief Project one (camera, gaussian) pair and write packed 2D outputs.
     inline __device__ void
-    projectionForward(int idx) {
-        if (idx >= C * N) {
+    projectionForward(int cid, int gid) {
+        if (gid >= N) {
             return;
         }
-        const auto cid = idx / N; // camera id
-        const auto gid = idx % N; // gaussian id
 
         const Vec3 meanWorldSpace(mMeansAcc[gid][0], mMeansAcc[gid][1], mMeansAcc[gid][2]);
         const Mat3 covar = computeCovarianceMatrix(gid);
@@ -144,7 +142,7 @@ template <typename T, typename Camera> struct ProjectionForward {
         mOutConicsAcc[cid][gid][1]               = conicPacked[1];
         mOutConicsAcc[cid][gid][2]               = conicPacked[2];
         if (mOutCompensationsAcc != nullptr) {
-            mOutCompensationsAcc[idx] = compensation;
+            mOutCompensationsAcc[cid * N + gid] = compensation;
         }
     }
 
@@ -165,9 +163,10 @@ projectionForwardKernel(int64_t offset,
     __syncthreads();
 
     // parallelize over C * N.
-    for (auto idx = blockIdx.x * blockDim.x + threadIdx.x; idx < count;
-         idx += blockDim.x * gridDim.x) {
-        projectionForward.projectionForward(idx + offset);
+    auto cid = blockIdx.y;
+    for (auto gid = blockIdx.x * blockDim.x + threadIdx.x; gid < count;
+         gid += blockDim.x * gridDim.x) {
+        projectionForward.projectionForward(cid, gid + offset);
     }
 }
 
@@ -220,7 +219,7 @@ dispatchGaussianProjectionForward<torch::kCUDA>(
 
     using scalar_t = float;
 
-    const size_t NUM_BLOCKS = GET_BLOCKS(C * N, DEFAULT_BLOCK_DIM);
+    const dim3 NUM_BLOCKS(GET_BLOCKS(N, DEFAULT_BLOCK_DIM), C, 1);
     const size_t SHARD_MEM_SIZE =
         C * (2 * sizeof(nanovdb::math::Mat3<scalar_t>) + sizeof(nanovdb::math::Vec3<scalar_t>));
 
@@ -247,7 +246,7 @@ dispatchGaussianProjectionForward<torch::kCUDA>(
             outCompensations);
         projectionForwardKernel<scalar_t, OrthographicCamera<scalar_t>>
             <<<NUM_BLOCKS, DEFAULT_BLOCK_DIM, SHARD_MEM_SIZE, stream>>>(
-                0, C * N, projectionForward);
+                0, N, projectionForward);
         C10_CUDA_KERNEL_LAUNCH_CHECK();
     } else {
         const auto camera = PerspectiveCamera<scalar_t>{projectionMatrices,
@@ -272,7 +271,7 @@ dispatchGaussianProjectionForward<torch::kCUDA>(
             outCompensations);
         projectionForwardKernel<scalar_t, PerspectiveCamera<scalar_t>>
             <<<NUM_BLOCKS, DEFAULT_BLOCK_DIM, SHARD_MEM_SIZE, stream>>>(
-                0, C * N, projectionForward);
+                0, N, projectionForward);
         C10_CUDA_KERNEL_LAUNCH_CHECK();
     }
     return std::make_tuple(outRadii, outMeans2d, outDepths, outConics, outCompensations);
@@ -327,9 +326,9 @@ dispatchGaussianProjectionForward<torch::kPrivateUse1>(
         auto stream = c10::cuda::getCurrentCUDAStream(deviceId);
 
         int64_t deviceProblemOffset, deviceProblemSize;
-        std::tie(deviceProblemOffset, deviceProblemSize) = deviceChunk(C * N, deviceId);
+        std::tie(deviceProblemOffset, deviceProblemSize) = deviceChunk(N, deviceId);
 
-        const size_t NUM_BLOCKS = GET_BLOCKS(deviceProblemSize, DEFAULT_BLOCK_DIM);
+        const dim3 NUM_BLOCKS(GET_BLOCKS(deviceProblemSize, DEFAULT_BLOCK_DIM), C, 1);
         const size_t SHARD_MEM_SIZE =
             C * (2 * sizeof(nanovdb::math::Mat3<scalar_t>) + sizeof(nanovdb::math::Vec3<scalar_t>));
 

--- a/src/fvdb/detail/ops/gsplat/GaussianProjectionForward.cu
+++ b/src/fvdb/detail/ops/gsplat/GaussianProjectionForward.cu
@@ -101,18 +101,17 @@ template <typename T, typename Camera> struct ProjectionForward {
         }
 
         const Vec3 meanWorldSpace(mMeansAcc[gid][0], mMeansAcc[gid][1], mMeansAcc[gid][2]);
+        if (!mCamera.isVisible(cid, meanWorldSpace)) {
+            return;
+        }
+
         const Mat3 covar = computeCovarianceMatrix(gid);
         auto [covar2d, mean2d, depthCam] =
             mCamera.projectWorldGaussianTo2D(cid, meanWorldSpace, covar);
-        if (!mCamera.isDepthVisible(depthCam)) {
-            mOutRadiiAcc[cid][gid] = 0;
-            return;
-        }
 
         T compensation;
         const T det = addBlur(mEps2d, covar2d, compensation);
         if (det <= 0.f) {
-            mOutRadiiAcc[cid][gid] = 0;
             return;
         }
 
@@ -122,13 +121,11 @@ template <typename T, typename Camera> struct ProjectionForward {
         const T radius = radiusFromCovariance2dDet(covar2d, det, T(3));
 
         if (radius <= mRadiusClip) {
-            mOutRadiiAcc[cid][gid] = 0;
             return;
         }
 
         // Mask out gaussians outside the image region
         if (mCamera.isProjectedFootprintOutsideImage(mean2d, radius, radius)) {
-            mOutRadiiAcc[cid][gid] = 0;
             return;
         }
 
@@ -202,7 +199,7 @@ dispatchGaussianProjectionForward<torch::kCUDA>(
     const auto C                = worldToCamMatrices.size(0); // number of cameras
     at::cuda::CUDAStream stream = at::cuda::getCurrentCUDAStream(means.device().index());
 
-    torch::Tensor outRadii   = torch::empty({C, N}, means.options().dtype(torch::kInt32));
+    torch::Tensor outRadii   = torch::zeros({C, N}, means.options().dtype(torch::kInt32));
     torch::Tensor outMeans2d = torch::empty({C, N, 2}, means.options());
     torch::Tensor outDepths  = torch::empty({C, N}, means.options());
     torch::Tensor outConics  = torch::empty({C, N, 3}, means.options());
@@ -302,7 +299,7 @@ dispatchGaussianProjectionForward<torch::kPrivateUse1>(
     const auto N = means.size(0);              // number of gaussians
     const auto C = worldToCamMatrices.size(0); // number of cameras
 
-    torch::Tensor outRadii   = torch::empty({C, N}, means.options().dtype(torch::kInt32));
+    torch::Tensor outRadii   = torch::zeros({C, N}, means.options().dtype(torch::kInt32));
     torch::Tensor outMeans2d = torch::empty({C, N, 2}, means.options());
     torch::Tensor outDepths  = torch::empty({C, N}, means.options());
     torch::Tensor outConics  = torch::empty({C, N, 3}, means.options());

--- a/src/fvdb/detail/ops/gsplat/GaussianProjectionJaggedForward.cu
+++ b/src/fvdb/detail/ops/gsplat/GaussianProjectionJaggedForward.cu
@@ -56,6 +56,10 @@ jaggedProjectionForwardKernel(const uint32_t B,
     // shift pointers to the current camera and gaussian
     means += gId * 3;
     const nanovdb::math::Vec3<T> meanWorldSpace(means[0], means[1], means[2]);
+    if (!camera.isVisible(cId, meanWorldSpace)) {
+        return;
+    }
+
     nanovdb::math::Mat3<T> covar;
     if (covars != nullptr) {
         covars += gId * 6;
@@ -70,15 +74,10 @@ jaggedProjectionForwardKernel(const uint32_t B,
         covar = quaternionAndScaleToCovariance<T>(quat, scale);
     }
     auto [covar2d, mean2d, depthCam] = camera.projectWorldGaussianTo2D(cId, meanWorldSpace, covar);
-    if (!camera.isDepthVisible(depthCam)) {
-        radii[idx] = 0;
-        return;
-    }
 
     T compensation;
     const T det = addBlur(eps2d, covar2d, compensation);
     if (det <= 0.f) {
-        radii[idx] = 0;
         return;
     }
 
@@ -91,13 +90,11 @@ jaggedProjectionForwardKernel(const uint32_t B,
     // T radius = ceil(3.f * sqrt(max(v1, v2)));
 
     if (radius <= radiusClip) {
-        radii[idx] = 0;
         return;
     }
 
     // mask out gaussians outside the image region
     if (camera.isProjectedFootprintOutsideImage(mean2d, radius, radius)) {
-        radii[idx] = 0;
         return;
     }
 
@@ -162,7 +159,7 @@ dispatchGaussianProjectionJaggedForward<torch::kCUDA>(
 
     at::cuda::CUDAStream stream = at::cuda::getCurrentCUDAStream(means.device().index());
 
-    torch::Tensor radii   = torch::empty({N}, means.options().dtype(torch::kInt32));
+    torch::Tensor radii   = torch::zeros({N}, means.options().dtype(torch::kInt32));
     torch::Tensor means2d = torch::empty({N, 2}, means.options());
     torch::Tensor depths  = torch::empty({N}, means.options());
     torch::Tensor conics  = torch::empty({N, 3}, means.options());

--- a/src/fvdb/detail/ops/gsplat/GaussianRasterizeBackward.cu
+++ b/src/fvdb/detail/ops/gsplat/GaussianRasterizeBackward.cu
@@ -123,12 +123,6 @@ struct RasterizeBackwardArgs {
                           "Bad size for outDLossDConics");
         TORCH_CHECK_VALUE(NUM_CHANNELS == mOutDLossDFeatures.size(CommonArgs::NUM_OUTER_DIMS),
                           "Bad size for outDLossDFeatures");
-        TORCH_CHECK_VALUE(2 == mOutDLossDMeans2d.size(CommonArgs::NUM_OUTER_DIMS),
-                          "Bad size for outDLossDMeans2d");
-        TORCH_CHECK_VALUE(3 == mOutDLossDConics.size(CommonArgs::NUM_OUTER_DIMS),
-                          "Bad size for outDLossDConics");
-        TORCH_CHECK_VALUE(NUM_CHANNELS == mOutDLossDFeatures.size(CommonArgs::NUM_OUTER_DIMS),
-                          "Bad size for outDLossDFeatures");
 
         if constexpr (IS_PACKED) {
             if (mAbsGrad) {
@@ -713,14 +707,13 @@ struct RasterizeBackwardArgs {
                 // For each Gaussian which contributes to this pixel, compute this pixel's
                 // gradient contribution to that Gaussian
                 const int32_t batchSize = min(blockSize, batchEnd + 1 - firstGaussianIdInBlock);
+                // (row, col) coordinates are relative to the specified image origin which may
+                // be a crop so we need to add the origin to get the absolute pixel coordinates
+                const ScalarType px =
+                    col + ScalarType(commonArgs.renderOriginX()) + ScalarType{0.5};
+                const ScalarType py =
+                    row + ScalarType(commonArgs.renderOriginY()) + ScalarType{0.5};
                 for (uint32_t t = max(0, batchEnd - lastGaussianIdInWarp); t < batchSize; ++t) {
-                    // (row, col) coordinates are relative to the specified image origin which may
-                    // be a crop so we need to add the origin to get the absolute pixel coordinates
-                    const ScalarType px =
-                        col + ScalarType(commonArgs.renderOriginX()) + ScalarType{0.5};
-                    const ScalarType py =
-                        row + ScalarType(commonArgs.renderOriginY()) + ScalarType{0.5};
-
                     bool valid = pixelIsActive && (batchEnd - t <= lastGaussianId);
 
                     const auto [gaussianIsValid, delta, expMinusSigma, alpha] = [&]() {
@@ -1253,6 +1246,19 @@ callRasterizeBackwardPrivateUse1(
         C10_CUDA_CHECK(cudaEventRecord(events[deviceId], stream));
     }
 
+    const size_t numChannels =
+        (NUM_SHARED_CHANNELS == NUM_CHANNELS) ? NUM_CHANNELS : NUM_SHARED_CHANNELS + 1;
+    const size_t sharedMemSize = getSharedMemRequirements<ScalarType>(numChannels, tileSize);
+
+    if (cudaFuncSetAttribute(
+            rasterizeGaussiansBackward<ScalarType, NUM_CHANNELS, NUM_SHARED_CHANNELS, IS_PACKED>,
+            cudaFuncAttributeMaxDynamicSharedMemorySize,
+            sharedMemSize) != cudaSuccess) {
+        AT_ERROR("Failed to set maximum shared memory size (requested ",
+                 sharedMemSize,
+                 " bytes), try lowering tileSize.");
+    }
+
     for (const auto deviceId: c10::irange(c10::cuda::device_count())) {
         C10_CUDA_CHECK(cudaSetDevice(deviceId));
         auto stream = c10::cuda::getCurrentCUDAStream(deviceId);
@@ -1288,27 +1294,9 @@ callRasterizeBackwardPrivateUse1(
                 tilePixelCumsum,
                 pixelMap);
 
-            const size_t numChannels =
-                (NUM_SHARED_CHANNELS == NUM_CHANNELS) ? NUM_CHANNELS : NUM_SHARED_CHANNELS + 1;
-            const size_t sharedMemSize =
-                getSharedMemRequirements<ScalarType>(numChannels, tileSize);
-
-            if (cudaFuncSetAttribute(rasterizeGaussiansBackward<ScalarType,
-                                                                NUM_CHANNELS,
-                                                                NUM_SHARED_CHANNELS,
-                                                                IS_PACKED>,
-                                     cudaFuncAttributeMaxDynamicSharedMemorySize,
-                                     sharedMemSize) != cudaSuccess) {
-                AT_ERROR("Failed to set maximum shared memory size (requested ",
-                         sharedMemSize,
-                         " bytes), try lowering tileSize.");
-            }
-
-            const dim3 blockDim = {tileSize, tileSize, 1};
-            const dim3 gridDim  = {deviceTileCount, 1, 1};
-
+            const dim3 gridDim = {deviceTileCount, 1, 1};
             rasterizeGaussiansBackward<ScalarType, NUM_CHANNELS, NUM_SHARED_CHANNELS, IS_PACKED>
-                <<<gridDim, blockDim, sharedMemSize, stream>>>(args);
+                <<<gridDim, args.commonArgs.getBlockDim(), sharedMemSize, stream>>>(args);
             C10_CUDA_KERNEL_LAUNCH_CHECK();
         }
     }

--- a/src/fvdb/detail/ops/gsplat/GaussianRasterizeForward.cu
+++ b/src/fvdb/detail/ops/gsplat/GaussianRasterizeForward.cu
@@ -561,8 +561,11 @@ launchRasterizeForwardKernels(
                                                                                   tilePixelCumsum,
                                                                                   pixelMap);
 
-            const dim3 gridDim  = {deviceTileCount, 1, 1};
-            rasterizeGaussiansForward<<<gridDim, args.commonArgs.getBlockDim(), sharedMem, stream>>>(args);
+            const dim3 gridDim = {deviceTileCount, 1, 1};
+            rasterizeGaussiansForward<<<gridDim,
+                                        args.commonArgs.getBlockDim(),
+                                        sharedMem,
+                                        stream>>>(args);
 
             C10_CUDA_KERNEL_LAUNCH_CHECK();
         }

--- a/src/fvdb/detail/ops/gsplat/GaussianRasterizeForward.cu
+++ b/src/fvdb/detail/ops/gsplat/GaussianRasterizeForward.cu
@@ -519,6 +519,20 @@ launchRasterizeForwardKernels(
         C10_CUDA_CHECK(cudaEventRecord(events[deviceId], stream));
     }
 
+    // Thread blocks cooperatively cache a tile of Gaussians in shared memory
+    const uint32_t sharedMem = getSharedMemRequirements<ScalarType>(tileSize);
+
+    // TODO: an optimization can be done by passing the actual number of
+    // channels into the kernel functions and avoid necessary global memory
+    // writes. This requires moving the channel padding from python to C side.
+    if (cudaFuncSetAttribute(rasterizeGaussiansForward<ScalarType, NUM_CHANNELS, IS_PACKED>,
+                             cudaFuncAttributeMaxDynamicSharedMemorySize,
+                             sharedMem) != cudaSuccess) {
+        AT_ERROR("Failed to set maximum shared memory size (requested ",
+                 sharedMem,
+                 " bytes), try lowering tile_size.");
+    }
+
     for (const auto deviceId: c10::irange(c10::cuda::device_count())) {
         C10_CUDA_CHECK(cudaSetDevice(deviceId));
         auto stream = c10::cuda::getCurrentCUDAStream(deviceId);
@@ -547,24 +561,8 @@ launchRasterizeForwardKernels(
                                                                                   tilePixelCumsum,
                                                                                   pixelMap);
 
-            // Thread blocks cooperatively cache a tile of Gaussians in shared memory
-            const uint32_t sharedMem = getSharedMemRequirements<ScalarType>(tileSize);
-
-            // TODO: an optimization can be done by passing the actual number of
-            // channels into the kernel functions and avoid necessary global memory
-            // writes. This requires moving the channel padding from python to C side.
-            if (cudaFuncSetAttribute(rasterizeGaussiansForward<ScalarType, NUM_CHANNELS, IS_PACKED>,
-                                     cudaFuncAttributeMaxDynamicSharedMemorySize,
-                                     sharedMem) != cudaSuccess) {
-                AT_ERROR("Failed to set maximum shared memory size (requested ",
-                         sharedMem,
-                         " bytes), try lowering tile_size.");
-            }
-
-            const dim3 blockDim = {tileSize, tileSize, 1};
             const dim3 gridDim  = {deviceTileCount, 1, 1};
-
-            rasterizeGaussiansForward<<<gridDim, blockDim, sharedMem, stream>>>(args);
+            rasterizeGaussiansForward<<<gridDim, args.commonArgs.getBlockDim(), sharedMem, stream>>>(args);
 
             C10_CUDA_KERNEL_LAUNCH_CHECK();
         }


### PR DESCRIPTION
1. Instead of parameterizing forward and backward projection as 1-D grids and blocks over C * N elements, we parameterize it as 2-D grids and blocks with N elements in the x direction and C elements in the y direction. This re-parameterization enables us to load a single camera for each block, thus bypassing the O(C^2) shared memory usage arising from each batch i.e. O(C) loading C cameras.
2. Instead of the first 9 threads loading two 3x3 matrices in sequence followed by a 3d vector, the first 21 threads simultaneously load the 3x3 matrices and 3d vector into shared memory.
3. The backwards pass now also uses cameras stored in shared memory to avoid repeated loads from global memory.
4. Added an `isVisible` call that computes if a Gaussian is visible based on the 3-D mean. This enables us to avoid the more expensive (relatively speaking) transcendental functions in covariance matrix computation by exiting early.
5. For the mGPU case, `cudaFuncSetAttribute` is called once on the function that is then launched on two different devices instead of being called (idempotently) once per device.

We expect these optimizations to have the most benefit with larger batch sizes. While a single GPU reconstruction with batch size = 1 stays about the same, an 8x GPU reconstruction with batch size = 8 is about 3.5% faster.