### PR TITLE
[CI] Get nanovdb-editor from pip instead from built whl

### DIFF
--- a/.github/scripts/get_viewer_dependency.py
+++ b/.github/scripts/get_viewer_dependency.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+# Copyright Contributors to the OpenVDB Project
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+
+def main() -> None:
+    tomllib = importlib.import_module("tomllib")
+    with Path("pyproject.toml").open("rb") as f:
+        viewer_deps = tomllib.load(f)["project"]["optional-dependencies"]["viewer"]
+
+    print(next(dep for dep in viewer_deps if dep.startswith("nanovdb-editor")))
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/cu128.yml
+++ b/.github/workflows/cu128.yml
@@ -157,6 +157,8 @@ jobs:
       - name: Build fvdb
         run: |
           source .venv/bin/activate
+          NANOVDB_EDITOR_SPEC=$(python .github/scripts/get_viewer_dependency.py)
+          pip install "$NANOVDB_EDITOR_SPEC"
           ./build.sh wheel verbose gtests benchmarks --cuda-arch-list '${{ needs.versions.outputs.cuda-arch-pr }}'
 
       - name: Upload wheel
@@ -316,17 +318,6 @@ jobs:
           uv venv
           uv pip install --no-cache-dir -r env/build_requirements.txt --extra-index-url https://download.pytorch.org/whl/cu128
 
-      - name: Download package with nanovdb_editor
-        uses: actions/download-artifact@v8
-        with:
-            name: fvdb-test-package
-            path: ./dist
-
-      - name: Install nanovdb_editor
-        run: |
-            source .venv/bin/activate
-            pip install ./dist/nanovdb_editor*.whl
-
       - name: Download gtests
         uses: actions/download-artifact@v8
         with:
@@ -435,6 +426,8 @@ jobs:
       - name: Run tests
         run: |
           source .venv/bin/activate
+          NANOVDB_EDITOR_SPEC=$(python .github/scripts/get_viewer_dependency.py)
+          pip install "$NANOVDB_EDITOR_SPEC"
           cd tests;
           pytest -v unit
 

--- a/.github/workflows/cu130.yml
+++ b/.github/workflows/cu130.yml
@@ -157,6 +157,8 @@ jobs:
       - name: Build fvdb
         run: |
           source .venv/bin/activate
+          NANOVDB_EDITOR_SPEC=$(python .github/scripts/get_viewer_dependency.py)
+          pip install "$NANOVDB_EDITOR_SPEC"
           ./build.sh wheel verbose gtests benchmarks --cuda-arch-list '${{ needs.versions.outputs.cuda-arch-pr }}'
 
       - name: Upload wheel
@@ -316,17 +318,6 @@ jobs:
           uv venv
           uv pip install --no-cache-dir -r env/build_requirements.txt --extra-index-url https://download.pytorch.org/whl/cu130
 
-      - name: Download package with nanovdb_editor
-        uses: actions/download-artifact@v8
-        with:
-            name: fvdb-test-package
-            path: ./dist
-
-      - name: Install nanovdb_editor
-        run: |
-            source .venv/bin/activate
-            pip install ./dist/nanovdb_editor*.whl
-
       - name: Download gtests
         uses: actions/download-artifact@v8
         with:
@@ -435,6 +426,8 @@ jobs:
       - name: Run tests
         run: |
           source .venv/bin/activate
+          NANOVDB_EDITOR_SPEC=$(python .github/scripts/get_viewer_dependency.py)
+          pip install "$NANOVDB_EDITOR_SPEC"
           cd tests;
           pytest -v unit
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -671,6 +671,8 @@ jobs:
       - name: Run unit tests
         run: |
           micromamba activate fvdb_test
+          NANOVDB_EDITOR_SPEC=$(python .github/scripts/get_viewer_dependency.py)
+          pip install "$NANOVDB_EDITOR_SPEC"
           cd tests
           pytest -v unit
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -130,6 +130,8 @@ jobs:
       - name: Build fvdb
         run: |
           micromamba activate fvdb_build
+          NANOVDB_EDITOR_SPEC=$(python .github/scripts/get_viewer_dependency.py)
+          pip install "$NANOVDB_EDITOR_SPEC"
           ./build.sh wheel verbose gtests benchmarks --cuda-arch-list '8.9+PTX'
 
       - name: Upload wheel
