### PR TITLE
Fixes to Sphinx Docs Build

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -100,7 +100,7 @@ source_suffix = [".rst", ".md"]
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", "wip", "tutorials"]
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", "wip"]
 
 autodoc_default_options = {"undoc-members": "forward, extra_repr"}
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -100,7 +100,7 @@ source_suffix = [".rst", ".md"]
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", "wip"]
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", "wip", "TEACHME"]
 
 autodoc_default_options = {"undoc-members": "forward, extra_repr"}
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,3 +2,5 @@ sphinx>=7.0.0
 sphinx-rtd-theme
 myst-parser
 linkify-it-py
+torch --index-url https://download.pytorch.org/whl/cpu
+numpy

--- a/fvdb/jagged_tensor.py
+++ b/fvdb/jagged_tensor.py
@@ -1,6 +1,8 @@
 # Copyright Contributors to the OpenVDB Project
 # SPDX-License-Identifier: Apache-2.0
 #
+from __future__ import annotations
+
 """
 Jagged Tensor data structure and operations for FVDB.
 

--- a/fvdb/viz/_viewer_server.py
+++ b/fvdb/viz/_viewer_server.py
@@ -1,6 +1,8 @@
 # Copyright Contributors to the OpenVDB Project
 # SPDX-License-Identifier: Apache-2.0
 #
+from __future__ import annotations
+
 import uuid
 import warnings
 import webbrowser


### PR DESCRIPTION

**Documentation and Dependency Updates:**

* Added `torch` (with a CPU-only index URL) and `numpy` as required dependencies in `docs/requirements.txt` to ensure all necessary packages are available for documentation builds.
* Updated the `exclude_patterns` in `docs/conf.py` to ignore the `TEACHME` directory instead of `tutorials`, refining which files are excluded during documentation generation.

**Code Modernization:**

* Added `from __future__ import annotations` to both `fvdb/jagged_tensor.py` and `fvdb/viz/_viewer_server.py` to enable postponed evaluation of type annotations, this fixes a crash when mocking the fvdb C++ module during documentation build. [[1]](diffhunk://#diff-5e46c4e6f36156ff527c9a356b3395d2268c7b526976405552fcbf978ce4bc88R4-R5) [[2]](diffhunk://#diff-648cda021acc59a014471063e2959e033ded63b40e5224efb2b79b5b858372c2R4-R5)