### PR TITLE
Improve mGPU partitioning for SH operators

### DIFF
--- a/src/fvdb/detail/ops/gsplat/GaussianSphericalHarmonicsBackward.cu
+++ b/src/fvdb/detail/ops/gsplat/GaussianSphericalHarmonicsBackward.cu
@@ -47,8 +47,7 @@ evalShFunctionVJP(const int64_t degree,                     // degree of SH to b
 ) {
     T dLossDRenderQuantitiesLocal = dLossDRenderQuantities[c];
 
-    atomicAdd_system(&dLossDSh0Coeffs[gi][0][c],
-                     T(0.2820947917738781) * dLossDRenderQuantitiesLocal);
+    gpuAtomicAdd(&dLossDSh0Coeffs[gi][0][c], T(0.2820947917738781) * dLossDRenderQuantitiesLocal);
 
     if (degree < 1) {
         return;
@@ -59,12 +58,11 @@ evalShFunctionVJP(const int64_t degree,                     // degree of SH to b
     const T z     = dir.z * inorm;
     T vX = 0.f, vY = 0.f, vZ = 0.f;
 
-    atomicAdd_system(&dLossDShNCoeffs[gi][0][c],
-                     T(-0.48860251190292) * y * dLossDRenderQuantitiesLocal);
-    atomicAdd_system(&dLossDShNCoeffs[gi][1][c],
-                     T(0.48860251190292) * z * dLossDRenderQuantitiesLocal);
-    atomicAdd_system(&dLossDShNCoeffs[gi][2][c],
-                     T(-0.48860251190292) * x * dLossDRenderQuantitiesLocal);
+    gpuAtomicAdd(&dLossDShNCoeffs[gi][0][c],
+                 T(-0.48860251190292) * y * dLossDRenderQuantitiesLocal);
+    gpuAtomicAdd(&dLossDShNCoeffs[gi][1][c], T(0.48860251190292) * z * dLossDRenderQuantitiesLocal);
+    gpuAtomicAdd(&dLossDShNCoeffs[gi][2][c],
+                 T(-0.48860251190292) * x * dLossDRenderQuantitiesLocal);
 
     if (dLossDViewDir != nullptr) {
         vX += T(-0.48860251190292) * coeffsN[gi][2][c] * dLossDRenderQuantitiesLocal;
@@ -87,11 +85,11 @@ evalShFunctionVJP(const int64_t degree,                     // degree of SH to b
     const T pSH5   = fTmp0B * y;
     const T pSH8   = T(0.5462742152960395) * fC1;
     const T pSH4   = T(0.5462742152960395) * fS1;
-    atomicAdd_system(&dLossDShNCoeffs[gi][3][c], pSH4 * dLossDRenderQuantitiesLocal);
-    atomicAdd_system(&dLossDShNCoeffs[gi][4][c], pSH5 * dLossDRenderQuantitiesLocal);
-    atomicAdd_system(&dLossDShNCoeffs[gi][5][c], pSH6 * dLossDRenderQuantitiesLocal);
-    atomicAdd_system(&dLossDShNCoeffs[gi][6][c], pSH7 * dLossDRenderQuantitiesLocal);
-    atomicAdd_system(&dLossDShNCoeffs[gi][7][c], pSH8 * dLossDRenderQuantitiesLocal);
+    gpuAtomicAdd(&dLossDShNCoeffs[gi][3][c], pSH4 * dLossDRenderQuantitiesLocal);
+    gpuAtomicAdd(&dLossDShNCoeffs[gi][4][c], pSH5 * dLossDRenderQuantitiesLocal);
+    gpuAtomicAdd(&dLossDShNCoeffs[gi][5][c], pSH6 * dLossDRenderQuantitiesLocal);
+    gpuAtomicAdd(&dLossDShNCoeffs[gi][6][c], pSH7 * dLossDRenderQuantitiesLocal);
+    gpuAtomicAdd(&dLossDShNCoeffs[gi][7][c], pSH8 * dLossDRenderQuantitiesLocal);
 
     T fTmp0B_z, fC1_x, fC1_y, fS1_x, fS1_y, pSH6_z, pSH7_x, pSH7_z, pSH5_y, pSH5_z, pSH8_x, pSH8_y,
         pSH4_x, pSH4_y;
@@ -141,13 +139,13 @@ evalShFunctionVJP(const int64_t degree,                     // degree of SH to b
     const T pSH15  = T(-0.5900435899266435) * fC2;
     const T pSH9   = T(-0.5900435899266435) * fS2;
 
-    atomicAdd_system(&dLossDShNCoeffs[gi][8][c], pSH9 * dLossDRenderQuantitiesLocal);
-    atomicAdd_system(&dLossDShNCoeffs[gi][9][c], pSH10 * dLossDRenderQuantitiesLocal);
-    atomicAdd_system(&dLossDShNCoeffs[gi][10][c], pSH11 * dLossDRenderQuantitiesLocal);
-    atomicAdd_system(&dLossDShNCoeffs[gi][11][c], pSH12 * dLossDRenderQuantitiesLocal);
-    atomicAdd_system(&dLossDShNCoeffs[gi][12][c], pSH13 * dLossDRenderQuantitiesLocal);
-    atomicAdd_system(&dLossDShNCoeffs[gi][13][c], pSH14 * dLossDRenderQuantitiesLocal);
-    atomicAdd_system(&dLossDShNCoeffs[gi][14][c], pSH15 * dLossDRenderQuantitiesLocal);
+    gpuAtomicAdd(&dLossDShNCoeffs[gi][8][c], pSH9 * dLossDRenderQuantitiesLocal);
+    gpuAtomicAdd(&dLossDShNCoeffs[gi][9][c], pSH10 * dLossDRenderQuantitiesLocal);
+    gpuAtomicAdd(&dLossDShNCoeffs[gi][10][c], pSH11 * dLossDRenderQuantitiesLocal);
+    gpuAtomicAdd(&dLossDShNCoeffs[gi][11][c], pSH12 * dLossDRenderQuantitiesLocal);
+    gpuAtomicAdd(&dLossDShNCoeffs[gi][12][c], pSH13 * dLossDRenderQuantitiesLocal);
+    gpuAtomicAdd(&dLossDShNCoeffs[gi][13][c], pSH14 * dLossDRenderQuantitiesLocal);
+    gpuAtomicAdd(&dLossDShNCoeffs[gi][14][c], pSH15 * dLossDRenderQuantitiesLocal);
 
     T fTmp0C_z, fTmp1B_z, fC2_x, fC2_y, fS2_x, fS2_y, pSH12_z, pSH13_x, pSH13_z, pSH11_y, pSH11_z,
         pSH14_x, pSH14_y, pSH14_z, pSH10_x, pSH10_y, pSH10_z, pSH15_x, pSH15_y, pSH9_x, pSH9_y;
@@ -214,15 +212,15 @@ evalShFunctionVJP(const int64_t degree,                     // degree of SH to b
     const T pSH24  = T(0.6258357354491763) * fC3;
     const T pSH16  = T(0.6258357354491763) * fS3;
 
-    atomicAdd_system(&dLossDShNCoeffs[gi][15][c], pSH16 * dLossDRenderQuantitiesLocal);
-    atomicAdd_system(&dLossDShNCoeffs[gi][16][c], pSH17 * dLossDRenderQuantitiesLocal);
-    atomicAdd_system(&dLossDShNCoeffs[gi][17][c], pSH18 * dLossDRenderQuantitiesLocal);
-    atomicAdd_system(&dLossDShNCoeffs[gi][18][c], pSH19 * dLossDRenderQuantitiesLocal);
-    atomicAdd_system(&dLossDShNCoeffs[gi][19][c], pSH20 * dLossDRenderQuantitiesLocal);
-    atomicAdd_system(&dLossDShNCoeffs[gi][20][c], pSH21 * dLossDRenderQuantitiesLocal);
-    atomicAdd_system(&dLossDShNCoeffs[gi][21][c], pSH22 * dLossDRenderQuantitiesLocal);
-    atomicAdd_system(&dLossDShNCoeffs[gi][22][c], pSH23 * dLossDRenderQuantitiesLocal);
-    atomicAdd_system(&dLossDShNCoeffs[gi][23][c], pSH24 * dLossDRenderQuantitiesLocal);
+    gpuAtomicAdd(&dLossDShNCoeffs[gi][15][c], pSH16 * dLossDRenderQuantitiesLocal);
+    gpuAtomicAdd(&dLossDShNCoeffs[gi][16][c], pSH17 * dLossDRenderQuantitiesLocal);
+    gpuAtomicAdd(&dLossDShNCoeffs[gi][17][c], pSH18 * dLossDRenderQuantitiesLocal);
+    gpuAtomicAdd(&dLossDShNCoeffs[gi][18][c], pSH19 * dLossDRenderQuantitiesLocal);
+    gpuAtomicAdd(&dLossDShNCoeffs[gi][19][c], pSH20 * dLossDRenderQuantitiesLocal);
+    gpuAtomicAdd(&dLossDShNCoeffs[gi][20][c], pSH21 * dLossDRenderQuantitiesLocal);
+    gpuAtomicAdd(&dLossDShNCoeffs[gi][21][c], pSH22 * dLossDRenderQuantitiesLocal);
+    gpuAtomicAdd(&dLossDShNCoeffs[gi][22][c], pSH23 * dLossDRenderQuantitiesLocal);
+    gpuAtomicAdd(&dLossDShNCoeffs[gi][23][c], pSH24 * dLossDRenderQuantitiesLocal);
 
     T fTmp0D_z, fTmp1C_z, fTmp2B_z, fC3_x, fC3_y, fS3_x, fS3_y, pSH20_z, pSH21_x, pSH21_z, pSH19_y,
         pSH19_z, pSH22_x, pSH22_y, pSH22_z, pSH18_x, pSH18_y, pSH18_z, pSH23_x, pSH23_y, pSH23_z,
@@ -302,16 +300,15 @@ computeShBackward(
 ) {
     // parallelize over C * N * D
     auto idx = blockIdx.x * blockDim.x + threadIdx.x; // cidx * N * D + gidx * D + c
-    if (idx >= count) {
+    if (idx >= count * C * D) {
         return;
     }
-    idx += offset;
 
-    const auto eid = idx / D; // cidx * N + gidx
-    const auto cid = eid / N; // camera index
-    const auto gid = eid % N; // gaussian index
-    const auto c   = idx % D; // render channel
-    if (radii != nullptr && radii[eid] <= 0) {
+    const auto eid = idx / D;              // cidx * N + gidx
+    const auto cid = eid / count;          // camera index
+    const auto gid = eid % count + offset; // gaussian index
+    const auto c   = idx % D;              // render channel
+    if (radii != nullptr && radii[cid * N + gid] <= 0) {
         return;
     }
 
@@ -335,9 +332,9 @@ computeShBackward(
                       outDLossDShNCoeffs,
                       outDLossDViewDirPtr);
     if (outDLossDViewDirs != nullptr) {
-        atomicAdd_system(outDLossDViewDirs + eid * 3, dLossDViewDir.x);
-        atomicAdd_system(outDLossDViewDirs + eid * 3 + 1, dLossDViewDir.y);
-        atomicAdd_system(outDLossDViewDirs + eid * 3 + 2, dLossDViewDir.z);
+        gpuAtomicAdd(outDLossDViewDirs + (cid * N + gid) * 3, dLossDViewDir.x);
+        gpuAtomicAdd(outDLossDViewDirs + (cid * N + gid) * 3 + 1, dLossDViewDir.y);
+        gpuAtomicAdd(outDLossDViewDirs + (cid * N + gid) * 3 + 2, dLossDViewDir.z);
     }
 }
 
@@ -356,21 +353,20 @@ computeShDiffuseOnlyBackward(
 ) {
     // parallelize over C * N * D
     auto idx = blockIdx.x * blockDim.x + threadIdx.x; // cidx * N * D + gidx * D + c
-    if (idx >= count) {
-        return;
-    }
-    idx += offset;
-
-    const auto eid = idx / D; // cidx * N + gidx
-    const auto cid = eid / N; // camera index
-    const auto gid = eid % N; // gaussian index
-    const auto c   = idx % D; // render channel
-    if (radii != nullptr && radii[eid] <= 0) {
+    if (idx >= count * C * D) {
         return;
     }
 
-    atomicAdd_system(&outDLossDSh0Coeffs[gid][0][c],
-                     T(0.2820947917738781) * dLossDRenderQuantities[cid][gid][c]);
+    const auto eid = idx / D;              // cidx * N + gidx
+    const auto cid = eid / count;          // camera index
+    const auto gid = eid % count + offset; // gaussian index
+    const auto c   = idx % D;              // render channel
+    if (radii != nullptr && radii[cid * N + gid] <= 0) {
+        return;
+    }
+
+    gpuAtomicAdd(&outDLossDSh0Coeffs[gid][0][c],
+                 T(0.2820947917738781) * dLossDRenderQuantities[cid][gid][c]);
 }
 
 } // namespace
@@ -452,7 +448,7 @@ dispatchSphericalHarmonicsBackward<torch::kCUDA>(
 
         computeShBackward<scalar_t><<<NUM_BLOCKS, DEFAULT_BLOCK_DIM, 0, stream>>>(
             0,
-            TOTAL_ELEMS,
+            N,
             C,
             N,
             K,
@@ -478,7 +474,7 @@ dispatchSphericalHarmonicsBackward<torch::kCUDA>(
 
         computeShDiffuseOnlyBackward<scalar_t><<<NUM_BLOCKS, DEFAULT_BLOCK_DIM, 0, stream>>>(
             0,
-            TOTAL_ELEMS,
+            N,
             C,
             N,
             D,
@@ -564,11 +560,9 @@ dispatchSphericalHarmonicsBackward<torch::kPrivateUse1>(
             auto stream = c10::cuda::getCurrentCUDAStream(deviceId);
 
             int64_t elementOffset, elementCount;
-            std::tie(elementOffset, elementCount) = deviceChunk(N * C, deviceId);
-            elementCount *= D;
-            elementOffset *= D;
+            std::tie(elementOffset, elementCount) = deviceChunk(N, deviceId);
 
-            const auto NUM_BLOCKS = GET_BLOCKS(elementCount, DEFAULT_BLOCK_DIM);
+            const auto NUM_BLOCKS = GET_BLOCKS(C * elementCount * D, DEFAULT_BLOCK_DIM);
 
             computeShBackward<scalar_t><<<NUM_BLOCKS, DEFAULT_BLOCK_DIM, 0, stream>>>(
                 elementOffset,
@@ -603,11 +597,9 @@ dispatchSphericalHarmonicsBackward<torch::kPrivateUse1>(
             auto stream = c10::cuda::getCurrentCUDAStream(deviceId);
 
             int64_t elementOffset, elementCount;
-            std::tie(elementOffset, elementCount) = deviceChunk(N * C, deviceId);
-            elementCount *= D;
-            elementOffset *= D;
+            std::tie(elementOffset, elementCount) = deviceChunk(N, deviceId);
 
-            const auto NUM_BLOCKS = GET_BLOCKS(elementCount, DEFAULT_BLOCK_DIM);
+            const auto NUM_BLOCKS = GET_BLOCKS(C * elementCount * D, DEFAULT_BLOCK_DIM);
 
             computeShDiffuseOnlyBackward<scalar_t><<<NUM_BLOCKS, DEFAULT_BLOCK_DIM, 0, stream>>>(
                 elementOffset,

--- a/src/fvdb/detail/ops/gsplat/GaussianSphericalHarmonicsBackward.cu
+++ b/src/fvdb/detail/ops/gsplat/GaussianSphericalHarmonicsBackward.cu
@@ -563,56 +563,60 @@ dispatchSphericalHarmonicsBackward<torch::kPrivateUse1>(
             C10_CUDA_CHECK(cudaEventRecord(events[deviceId], stream));
         }
 
-        for (const auto deviceId: c10::irange(c10::cuda::device_count())) {
-            C10_CUDA_CHECK(cudaSetDevice(deviceId));
-            auto stream = c10::cuda::getStreamFromPool(false, deviceId);
-            C10_CUDA_CHECK(cudaStreamWaitEvent(stream, events[deviceId]));
+        if (computeDLossDViewDirs) {
+            for (const auto deviceId: c10::irange(c10::cuda::device_count())) {
+                C10_CUDA_CHECK(cudaSetDevice(deviceId));
+                auto stream = c10::cuda::getStreamFromPool(false, deviceId);
+                C10_CUDA_CHECK(cudaStreamWaitEvent(stream, events[deviceId]));
 
-            int64_t elementOffset, elementCount;
-            std::tie(elementOffset, elementCount) = deviceChunk(N, deviceId);
+                int64_t elementOffset, elementCount;
+                std::tie(elementOffset, elementCount) = deviceChunk(N, deviceId);
 
 #if (CUDART_VERSION < 13000)
-            for (int cameraIndex = 0; cameraIndex < C; ++cameraIndex) {
-                nanovdb::util::cuda::memPrefetchAsync(
-                    dLossDViewDirs.data_ptr<scalar_t>() + cameraIndex * dLossDViewDirs.stride(0) +
-                        elementOffset * dLossDViewDirs.stride(1),
-                    elementCount * dLossDViewDirs.stride(1) * sizeof(scalar_t),
-                    deviceId,
-                    stream);
-            }
+                for (int cameraIndex = 0; cameraIndex < C; ++cameraIndex) {
+                    nanovdb::util::cuda::memPrefetchAsync(
+                        dLossDViewDirs.data_ptr<scalar_t>() +
+                            cameraIndex * dLossDViewDirs.stride(0) +
+                            elementOffset * dLossDViewDirs.stride(1),
+                        elementCount * dLossDViewDirs.stride(1) * sizeof(scalar_t),
+                        deviceId,
+                        stream);
+                }
 #else
-            std::vector<void *> prefetchPtrs;
-            std::vector<size_t> prefetchSizes;
-            const cudaMemLocation location                 = {cudaMemLocationTypeDevice, deviceId};
-            std::vector<cudaMemLocation> prefetchLocations = {location};
-            std::vector<size_t> prefetchLocationIndices    = {0};
+                std::vector<void *> prefetchPtrs;
+                std::vector<size_t> prefetchSizes;
+                const cudaMemLocation location = {cudaMemLocationTypeDevice, deviceId};
+                std::vector<cudaMemLocation> prefetchLocations = {location};
+                std::vector<size_t> prefetchLocationIndices    = {0};
 
-            for (int cameraIndex = 0; cameraIndex < C; ++cameraIndex) {
-                prefetchPtrs.emplace_back(dLossDViewDirs.data_ptr<scalar_t>() +
-                                          cameraIndex * dLossDViewDirs.stride(0) +
-                                          elementOffset * dLossDViewDirs.stride(1));
-                prefetchSizes.emplace_back(elementCount * dLossDViewDirs.stride(1) *
-                                           sizeof(scalar_t));
-            }
+                for (int cameraIndex = 0; cameraIndex < C; ++cameraIndex) {
+                    prefetchPtrs.emplace_back(dLossDViewDirs.data_ptr<scalar_t>() +
+                                              cameraIndex * dLossDViewDirs.stride(0) +
+                                              elementOffset * dLossDViewDirs.stride(1));
+                    prefetchSizes.emplace_back(elementCount * dLossDViewDirs.stride(1) *
+                                               sizeof(scalar_t));
+                }
 
-            C10_CUDA_CHECK(cudaMemPrefetchBatchAsync(prefetchPtrs.data(),
-                                                     prefetchSizes.data(),
-                                                     prefetchPtrs.size(),
-                                                     prefetchLocations.data(),
-                                                     prefetchLocationIndices.data(),
-                                                     prefetchLocations.size(),
-                                                     0,
-                                                     stream));
+                C10_CUDA_CHECK(cudaMemPrefetchBatchAsync(prefetchPtrs.data(),
+                                                         prefetchSizes.data(),
+                                                         prefetchPtrs.size(),
+                                                         prefetchLocations.data(),
+                                                         prefetchLocationIndices.data(),
+                                                         prefetchLocations.size(),
+                                                         0,
+                                                         stream));
 #endif
-            for (int cameraIndex = 0; cameraIndex < C; ++cameraIndex) {
-                C10_CUDA_CHECK(cudaMemsetAsync(
-                    dLossDViewDirs.data_ptr<scalar_t>() + cameraIndex * dLossDViewDirs.stride(0) +
-                        elementOffset * dLossDViewDirs.stride(1),
-                    0,
-                    elementCount * dLossDViewDirs.stride(1) * sizeof(scalar_t),
-                    stream));
+                for (int cameraIndex = 0; cameraIndex < C; ++cameraIndex) {
+                    C10_CUDA_CHECK(
+                        cudaMemsetAsync(dLossDViewDirs.data_ptr<scalar_t>() +
+                                            cameraIndex * dLossDViewDirs.stride(0) +
+                                            elementOffset * dLossDViewDirs.stride(1),
+                                        0,
+                                        elementCount * dLossDViewDirs.stride(1) * sizeof(scalar_t),
+                                        stream));
+                }
+                C10_CUDA_CHECK(cudaEventRecord(events[deviceId], stream));
             }
-            C10_CUDA_CHECK(cudaEventRecord(events[deviceId], stream));
         }
 
         for (const auto deviceId: c10::irange(c10::cuda::device_count())) {

--- a/src/fvdb/detail/ops/gsplat/GaussianSphericalHarmonicsBackward.cu
+++ b/src/fvdb/detail/ops/gsplat/GaussianSphericalHarmonicsBackward.cu
@@ -549,15 +549,77 @@ dispatchSphericalHarmonicsBackward<torch::kPrivateUse1>(
         torch::Tensor dLossDSh0Coeffs = torch::zeros({N, 1, D}, tensorOptions);
         torch::Tensor dLossDViewDirs;
         if (computeDLossDViewDirs) {
-            dLossDViewDirs = torch::zeros_like(viewDirs);
+            dLossDViewDirs = torch::empty_like(viewDirs);
         }
         if (N == 0) {
             return std::make_tuple(dLossDSh0Coeffs, dLossDShNCoeffs, dLossDViewDirs);
         }
 
+        std::vector<cudaEvent_t> events(c10::cuda::device_count());
         for (const auto deviceId: c10::irange(c10::cuda::device_count())) {
             C10_CUDA_CHECK(cudaSetDevice(deviceId));
             auto stream = c10::cuda::getCurrentCUDAStream(deviceId);
+            C10_CUDA_CHECK(cudaEventCreate(&events[deviceId], cudaEventDisableTiming));
+            C10_CUDA_CHECK(cudaEventRecord(events[deviceId], stream));
+        }
+
+        for (const auto deviceId: c10::irange(c10::cuda::device_count())) {
+            C10_CUDA_CHECK(cudaSetDevice(deviceId));
+            auto stream = c10::cuda::getStreamFromPool(false, deviceId);
+            C10_CUDA_CHECK(cudaStreamWaitEvent(stream, events[deviceId]));
+
+            int64_t elementOffset, elementCount;
+            std::tie(elementOffset, elementCount) = deviceChunk(N, deviceId);
+
+#if (CUDART_VERSION < 13000)
+            for (int cameraIndex = 0; cameraIndex < C; ++cameraIndex) {
+                nanovdb::util::cuda::memPrefetchAsync(
+                    dLossDViewDirs.data_ptr<scalar_t>() + cameraIndex * dLossDViewDirs.stride(0) +
+                        elementOffset * dLossDViewDirs.stride(1),
+                    elementCount * dLossDViewDirs.stride(1) * sizeof(scalar_t),
+                    deviceId,
+                    stream);
+            }
+#else
+            std::vector<void *> prefetchPtrs;
+            std::vector<size_t> prefetchSizes;
+            const cudaMemLocation location                 = {cudaMemLocationTypeDevice, deviceId};
+            std::vector<cudaMemLocation> prefetchLocations = {location};
+            std::vector<size_t> prefetchLocationIndices    = {0};
+
+            for (int cameraIndex = 0; cameraIndex < C; ++cameraIndex) {
+                prefetchPtrs.emplace_back(dLossDViewDirs.data_ptr<scalar_t>() +
+                                          cameraIndex * dLossDViewDirs.stride(0) +
+                                          elementOffset * dLossDViewDirs.stride(1));
+                prefetchSizes.emplace_back(elementCount * dLossDViewDirs.stride(1) *
+                                           sizeof(scalar_t));
+            }
+
+            C10_CUDA_CHECK(cudaMemPrefetchBatchAsync(prefetchPtrs.data(),
+                                                     prefetchSizes.data(),
+                                                     prefetchPtrs.size(),
+                                                     prefetchLocations.data(),
+                                                     prefetchLocationIndices.data(),
+                                                     prefetchLocations.size(),
+                                                     0,
+                                                     stream));
+#endif
+            for (int cameraIndex = 0; cameraIndex < C; ++cameraIndex) {
+                C10_CUDA_CHECK(cudaMemsetAsync(
+                    dLossDViewDirs.data_ptr<scalar_t>() + cameraIndex * dLossDViewDirs.stride(0) +
+                        elementOffset * dLossDViewDirs.stride(1),
+                    0,
+                    elementCount * dLossDViewDirs.stride(1) * sizeof(scalar_t),
+                    stream));
+            }
+            C10_CUDA_CHECK(cudaEventRecord(events[deviceId], stream));
+        }
+
+        for (const auto deviceId: c10::irange(c10::cuda::device_count())) {
+            C10_CUDA_CHECK(cudaSetDevice(deviceId));
+            auto stream = c10::cuda::getCurrentCUDAStream(deviceId);
+            C10_CUDA_CHECK(cudaStreamWaitEvent(stream, events[deviceId]));
+            C10_CUDA_CHECK(cudaEventDestroy(events[deviceId]));
 
             int64_t elementOffset, elementCount;
             std::tie(elementOffset, elementCount) = deviceChunk(N, deviceId);

--- a/src/fvdb/detail/ops/gsplat/GaussianSphericalHarmonicsForward.cu
+++ b/src/fvdb/detail/ops/gsplat/GaussianSphericalHarmonicsForward.cu
@@ -149,25 +149,24 @@ computeSh(
 ) {
     // parallelize over C * N * D
     auto idx = blockIdx.x * blockDim.x + threadIdx.x; // cidx * N * D + gidx * D + kidx
-    if (idx >= count) {
+    if (idx >= count * C * D) {
         return;
     }
-    idx += offset;
 
-    const auto eid = idx / D; // cidx * N + gidx
-    const auto cid = eid / N; // camera index
-    const auto gid = eid % N; // gaussian index
-    const auto c   = idx % D; // render channel
+    const auto eid = idx / D;              // cidx * N + gidx
+    const auto cid = eid / count;          // camera index
+    const auto gid = eid % count + offset; // gaussian index
+    const auto c   = idx % D;              // render channel
 
     T result = T(0);
-    if (!(radii != nullptr && radii[eid] <= 0)) {
+    if (!(radii != nullptr && radii[cid * N + gid] <= 0)) {
         using vec3t            = typename Vec3Type<T>::type;
         const bool hasViewDirs = viewDirs.size(0) > 0;
         const vec3t dir        = hasViewDirs ? *reinterpret_cast<vec3t *>(viewDirs[cid][gid].data())
                                              : vec3t{0.f, 0.f, 0.f};
         result = evalShFunction(shDegreeToUse, cid, gid, c, dir, sh0Coeffs, shNCoeffs);
     }
-    outRenderQuantities[eid * D + c] = result;
+    outRenderQuantities[(cid * N + gid) * D + c] = result;
 }
 
 template <typename T>
@@ -182,18 +181,19 @@ computeShDiffuseOnly(const int64_t offset,
                      T *__restrict__ outRenderQuantities) {
     // parallelize over C * N * D
     auto idx = blockIdx.x * blockDim.x + threadIdx.x; // cidx * N * D + gidx * D + kidx
-    if (idx >= count) {
+    if (idx >= count * C * D) {
         return;
     }
-    idx += offset;
 
-    const auto eid = idx / D; // cidx * N + gidx
-    const auto gid = eid % N; // gaussian index
-    const auto c   = idx % D; // render channel
-    if (radii != nullptr && radii[eid] <= 0) {
-        outRenderQuantities[eid * D + c] = T(0);
+    const auto eid = idx / D;              // cidx * N + gidx
+    const auto cid = eid / count;          // camera index
+    const auto gid = eid % count + offset; // gaussian index
+    const auto c   = idx % D;              // render channel
+    if (radii != nullptr && radii[cid * N + gid] <= 0) {
+        outRenderQuantities[(cid * N + gid) * D + c] = T(0);
     } else {
-        outRenderQuantities[eid * D + c] = T(0.2820947917738781) * sh0Coeffs[gid][0][c] + T(0.5);
+        outRenderQuantities[(cid * N + gid) * D + c] =
+            T(0.2820947917738781) * sh0Coeffs[gid][0][c] + T(0.5);
     }
 }
 
@@ -274,7 +274,7 @@ dispatchSphericalHarmonicsForward<torch::kCUDA>(const int64_t shDegreeToUse,
     if (hasShNCoeffs && shDegreeToUse > 0) {
         computeSh<scalar_t><<<NUM_BLOCKS, DEFAULT_BLOCK_DIM, 0, stream>>>(
             0,
-            TOTAL_ELEMS,
+            N,
             C,
             N,
             D,
@@ -288,7 +288,7 @@ dispatchSphericalHarmonicsForward<torch::kCUDA>(const int64_t shDegreeToUse,
     } else {
         computeShDiffuseOnly<scalar_t><<<NUM_BLOCKS, DEFAULT_BLOCK_DIM, 0, stream>>>(
             0,
-            TOTAL_ELEMS,
+            N,
             C,
             N,
             D,
@@ -310,6 +310,7 @@ dispatchSphericalHarmonicsForward<torch::kPrivateUse1>(
     const torch::Tensor &shNCoeffs, // [N, K-1, D]
     const torch::Tensor &radii      // [C, N]
 ) {
+    FVDB_FUNC_RANGE();
     // Valid modes:
     // 0: sh0Coeffs only
     // 1: sh0Coeffs + radii
@@ -373,11 +374,9 @@ dispatchSphericalHarmonicsForward<torch::kPrivateUse1>(
         auto stream = c10::cuda::getCurrentCUDAStream(deviceId);
 
         int64_t elementOffset, elementCount;
-        std::tie(elementOffset, elementCount) = deviceChunk(N * C, deviceId);
-        elementCount *= D;
-        elementOffset *= D;
+        std::tie(elementOffset, elementCount) = deviceChunk(N, deviceId);
 
-        const auto NUM_BLOCKS = GET_BLOCKS(elementCount, DEFAULT_BLOCK_DIM);
+        const auto NUM_BLOCKS = GET_BLOCKS(C * elementCount * D, DEFAULT_BLOCK_DIM);
 
         if (hasShNCoeffs && shDegreeToUse > 0) {
             computeSh<scalar_t><<<NUM_BLOCKS, DEFAULT_BLOCK_DIM, 0, stream>>>(


### PR DESCRIPTION
Prior to this change, mGPU spherical harmonics calculations were partitioned across the camera-Gaussian pairs, i.e. C * N. This means that each GPU would need to write to each of the N derivatives associated with the spherical harmonics coefficients which necessitated the use of system-scope atomics across GPUs therefore bottlenecking the interconnect.

Instead, we partition the calculations across Gaussians. Each mGPU processes a distinct segment of Gaussians for all cameras which means that atomics only need to be device scoped and never need to traverse the interconnect. Furthermore, each mGPU only needs to access the memory that's physically resident on itself further speeding up calculations.

Naturally, the forward and backward passes should match in order to prevent ping-ponging of shared tensors between the forward and backwards pass. On an 8x A100 reconstruction, this improves performance by about 5%.