### PR TITLE
publish: dual S3 + PyPI publish on release (with GPU tests)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -88,6 +88,7 @@ jobs:
         with:
           sparse-checkout: env/test_environment.yml
           sparse-checkout-cone-mode: false
+          ref: ${{ inputs.branch || github.ref }}
       - name: Parse test environment versions
         id: test-env
         run: |
@@ -176,7 +177,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0 # Fetch all history for all branches
-          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.ref || github.ref }}
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.ref || inputs.branch || github.ref }}
 
       - name: Fetch PR branch
         if: github.event_name == 'pull_request_target'
@@ -323,6 +324,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          ref: ${{ inputs.branch || github.ref }}
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -639,7 +641,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          ref: ${{ github.ref }}
+          ref: ${{ inputs.branch || github.ref }}
 
       - name: Set up fvdb_test Conda env
         uses: mamba-org/setup-micromamba@v2


### PR DESCRIPTION
On GitHub Release events, upload the full wheel matrix to the S3 production index (simple/ prefix) AND publish an sdist to PyPI. Previously these paths were mutually exclusive.

- Add `pypi` and `release` routing flags to pr-flags job
- Handle `release` event: set s3=true, pypi=true, release=true
- Rewrite publish-dist to build and upload an sdist instead of downloading pre-built wheels, matching what PyPI hosts today
- Extend auditwheel repair condition to also run for release events
- Enable GPU validation (smoke test + unit tests) on releases
- Add `release` as a workflow_dispatch publish_target option so a failed release can be re-triggered manually
- Replace github.event_name checks with the release flag so manual dispatch with publish_target=release correctly targets production S3 (simple/) and PyPI