### PR TITLE
Materialize repeated opacities for compatibility with multiple splatting implementations

### DIFF
--- a/fvdb/gaussian_splatting.py
+++ b/fvdb/gaussian_splatting.py
@@ -1625,7 +1625,10 @@ class GaussianSplat3d:
     ) -> torch.Tensor:
         """Sigmoid of logit_opacities, optionally scaled by antialias compensations."""
 
-        # TODO(fvdb): Avoid materializing a repeated [C,N] tensor when opacities are shared across cameras (similar to PR #451).
+        # Ideally, we would like to avoid materializing the repeated [C,N] tensor when opacities
+        # are shared across cameras by replacing the repeat call with .unsqueeze(0).expand(C, -1).
+        # However, a non-contiguous opacities tensor is not currently supported in world space
+        # rasterization and mGPU image space rasterization.
         opacities = torch.sigmoid(self._logit_opacities).repeat(C, 1)
         if antialias and compensations is not None:
             opacities = opacities * compensations

--- a/fvdb/gaussian_splatting.py
+++ b/fvdb/gaussian_splatting.py
@@ -1624,7 +1624,9 @@ class GaussianSplat3d:
         antialias: bool,
     ) -> torch.Tensor:
         """Sigmoid of logit_opacities, optionally scaled by antialias compensations."""
-        opacities = torch.sigmoid(self._logit_opacities).unsqueeze(0).expand(C, -1)
+
+        # TODO(fvdb): Avoid materializing a repeated [C,N] tensor when opacities are shared across cameras (similar to PR #451).
+        opacities = torch.sigmoid(self._logit_opacities).repeat(C, 1)
         if antialias and compensations is not None:
             opacities = opacities * compensations
         return opacities

--- a/src/fvdb/detail/ops/gsplat/GaussianRasterizeFromWorldBackward.cu
+++ b/src/fvdb/detail/ops/gsplat/GaussianRasterizeFromWorldBackward.cu
@@ -500,16 +500,9 @@ dispatchGaussianRasterizeFromWorld3DGSBackward<torch::kCUDA>(
     const int64_t C = features.size(0);
     const int64_t N = means.size(0);
 
-    // Opacities may be provided either per-camera ([C,N]) or shared across cameras ([N]).
-    // TODO(fvdb): Avoid materializing a repeated [C,N] tensor when opacities are shared across
-    // cameras (similar to PR #451).
-    torch::Tensor opacitiesBatched = opacities;
-    if (opacitiesBatched.dim() == 1) {
-        TORCH_CHECK_VALUE(opacitiesBatched.size(0) == N,
-                          "opacities must have shape [N] or [C,N] matching N");
-        opacitiesBatched = opacitiesBatched.unsqueeze(0).repeat({C, 1});
-    }
-    opacitiesBatched = opacitiesBatched.contiguous();
+    TORCH_CHECK_VALUE(opacities.dim() == 2, "opacities must have shape [C,N]");
+    TORCH_CHECK_VALUE(opacities.size(0) == C && opacities.size(1) == N,
+                      "opacities must have shape [C,N] matching features and N");
 
     const uint32_t channels = (uint32_t)features.size(2);
 
@@ -519,7 +512,7 @@ dispatchGaussianRasterizeFromWorld3DGSBackward<torch::kCUDA>(
                                             quats,                  \
                                             logScales,              \
                                             features,               \
-                                            opacitiesBatched,       \
+                                            opacities,              \
                                             OP_VAL,                 \
                                             imageWidth,             \
                                             imageHeight,            \

--- a/src/fvdb/detail/ops/gsplat/GaussianRasterizeFromWorldForward.cu
+++ b/src/fvdb/detail/ops/gsplat/GaussianRasterizeFromWorldForward.cu
@@ -333,20 +333,9 @@ dispatchGaussianRasterizeFromWorld3DGSForward<torch::kCUDA>(
     TORCH_CHECK_VALUE(features.size(1) == N, "features must have shape [C,N,D] matching N");
     TORCH_CHECK_VALUE(opacities.is_cuda(), "opacities must be CUDA");
 
-    // Opacities may be provided either per-camera ([C,N]) or shared across cameras ([N]).
-    // TODO(fvdb): Avoid materializing a repeated [C,N] tensor when opacities are shared across
-    // cameras. We should be able to pass a view (or otherwise avoid the repeat) similar to the
-    // approach used in PR #451 for other rasterization paths.
-    torch::Tensor opacitiesBatched = opacities;
-    if (opacitiesBatched.dim() == 1) {
-        TORCH_CHECK_VALUE(opacitiesBatched.size(0) == N,
-                          "opacities must have shape [N] or [C,N] matching N");
-        opacitiesBatched = opacitiesBatched.unsqueeze(0).repeat({C, 1});
-    }
-    TORCH_CHECK_VALUE(opacitiesBatched.dim() == 2, "opacities must have shape [C,N]");
-    TORCH_CHECK_VALUE(opacitiesBatched.size(0) == C && opacitiesBatched.size(1) == N,
+    TORCH_CHECK_VALUE(opacities.dim() == 2, "opacities must have shape [C,N]");
+    TORCH_CHECK_VALUE(opacities.size(0) == C && opacities.size(1) == N,
                       "opacities must have shape [C,N] matching features and N");
-    opacitiesBatched = opacitiesBatched.contiguous();
 
     TORCH_CHECK_VALUE(worldToCamMatricesStart.sizes() == torch::IntArrayRef({C, 4, 4}),
                       "worldToCamMatricesStart must have shape [C,4,4]");
@@ -368,22 +357,22 @@ dispatchGaussianRasterizeFromWorld3DGSForward<torch::kCUDA>(
 
     const uint32_t channels = (uint32_t)features.size(2);
 
-#define CALL_FWD_WITH_OP(NCH, OP_TYPE, OP_VAL)               \
-    case NCH:                                                \
-        return launchForward<NCH, OP_TYPE>(means,            \
-                                           quats,            \
-                                           logScales,        \
-                                           features,         \
-                                           opacitiesBatched, \
-                                           OP_VAL,           \
-                                           imageWidth,       \
-                                           imageHeight,      \
-                                           imageOriginW,     \
-                                           imageOriginH,     \
-                                           tileSize,         \
-                                           tileOffsets,      \
-                                           tileGaussianIds,  \
-                                           backgrounds,      \
+#define CALL_FWD_WITH_OP(NCH, OP_TYPE, OP_VAL)              \
+    case NCH:                                               \
+        return launchForward<NCH, OP_TYPE>(means,           \
+                                           quats,           \
+                                           logScales,       \
+                                           features,        \
+                                           opacities,       \
+                                           OP_VAL,          \
+                                           imageWidth,      \
+                                           imageHeight,     \
+                                           imageOriginW,    \
+                                           imageOriginH,    \
+                                           tileSize,        \
+                                           tileOffsets,     \
+                                           tileGaussianIds, \
+                                           backgrounds,     \
                                            masks);
 
     if (cameraModel == DistortionModel::ORTHOGRAPHIC) {


### PR DESCRIPTION
Currently, we unsqueeze and expand the opacities (following the optimization in #451) creating a non-contiguous view. However, the image space mGPU rasterization and world space rasterization implementations require contiguous expanded opacities. This PR changes opacities to always be expanded for consistent behavior across multiple splatting implementations. Note that we can't simply call `contiguous()` in the specific operator impl because the shared autograd code caches the opacities for the backwards pass.

This undoes the optimization in #451 and results in a small (~0.5%) decrease in performance in the single GPU case. However, this is outweighed by the corresponding speedups in the mGPU and world space case due to one fewer allocation and more efficient paging.