### PR TITLE
Implement GitHub Actions workflow for Sphinx documentation build test

### DIFF
--- a/.github/workflows/docs-build-test.yml
+++ b/.github/workflows/docs-build-test.yml
@@ -1,0 +1,36 @@
+# Copyright Contributors to the OpenVDB Project
+# SPDX-License-Identifier: Apache-2.0
+#
+# Validate that the Sphinx documentation builds without errors or warnings,
+# replicating the Read the Docs environment (see .readthedocs.yaml).
+
+name: Documentation Build Test
+
+on:
+  pull_request:
+    branches:
+      - '**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  sphinx-build:
+    name: Sphinx build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install documentation dependencies
+        run: pip install -r docs/requirements.txt
+
+      - name: Generate version stub
+        run: python devtools/generate-version-stub.py
+
+      - name: Build documentation
+        run: sphinx-build -W --keep-going -a ./docs build/sphinx


### PR DESCRIPTION
This commit introduces a new GitHub Actions workflow to validate that the Sphinx documentation builds without errors or warnings in order to make sure any issues are caught before builds happen for our official docs on Read the Docs. The workflow is triggered on pull requests and includes steps for checking out the code, setting up Python, installing dependencies, generating a version stub, and building the documentation.

Key features:
- Runs on `ubuntu-latest`
- Uses Python 3.12
- Installs dependencies from `docs/requirements.txt`
- Generates version information using `devtools/generate-version-stub.py`
- Builds documentation with Sphinx, ensuring a clean build process

This addition enhances the CI/CD pipeline for documentation, ensuring that changes do not introduce build issues on Read the Docs.

fixes #619 