### PR TITLE
Fix missing CUDA device guards in kernel-launching functions

### DIFF
--- a/src/fvdb/detail/GridBatchDataFactory.cu
+++ b/src/fvdb/detail/GridBatchDataFactory.cu
@@ -112,6 +112,7 @@ computeBatchOffsets(GridBatchData::GridMetadata *hostMeta,
     torch::Tensor offsets = torch::empty(
         {batchSize + 1}, torch::TensorOptions().dtype(fvdb::JOffsetsScalarType).device(device));
     if (device.is_cuda()) {
+        const c10::cuda::CUDAGuard device_guard(device);
         cudaStream_t stream = c10::cuda::getCurrentCUDAStream(device.index()).stream();
         computeBatchOffsetsFromMetadata<<<1, 1, 0, stream>>>(
             batchSize,

--- a/src/fvdb/detail/ops/BuildFineGridFromCoarse.cu
+++ b/src/fvdb/detail/ops/BuildFineGridFromCoarse.cu
@@ -137,6 +137,8 @@ dispatchFineIJKForCoarseGrid<torch::kCUDA>(const GridBatchData &batchHdl,
     TORCH_CHECK(batchHdl.device().is_cuda(), "GridBatchData must be on CUDA device");
     TORCH_CHECK(batchHdl.device().has_index(), "GridBatchData must have a valid index");
 
+    const c10::cuda::CUDAGuard device_guard(batchHdl.device());
+
     const int64_t totalPadAmount = upsamplingFactor[0] * upsamplingFactor[1] * upsamplingFactor[2];
 
     const auto optsData = torch::TensorOptions().dtype(torch::kInt32).device(batchHdl.device());

--- a/src/fvdb/detail/ops/IjkForMesh.cu
+++ b/src/fvdb/detail/ops/IjkForMesh.cu
@@ -66,8 +66,7 @@ countVoxelsPerTriToCheck(int32_t bidx,
 
 template <typename ScalarF,
           typename ScalarI,
-          template <typename T, int32_t D>
-          typename TensorAccessor>
+          template <typename T, int32_t D> typename TensorAccessor>
 __global__ __launch_bounds__(DEFAULT_BLOCK_DIM) void
 generateSurfaceSamples(const VoxelCoordTransform *transforms,
                        const JaggedRAcc64<ScalarF, 2> vertices,
@@ -192,6 +191,8 @@ dispatchIJKForMesh<torch::kCUDA>(const JaggedTensor &meshVertices,
     TORCH_CHECK(meshVertices.device().has_index(), "GridBatchData must have a valid index");
     TORCH_CHECK(meshFaces.device().is_cuda(), "GridBatchData must be on CUDA device");
     TORCH_CHECK(meshFaces.device().has_index(), "GridBatchData must have a valid index");
+
+    const c10::cuda::CUDAGuard device_guard(meshFaces.device());
 
     RAIIRawDeviceBuffer<VoxelCoordTransform> transformsDVec(transforms.size(),
                                                             meshVertices.device());

--- a/src/fvdb/detail/ops/IjkForMesh.cu
+++ b/src/fvdb/detail/ops/IjkForMesh.cu
@@ -66,7 +66,8 @@ countVoxelsPerTriToCheck(int32_t bidx,
 
 template <typename ScalarF,
           typename ScalarI,
-          template <typename T, int32_t D> typename TensorAccessor>
+          template <typename T, int32_t D>
+          typename TensorAccessor>
 __global__ __launch_bounds__(DEFAULT_BLOCK_DIM) void
 generateSurfaceSamples(const VoxelCoordTransform *transforms,
                        const JaggedRAcc64<ScalarF, 2> vertices,

--- a/src/fvdb/detail/ops/IntegrateTSDF.cu
+++ b/src/fvdb/detail/ops/IntegrateTSDF.cu
@@ -330,6 +330,8 @@ unprojectDepthMapToPoints(const torch::Tensor &depthImages,
                           const torch::Tensor &projectionMatrices,
                           const torch::Tensor &invProjectionMatrices,
                           const torch::Tensor &camToWorldMatrices) {
+    const c10::cuda::CUDAGuard device_guard(depthImages.device());
+
     const int64_t batchSize      = depthImages.size(0);
     const int64_t imageHeight    = depthImages.size(1);
     const int64_t imageWidth     = depthImages.size(2);
@@ -434,6 +436,8 @@ doIntegrate(const float truncationMargin,
             const JaggedTensor &tsdf,
             const JaggedTensor &weights,
             const JaggedTensor &features) {
+    const c10::cuda::CUDAGuard device_guard(tsdf.device());
+
     const int64_t batchSize      = depthImages.size(0);
     const int64_t imageHeight    = depthImages.size(1);
     const int64_t imageWidth     = depthImages.size(2);

--- a/src/fvdb/detail/ops/JIdxForJOffsets.cu
+++ b/src/fvdb/detail/ops/JIdxForJOffsets.cu
@@ -57,6 +57,9 @@ jIdxForJOffsetsCUDA(torch::Tensor joffsets, int64_t numElements) {
     if (!numElements) {
         return torch::zeros({0}, options);
     }
+
+    const c10::cuda::CUDAGuard device_guard(joffsets.device());
+
     torch::Tensor retJIdx = torch::empty({numElements}, options);
 
     cudaStream_t stream  = c10::cuda::getCurrentCUDAStream(joffsets.device().index()).stream();

--- a/src/fvdb/detail/ops/JaggedTensorIndex.cu
+++ b/src/fvdb/detail/ops/JaggedTensorIndex.cu
@@ -246,6 +246,8 @@ jaggedTensorIndexJaggedTensorImpl(const JaggedTensor &jt, const JaggedTensor &jt
 //      (inclusive) is selected
 JaggedTensor
 jaggedTensorIndexSliceCuda(const JaggedTensor &jt, int64_t start, int64_t end, int64_t step) {
+    const c10::cuda::CUDAGuard device_guard(jt.device());
+
     // Convert indexes to positive values in the range [0, num_outer_lists]
     if (start < 0) {
         start += jt.num_outer_lists();
@@ -547,6 +549,8 @@ jaggedTensorIndexIntOneList(const JaggedTensor &jt, int64_t idxVal) {
 //      jt[2] -> JaggedTensor([...]) where the 3rd list is selected
 JaggedTensor
 jaggedTensorIndexIntCuda(const JaggedTensor &jt, int64_t idxVal) {
+    const c10::cuda::CUDAGuard device_guard(jt.device());
+
     if (idxVal < 0) {
         idxVal += jt.num_outer_lists();
     }

--- a/src/fvdb/detail/ops/convolution/PredGatherIGemm.cu
+++ b/src/fvdb/detail/ops/convolution/PredGatherIGemm.cu
@@ -21,6 +21,7 @@
 
 #include <nanovdb/NanoVDB.h>
 
+#include <c10/cuda/CUDAGuard.h>
 #include <c10/cuda/CUDAStream.h>
 #include <torch/types.h>
 
@@ -1013,6 +1014,8 @@ struct pred_gather_igemm_op {
         constexpr int kout_denom = static_cast<int>(dispatch::tag_get<conv_kout_denom>(tg));
         using GeomT              = Geometry<ks, ks, ks, st, st, st, kout_denom>;
         using ConvOp             = SparseFpropSm80<GeomT>;
+
+        const c10::cuda::CUDAGuard device_guard(features.device());
 
         const int64_t C = features.size(1);
         const int64_t K = weights.size(0);

--- a/src/fvdb/detail/ops/gsplat/GaussianRasterizeFromWorldBackward.cu
+++ b/src/fvdb/detail/ops/gsplat/GaussianRasterizeFromWorldBackward.cu
@@ -449,7 +449,7 @@ launchBackward(const torch::Tensor &means,
         dFeatures.packed_accessor64<float, 3, torch::RestrictPtrTraits>(),
         dOpacities.packed_accessor64<float, 2, torch::RestrictPtrTraits>()};
 
-    auto stream = at::cuda::getDefaultCUDAStream();
+    auto stream = at::cuda::getCurrentCUDAStream(means.device().index());
     rasterizeFromWorld3DGSBackwardKernel<NUM_CHANNELS, Camera>
         <<<gridDim, blockDim, sharedMem, stream>>>(kernelArgs);
     C10_CUDA_KERNEL_LAUNCH_CHECK();
@@ -482,6 +482,8 @@ dispatchGaussianRasterizeFromWorld3DGSBackward<torch::kCUDA>(
     const at::optional<torch::Tensor> &backgrounds,
     const at::optional<torch::Tensor> &masks) {
     FVDB_FUNC_RANGE();
+
+    const at::cuda::OptionalCUDAGuard device_guard(device_of(means));
 
     const uint32_t imageWidth   = settings.imageWidth;
     const uint32_t imageHeight  = settings.imageHeight;

--- a/src/fvdb/detail/ops/gsplat/GaussianRasterizeFromWorldForward.cu
+++ b/src/fvdb/detail/ops/gsplat/GaussianRasterizeFromWorldForward.cu
@@ -278,7 +278,7 @@ launchForward(const torch::Tensor &means,
     sharedMem += (alignof(SharedGaussian<NUM_CHANNELS>) - 1) +
                  blockSize * sizeof(SharedGaussian<NUM_CHANNELS>);
 
-    auto stream = at::cuda::getDefaultCUDAStream();
+    auto stream = at::cuda::getCurrentCUDAStream(means.device().index());
     rasterizeGaussiansFromWorld<NUM_CHANNELS, Camera>
         <<<gridDim, blockDim, sharedMem, stream>>>(args);
 
@@ -308,6 +308,8 @@ dispatchGaussianRasterizeFromWorld3DGSForward<torch::kCUDA>(
     const at::optional<torch::Tensor> &backgrounds,
     const at::optional<torch::Tensor> &masks) {
     FVDB_FUNC_RANGE();
+
+    const at::cuda::OptionalCUDAGuard device_guard(device_of(means));
 
     const uint32_t imageWidth   = settings.imageWidth;
     const uint32_t imageHeight  = settings.imageHeight;


### PR DESCRIPTION
- Add CUDA device guards to all kernel-launching functions that were
  missing them, completing the second half of #94 (the first half,
  stream passing, was addressed by #587).
- Fix two `getDefaultCUDAStream()` calls in the rasterize-from-world
  forward/backward paths that were missed by #587, replacing them with
  `getCurrentCUDAStream()`.
- Add defensive guards to internal helper functions (IntegrateTSDF,
  JaggedTensorIndex, GridBatchDataFactory) whose callers already hold
  guards, hardening them against future use outside those callers.

fixes #94 