@@ -253,17 +255,6 @@ jobs:
           environment-name: fvdb_test
           environment-file: env/test_environment.yml
 
-      - name: Download package with nanovdb_editor
-        uses: actions/download-artifact@v8
-        with:
-            name: fvdb-test-package
-            path: ./dist
-
-      - name: Install nanovdb_editor
-        run: |
-            micromamba activate fvdb_test
-            pip install ./dist/nanovdb_editor*.whl
-
       - name: Download gtests
         uses: actions/download-artifact@v8
         with:
@@ -345,6 +336,8 @@ jobs:
       - name: Run tests
         run: |
             micromamba activate fvdb_test
+            NANOVDB_EDITOR_SPEC=$(python .github/scripts/get_viewer_dependency.py)
+            pip install "$NANOVDB_EDITOR_SPEC"
             cd tests;
             pytest -v unit
 

--- a/src/cmake/get_nanovdb_editor.cmake
+++ b/src/cmake/get_nanovdb_editor.cmake
@@ -15,13 +15,13 @@ option(NANOVDB_EDITOR_SKIP "Skip nanovdb_editor wheel build" OFF)
 set(NANOVDB_EDITOR_BUILD_TYPE "Release" CACHE STRING "Build type for nanovdb_editor (Release/Debug)")
 
 # For fVDB main use nanovdb-editor main
-set(NANOVDB_EDITOR_TAG 62861a3b7f0fe2d4d61e7025b7f5b872086e965c)
-set(NANOVDB_EDITOR_VERSION 0.0.23)   # version at this commit
+set(NANOVDB_EDITOR_TAG 73f066b8387eb53a718eba1ef1f7b91738df6ba8)
+set(NANOVDB_EDITOR_VERSION 0.0.24)   # version at this commit
 
 # If skip is set, get the latest tagged version to prevent unnecessary rebuilds each hash update
 if(NANOVDB_EDITOR_SKIP)
-    set(NANOVDB_EDITOR_VERSION 0.0.23)   # latest tagged version
-    set(NANOVDB_EDITOR_TAG v${NANOVDB_EDITOR_VERSION}-dev)  # use dev tag according to PyPI published wheel
+    set(NANOVDB_EDITOR_VERSION 0.0.24)   # latest tagged version
+    set(NANOVDB_EDITOR_TAG v${NANOVDB_EDITOR_VERSION})  # use dev tag according to PyPI published wheel
 endif()
 
 CPMAddPackage(

--- a/src/cmake/get_nanovdb_editor.cmake
+++ b/src/cmake/get_nanovdb_editor.cmake
@@ -15,12 +15,12 @@ option(NANOVDB_EDITOR_SKIP "Skip nanovdb_editor wheel build" OFF)
 set(NANOVDB_EDITOR_BUILD_TYPE "Release" CACHE STRING "Build type for nanovdb_editor (Release/Debug)")
 
 # For fVDB main use nanovdb-editor main
-set(NANOVDB_EDITOR_TAG 73f066b8387eb53a718eba1ef1f7b91738df6ba8)
-set(NANOVDB_EDITOR_VERSION 0.0.24)   # version at this commit
+set(NANOVDB_EDITOR_TAG c2eeb18b2e381e8e7cf0979b84ef3551620d7f74)
+set(NANOVDB_EDITOR_VERSION 0.0.25)   # version at this commit
 
 # If skip is set, get the latest tagged version to prevent unnecessary rebuilds each hash update
 if(NANOVDB_EDITOR_SKIP)
-    set(NANOVDB_EDITOR_VERSION 0.0.24)   # latest tagged version
+    set(NANOVDB_EDITOR_VERSION 0.0.25)   # latest tagged version
     set(NANOVDB_EDITOR_TAG v${NANOVDB_EDITOR_VERSION})  # use dev tag according to PyPI published wheel
 endif()
 


### PR DESCRIPTION
Prerequisite to pass tests in https://github.com/openvdb/fvdb-core/pull/580

CI on this PR is passing because it takes config from main. When run manually from the Actions on this branch it first failed due nanovdb-editor manylinux wheel not compatible with rockylinux8:
https://github.com/openvdb/fvdb-core/actions/runs/23818100932/job/69423229362#step:8:47

The most recent build after nanovdb-editor wheel bump is passing:
https://github.com/openvdb/fvdb-core/actions/runs/24187023930