### PR TITLE
Fix additional sync point introduced in autograd change

### DIFF
--- a/fvdb/gaussian_splatting.py
+++ b/fvdb/gaussian_splatting.py
@@ -1589,7 +1589,7 @@ class GaussianSplat3d:
             sh_degree_to_use = sh_degree
 
         if sh_degree_to_use > 0:
-            cam_to_world = torch.linalg.inv(w2c)
+            cam_to_world, info = torch.linalg.inv_ex(w2c)
             view_dirs = means[None, :, :] - cam_to_world[:, None, :3, 3]
             return _EvaluateGaussianSHFn.apply(sh_degree_to_use, C, view_dirs, sh0, shN, radii)
         else:


### PR DESCRIPTION
Prior to #594 , `torch::linalg::inv_ex` was called to obtain the camera to world matrices. #594 switched to the Python `torch.linalg.inv` instead which is equivalent, _but introduces a host-device synchronization_. Revert this to using `inv_ex` to recover the prior behavior w/o the sync and recover performance.