### PR TITLE
Improve mGPU partitioning for Gaussian projection operators

### DIFF
--- a/src/fvdb/detail/ops/gsplat/GaussianProjectionBackward.cu
+++ b/src/fvdb/detail/ops/gsplat/GaussianProjectionBackward.cu
@@ -102,15 +102,16 @@ projectionBackwardKernel(const int32_t offset,
 ) {
     // parallelize over C * N.
     uint32_t idx = cg::this_grid().thread_rank();
-    if (idx >= count) {
+    if (idx >= C * count) {
         return;
     }
-    idx += offset;
+    const uint32_t cId = idx / count;          // camera id
+    const uint32_t gId = idx % count + offset; // gaussian id
+
+    idx = cId * N + gId;
     if (radii[idx] <= 0) {
         return;
     }
-    const uint32_t cId = idx / N; // camera id
-    const uint32_t gId = idx % N; // gaussian id
 
     // shift pointers to the current camera and gaussian
     means += gId * 3;
@@ -167,7 +168,7 @@ projectionBackwardKernel(const int32_t offset,
             outDLossDMeans += gId * 3;
             GSPLAT_PRAGMA_UNROLL
             for (uint32_t i = 0; i < 3; i++) {
-                atomicAdd_system(outDLossDMeans + i, dLossDPoint[i]);
+                gpuAtomicAdd(outDLossDMeans + i, dLossDPoint[i]);
             }
         }
     }
@@ -176,12 +177,12 @@ projectionBackwardKernel(const int32_t offset,
         warpSum(dLossDCovar, warp_group_g);
         if (warp_group_g.thread_rank() == 0) {
             outDLossDCovars += gId * 6;
-            atomicAdd_system(outDLossDCovars, dLossDCovar[0][0]);
-            atomicAdd_system(outDLossDCovars + 1, dLossDCovar[0][1] + dLossDCovar[1][0]);
-            atomicAdd_system(outDLossDCovars + 2, dLossDCovar[0][2] + dLossDCovar[2][0]);
-            atomicAdd_system(outDLossDCovars + 3, dLossDCovar[1][1]);
-            atomicAdd_system(outDLossDCovars + 4, dLossDCovar[1][2] + dLossDCovar[2][1]);
-            atomicAdd_system(outDLossDCovars + 5, dLossDCovar[2][2]);
+            gpuAtomicAdd(outDLossDCovars, dLossDCovar[0][0]);
+            gpuAtomicAdd(outDLossDCovars + 1, dLossDCovar[0][1] + dLossDCovar[1][0]);
+            gpuAtomicAdd(outDLossDCovars + 2, dLossDCovar[0][2] + dLossDCovar[2][0]);
+            gpuAtomicAdd(outDLossDCovars + 3, dLossDCovar[1][1]);
+            gpuAtomicAdd(outDLossDCovars + 4, dLossDCovar[1][2] + dLossDCovar[2][1]);
+            gpuAtomicAdd(outDLossDCovars + 5, dLossDCovar[2][2]);
         }
     } else {
         // Directly output gradients w.r.t. the quaternion and log_scale
@@ -198,13 +199,13 @@ projectionBackwardKernel(const int32_t offset,
         if (warp_group_g.thread_rank() == 0) {
             outDLossDQuats += gId * 4;
             outDLossDScales += gId * 3;
-            atomicAdd_system(outDLossDQuats, dLossDQuat[0]);
-            atomicAdd_system(outDLossDQuats + 1, dLossDQuat[1]);
-            atomicAdd_system(outDLossDQuats + 2, dLossDQuat[2]);
-            atomicAdd_system(outDLossDQuats + 3, dLossDQuat[3]);
-            atomicAdd_system(outDLossDScales, dLossDLogScale[0]);
-            atomicAdd_system(outDLossDScales + 1, dLossDLogScale[1]);
-            atomicAdd_system(outDLossDScales + 2, dLossDLogScale[2]);
+            gpuAtomicAdd(outDLossDQuats, dLossDQuat[0]);
+            gpuAtomicAdd(outDLossDQuats + 1, dLossDQuat[1]);
+            gpuAtomicAdd(outDLossDQuats + 2, dLossDQuat[2]);
+            gpuAtomicAdd(outDLossDQuats + 3, dLossDQuat[3]);
+            gpuAtomicAdd(outDLossDScales, dLossDLogScale[0]);
+            gpuAtomicAdd(outDLossDScales + 1, dLossDLogScale[1]);
+            gpuAtomicAdd(outDLossDScales + 2, dLossDLogScale[2]);
         }
     }
     if (outDLossDWorldToCamMatrices != nullptr) {
@@ -300,19 +301,19 @@ dispatchGaussianProjectionBackward<torch::kCUDA>(
         dLossDWorldToCamMatrices = torch::zeros_like(worldToCamMatrices);
     }
     if (C && N) {
+        const unsigned int NUM_BLOCKS = GET_BLOCKS(C * N, DEFAULT_BLOCK_DIM);
         if (ortho) {
-            const size_t NUM_BLOCKS = GET_BLOCKS(C * N, DEFAULT_BLOCK_DIM);
-            const auto camera       = OrthographicCamera<float>{projectionMatrices,
-                                                                worldToCamMatrices,
-                                                                static_cast<int32_t>(C),
-                                                                static_cast<int32_t>(imageWidth),
-                                                                static_cast<int32_t>(imageHeight),
-                                                                kBackwardProjectionNearPlane,
-                                                                kBackwardProjectionFarPlane};
+            const auto camera = OrthographicCamera<float>{projectionMatrices,
+                                                          worldToCamMatrices,
+                                                          static_cast<int32_t>(C),
+                                                          static_cast<int32_t>(imageWidth),
+                                                          static_cast<int32_t>(imageHeight),
+                                                          kBackwardProjectionNearPlane,
+                                                          kBackwardProjectionFarPlane};
             projectionBackwardKernel<float, OrthographicCamera<float>>
                 <<<NUM_BLOCKS, DEFAULT_BLOCK_DIM, 0, stream>>>(
                     0,
-                    C * N,
+                    N,
                     C,
                     N,
                     means.data_ptr<float>(),
@@ -336,18 +337,17 @@ dispatchGaussianProjectionBackward<torch::kCUDA>(
                     worldToCamMatricesRequiresGrad ? dLossDWorldToCamMatrices.data_ptr<float>()
                                                    : nullptr);
         } else {
-            const size_t NUM_BLOCKS = GET_BLOCKS(C * N, DEFAULT_BLOCK_DIM);
-            const auto camera       = PerspectiveCamera<float>{projectionMatrices,
-                                                               worldToCamMatrices,
-                                                               static_cast<int32_t>(C),
-                                                               static_cast<int32_t>(imageWidth),
-                                                               static_cast<int32_t>(imageHeight),
-                                                               kBackwardProjectionNearPlane,
-                                                               kBackwardProjectionFarPlane};
+            const auto camera = PerspectiveCamera<float>{projectionMatrices,
+                                                         worldToCamMatrices,
+                                                         static_cast<int32_t>(C),
+                                                         static_cast<int32_t>(imageWidth),
+                                                         static_cast<int32_t>(imageHeight),
+                                                         kBackwardProjectionNearPlane,
+                                                         kBackwardProjectionFarPlane};
             projectionBackwardKernel<float, PerspectiveCamera<float>>
                 <<<NUM_BLOCKS, DEFAULT_BLOCK_DIM, 0, stream>>>(
                     0,
-                    C * N,
+                    N,
                     C,
                     N,
                     means.data_ptr<float>(),
@@ -470,8 +470,8 @@ dispatchGaussianProjectionBackward<torch::kPrivateUse1>(
             auto stream = c10::cuda::getCurrentCUDAStream(deviceId);
 
             int64_t deviceProblemOffset, deviceProblemSize;
-            std::tie(deviceProblemOffset, deviceProblemSize) = deviceChunk(C * N, deviceId);
-            const size_t NUM_BLOCKS = GET_BLOCKS(deviceProblemSize, DEFAULT_BLOCK_DIM);
+            std::tie(deviceProblemOffset, deviceProblemSize) = deviceChunk(N, deviceId);
+            const unsigned int NUM_BLOCKS = GET_BLOCKS(C * deviceProblemSize, DEFAULT_BLOCK_DIM);
 
             if (ortho) {
                 const auto camera = OrthographicCamera<float>{projectionMatrices,

--- a/src/fvdb/detail/ops/gsplat/GaussianProjectionBackward.cu
+++ b/src/fvdb/detail/ops/gsplat/GaussianProjectionBackward.cu
@@ -100,6 +100,10 @@ projectionBackwardKernel(const int32_t offset,
                          T *__restrict__ outDLossDScales,            // [N, 3] optional
                          T *__restrict__ outDLossDWorldToCamMatrices // [C, 4, 4] optional
 ) {
+    alignas(nanovdb::math::Mat3<T>) extern __shared__ char sharedMemory[];
+    camera.loadSharedMemory(sharedMemory);
+    __syncthreads();
+
     // parallelize over C * N.
     uint32_t idx = cg::this_grid().thread_rank();
     if (idx >= C * count) {
@@ -311,7 +315,7 @@ dispatchGaussianProjectionBackward<torch::kCUDA>(
                                                           kBackwardProjectionNearPlane,
                                                           kBackwardProjectionFarPlane};
             projectionBackwardKernel<float, OrthographicCamera<float>>
-                <<<NUM_BLOCKS, DEFAULT_BLOCK_DIM, 0, stream>>>(
+                <<<NUM_BLOCKS, DEFAULT_BLOCK_DIM, camera.numSharedMemBytes(), stream>>>(
                     0,
                     N,
                     C,
@@ -345,7 +349,7 @@ dispatchGaussianProjectionBackward<torch::kCUDA>(
                                                          kBackwardProjectionNearPlane,
                                                          kBackwardProjectionFarPlane};
             projectionBackwardKernel<float, PerspectiveCamera<float>>
-                <<<NUM_BLOCKS, DEFAULT_BLOCK_DIM, 0, stream>>>(
+                <<<NUM_BLOCKS, DEFAULT_BLOCK_DIM, camera.numSharedMemBytes(), stream>>>(
                     0,
                     N,
                     C,
@@ -482,7 +486,7 @@ dispatchGaussianProjectionBackward<torch::kPrivateUse1>(
                                                               kBackwardProjectionNearPlane,
                                                               kBackwardProjectionFarPlane};
                 projectionBackwardKernel<float, OrthographicCamera<float>>
-                    <<<NUM_BLOCKS, DEFAULT_BLOCK_DIM, 0, stream>>>(
+                    <<<NUM_BLOCKS, DEFAULT_BLOCK_DIM, camera.numSharedMemBytes(), stream>>>(
                         deviceProblemOffset,
                         deviceProblemSize,
                         C,
@@ -518,7 +522,7 @@ dispatchGaussianProjectionBackward<torch::kPrivateUse1>(
                                                              kBackwardProjectionNearPlane,
                                                              kBackwardProjectionFarPlane};
                 projectionBackwardKernel<float, PerspectiveCamera<float>>
-                    <<<NUM_BLOCKS, DEFAULT_BLOCK_DIM, 0, stream>>>(
+                    <<<NUM_BLOCKS, DEFAULT_BLOCK_DIM, camera.numSharedMemBytes(), stream>>>(
                         deviceProblemOffset,
                         deviceProblemSize,
                         C,

--- a/src/fvdb/detail/ops/gsplat/GaussianProjectionForward.cu
+++ b/src/fvdb/detail/ops/gsplat/GaussianProjectionForward.cu
@@ -165,9 +165,12 @@ projectionForwardKernel(int64_t offset,
     __syncthreads();
 
     // parallelize over C * N.
-    for (auto idx = blockIdx.x * blockDim.x + threadIdx.x; idx < count;
+    for (auto idx = blockIdx.x * blockDim.x + threadIdx.x; idx < projectionForward.C * count;
          idx += blockDim.x * gridDim.x) {
-        projectionForward.projectionForward(idx + offset);
+        const uint32_t cId = idx / count;          // camera id
+        const uint32_t gId = idx % count + offset; // gaussian id
+
+        projectionForward.projectionForward(cId * projectionForward.N + gId);
     }
 }
 
@@ -220,9 +223,7 @@ dispatchGaussianProjectionForward<torch::kCUDA>(
 
     using scalar_t = float;
 
-    const size_t NUM_BLOCKS = GET_BLOCKS(C * N, DEFAULT_BLOCK_DIM);
-    const size_t SHARD_MEM_SIZE =
-        C * (2 * sizeof(nanovdb::math::Mat3<scalar_t>) + sizeof(nanovdb::math::Vec3<scalar_t>));
+    const unsigned int NUM_BLOCKS = GET_BLOCKS(C * N, DEFAULT_BLOCK_DIM);
 
     if (ortho) {
         const auto camera = OrthographicCamera<scalar_t>{projectionMatrices,
@@ -246,8 +247,8 @@ dispatchGaussianProjectionForward<torch::kCUDA>(
             outConics,
             outCompensations);
         projectionForwardKernel<scalar_t, OrthographicCamera<scalar_t>>
-            <<<NUM_BLOCKS, DEFAULT_BLOCK_DIM, SHARD_MEM_SIZE, stream>>>(
-                0, C * N, projectionForward);
+            <<<NUM_BLOCKS, DEFAULT_BLOCK_DIM, camera.numSharedMemBytes(), stream>>>(
+                0, N, projectionForward);
         C10_CUDA_KERNEL_LAUNCH_CHECK();
     } else {
         const auto camera = PerspectiveCamera<scalar_t>{projectionMatrices,
@@ -271,8 +272,8 @@ dispatchGaussianProjectionForward<torch::kCUDA>(
             outConics,
             outCompensations);
         projectionForwardKernel<scalar_t, PerspectiveCamera<scalar_t>>
-            <<<NUM_BLOCKS, DEFAULT_BLOCK_DIM, SHARD_MEM_SIZE, stream>>>(
-                0, C * N, projectionForward);
+            <<<NUM_BLOCKS, DEFAULT_BLOCK_DIM, camera.numSharedMemBytes(), stream>>>(
+                0, N, projectionForward);
         C10_CUDA_KERNEL_LAUNCH_CHECK();
     }
     return std::make_tuple(outRadii, outMeans2d, outDepths, outConics, outCompensations);
@@ -327,11 +328,9 @@ dispatchGaussianProjectionForward<torch::kPrivateUse1>(
         auto stream = c10::cuda::getCurrentCUDAStream(deviceId);
 
         int64_t deviceProblemOffset, deviceProblemSize;
-        std::tie(deviceProblemOffset, deviceProblemSize) = deviceChunk(C * N, deviceId);
+        std::tie(deviceProblemOffset, deviceProblemSize) = deviceChunk(N, deviceId);
 
-        const size_t NUM_BLOCKS = GET_BLOCKS(deviceProblemSize, DEFAULT_BLOCK_DIM);
-        const size_t SHARD_MEM_SIZE =
-            C * (2 * sizeof(nanovdb::math::Mat3<scalar_t>) + sizeof(nanovdb::math::Vec3<scalar_t>));
+        const unsigned int NUM_BLOCKS = GET_BLOCKS(C * deviceProblemSize, DEFAULT_BLOCK_DIM);
 
         if (ortho) {
             const auto camera = OrthographicCamera<scalar_t>{projectionMatrices,
@@ -355,7 +354,7 @@ dispatchGaussianProjectionForward<torch::kPrivateUse1>(
                 outConics,
                 outCompensations);
             projectionForwardKernel<scalar_t, OrthographicCamera<scalar_t>>
-                <<<NUM_BLOCKS, DEFAULT_BLOCK_DIM, SHARD_MEM_SIZE, stream>>>(
+                <<<NUM_BLOCKS, DEFAULT_BLOCK_DIM, camera.numSharedMemBytes(), stream>>>(
                     deviceProblemOffset, deviceProblemSize, projectionForward);
             C10_CUDA_KERNEL_LAUNCH_CHECK();
         } else {
@@ -380,7 +379,7 @@ dispatchGaussianProjectionForward<torch::kPrivateUse1>(
                 outConics,
                 outCompensations);
             projectionForwardKernel<scalar_t, PerspectiveCamera<scalar_t>>
-                <<<NUM_BLOCKS, DEFAULT_BLOCK_DIM, SHARD_MEM_SIZE, stream>>>(
+                <<<NUM_BLOCKS, DEFAULT_BLOCK_DIM, camera.numSharedMemBytes(), stream>>>(
                     deviceProblemOffset, deviceProblemSize, projectionForward);
             C10_CUDA_KERNEL_LAUNCH_CHECK();
         }


### PR DESCRIPTION
Similar to #546 . Prior to this change, mGPU projection calculations were partitioned across the camera-Gaussian pairs, i.e. C * N. This means that each GPU would need to write to each of the N derivatives associated with the projection outputs which necessitated the use of system-scope atomics across GPUs therefore bottlenecking the interconnect.

Instead, we partition the calculations across Gaussians. Each mGPU processes a distinct segment of Gaussians for all cameras which means that atomics only need to be device scoped (with the exception of the camera pose derivative).

In addition, we load the cameras into shared memory for the backwards pass following the example of the forwards pass. Overall, these changes provide a >5% speedup on 2x RTX 3090s.