### PR TITLE
PyTorch 2.11 support for venv CI

### DIFF
--- a/env/build_requirements.txt
+++ b/env/build_requirements.txt
@@ -3,4 +3,4 @@ scikit_build_core
 wheel
 ninja
 numpy
-torch ~=2.10.0
+torch

--- a/env/test_requirements.txt
+++ b/env/test_requirements.txt
@@ -4,7 +4,7 @@ wheel
 ninja
 tqdm
 numpy
-torch ~=2.10.0
+torch
 GitPython
 pandas
 pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ requires-python = ">=3.10"
 readme = "README.md"
 dependencies = [
     # Require torch; users will choose the correct CUDA build from PyTorch's index
-    "torch>=2.8,<2.11",
+    "torch>=2.8,<2.12",
     "numpy",
 ]
 classifiers = [


### PR DESCRIPTION
PyTorch 2.11 was released earlier this week. Tests, etc. already pass with PyTorch 2.11. We simply need to remove the `<2.11` in the fvdb-core pyproject.toml so that pip does not erroneously replace 2.11 with 2.10 during the CI which leads to an ABI mismatch.