### PR TITLE
Reduce shared memory usage in pinhole projection by re-arranging blocks

### DIFF
--- a/src/fvdb/detail/ops/gsplat/GaussianCameras.cuh
+++ b/src/fvdb/detail/ops/gsplat/GaussianCameras.cuh
@@ -194,28 +194,41 @@ template <typename T> struct PerspectiveCamera {
     T nearPlane         = T(kBackwardProjectionNearPlane);
     T farPlane          = T(kBackwardProjectionFarPlane);
 
-    Mat3 *__restrict__ projectionMatsShared        = nullptr; // [C,3,3], optional
-    Mat3 *__restrict__ worldToCamRotMatsShared     = nullptr; // [C,3,3], optional
-    Vec3 *__restrict__ worldToCamTranslationShared = nullptr; // [C,3], optional
+    Mat3 *__restrict__ projectionMatShared         = nullptr; // [3,3], optional
+    Mat3 *__restrict__ worldToCamRotMatShared      = nullptr; // [3,3], optional
+    Vec3 *__restrict__ worldToCamTranslationShared = nullptr; // [3], optional
 
   public:
     /// @brief Returns dynamic shared-memory bytes required to cache camera matrices.
-    inline __host__ __device__ size_t
+    constexpr __host__ __device__ size_t
     numSharedMemBytes() const {
-        return static_cast<size_t>(2 * numCameras) * sizeof(Mat3) +
-               static_cast<size_t>(numCameras) * sizeof(Vec3);
+        return 2 * sizeof(Mat3) + sizeof(Vec3);
     }
 
     /// @brief Loads per-camera intrinsics/extrinsics into dynamic shared memory.
     inline __device__ void
-    loadSharedMemory(void *sharedMemory) {
-        const int64_t C             = numCameras;
-        projectionMatsShared        = reinterpret_cast<Mat3 *>(sharedMemory);
-        worldToCamRotMatsShared     = projectionMatsShared + C;
-        worldToCamTranslationShared = reinterpret_cast<Vec3 *>(worldToCamRotMatsShared + C);
-        copyMat3Accessor<T>(C, projectionMatsShared, projectionMatricesAcc);
-        copyMat3Accessor<T>(C, worldToCamRotMatsShared, worldToCamMatricesAcc);
-        copyWorldToCamTranslation<T>(C, worldToCamTranslationShared, worldToCamMatricesAcc);
+    loadSharedMemory(const int64_t cid, void *sharedMemory) {
+        projectionMatShared         = reinterpret_cast<Mat3 *>(sharedMemory);
+        worldToCamRotMatShared      = projectionMatShared + 1;
+        worldToCamTranslationShared = reinterpret_cast<Vec3 *>(worldToCamRotMatShared + 1);
+
+        if (threadIdx.x < 9) {
+            const auto i     = threadIdx.x;
+            const auto rowId = i / 3;
+            const auto colId = i % 3;
+
+            (*projectionMatShared)[rowId][colId] = projectionMatricesAcc[cid][rowId][colId];
+        } else if (threadIdx.x < 18) {
+            const auto i     = threadIdx.x - 9;
+            const auto rowId = i / 3;
+            const auto colId = i % 3;
+
+            (*worldToCamRotMatShared)[rowId][colId] = worldToCamMatricesAcc[cid][rowId][colId];
+        } else if (threadIdx.x < 21) {
+            const auto i = threadIdx.x - 18;
+
+            (*worldToCamTranslationShared)[i] = worldToCamMatricesAcc[cid][i][3];
+        }
     }
 
     /// @brief Returns true if camera-space depth is within [nearPlane, farPlane].
@@ -243,8 +256,8 @@ template <typename T> struct PerspectiveCamera {
     /// `p_c = R * p_w + t`.
     inline __device__ std::tuple<Mat3, Vec3>
     worldToCamTransform(const int64_t cid) const {
-        if (worldToCamRotMatsShared != nullptr) {
-            return std::make_tuple(worldToCamRotMatsShared[cid], worldToCamTranslationShared[cid]);
+        if (worldToCamRotMatShared != nullptr) {
+            return std::make_tuple(*worldToCamRotMatShared, *worldToCamTranslationShared);
         }
         const auto W = worldToCamMatricesAcc[cid];
         return std::make_tuple(
@@ -265,8 +278,8 @@ template <typename T> struct PerspectiveCamera {
         using Vec2   = nanovdb::math::Vec2<T>;
 
         T fx, fy, cx, cy;
-        if (projectionMatsShared != nullptr) {
-            const Mat3 &K = projectionMatsShared[cid];
+        if (projectionMatShared != nullptr) {
+            const Mat3 &K = *projectionMatShared;
             fx            = K[0][0];
             fy            = K[1][1];
             cx            = K[0][2];
@@ -320,8 +333,8 @@ template <typename T> struct PerspectiveCamera {
         using Vec3   = nanovdb::math::Vec3<T>;
 
         T fx, fy, cx, cy;
-        if (projectionMatsShared != nullptr) {
-            const Mat3 &K = projectionMatsShared[cid];
+        if (projectionMatShared != nullptr) {
+            const Mat3 &K = *projectionMatShared;
             fx            = K[0][0];
             fy            = K[1][1];
             cx            = K[0][2];
@@ -459,28 +472,41 @@ template <typename T> struct OrthographicCamera {
     T nearPlane         = T(kBackwardProjectionNearPlane);
     T farPlane          = T(kBackwardProjectionFarPlane);
 
-    Mat3 *__restrict__ projectionMatsShared        = nullptr; // [C,3,3], optional
-    Mat3 *__restrict__ worldToCamRotMatsShared     = nullptr; // [C,3,3], optional
-    Vec3 *__restrict__ worldToCamTranslationShared = nullptr; // [C,3], optional
+    Mat3 *__restrict__ projectionMatShared         = nullptr; // [3,3], optional
+    Mat3 *__restrict__ worldToCamRotMatShared      = nullptr; // [3,3], optional
+    Vec3 *__restrict__ worldToCamTranslationShared = nullptr; // [3], optional
 
   public:
     /// @brief Returns dynamic shared-memory bytes required to cache camera matrices.
-    inline __host__ __device__ size_t
+    constexpr __host__ __device__ size_t
     numSharedMemBytes() const {
-        return static_cast<size_t>(2 * numCameras) * sizeof(Mat3) +
-               static_cast<size_t>(numCameras) * sizeof(Vec3);
+        return 2 * sizeof(Mat3) + sizeof(Vec3);
     }
 
     /// @brief Loads per-camera intrinsics/extrinsics into dynamic shared memory.
     inline __device__ void
-    loadSharedMemory(void *sharedMemory) {
-        const int64_t C             = numCameras;
-        projectionMatsShared        = reinterpret_cast<Mat3 *>(sharedMemory);
-        worldToCamRotMatsShared     = projectionMatsShared + C;
-        worldToCamTranslationShared = reinterpret_cast<Vec3 *>(worldToCamRotMatsShared + C);
-        copyMat3Accessor<T>(C, projectionMatsShared, projectionMatricesAcc);
-        copyMat3Accessor<T>(C, worldToCamRotMatsShared, worldToCamMatricesAcc);
-        copyWorldToCamTranslation<T>(C, worldToCamTranslationShared, worldToCamMatricesAcc);
+    loadSharedMemory(int64_t cid, void *sharedMemory) {
+        projectionMatShared         = reinterpret_cast<Mat3 *>(sharedMemory);
+        worldToCamRotMatShared      = projectionMatShared + 1;
+        worldToCamTranslationShared = reinterpret_cast<Vec3 *>(worldToCamRotMatShared + 1);
+
+        if (threadIdx.x < 9) {
+            const auto i     = threadIdx.x;
+            const auto rowId = i / 3;
+            const auto colId = i % 3;
+
+            (*projectionMatShared)[rowId][colId] = projectionMatricesAcc[cid][rowId][colId];
+        } else if (threadIdx.x < 18) {
+            const auto i     = threadIdx.x - 9;
+            const auto rowId = i / 3;
+            const auto colId = i % 3;
+
+            (*worldToCamRotMatShared)[rowId][colId] = worldToCamMatricesAcc[cid][rowId][colId];
+        } else if (threadIdx.x < 21) {
+            const auto i = threadIdx.x - 18;
+
+            (*worldToCamTranslationShared)[i] = worldToCamMatricesAcc[cid][i][3];
+        }
     }
 
     /// @brief Returns true if camera-space depth is within [nearPlane, farPlane].
@@ -508,8 +534,8 @@ template <typename T> struct OrthographicCamera {
     /// `p_c = R * p_w + t`.
     inline __device__ std::tuple<Mat3, Vec3>
     worldToCamTransform(const int64_t cid) const {
-        if (worldToCamRotMatsShared != nullptr) {
-            return std::make_tuple(worldToCamRotMatsShared[cid], worldToCamTranslationShared[cid]);
+        if (worldToCamRotMatShared != nullptr) {
+            return std::make_tuple(*worldToCamRotMatShared, *worldToCamTranslationShared);
         }
         const auto W = worldToCamMatricesAcc[cid];
         return std::make_tuple(
@@ -530,8 +556,8 @@ template <typename T> struct OrthographicCamera {
         using Vec2   = nanovdb::math::Vec2<T>;
 
         T fx, fy, cx, cy;
-        if (projectionMatsShared != nullptr) {
-            const Mat3 &K = projectionMatsShared[cid];
+        if (projectionMatShared != nullptr) {
+            const Mat3 &K = *projectionMatShared;
             fx            = K[0][0];
             fy            = K[1][1];
             cx            = K[0][2];
@@ -571,8 +597,8 @@ template <typename T> struct OrthographicCamera {
         using Vec3   = nanovdb::math::Vec3<T>;
 
         T fx, fy, cx, cy;
-        if (projectionMatsShared != nullptr) {
-            const Mat3 &K = projectionMatsShared[cid];
+        if (projectionMatShared != nullptr) {
+            const Mat3 &K = *projectionMatShared;
             fx            = K[0][0];
             fy            = K[1][1];
             cx            = K[0][2];

--- a/src/fvdb/detail/ops/gsplat/GaussianCameras.cuh
+++ b/src/fvdb/detail/ops/gsplat/GaussianCameras.cuh
@@ -205,7 +205,11 @@ template <typename T> struct PerspectiveCamera {
         return 2 * sizeof(Mat3) + sizeof(Vec3);
     }
 
-    /// @brief Loads per-camera intrinsics/extrinsics into dynamic shared memory.
+    /// @brief Load camera intrinsics/extrinsics into dynamic shared memory for the specified camera
+    /// id. For pinhole projection, we launch a 2D grid where the Y axis corresponds to the camera
+    /// id and the X axis corresponds to the Gaussians matching the stride order of the input/output
+    /// arrays. In particular, blockDim.y == 1, so each block only needs to load one camera into
+    /// shared memory.
     inline __device__ void
     loadSharedMemory(const int64_t cid, void *sharedMemory) {
         projectionMatShared         = reinterpret_cast<Mat3 *>(sharedMemory);
@@ -483,7 +487,11 @@ template <typename T> struct OrthographicCamera {
         return 2 * sizeof(Mat3) + sizeof(Vec3);
     }
 
-    /// @brief Loads per-camera intrinsics/extrinsics into dynamic shared memory.
+    /// @brief Load camera intrinsics/extrinsics into dynamic shared memory for the specified camera
+    /// id. For pinhole projection, we launch a 2D grid where the Y axis corresponds to the camera
+    /// id and the X axis corresponds to the Gaussians matching the stride order of the input/output
+    /// arrays. In particular, blockDim.y == 1, so each block only needs to load one camera into
+    /// shared memory.
     inline __device__ void
     loadSharedMemory(int64_t cid, void *sharedMemory) {
         projectionMatShared         = reinterpret_cast<Mat3 *>(sharedMemory);

--- a/src/fvdb/detail/ops/gsplat/GaussianProjectionBackward.cu
+++ b/src/fvdb/detail/ops/gsplat/GaussianProjectionBackward.cu
@@ -60,19 +60,18 @@ projectionBackwardKernel(const int32_t offset,
                          int32_t *__restrict__ outMaxRadiiAccum,     // [N]
                          int32_t *__restrict__ outGradientStepCounts // [N]
 ) {
+    uint32_t cId = blockIdx.y;
     alignas(nanovdb::math::Mat3<T>) extern __shared__ char sharedMemory[];
-    camera.loadSharedMemory(sharedMemory);
+    camera.loadSharedMemory(cId, sharedMemory);
     __syncthreads();
 
-    // parallelize over C * N.
-    uint32_t idx = cg::this_grid().thread_rank();
-    if (idx >= C * count) {
+    // parallelize over N.
+    uint32_t gId = blockIdx.x * blockDim.x + threadIdx.x;
+    if (gId >= count) {
         return;
     }
-    const uint32_t cId = idx / count;          // camera id
-    const uint32_t gId = idx % count + offset; // gaussian id
-
-    idx = cId * N + gId;
+    gId += offset;
+    auto idx = cId * N + gId;
     if (radii[idx] <= 0) {
         return;
     }
@@ -276,7 +275,7 @@ dispatchGaussianProjectionBackward<torch::kCUDA>(
         dLossDWorldToCamMatrices = torch::zeros_like(worldToCamMatrices);
     }
     if (C && N) {
-        const unsigned int NUM_BLOCKS = GET_BLOCKS(C * N, DEFAULT_BLOCK_DIM);
+        const dim3 NUM_BLOCKS(GET_BLOCKS(N, DEFAULT_BLOCK_DIM), C);
         if (ortho) {
             const auto camera = OrthographicCamera<float>{projectionMatrices,
                                                           worldToCamMatrices,
@@ -428,7 +427,7 @@ dispatchGaussianProjectionBackward<torch::kPrivateUse1>(
 
             int64_t deviceProblemOffset, deviceProblemSize;
             std::tie(deviceProblemOffset, deviceProblemSize) = deviceChunk(N, deviceId);
-            const unsigned int NUM_BLOCKS = GET_BLOCKS(C * deviceProblemSize, DEFAULT_BLOCK_DIM);
+            const dim3 NUM_BLOCKS(GET_BLOCKS(deviceProblemSize, DEFAULT_BLOCK_DIM), C);
 
             if (ortho) {
                 const auto camera = OrthographicCamera<float>{projectionMatrices,

--- a/src/fvdb/detail/ops/gsplat/GaussianProjectionForward.cu
+++ b/src/fvdb/detail/ops/gsplat/GaussianProjectionForward.cu
@@ -95,12 +95,10 @@ template <typename T, typename Camera> struct ProjectionForward {
 
     /// @brief Project one (camera, gaussian) pair and write packed 2D outputs.
     inline __device__ void
-    projectionForward(int idx) {
-        if (idx >= C * N) {
+    projectionForward(int cid, int gid) {
+        if (gid >= N) {
             return;
         }
-        const auto cid = idx / N; // camera id
-        const auto gid = idx % N; // gaussian id
 
         const Vec3 meanWorldSpace(mMeansAcc[gid][0], mMeansAcc[gid][1], mMeansAcc[gid][2]);
         const Mat3 covar = computeCovarianceMatrix(gid);
@@ -144,15 +142,15 @@ template <typename T, typename Camera> struct ProjectionForward {
         mOutConicsAcc[cid][gid][1]               = conicPacked[1];
         mOutConicsAcc[cid][gid][2]               = conicPacked[2];
         if (mOutCompensationsAcc != nullptr) {
-            mOutCompensationsAcc[idx] = compensation;
+            mOutCompensationsAcc[cid * N + gid] = compensation;
         }
     }
 
     /// @brief Stage per-camera projection and pose matrices into shared memory.
     inline __device__ void
-    loadCamerasIntoSharedMemory() {
+    loadCameraIntoSharedMemory(unsigned int cid) {
         alignas(Mat3) extern __shared__ char sharedMemory[];
-        mCamera.loadSharedMemory(sharedMemory);
+        mCamera.loadSharedMemory(cid, sharedMemory);
     }
 };
 
@@ -161,16 +159,14 @@ __global__ __launch_bounds__(DEFAULT_BLOCK_DIM) void
 projectionForwardKernel(int64_t offset,
                         int64_t count,
                         ProjectionForward<T, Camera> projectionForward) {
-    projectionForward.loadCamerasIntoSharedMemory();
+    auto cid = blockIdx.y;
+    projectionForward.loadCameraIntoSharedMemory(cid);
     __syncthreads();
 
-    // parallelize over C * N.
-    for (auto idx = blockIdx.x * blockDim.x + threadIdx.x; idx < projectionForward.C * count;
-         idx += blockDim.x * gridDim.x) {
-        const uint32_t cId = idx / count;          // camera id
-        const uint32_t gId = idx % count + offset; // gaussian id
-
-        projectionForward.projectionForward(cId * projectionForward.N + gId);
+    // parallelize over N.
+    for (auto gid = blockIdx.x * blockDim.x + threadIdx.x; gid < count;
+         gid += blockDim.x * gridDim.x) {
+        projectionForward.projectionForward(cid, gid + offset);
     }
 }
 
@@ -223,7 +219,7 @@ dispatchGaussianProjectionForward<torch::kCUDA>(
 
     using scalar_t = float;
 
-    const unsigned int NUM_BLOCKS = GET_BLOCKS(C * N, DEFAULT_BLOCK_DIM);
+    const dim3 NUM_BLOCKS(GET_BLOCKS(N, DEFAULT_BLOCK_DIM), C);
 
     if (ortho) {
         const auto camera = OrthographicCamera<scalar_t>{projectionMatrices,
@@ -330,7 +326,7 @@ dispatchGaussianProjectionForward<torch::kPrivateUse1>(
         int64_t deviceProblemOffset, deviceProblemSize;
         std::tie(deviceProblemOffset, deviceProblemSize) = deviceChunk(N, deviceId);
 
-        const unsigned int NUM_BLOCKS = GET_BLOCKS(C * deviceProblemSize, DEFAULT_BLOCK_DIM);
+        const dim3 NUM_BLOCKS(GET_BLOCKS(deviceProblemSize, DEFAULT_BLOCK_DIM), C);
 
         if (ortho) {
             const auto camera = OrthographicCamera<scalar_t>{projectionMatrices,


### PR DESCRIPTION
Currently, each block loads all C cameras. Furthermore, the number of blocks scales with C and therefore our shared memory bandwidth scales as O(C^2). To address this, we parameterize the blocks with the cameras in the Y direction ensuring that each block only requires one camera. This enables us to load just the single camera into shared memory and have aggregate shared memory bandwidth that scales with C.

Note that this optimization doesn't apply to the non-pinhole case. In that scenario, the rasterization pass needs access to all the cameras since it is parameterized by tiles though it's possible this could be changed at a future point with more extensive refactoring.