### PR TITLE
Documentation:  Add pre_build job to Read the Docs configuration for version generation

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,6 +7,15 @@ build:
   os: ubuntu-24.04
   tools:
     python: "3.12"
+  jobs:
+    pre_build:
+      # Generate fvdb/version.py if absent (normally created by CMake).
+      - test -f fvdb/version.py || python -c "
+          import tomllib, pathlib;
+          v = tomllib.loads(pathlib.Path('pyproject.toml').read_text())['project']['version'];
+          pathlib.Path('fvdb/version.py').write_text(
+            f'__version__ = \"{v}\"\nfvdb = __version__\ngit = \"unknown\"\n'
+          )"
 
 sphinx:
   configuration: docs/conf.py


### PR DESCRIPTION
This update introduces a pre_build job in the .readthedocs.yaml file to automatically generate the fvdb/version.py file if it is absent (usually generated by cmake build). The version is extracted from the pyproject.toml file, ensuring that the documentation reflects the correct versioning without manual intervention.