### PR TITLE
Remove torchsparse from all environment and CI configurations

### DIFF
--- a/.github/workflows/cu128.yml
+++ b/.github/workflows/cu128.yml
@@ -413,7 +413,7 @@ jobs:
           AGENT_TOOLSDIRECTORY: "/opt/hostedtoolcache"
 
       - name: Install apt dependencies
-        run: apt install -y zlib1g-dev libpng-dev libsparsehash-dev
+        run: apt install -y zlib1g-dev libpng-dev
 
       - name: Install pip dependencies
         run: |
@@ -421,7 +421,6 @@ jobs:
           uv pip install --no-cache-dir -r env/test_requirements.txt --extra-index-url https://download.pytorch.org/whl/cu128
           uv pip install --no-cache-dir setuptools
           TORCH_CUDA_ARCH_LIST="${{ needs.versions.outputs.cuda-arch-pr }}" uv pip install -v --no-build-isolation git+https://github.com/rusty1s/pytorch_scatter.git
-          TORCH_CUDA_ARCH_LIST="${{ needs.versions.outputs.cuda-arch-pr }}" uv pip install -v --no-build-isolation git+https://github.com/heiwang1997/torchsparse.git
 
       - name: Download package
         uses: actions/download-artifact@v8

--- a/.github/workflows/cu130.yml
+++ b/.github/workflows/cu130.yml
@@ -413,7 +413,7 @@ jobs:
           AGENT_TOOLSDIRECTORY: "/opt/hostedtoolcache"
 
       - name: Install apt dependencies
-        run: apt install -y zlib1g-dev libpng-dev libsparsehash-dev
+        run: apt install -y zlib1g-dev libpng-dev
 
       - name: Install pip dependencies
         run: |
@@ -421,7 +421,6 @@ jobs:
           uv pip install --no-cache-dir -r env/test_requirements.txt --extra-index-url https://download.pytorch.org/whl/cu130 --index-strategy unsafe-best-match
           uv pip install --no-cache-dir setuptools
           TORCH_CUDA_ARCH_LIST="${{ needs.versions.outputs.cuda-arch-pr }}" uv pip install -v --no-build-isolation git+https://github.com/rusty1s/pytorch_scatter.git
-          TORCH_CUDA_ARCH_LIST="${{ needs.versions.outputs.cuda-arch-pr }}" uv pip install -v --no-build-isolation git+https://github.com/heiwang1997/torchsparse.git
 
       - name: Download package
         uses: actions/download-artifact@v8

--- a/env/dev_environment.yml
+++ b/env/dev_environment.yml
@@ -56,7 +56,6 @@ dependencies:
   - seaborn
   - scikit-build-core
   - setuptools>=68.2.2
-  - sparsehash
   - sphinx_rtd_theme
   - sphinx>=7.0.0
   - tensorboard
@@ -76,8 +75,6 @@ dependencies:
   - pip:
     - point-cloud-utils
     - pytest-markdown-docs
-    - https://fvdb-packages.s3.us-east-2.amazonaws.com/dev-whls/pt210cu130/torchsparse-2.1.0-cp312-cp312-linux_x86_64.whl
-    - https://fvdb-packages.s3.us-east-2.amazonaws.com/dev-whls/pt210cu130/torch_scatter-2.1.2-cp312-cp312-linux_x86_64.whl
     ## 3dgs tests
     - dlnr_lite
     - einops

--- a/env/learn_environment.yml
+++ b/env/learn_environment.yml
@@ -24,7 +24,6 @@ dependencies:
   - pytest-benchmark
   - python=3.12
   - pytorch-gpu=2.10.0
-  - sparsehash
   - tensorboard
   - tqdm
   ## 3dgs
@@ -38,5 +37,4 @@ dependencies:
   - viser
   - pip:
     - point-cloud-utils
-    - https://fvdb-packages.s3.us-east-2.amazonaws.com/dev-whls/pt210cu130/torchsparse-2.1.0-cp312-cp312-linux_x86_64.whl
     - https://fvdb-packages.s3.us-east-2.amazonaws.com/dev-whls/pt210cu130/torch_scatter-2.1.2-cp312-cp312-linux_x86_64.whl

--- a/env/test_environment.yml
+++ b/env/test_environment.yml
@@ -45,7 +45,6 @@ dependencies:
     - gsplat
     - pytest-markdown-docs
     - point-cloud-utils
-    - torchsparse @ https://fvdb-packages.s3.us-east-2.amazonaws.com/dev-whls/pt210cu130/torchsparse-2.1.0-cp312-cp312-linux_x86_64.whl
     - torch_scatter @ https://fvdb-packages.s3.us-east-2.amazonaws.com/dev-whls/pt210cu130/torch_scatter-2.1.2-cp312-cp312-linux_x86_64.whl
     ## 3dgs tests
     - oiio-static-python


### PR DESCRIPTION
torchsparse is only used by optional benchmark comparison scripts (which already handle its absence gracefully) and WIP code excluded from test collection. No unit tests or production code depend on it.

- Remove torchsparse wheel from env/test_environment.yml, env/dev_environment.yml, and env/learn_environment.yml
- Remove sparsehash conda dep from dev and learn environments (only needed for building torchsparse)
- Remove libsparsehash-dev apt install and torchsparse pip install from .github/workflows/cu128.yml and cu130.yml
- Remove both torchsparse wheels from fvdb-reality-capture tests/benchmarks/comparative/docker/benchmark_environment.yml

Closes #34 