### PR TITLE
Fix URLs in the README to point to the ReadtheDocs site

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@ spatial intelligence research and applications.
 
 ## Learning to Use *f*VDB
 
-After [installing *f*VDB](#installing-fvdb), we recommend starting with our [documentation](https://openvdb.github.io/fvdb-core).
+After [installing *f*VDB](#installing-fvdb), we recommend starting with our [documentation](https://fvdb-core.readthedocs.io/).
 
 You can also try our [TEACHME](docs/TEACHME) interactive lessons, designed to be used with an LLM coding agent (Claude Code, Cursor, or similar) that teaches you the *f*VDB API interactively. Just prompt: `Read docs/TEACHME and teach me how to use fvdb-core.`
 
-Beyond the [documentation](https://openvdb.github.io/fvdb-core), the walk-through [notebooks](notebooks) in this repository
+Beyond the [documentation](https://fvdb-core.readthedocs.io/), the walk-through [notebooks](notebooks) in this repository
 can provide an illustrated introduction to the main concepts in *f*VDB.
 
 
@@ -35,12 +35,12 @@ The `fvdb-core` Python package can be installed either using published packages 
 from source.
 
 For the most up-to-date information on installing *f*VDB's pip packages, please see the
-[installation documentation](https://openvdb.github.io/fvdb-core/installation.html).
+[installation documentation](https://fvdb-core.readthedocs.io/latest/installation.html).
 
 
 ## Building *f*VDB from Source
 
-If the [pre-built packages](https://openvdb.github.io/fvdb-core/installation.html) do not meet your needs, you can build *f*VDB from source in this repository.
+If the [pre-built packages](https://fvdb-core.readthedocs.io/latest/installation.html) do not meet your needs, you can build *f*VDB from source in this repository.
 
 ### Environment Management
 


### PR DESCRIPTION
This pull request updates the documentation links in the `README.md` file to point to the new `fvdb-core.readthedocs.io` site instead of the previous GitHub Pages site. This ensures users are directed to the most current and authoritative documentation.

Documentation updates:

* Updated all references to the documentation site from `https://openvdb.github.io/fvdb-core` to `https://fvdb-core.readthedocs.io/` for general docs and from `https://openvdb.github.io/fvdb-core/installation.html` to `https://fvdb-core.readthedocs.io/latest/installation.html` for installation instructions. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L24-R28) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L38-R43)