### PR TITLE
Reorder Gaussian2D to improve field alignment

### DIFF
--- a/src/fvdb/detail/utils/gsplat/Gaussian2D.cuh
+++ b/src/fvdb/detail/utils/gsplat/Gaussian2D.cuh
@@ -8,14 +8,18 @@
 
 namespace fvdb::detail::ops {
 
-template <typename ScalarType> struct alignas(32) Gaussian2D { // 28 bytes
+template <typename ScalarType> struct alignas(32) Gaussian2D { // 32 bytes
     using vec2t = nanovdb::math::Vec2<ScalarType>;
     using vec3t = nanovdb::math::Vec3<ScalarType>;
 
-    int32_t id;         // 4 bytes
-    vec2t xy;           // 8 bytes
-    ScalarType opacity; // 4 bytes
-    vec3t conic;        // 12 bytes
+    // First 16 bytes: id(4) + opacity(4) + xy(8, 8-byte aligned)
+    int32_t id;         // 4 bytes  (offset 0)
+    ScalarType opacity; // 4 bytes  (offset 4)
+    vec2t xy;           // 8 bytes  (offset 8)
+
+    // Second 16 bytes: conic(12) + pad(4)
+    vec3t conic;     // 12 bytes (offset 16)
+    ScalarType _pad; // 4 bytes  (offset 28)
 
     inline __device__ vec2t
     delta(const ScalarType px, const ScalarType py) const {

--- a/src/fvdb/detail/utils/gsplat/Gaussian2D.cuh
+++ b/src/fvdb/detail/utils/gsplat/Gaussian2D.cuh
@@ -17,9 +17,9 @@ template <typename ScalarType> struct alignas(32) Gaussian2D { // 32 bytes
     ScalarType opacity; // 4 bytes  (offset 4)
     vec2t xy;           // 8 bytes  (offset 8)
 
-    // Second 16 bytes: conic(12) + pad(4)
-    vec3t conic;     // 12 bytes (offset 16)
-    ScalarType _pad; // 4 bytes  (offset 28)
+    // Second 16 bytes: conic(12) + implicit padding(4) due to the struct being declared as
+    // alignas(32)
+    vec3t conic; // 12 bytes (offset 16)
 
     inline __device__ vec2t
     delta(const ScalarType px, const ScalarType py) const {

--- a/src/fvdb/detail/utils/gsplat/GaussianRasterize.cuh
+++ b/src/fvdb/detail/utils/gsplat/GaussianRasterize.cuh
@@ -311,16 +311,16 @@ template <typename ScalarType, size_t NUM_CHANNELS, bool IS_PACKED> struct Raste
         if constexpr (IS_PACKED) {
             return Gaussian2D<ScalarType>(
                 index,
-                vec2t(mMeans2d[index][0], mMeans2d[index][1]),
                 mOpacities[index],
+                vec2t(mMeans2d[index][0], mMeans2d[index][1]),
                 vec3t(mConics[index][0], mConics[index][1], mConics[index][2]));
         } else {
             auto cid = index / mNumGaussiansPerCamera;
             auto gid = index % mNumGaussiansPerCamera;
             return Gaussian2D<ScalarType>(
                 index,
-                vec2t(mMeans2d[cid][gid][0], mMeans2d[cid][gid][1]),
                 mOpacities[cid][gid],
+                vec2t(mMeans2d[cid][gid][0], mMeans2d[cid][gid][1]),
                 vec3t(mConics[cid][gid][0], mConics[cid][gid][1], mConics[cid][gid][2]));
         }
     }


### PR DESCRIPTION
Currently, the alignment of the fields in Gaussian2D is not optimal. The `xy` member is a `float2`, but it is 4-byte aligned so it cannot be loaded in a vectorized manner. This can be addressed by switching the order to `opacity` and `xy`.