### PR TITLE
Eliminate `.item()` synchronization stalls in hot C++ paths

### DIFF
--- a/src/fvdb/detail/io/SaveNanoVDB.cpp
+++ b/src/fvdb/detail/io/SaveNanoVDB.cpp
@@ -126,6 +126,10 @@ fvdbToNanovdbGridWithValues(const GridBatchData &gridBatchData,
     auto ijkAccessor   = ijkValues.jdata().accessor<int, 2>();
     auto jdataAccessor = jdataCpu.accessor<InScalarType, 2>();
 
+    auto ijkOffsetsAcc  = ijkValues.joffsets().accessor<JOffsetsType, 1>();
+    auto dataOffsetsCpu = data.joffsets().cpu();
+    auto dataOffsetsAcc = dataOffsetsCpu.accessor<JOffsetsType, 1>();
+
     // Populate a vector of host buffers for each grid in the batch
     std::vector<HostGridHandle> buffers(gridBatchData.batchSize());
     for (int64_t bi = 0; bi < gridBatchData.batchSize(); bi += 1) {
@@ -152,11 +156,10 @@ fvdbToNanovdbGridWithValues(const GridBatchData &gridBatchData,
 
         auto proxyGridAccessor = proxyGrid->getWriteAccessor();
 
-        const int start         = ijkValues.joffsets()[bi].item<int>();
-        const int end           = ijkValues.joffsets()[bi + 1].item<int>();
+        const int start         = static_cast<int>(ijkOffsetsAcc[bi]);
+        const int end           = static_cast<int>(ijkOffsetsAcc[bi + 1]);
         const int64_t numVoxels = end - start;
-        const int64_t numData =
-            data.joffsets()[bi + 1].item<int>() - data.joffsets()[bi].item<int>();
+        const int64_t numData   = dataOffsetsAcc[bi + 1] - dataOffsetsAcc[bi];
         TORCH_CHECK_VALUE(
             numData == gridBatchData.numVoxelsAt(bi),
             "Invalid number of voxels in jagged tensor at index " + std::to_string(bi) +

--- a/src/fvdb/detail/ops/JIdxForJOffsets.cu
+++ b/src/fvdb/detail/ops/JIdxForJOffsets.cu
@@ -89,6 +89,9 @@ jIdxForJOffsetsPrivateUse1(torch::Tensor joffsets, int64_t numElements) {
     }
     torch::Tensor retJIdx = torch::empty({numElements}, options);
 
+    auto joffsets_cpu = joffsets.cpu();
+    auto joffsets_acc = joffsets_cpu.accessor<fvdb::JOffsetsType, 1>();
+
     for (const auto deviceId: c10::irange(c10::cuda::device_count())) {
         C10_CUDA_CHECK(cudaSetDevice(deviceId));
         cudaStream_t stream = c10::cuda::getCurrentCUDAStream(deviceId).stream();
@@ -99,8 +102,8 @@ jIdxForJOffsetsPrivateUse1(torch::Tensor joffsets, int64_t numElements) {
         size_t deviceJOffsetsEnd = deviceJOffsetsStart + deviceJOffsetsCount;
 
         for (auto i = deviceJOffsetsStart; i < deviceJOffsetsEnd; ++i) {
-            auto start = joffsets[i].item<fvdb::JOffsetsType>();
-            auto end   = joffsets[i + 1].item<fvdb::JOffsetsType>();
+            auto start = joffsets_acc[i];
+            auto end   = joffsets_acc[i + 1];
             if (start < end) {
                 const int numBlocks = GET_BLOCKS(end - start, DEFAULT_BLOCK_DIM);
                 jIdxFill<DEFAULT_BLOCK_DIM><<<numBlocks, DEFAULT_BLOCK_DIM, 0, stream>>>(
@@ -130,9 +133,9 @@ jIdxForJOffsetsCPU(torch::Tensor joffsets, int64_t numElements) {
     }
     std::vector<torch::Tensor> batchIdxs;
     batchIdxs.reserve(joffsets.size(0));
+    auto joffsets_acc = joffsets.accessor<fvdb::JOffsetsType, 1>();
     for (int i = 0; i < joffsets.size(0) - 1; i += 1) {
-        auto count =
-            joffsets[i + 1].item<fvdb::JOffsetsType>() - joffsets[i].item<fvdb::JOffsetsType>();
+        auto count = joffsets_acc[i + 1] - joffsets_acc[i];
         batchIdxs.push_back(torch::full({count}, i, options));
     }
     return torch::cat(batchIdxs, 0);

--- a/src/fvdb/detail/ops/JaggedTensorIndex.cu
+++ b/src/fvdb/detail/ops/JaggedTensorIndex.cu
@@ -259,8 +259,10 @@ jaggedTensorIndexSliceCuda(const JaggedTensor &jt, int64_t start, int64_t end, i
     // Single list case with step size 1 (ldim = 1)
     if (jt.ldim() == 1 && step == 1) {
         TORCH_CHECK(jt.ldim() == 1, "bad list indexes. this should never happen");
-        const JOffsetsType startIdx = jt.joffsets()[start].item<JOffsetsType>();
-        const JOffsetsType endIdx   = jt.joffsets()[end].item<JOffsetsType>();
+        auto offsets_slice          = jt.joffsets().narrow(0, start, end - start + 1).cpu();
+        auto offsets_acc            = offsets_slice.accessor<JOffsetsType, 1>();
+        const JOffsetsType startIdx = offsets_acc[0];
+        const JOffsetsType endIdx   = offsets_acc[end - start];
         const torch::Tensor retLidx = jt.jlidx().numel() == 0
                                           ? jt.jlidx()
                                           : jt.jlidx().index({torch::indexing::Slice(start, end)});
@@ -520,8 +522,12 @@ jaggedTensorIndexIntOneList(const JaggedTensor &jt, int64_t idxVal) {
     torch::Tensor jlidx    = jt.jlidx();
 
     TORCH_CHECK(jt.ldim() == 1, "bad list indexes. this should never happen");
-    const JOffsetsType startIdx = joffsets[idxVal].item<JOffsetsType>();
-    const JOffsetsType endIdx   = joffsets[idxVal + 1].item<JOffsetsType>();
+    auto two_offsets = joffsets.narrow(0, idxVal, 2);
+    if (!two_offsets.is_cpu())
+        two_offsets = two_offsets.cpu();
+    auto two_acc                = two_offsets.accessor<JOffsetsType, 1>();
+    const JOffsetsType startIdx = two_acc[0];
+    const JOffsetsType endIdx   = two_acc[1];
     const torch::Tensor retJoffsets =
         torch::tensor({JOffsetsType(0), endIdx - startIdx},
                       torch::TensorOptions().dtype(JOffsetsScalarType).device(jdata.device()));
@@ -575,10 +581,11 @@ jaggedTensorIndexIntCuda(const JaggedTensor &jt, int64_t idxVal) {
     C10_CUDA_KERNEL_LAUNCH_CHECK();
 
     offsetsAndRange                       = offsetsAndRange.cpu();
-    const JOffsetsType elementStartOffset = offsetsAndRange[0].item<JOffsetsType>();
-    const JOffsetsType elementEndOffset   = offsetsAndRange[1].item<JOffsetsType>();
-    const JOffsetsType startIdx           = offsetsAndRange[2].item<JOffsetsType>();
-    const JOffsetsType endIdx             = offsetsAndRange[3].item<JOffsetsType>();
+    auto oar_acc                          = offsetsAndRange.accessor<JOffsetsType, 1>();
+    const JOffsetsType elementStartOffset = oar_acc[0];
+    const JOffsetsType elementEndOffset   = oar_acc[1];
+    const JOffsetsType startIdx           = oar_acc[2];
+    const JOffsetsType endIdx             = oar_acc[3];
     torch::Tensor retOffsets =
         joffsets.index({torch::indexing::Slice(startIdx, endIdx + 1)}) - elementStartOffset;
     const torch::Tensor retData =

--- a/src/fvdb/detail/ops/convolution/GatherScatterDefault.cu
+++ b/src/fvdb/detail/ops/convolution/GatherScatterDefault.cu
@@ -159,8 +159,9 @@ struct twopass_topology_op {
         if (K > 0) {
             offsets_dev.slice(0, 1, K + 1).copy_(torch::cumsum(counts.to(torch::kInt64), 0));
         }
-        int64_t total_pairs = (K > 0) ? offsets_dev[K].item<int64_t>() : 0;
         auto offsets_host   = offsets_dev.cpu();
+        auto offsets_acc    = offsets_host.accessor<int64_t, 1>();
+        int64_t total_pairs = (K > 0) ? offsets_acc[K] : 0;
 
         if (total_pairs == 0) {
             return GatherScatterDefaultTopology{

--- a/src/fvdb/detail/viewer/Viewer.cpp
+++ b/src/fvdb/detail/viewer/Viewer.cpp
@@ -448,18 +448,20 @@ Viewer::addCameraView(const std::string &scene_name,
     for (int i = 0; i < (int)it->second.mView.num_cameras; i++) {
         torch::Tensor c2w = cameraToWorldMatrices.index({i}).contiguous().cpu();
         torch::Tensor K   = projectionMatrices.index({i}).contiguous().cpu();
+        auto c2w_acc      = c2w.accessor<float, 2>();
+        auto K_acc        = K.accessor<float, 2>();
 
-        float px = c2w[0][3].item<float>();
-        float py = c2w[1][3].item<float>();
-        float pz = c2w[2][3].item<float>();
+        float px = c2w_acc[0][3];
+        float py = c2w_acc[1][3];
+        float pz = c2w_acc[2][3];
 
-        float zx = c2w[0][2].item<float>();
-        float zy = c2w[1][2].item<float>();
-        float zz = c2w[2][2].item<float>();
+        float zx = c2w_acc[0][2];
+        float zy = c2w_acc[1][2];
+        float zz = c2w_acc[2][2];
 
-        float ux = c2w[0][1].item<float>();
-        float uy = c2w[1][1].item<float>();
-        float uz = c2w[2][1].item<float>();
+        float ux = c2w_acc[0][1];
+        float uy = c2w_acc[1][1];
+        float uz = c2w_acc[2][1];
 
         // NanoVDB editor camera
         // - state.position: orbit center (c2w translation)
@@ -483,14 +485,15 @@ Viewer::addCameraView(const std::string &scene_name,
         it->second.mView.configs[i].far_plane  = frustumFar;
 
         // Set perspective parameters from image sizes when available
-        float fy      = K[1][1].item<float>();
+        float fy      = K_acc[1][1];
         float width   = 0.f;
         float height  = 0.f;
         bool haveDims = imageSizes.numel() != 0;
         if (haveDims) {
             torch::Tensor dims = imageSizes.index({i}).contiguous().cpu();
-            height             = dims[0].item<float>();
-            width              = dims[1].item<float>();
+            auto dims_acc      = dims.accessor<float, 1>();
+            height             = dims_acc[0];
+            width              = dims_acc[1];
         }
 
         if (haveDims && height > 0.f && fy > 0.f) {


### PR DESCRIPTION
We had several spots where we were making redundant .item() calls on CUDA tensors triggering implicit device syncs.  This replaces the worst offenders with bulk .cpu() + accessor patterns that consolidate multiple per-element syncs into at most one transfer.

- Replace per-iteration `.item<T>()` calls on GPU tensors with a single
  bulk `.cpu()` copy and typed accessor reads, eliminating N implicit
  `cudaDeviceSynchronize` stalls per loop in `JIdxForJOffsets` (PrivateUse1
  path) and `SaveNanoVDB` (batch export loop).
- Reorder `.item()` after `.cpu()` in `GatherScatterDefault` convolution
  topology building so the inevitable host transfer is not preceded by a
  redundant device sync.
- Consolidate two `.item()` calls into a single `narrow(...).cpu()` in
  `JaggedTensorIndex` CUDA slice and integer-index paths, halving the
  sync count per indexing operation.
- Switch Viewer camera registration and several already-CPU
  `JaggedTensorIndex`/`JIdxForJOffsets` code paths from `.item()` to
  typed accessors, avoiding per-element dispatch overhead.