### PR TITLE
Restore useful comments from autograd/pipeline refactor

### DIFF
--- a/fvdb/__init__.py
+++ b/fvdb/__init__.py
@@ -79,6 +79,7 @@ from ._gaussian_autograd import (
 )
 
 
+# TODO: Make a batched class to encapsulate this jagged rendering pipeline.
 def gaussian_render_jagged(
     means: JaggedTensor,  # [N1 + N2 + ..., 3]
     quats: JaggedTensor,  # [N1 + N2 + ..., 4]
@@ -139,6 +140,13 @@ def gaussian_render_jagged(
     ccz = viewmats.jdata.size(0)  # total cameras across all batches
 
     # --- Build cross-batch index arrays ---
+    # TODO: This indexing logic is convoluted but there is no better way without
+    # custom CUDA kernels.  Given Gaussians with shape [sum(N_i), ...] and cameras
+    # with shape [sum(C_i), ...], we compute the cross-product of each batch's
+    # Gaussians with that batch's cameras, producing a flat tensor of shape
+    # [sum(C_i * N_i), ...].  We need to track two index arrays:
+    #   camera_ids:   shape [sum(C_i * N_i)], values in [0, sum(C_i))
+    #   gaussian_ids: shape [sum(C_i * N_i)], values in [0, sum(N_i))
     # g_sizes: [N1, N2, ...], c_sizes: [C1, C2, ...]
     g_sizes = means.joffsets[1:] - means.joffsets[:-1]
     c_sizes = Ks.joffsets[1:] - Ks.joffsets[:-1]
@@ -209,7 +217,12 @@ def gaussian_render_jagged(
     else:
         sh0 = sh_coeffs_batched[0, :, :].unsqueeze(0)  # [1, nnz, D]
         shN = sh_coeffs_batched[1:, :, :]  # [K-1, nnz, D]
+        # FIXME (Francis): Compute view directions in the kernel instead of
+        # materializing a large tensor here.  Doing so would require updating
+        # the current backward pass as well.
         camtoworlds = torch.linalg.inv(viewmats.jdata)  # [ccz, 4, 4]
+        # NOTE: dirs are not normalized here; the SH evaluation kernel normalizes
+        # them internally.
         dirs = means.jdata[gaussian_ids] - camtoworlds[camera_ids, :3, 3]
         render_quantities = _EvaluateGaussianSHFn.apply(
             actual_sh_degree,

--- a/fvdb/gaussian_splatting.py
+++ b/fvdb/gaussian_splatting.py
@@ -7,7 +7,6 @@ from typing import Any, Mapping, Sequence, TypeVar, cast, overload
 
 import torch
 import torch.nn.functional as F
-
 from fvdb.enums import CameraModel, ProjectionMethod
 
 from . import _fvdb_cpp as _C
@@ -1589,7 +1588,12 @@ class GaussianSplat3d:
             sh_degree_to_use = sh_degree
 
         if sh_degree_to_use > 0:
+            # FIXME (Francis): Compute view directions in the kernel instead of
+            # materializing a large [C, N, 3] tensor here.  Doing so would require
+            # updating the current backward pass as well.
             cam_to_world, info = torch.linalg.inv_ex(w2c)
+            # NOTE: view_dirs are not normalized here; the SH evaluation kernel
+            # normalizes them internally.
             view_dirs = means[None, :, :] - cam_to_world[:, None, :3, 3]
             return _EvaluateGaussianSHFn.apply(sh_degree_to_use, C, view_dirs, sh0, shN, radii)
         else:
@@ -3922,6 +3926,13 @@ class GaussianSplat3d:
                 jagged tensor containing the weights of the contributing Gaussians of each rendered pixel for each camera. The weights are in row-major order and
                 sum to 1 for each pixel if that pixel is opaque (alpha=1).
         """
+        # TODO: Projection currently always evaluates SH, but this method only needs
+        # geometric projection (2D means, conics, opacities) -- the SH color values are
+        # unused.  Ideally rendering should be more generic: accept an arbitrary feature
+        # tensor (e.g. integer IDs, raw features) without requiring SH evaluation.  That
+        # would also let us avoid the wasted SH computation here and support additional
+        # shading models in the future.  For now we just render "deep IDs" as a fixed
+        # function.  (Ported from the C++ renderContributingGaussianIdsImpl TODO.)
         with torch.no_grad():
             radii, means2d, depths, conics, compensations = self._do_projection(
                 world_to_camera_matrices,

--- a/src/fvdb/detail/io/GaussianPlyIO.cpp
+++ b/src/fvdb/detail/io/GaussianPlyIO.cpp
@@ -351,7 +351,10 @@ saveGaussianPly(const std::string &filename,
     // [N, D]
     const torch::Tensor shCoeffs0CPU =
         sh0.index({validMask.jdata(), 0, torch::indexing::Ellipsis}).cpu().contiguous();
-    // [N, K-1, D]
+    // shN has shape [N, K-1, D], meaning SH coefficients are ordered by basis then
+    // channel (i.e. RGBRGB...).  Gaussian PLY files expect coefficients ordered by
+    // channel then basis (i.e. RR...GG...BB...), so we permute to [N, D, K-1] and
+    // then reshape to [N, D*(K-1)].
     const torch::Tensor shCoeffsNCPU = [&]() {
         if (shN.numel() <= 0) {
             return torch::zeros({meansCPU.size(0), 0}, shN.options().device(torch::kCPU));


### PR DESCRIPTION
Several useful comments/todos/fixmes that were part of GaussianSplat3d.cpp were not carried over during PR #595, this attempts to restore those back to appropriate locations