### PR TITLE
Initialize gradient accumulation tensors before UT projection path

### DIFF
--- a/fvdb/gaussian_splatting.py
+++ b/fvdb/gaussian_splatting.py
@@ -1497,30 +1497,6 @@ class GaussianSplat3d:
             if distortion_coeffs is None:
                 raise RuntimeError("distortionCoeffs must be provided for OpenCV camera models")
 
-        if self._use_ut(camera_model, projection_method):
-            if distortion_coeffs is None:
-                distortion_coeffs = torch.empty(C, 0, device=means.device, dtype=means.dtype)
-            result = _C.project_gaussians_ut_fwd(
-                means,
-                quats,
-                log_scales,
-                w2c,
-                K,
-                distortion_coeffs,
-                self._camera_model_to_cpp(camera_model),
-                W,
-                H,
-                eps2d,
-                near,
-                far,
-                min_radius,
-                antialias,
-            )
-            radii, means2d, depths, conics, compensations = result
-            if not antialias:
-                compensations = None
-            return radii, means2d, depths, conics, compensations
-
         N = means.size(0)
         accum_grad_norms: torch.Tensor | None = None
         accum_step_counts: torch.Tensor | None = None
@@ -1545,6 +1521,30 @@ class GaussianSplat3d:
                 mr = torch.zeros(N, device=means.device, dtype=torch.int32)
                 self._accumulated_max_2d_radii = mr
             accum_max_radii = mr
+
+        if self._use_ut(camera_model, projection_method):
+            if distortion_coeffs is None:
+                distortion_coeffs = torch.empty(C, 0, device=means.device, dtype=means.dtype)
+            result = _C.project_gaussians_ut_fwd(
+                means,
+                quats,
+                log_scales,
+                w2c,
+                K,
+                distortion_coeffs,
+                self._camera_model_to_cpp(camera_model),
+                W,
+                H,
+                eps2d,
+                near,
+                far,
+                min_radius,
+                antialias,
+            )
+            radii, means2d, depths, conics, compensations = result
+            if not antialias:
+                compensations = None
+            return radii, means2d, depths, conics, compensations
 
         result = _ProjectGaussiansFn.apply(
             means,

--- a/tests/unit/test_gaussian_splat_3d.py
+++ b/tests/unit/test_gaussian_splat_3d.py
@@ -4517,6 +4517,70 @@ class TestGaussianCameraApi(unittest.TestCase):
                 sh_degree_to_use=0,
             )
 
+    def test_ut_projection_initializes_gradient_accumulation(self):
+        """UT projection path must initialize gradient accumulation state when enabled.
+
+        When accumulate_mean_2d_gradients is True, the ANALYTIC projection path lazily
+        initializes _accumulated_gradient_step_counts and _accumulated_mean_2d_gradient_norms.
+        The UNSCENTED (UT) path must do the same, otherwise downstream consumers (e.g.,
+        refinement in fvdb-reality-capture) crash on None tensors.
+
+        See: https://github.com/openvdb/fvdb-reality-capture/issues/279
+        """
+        self.gs3d.accumulate_mean_2d_gradients = True
+
+        # Reset state so tensors are None
+        self.gs3d.set_state(
+            means=self.gs3d.means,
+            quats=self.gs3d.quats,
+            log_scales=self.gs3d.log_scales,
+            logit_opacities=self.gs3d.logit_opacities,
+            sh0=self.gs3d.sh0,
+            shN=self.gs3d.shN,
+        )
+        self.assertIsNone(self.gs3d.accumulated_gradient_step_counts)
+        self.assertIsNone(self.gs3d.accumulated_mean_2d_gradient_norms)
+
+        # ANALYTIC path initializes gradient accumulation state
+        pinhole_args = self._render_args(CameraModel.PINHOLE)
+        self.gs3d.project_gaussians_for_images(
+            **self._with_overrides(pinhole_args, projection_method=ProjectionMethod.ANALYTIC),
+            sh_degree_to_use=0,
+        )
+        self.assertIsNotNone(
+            self.gs3d.accumulated_gradient_step_counts,
+            "ANALYTIC projection should initialize gradient accumulation state",
+        )
+        self.assertIsNotNone(
+            self.gs3d.accumulated_mean_2d_gradient_norms,
+            "ANALYTIC projection should initialize gradient accumulation state",
+        )
+
+        # Reset state again
+        self.gs3d.set_state(
+            means=self.gs3d.means,
+            quats=self.gs3d.quats,
+            log_scales=self.gs3d.log_scales,
+            logit_opacities=self.gs3d.logit_opacities,
+            sh0=self.gs3d.sh0,
+            shN=self.gs3d.shN,
+        )
+        self.assertIsNone(self.gs3d.accumulated_gradient_step_counts)
+
+        # UNSCENTED path must also initialize gradient accumulation state
+        self.gs3d.project_gaussians_for_images(
+            **self._with_overrides(pinhole_args, projection_method=ProjectionMethod.UNSCENTED),
+            sh_degree_to_use=0,
+        )
+        self.assertIsNotNone(
+            self.gs3d.accumulated_gradient_step_counts,
+            "UNSCENTED projection should initialize gradient accumulation state",
+        )
+        self.assertIsNotNone(
+            self.gs3d.accumulated_mean_2d_gradient_norms,
+            "UNSCENTED projection should initialize gradient accumulation state",
+        )
+
     def test_pinhole_and_orthographic_ignore_distortion_coeffs_tensor(self):
         ignored_distortion = torch.tensor(
             [[0.12, -0.03, 0.01, 0.0, 0.0, 0.0, 0.02, -0.015, 0.004, -0.003, 0.002, -0.001]],


### PR DESCRIPTION
## Summary
- Move lazy initialization of gradient accumulation tensors (`_accumulated_gradient_step_counts`, `_accumulated_mean_2d_gradient_norms`, `_accumulated_max_2d_radii`) to before the Unscented Transform early return in `_do_projection`
- Add test proving the UT path now initializes gradient state when `accumulate_mean_2d_gradients=True`

## Root Cause

The UT projection path in `_do_projection` returned early (line ~1500) without lazily initializing the gradient accumulation tensors. The lazy init block (lines ~1524-1547) only ran for the ANALYTIC path. This left `accumulated_gradient_step_counts` and `accumulated_mean_2d_gradient_norms` as `None` for the entire training run when using OpenCV camera models, causing downstream consumers to crash.

## Fix

Move the lazy init block before the `_use_ut()` check. The UT kernel (`_C.project_gaussians_ut_fwd`) does not accumulate into these tensors, so they remain zero — a correct "no gradient data" representation. Full UT gradient accumulation support can follow as a separate enhancement.

See: https://github.com/openvdb/fvdb-reality-capture/issues/279

## Test plan
- [x] New test `test_ut_projection_initializes_gradient_accumulation` fails before fix (asserting None), passes after
- [x] All 8 `TestGaussianCameraApi` tests pass with zero regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)