### PR TITLE
Fix inject_from CUDA crash when source grid has 0 voxels

### DIFF
--- a/src/fvdb/detail/ops/Inject.cu
+++ b/src/fvdb/detail/ops/Inject.cu
@@ -242,9 +242,11 @@ dispatchInject<torch::kCUDA>(const GridBatchImpl &dstGridBatch,
 
         const auto srcLeafCount = srcGridBatch.numLeavesAt(i);
         if (srcLeafCount == 0) {
-            // Nothing to inject from an empty source grid. Destination is already
-            // initialized with default_value by the Python wrapper (grid.py).
-            // Skip the kernel launch — CUDA rejects <<<0, ...>>> as invalid config.
+            // Nothing to inject from an empty source grid. In the out-of-place path,
+            // the Python wrapper (grid.py) prefills the destination with default_value;
+            // if the caller provided an explicit destination, skipping the kernel
+            // leaves that tensor unchanged. Skip the kernel launch — CUDA rejects
+            // <<<0, ...>>> as invalid config.
             continue;
         }
         const at::cuda::CUDAStream stream =
@@ -329,6 +331,11 @@ dispatchInject<torch::kPrivateUse1>(const GridBatchImpl &dstGridBatch,
 
             size_t deviceSrcLeafOffset, deviceSrcLeafCount;
             std::tie(deviceSrcLeafOffset, deviceSrcLeafCount) = deviceChunk(srcLeafCount, deviceId);
+            if (deviceSrcLeafCount == 0) {
+                // deviceChunk may yield 0 leaves on some devices when
+                // srcLeafCount < device_count(). Skip — CUDA rejects <<<0, ...>>>.
+                continue;
+            }
 
             AT_DISPATCH_V2(
                 src.scalar_type(),

--- a/src/fvdb/detail/ops/Inject.cu
+++ b/src/fvdb/detail/ops/Inject.cu
@@ -241,6 +241,12 @@ dispatchInject<torch::kCUDA>(const GridBatchImpl &dstGridBatch,
         const torch::Tensor srcI = src.index(i).jdata();
 
         const auto srcLeafCount = srcGridBatch.numLeavesAt(i);
+        if (srcLeafCount == 0) {
+            // Nothing to inject from an empty source grid. Destination is already
+            // initialized with default_value by the Python wrapper (grid.py).
+            // Skip the kernel launch — CUDA rejects <<<0, ...>>> as invalid config.
+            continue;
+        }
         const at::cuda::CUDAStream stream =
             at::cuda::getCurrentCUDAStream(srcGridBatch.device().index());
 
@@ -310,7 +316,10 @@ dispatchInject<torch::kPrivateUse1>(const GridBatchImpl &dstGridBatch,
         torch::Tensor dstI       = dst.index(i).jdata();
         const torch::Tensor srcI = src.index(i).jdata();
 
-        const auto srcLeafCount                   = srcGridBatch.numLeavesAt(i);
+        const auto srcLeafCount = srcGridBatch.numLeavesAt(i);
+        if (srcLeafCount == 0) {
+            continue;
+        }
         const auto [srcContigStrides, srcStrides] = stridesAndContiguousStrides(srcI);
         const auto [dstContigStrides, dstStrides] = stridesAndContiguousStrides(dstI);
 

--- a/tests/unit/test_inject.py
+++ b/tests/unit/test_inject.py
@@ -6,6 +6,7 @@ import unittest
 from typing import Callable
 
 import numpy as np
+import pytest
 import torch
 from parameterized import parameterized, parameterized_class
 
@@ -760,6 +761,7 @@ class InjectionTests(unittest.TestCase):
         self.assertTrue(torch.all(one_indices == frominds))
 
 
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
 def test_empty_src_grid_inject_fills_default():
     device = "cuda"
     dst_ijk = torch.tensor([[0, 0, 0], [1, 0, 0], [0, 1, 0]], dtype=torch.int32, device=device)
@@ -774,6 +776,7 @@ def test_empty_src_grid_inject_fills_default():
     assert (result == 99.0).all()
 
 
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
 def test_prune_all_then_dilate_then_inject():
     device = "cuda"
     ijk = torch.tensor([[0, 0, 0], [1, 0, 0], [0, 1, 0]], dtype=torch.int32, device=device)

--- a/tests/unit/test_inject.py
+++ b/tests/unit/test_inject.py
@@ -795,5 +795,38 @@ def test_prune_all_then_dilate_then_inject():
     assert result.shape == (0, 1)
 
 
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_gridbatch_inject_with_empty_grid_in_batch():
+    # GridBatch.inject_from must handle a batch that mixes non-empty and empty
+    # source grids. The per-batch kernel launch previously used <<<0, ...>>>
+    # for the empty entry and CUDA rejected the config.
+    device = "cuda"
+    ijk_a = torch.tensor([[0, 0, 0], [1, 0, 0], [0, 1, 0]], dtype=torch.int32, device=device)
+    ijk_empty = torch.zeros((0, 3), dtype=torch.int32, device=device)
+    ijk_c = torch.tensor([[2, 0, 0], [2, 1, 0]], dtype=torch.int32, device=device)
+
+    # Destination has voxels for every batch entry; source is empty at index 1.
+    dst_grid = fvdb.GridBatch.from_ijk(fvdb.JaggedTensor([ijk_a, ijk_c, ijk_a]))
+    src_grid = fvdb.GridBatch.from_ijk(fvdb.JaggedTensor([ijk_a, ijk_empty, ijk_a]))
+
+    src_values = torch.arange(src_grid.total_voxels, device=device, dtype=torch.float32).view(-1, 1)
+    src_data = src_grid.jagged_like(src_values)
+
+    result = dst_grid.inject_from(src_grid, src_data, default_value=-1.0)
+
+    # Batch 0: src and dst share the same ijk — every dst voxel was written
+    # and the set of values matches src.
+    assert torch.equal(
+        torch.sort(result[0].jdata.flatten())[0], torch.sort(src_data[0].jdata.flatten())[0]
+    )
+    # Batch 1: src is empty but dst has voxels — all slots retain default_value.
+    assert result[1].jdata.shape == (ijk_c.shape[0], 1)
+    assert (result[1].jdata == -1.0).all()
+    # Batch 2: src and dst share the same ijk — every dst voxel was written.
+    assert torch.equal(
+        torch.sort(result[2].jdata.flatten())[0], torch.sort(src_data[2].jdata.flatten())[0]
+    )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/test_inject.py
+++ b/tests/unit/test_inject.py
@@ -816,16 +816,12 @@ def test_gridbatch_inject_with_empty_grid_in_batch():
 
     # Batch 0: src and dst share the same ijk — every dst voxel was written
     # and the set of values matches src.
-    assert torch.equal(
-        torch.sort(result[0].jdata.flatten())[0], torch.sort(src_data[0].jdata.flatten())[0]
-    )
+    assert torch.equal(torch.sort(result[0].jdata.flatten())[0], torch.sort(src_data[0].jdata.flatten())[0])
     # Batch 1: src is empty but dst has voxels — all slots retain default_value.
     assert result[1].jdata.shape == (ijk_c.shape[0], 1)
     assert (result[1].jdata == -1.0).all()
     # Batch 2: src and dst share the same ijk — every dst voxel was written.
-    assert torch.equal(
-        torch.sort(result[2].jdata.flatten())[0], torch.sort(src_data[2].jdata.flatten())[0]
-    )
+    assert torch.equal(torch.sort(result[2].jdata.flatten())[0], torch.sort(src_data[2].jdata.flatten())[0])
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_inject.py
+++ b/tests/unit/test_inject.py
@@ -760,5 +760,37 @@ class InjectionTests(unittest.TestCase):
         self.assertTrue(torch.all(one_indices == frominds))
 
 
+def test_empty_src_grid_inject_fills_default():
+    device = "cuda"
+    dst_ijk = torch.tensor([[0, 0, 0], [1, 0, 0], [0, 1, 0]], dtype=torch.int32, device=device)
+    dst_grid = fvdb.Grid.from_ijk(dst_ijk, voxel_size=0.01, origin=0.0)
+
+    src_ijk = torch.zeros((0, 3), dtype=torch.int32, device=device)
+    src_grid = fvdb.Grid.from_ijk(src_ijk, voxel_size=0.01, origin=0.0)
+    src_data = torch.zeros((0, 1), device=device)
+
+    result = dst_grid.inject_from(src_grid=src_grid, src=src_data, default_value=99.0)
+    assert result.shape == (3, 1)
+    assert (result == 99.0).all()
+
+
+def test_prune_all_then_dilate_then_inject():
+    device = "cuda"
+    ijk = torch.tensor([[0, 0, 0], [1, 0, 0], [0, 1, 0]], dtype=torch.int32, device=device)
+    grid = fvdb.Grid.from_ijk(ijk, voxel_size=0.01, origin=0.0)
+    data = torch.randn(grid.num_voxels, 1, device=device)
+
+    mask = torch.zeros(grid.num_voxels, dtype=torch.bool, device=device)
+    empty_grid = grid.pruned_grid(mask)
+    empty_data = data[mask]
+    assert empty_grid.num_voxels == 0
+
+    dilated = empty_grid.dilated_grid(1)
+    assert dilated.num_voxels == 0
+
+    result = dilated.inject_from(src_grid=empty_grid, src=empty_data, default_value=0.0)
+    assert result.shape == (0, 1)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

`Grid.inject_from()` was crashing with `torch.AcceleratorError: CUDA error: invalid configuration argument` when the source grid had 0 active voxels. The CUDA kernel in `src/fvdb/detail/ops/Inject.cu` was launched with `srcLeafCount` as the grid dimension; CUDA rejects `<<<0, ...>>>` as an invalid kernel configuration.

This surfaces in narrow-band level-set simulations: when the surface outruns the band (a CFL-like violation), all voxels get pruned. The next step dilates the empty grid (which correctly returns an empty grid), then `inject_from` on that grid crashes.

## Fix

Skip the kernel launch when `srcLeafCount == 0` in both `dispatchInject<torch::kCUDA>` and `dispatchInject<torch::kPrivateUse1>`. This is safe because when `dst` is `None`, the Python wrapper (`grid.py:895`) has already pre-filled the destination with `default_value` — so skipping yields the semantically correct result.

This follows the established pattern in the codebase (see `BuildPrunedGrid.cu:54-59`, `JIdxForGrid.cu:16-22`).

Fixes #614

## Test plan

- [x] New `test_empty_src_grid_inject_fills_default` — empty source, non-empty destination, asserts `default_value` fill
- [x] New `test_prune_all_then_dilate_then_inject` — end-to-end reproduction of the narrow-band scenario
- [x] Full inject test suite still passes (170 tests)
- [x] black, clang-format-18, trailing-whitespace, tabs checks all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)