### PR TITLE
Documentation: Improve version label contrast in sidebar and fix reality-capture URLs

### DIFF
--- a/docs/imgs/css/custom.css
+++ b/docs/imgs/css/custom.css
@@ -1,3 +1,8 @@
 .wy-side-nav-search {
     background-color: #76b900;
 }
+
+.wy-side-nav-search > div.version,
+.wy-side-nav-search > div.version a {
+    color: inherit;
+}

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -73,9 +73,9 @@ spatial intelligence research and applications.
 ƒVDB Reality Capture
 --------------------------------
 
-In addition to the core ƒVDB library, we also provide the `ƒVDB Reality Capture <https://openvdb.github.io/fvdb-core/reality-capture/>`_ toolbox,
+In addition to the core ƒVDB library, we also provide the `ƒVDB Reality Capture <https://fvdb-reality-capture.readthedocs.io/>`_ toolbox,
 which is a collection of tools and utilities for 3D reconstruction and scene understanding using ƒVDB. Analogous to how `torchvision <https://pytorch.org/vision/stable/index.html>`_
-provides datasets, models, and transforms for computer vision tasks, `ƒVDB Reality Capture <https://openvdb.github.io/fvdb-core/reality-capture/>`_ provides datasets, models, and
+provides datasets, models, and transforms for computer vision tasks, `ƒVDB Reality Capture <https://fvdb-reality-capture.readthedocs.io/>`_ provides datasets, models, and
 algorithms for 3D reconstruction from sensor data.
 
 .. toctree::
@@ -90,7 +90,7 @@ algorithms for 3D reconstruction from sensor data.
 .. toctree::
    :caption: Applications
 
-   ƒVDB Reality Capture <https://openvdb.github.io/fvdb-core/reality-capture/>
+   ƒVDB Reality Capture <https://fvdb-reality-capture.readthedocs.io/>
 
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION
The sphinx-rtd-theme renders the version label (e.g. "latest") under the project title using `hsla(0,0%,100%,.3)`, which is nearly invisible against the NVIDIA-green `.wy-side-nav-search` background. Override the color to inherit from the parent so it matches the "ƒVDB" title (`#fcfcfc`) and tracks any future theme changes.

Also updated URLs that pointed to the reality-capture docs that were being built in `fvdb-core`'s docs to the readthedocs location for reality-capture's docs.