### PR TITLE
Documentation: Switch docs redirect to point to main RTD URL

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - name: Create redirect page
         env:
-          RTD_URL: https://fvdb-core.readthedocs.io/en/stable/
+          RTD_URL: https://fvdb-core.readthedocs.io/
         run: |
           mkdir -p _site
           printf '%s\n' \


### PR DESCRIPTION
Switch Github pages redirect to point to main RTD URL instead of the specific stable version