### PR TITLE
Add cache clearing step in nightly publish workflow

### DIFF
--- a/.github/workflows/nightly-publish.yml
+++ b/.github/workflows/nightly-publish.yml
@@ -162,6 +162,9 @@ jobs:
           echo "Nightly version: $NIGHTLY_VERSION"
           grep '^version' pyproject.toml
 
+      - name: Drop page cache to free RAM before build
+        run: sync && echo 3 > /proc/sys/vm/drop_caches
+
       - name: Build fvdb
         run: |
           source .venv/bin/activate


### PR DESCRIPTION
This commit introduces a new step in the nightly publish workflow to drop page cache before the build process. This aims to free up RAM and potentially improve build performance.