### PR TITLE
Add `sample_nearest` operator for GridBatch and Grid

### DIFF
--- a/fvdb/_fvdb_cpp.pyi
+++ b/fvdb/_fvdb_cpp.pyi
@@ -628,6 +628,11 @@ def concatenate_grids(elements: list[GridBatchData]) -> GridBatchData: ...
 # ---------------------------------------------------------------------------
 
 # Interpolation: forward
+def sample_nearest(
+    grid: GridBatchData,
+    points: JaggedTensor,
+    data: torch.Tensor,
+) -> list[torch.Tensor]: ...
 def sample_trilinear(
     grid: GridBatchData,
     points: JaggedTensor,

--- a/fvdb/functional/__init__.py
+++ b/fvdb/functional/__init__.py
@@ -16,6 +16,8 @@ from ._interpolation import (
     sample_bezier_single,
     sample_bezier_with_grad_batch,
     sample_bezier_with_grad_single,
+    sample_nearest_batch,
+    sample_nearest_single,
     sample_trilinear_batch,
     sample_trilinear_single,
     sample_trilinear_with_grad_batch,
@@ -174,6 +176,7 @@ from ._io import load_nanovdb, load_nanovdb_single, save_nanovdb, save_nanovdb_s
 
 __all__ = [
     # Interpolation (batch)
+    "sample_nearest_batch",
     "sample_trilinear_batch",
     "sample_trilinear_with_grad_batch",
     "sample_bezier_batch",
@@ -181,6 +184,7 @@ __all__ = [
     "splat_trilinear_batch",
     "splat_bezier_batch",
     # Interpolation (single)
+    "sample_nearest_single",
     "sample_trilinear_single",
     "sample_trilinear_with_grad_single",
     "sample_bezier_single",

--- a/fvdb/functional/_interpolation.py
+++ b/fvdb/functional/_interpolation.py
@@ -160,6 +160,8 @@ def sample_nearest_batch(
     """Sample voxel data at world-space points using nearest-neighbor lookup for a grid batch.
 
     For each query point the 8 nearest voxel centers are checked and the value of the closest active one is returned.
+    When two or more active corners are equidistant, the corner encountered first in the stencil's zig-zag
+    traversal order wins (the same ordering used by ``sample_trilinear``).
     Points where none of the 8 surrounding voxel centers are active return zero.
 
     Supports backpropagation w.r.t. ``voxel_data``.
@@ -186,6 +188,8 @@ def sample_nearest_single(
     """Sample voxel data at world-space points using nearest-neighbor lookup for a single grid.
 
     For each query point the 8 nearest voxel centers are checked and the value of the closest active one is returned.
+    When two or more active corners are equidistant, the corner encountered first in the stencil's zig-zag
+    traversal order wins (the same ordering used by ``sample_trilinear``).
     Points where none of the 8 surrounding voxel centers are active return zero.
 
     Supports backpropagation w.r.t. ``voxel_data``.

--- a/fvdb/functional/_interpolation.py
+++ b/fvdb/functional/_interpolation.py
@@ -4,7 +4,7 @@
 """Functional API for sparse grid interpolation: sampling and splatting."""
 from __future__ import annotations
 
-from typing import Any, TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import torch
 
@@ -121,6 +121,88 @@ class _SampleBezierWithGradFn(torch.autograd.Function):
             ctx.grid_data, ctx.pts_impl, grad_features, grad_grad_features, voxel_data
         )
         return grad_data, None, None
+
+
+class _SampleNearestFn(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, voxel_data, grid_data, pts_impl):
+        result_list = _fvdb_cpp.sample_nearest(grid_data, pts_impl, voxel_data)
+        sampled_values = result_list[0]
+        selected_indices = result_list[1]
+        ctx.save_for_backward(selected_indices)
+        ctx.voxel_shape = voxel_data.shape
+        ctx.dtype = voxel_data.dtype
+        ctx.device = voxel_data.device
+        return sampled_values
+
+    @staticmethod
+    def backward(ctx: Any, *grad_outputs: torch.Tensor | None) -> tuple[torch.Tensor | None, ...]:
+        (grad_output,) = grad_outputs
+        assert grad_output is not None
+        (selected_indices,) = ctx.saved_tensors
+        grad_voxel_data = torch.zeros(ctx.voxel_shape, dtype=ctx.dtype, device=ctx.device)
+        valid = selected_indices >= 0
+        if valid.any():
+            grad_voxel_data.index_add_(0, selected_indices[valid], grad_output[valid])
+        return grad_voxel_data, None, None
+
+
+# ---------------------------------------------------------------------------
+#  Public API -- sample_nearest
+# ---------------------------------------------------------------------------
+
+
+def sample_nearest_batch(
+    grid: GridBatch,
+    points: JaggedTensor,
+    voxel_data: JaggedTensor,
+) -> JaggedTensor:
+    """Sample voxel data at world-space points using nearest-neighbor lookup for a grid batch.
+
+    For each query point the 8 nearest voxel centers are checked and the value of the closest active one is returned.
+    Points where none of the 8 surrounding voxel centers are active return zero.
+
+    Supports backpropagation w.r.t. ``voxel_data``.
+
+    Args:
+        grid (GridBatch): The grid batch defining the sparse topology.
+        points (JaggedTensor): World-space query points, shape ``(B, -1, 3)``.
+        voxel_data (JaggedTensor): Per-voxel feature data.
+
+    Returns:
+        result (JaggedTensor): Sampled values at each query point.
+
+    .. seealso:: :func:`sample_nearest_single`
+    """
+    result = cast(torch.Tensor, _SampleNearestFn.apply(voxel_data.jdata, grid.data, points._impl))
+    return points.jagged_like(result)
+
+
+def sample_nearest_single(
+    grid: Grid,
+    points: torch.Tensor,
+    voxel_data: torch.Tensor,
+) -> torch.Tensor:
+    """Sample voxel data at world-space points using nearest-neighbor lookup for a single grid.
+
+    For each query point the 8 nearest voxel centers are checked and the value of the closest active one is returned.
+    Points where none of the 8 surrounding voxel centers are active return zero.
+
+    Supports backpropagation w.r.t. ``voxel_data``.
+
+    Args:
+        grid (Grid): The single grid defining the sparse topology.
+        points (torch.Tensor): World-space query points, shape ``(N, 3)``.
+        voxel_data (torch.Tensor): Per-voxel feature data.
+
+    Returns:
+        result (torch.Tensor): Sampled values at each query point.
+
+    .. seealso:: :func:`sample_nearest_batch`
+    """
+    pts_jt = JaggedTensor(points)
+    vd_jt = JaggedTensor(voxel_data)
+    return cast(torch.Tensor, _SampleNearestFn.apply(vd_jt.jdata, grid.data, pts_jt._impl))
 
 
 # ---------------------------------------------------------------------------

--- a/fvdb/grid.py
+++ b/fvdb/grid.py
@@ -25,18 +25,14 @@ Class-methods for creating Grid objects from various sources:
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, overload
-
 import pathlib
+from typing import TYPE_CHECKING, Any, overload
 
 import torch
 
 from ._fvdb_cpp import GridBatchData
 from .jagged_tensor import JaggedTensor
-from .types import (
-    DeviceIdentifier,
-    NumericMaxRank1,
-)
+from .types import DeviceIdentifier, NumericMaxRank1
 
 if TYPE_CHECKING:
     from .grid_batch import GridBatch
@@ -884,6 +880,28 @@ class Grid:
     # ============================================================
     #                  Sampling / Splatting
     # ============================================================
+
+    def sample_nearest(self, points: torch.Tensor, voxel_data: torch.Tensor) -> torch.Tensor:
+        """Sample voxel data at world-space points using nearest-neighbor lookup.
+
+        For each query point the 8 nearest voxel centers are checked and the value of the closest active one is returned.
+        Points where none of the 8 surrounding voxel centers are active return zero.
+
+        .. note:: Supports backpropagation w.r.t. ``voxel_data``.
+
+        Args:
+            points (torch.Tensor): World-space points of shape ``(N, 3)``.
+            voxel_data (torch.Tensor): Voxel data of shape
+                ``(num_voxels, channels*)``.
+
+        Returns:
+            sampled_data (torch.Tensor): Shape ``(N, channels*)``.
+
+        .. seealso:: :meth:`GridBatch.sample_nearest`, :meth:`sample_trilinear`
+        """
+        from . import functional
+
+        return functional.sample_nearest_single(self, points, voxel_data)
 
     def sample_trilinear(self, points: torch.Tensor, voxel_data: torch.Tensor) -> torch.Tensor:
         """Sample voxel data at world-space points using trilinear interpolation.

--- a/fvdb/grid_batch.py
+++ b/fvdb/grid_batch.py
@@ -35,12 +35,7 @@ import torch
 
 from . import _fvdb_cpp, _parse_device_string
 from .jagged_tensor import JaggedTensor
-from .types import (
-    DeviceIdentifier,
-    GridBatchIndex,
-    NumericMaxRank1,
-    NumericMaxRank2,
-)
+from .types import DeviceIdentifier, GridBatchIndex, NumericMaxRank1, NumericMaxRank2
 
 if TYPE_CHECKING:
     from .grid import Grid
@@ -1242,6 +1237,27 @@ class GridBatch:
         from . import functional
 
         return functional.sample_bezier_with_grad_batch(self, points, voxel_data)
+
+    def sample_nearest(self, points: JaggedTensor, voxel_data: JaggedTensor) -> JaggedTensor:
+        """Sample voxel data at world-space points using nearest-neighbor lookup on this grid batch.
+
+        For each query point the 8 nearest voxel centers are checked and the value of the closest active one is returned.
+        Points where none of the 8 surrounding voxel centers are active return zero, matching :meth:`sample_trilinear` boundary behaviour.
+
+        Supports backpropagation w.r.t. ``voxel_data``.
+
+        Args:
+            points (JaggedTensor): World-space sample points. Shape: ``(batch_size, num_points_for_grid_b, 3)``.
+            voxel_data (JaggedTensor): Per-voxel data. Shape: ``(batch_size, total_voxels, channels*)``.
+
+        Returns:
+            sampled_data (JaggedTensor): Sampled values. Shape: ``(batch_size, num_points_for_grid_b, channels*)``.
+
+        .. seealso:: :meth:`Grid.sample_nearest`, :meth:`sample_trilinear`
+        """
+        from . import functional
+
+        return functional.sample_nearest_batch(self, points, voxel_data)
 
     def sample_trilinear(self, points: JaggedTensor, voxel_data: JaggedTensor) -> JaggedTensor:
         """Sample voxel data at world-space points using trilinear interpolation on this grid batch.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -131,6 +131,7 @@ set(FVDB_CU_FILES
     fvdb/detail/ops/SampleBezier.cu
     fvdb/detail/ops/SampleBezierWithGrad.cu
     fvdb/detail/ops/SampleBezierWithGradBackward.cu
+    fvdb/detail/ops/SampleNearest.cu
     fvdb/detail/ops/SampleTrilinear.cu
     fvdb/detail/ops/SampleTrilinearWithGrad.cu
     fvdb/detail/ops/SampleTrilinearWithGradBackward.cu

--- a/src/fvdb/detail/ops/SampleNearest.cu
+++ b/src/fvdb/detail/ops/SampleNearest.cu
@@ -1,0 +1,338 @@
+// Copyright Contributors to the OpenVDB Project
+// SPDX-License-Identifier: Apache-2.0
+//
+#include <fvdb/detail/ops/SampleNearest.h>
+#include <fvdb/detail/utils/AccessorHelpers.cuh>
+#include <fvdb/detail/utils/ForEachCPU.h>
+#include <fvdb/detail/utils/Utils.h>
+#include <fvdb/detail/utils/cuda/ForEachCUDA.cuh>
+#include <fvdb/detail/utils/cuda/ForEachPrivateUse1.cuh>
+
+#include <ATen/OpMathType.h>
+#include <c10/cuda/CUDAException.h>
+
+#include <cstdint>
+
+namespace fvdb {
+namespace detail {
+namespace ops {
+
+// ---------------------------------------------------------------------------
+// Resolve the nearest active corner among the 8 surrounding voxels.
+//
+// Uses the same NanoVDB-style ijk traversal order as resolveTrilinearStencil
+// to maximise ReadAccessor node-cache hits.
+//
+// Returns the cumulative linear index of the nearest active corner, or -1 if
+// none of the 8 corners are active.
+// ---------------------------------------------------------------------------
+template <typename MathType, typename GridAccessorType>
+__hostdev__ inline int64_t
+resolveNearestCorner(const nanovdb::math::Vec3<MathType> &xyz,
+                     GridAccessorType &gridAcc,
+                     int64_t baseOffset) {
+    nanovdb::Coord ijk = xyz.floor();
+    const MathType u   = xyz[0] - MathType(ijk[0]);
+    const MathType v   = xyz[1] - MathType(ijk[1]);
+    const MathType w   = xyz[2] - MathType(ijk[2]);
+
+    // Squared-distance from the query point to each of the 8 unit-cube
+    // corners (di, dj, dk) where di/dj/dk are each 0 or 1.
+    // dist2 = (di - u)^2 + (dj - v)^2 + (dk - w)^2
+    //
+    // Corner ordering matches TrilinearStencil.h for accessor-cache
+    // efficiency (increment one component at a time).
+    struct CornerInfo {
+        int di, dj, dk;
+    };
+    constexpr CornerInfo corners[8] = {
+        {0, 0, 0}, // corner 0  (i,   j,   k  )
+        {0, 0, 1}, // corner 1  (i,   j,   k+1)
+        {0, 1, 1}, // corner 2  (i,   j+1, k+1)
+        {0, 1, 0}, // corner 3  (i,   j+1, k  )
+        {1, 0, 0}, // corner 4  (i+1, j,   k  )
+        {1, 0, 1}, // corner 5  (i+1, j,   k+1)
+        {1, 1, 1}, // corner 6  (i+1, j+1, k+1)
+        {1, 1, 0}, // corner 7  (i+1, j+1, k  )
+    };
+
+    int64_t bestIdx   = -1;
+    MathType bestDist = MathType(4); // > max possible dist2 of 3
+
+    // Walk corners in the same ijk-mutation order as TrilinearStencil.h.
+#define FVDB_NEAREST_CORNER(CORNER)                            \
+    if (gridAcc.isActive(ijk)) {                               \
+        const MathType du = MathType(corners[CORNER].di) - u;  \
+        const MathType dv = MathType(corners[CORNER].dj) - v;  \
+        const MathType dw = MathType(corners[CORNER].dk) - w;  \
+        const MathType d2 = du * du + dv * dv + dw * dw;       \
+        if (d2 < bestDist) {                                   \
+            bestDist = d2;                                     \
+            bestIdx  = gridAcc.getValue(ijk) - 1 + baseOffset; \
+        }                                                      \
+    }
+
+    FVDB_NEAREST_CORNER(0) // (i,   j,   k  )
+    ijk[2] += 1;
+    FVDB_NEAREST_CORNER(1) // (i,   j,   k+1)
+    ijk[1] += 1;
+    FVDB_NEAREST_CORNER(2) // (i,   j+1, k+1)
+    ijk[2] -= 1;
+    FVDB_NEAREST_CORNER(3) // (i,   j+1, k  )
+    ijk[0] += 1;
+    ijk[1] -= 1;
+    FVDB_NEAREST_CORNER(4) // (i+1, j,   k  )
+    ijk[2] += 1;
+    FVDB_NEAREST_CORNER(5) // (i+1, j,   k+1)
+    ijk[1] += 1;
+    FVDB_NEAREST_CORNER(6) // (i+1, j+1, k+1)
+    ijk[2] -= 1;
+    FVDB_NEAREST_CORNER(7) // (i+1, j+1, k  )
+
+#undef FVDB_NEAREST_CORNER
+
+    return bestIdx;
+}
+
+// ---------------------------------------------------------------------------
+// Per-point callback (scalar, all dtypes, CPU + GPU)
+// ---------------------------------------------------------------------------
+template <typename ScalarType,
+          template <typename T, int32_t D>
+          typename JaggedAccessor,
+          template <typename T, int32_t D>
+          typename TensorAccessor>
+__hostdev__ void
+sampleNearestCallback(int32_t bidx,
+                      int32_t eidx,
+                      int32_t /*cidx*/,
+                      JaggedAccessor<ScalarType, 2> points,
+                      TensorAccessor<ScalarType, 2> gridData,
+                      BatchGridAccessor batchAccessor,
+                      TensorAccessor<ScalarType, 2> outFeatures,
+                      int64_t *outIndices,
+                      int64_t numChannels) {
+    using MathType = at::opmath_type<ScalarType>;
+
+    const auto &pointsData               = points.data();
+    const nanovdb::OnIndexGrid *grid     = batchAccessor.grid(bidx);
+    const VoxelCoordTransform &transform = batchAccessor.primalTransform(bidx);
+    const int64_t baseOffset             = batchAccessor.voxelOffset(bidx);
+    auto gridAcc                         = grid->tree().getAccessor();
+
+    const nanovdb::math::Vec3<MathType> xyz =
+        transform.apply(static_cast<MathType>(pointsData[eidx][0]),
+                        static_cast<MathType>(pointsData[eidx][1]),
+                        static_cast<MathType>(pointsData[eidx][2]));
+
+    const int64_t bestIdx = resolveNearestCorner(xyz, gridAcc, baseOffset);
+
+    outIndices[eidx] = bestIdx;
+
+    if (bestIdx < 0)
+        return;
+
+    for (int64_t c = 0; c < numChannels; ++c) {
+        outFeatures[eidx][c] = gridData[bestIdx][c];
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Per-point callback (float, vec4 fast path, GPU only)
+// ---------------------------------------------------------------------------
+template <template <typename T, int32_t D> typename JaggedAccessor,
+          template <typename T, int32_t D>
+          typename TensorAccessor>
+__device__ void
+sampleNearestCallbackVec4(int32_t bidx,
+                          int32_t eidx,
+                          int32_t /*cidx*/,
+                          JaggedAccessor<float, 2> points,
+                          TensorAccessor<float, 2> gridData,
+                          BatchGridAccessor batchAccessor,
+                          TensorAccessor<float, 2> outFeatures,
+                          int64_t *outIndices,
+                          int64_t numChannels) {
+    const auto &pointsData               = points.data();
+    const nanovdb::OnIndexGrid *grid     = batchAccessor.grid(bidx);
+    const VoxelCoordTransform &transform = batchAccessor.primalTransform(bidx);
+    const int64_t baseOffset             = batchAccessor.voxelOffset(bidx);
+    auto gridAcc                         = grid->tree().getAccessor();
+
+    const nanovdb::math::Vec3<float> xyz =
+        transform.apply(pointsData[eidx][0], pointsData[eidx][1], pointsData[eidx][2]);
+
+    const int64_t bestIdx = resolveNearestCorner(xyz, gridAcc, baseOffset);
+
+    outIndices[eidx] = bestIdx;
+
+    if (bestIdx < 0)
+        return;
+
+    const int64_t numGroups = numChannels / 4;
+    for (int64_t g = 0; g < numGroups; ++g) {
+        const int64_t cBase = g * 4;
+        *reinterpret_cast<float4 *>(&outFeatures[eidx][cBase]) =
+            *reinterpret_cast<const float4 *>(&gridData[bestIdx][cBase]);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Dispatch
+// ---------------------------------------------------------------------------
+template <torch::DeviceType DeviceTag, typename scalar_t>
+std::vector<torch::Tensor>
+SampleGridNearest(const GridBatchData &batchHdl,
+                  const JaggedTensor &points,
+                  const torch::Tensor &gridData) {
+    auto opts = torch::TensorOptions()
+                    .dtype(gridData.dtype())
+                    .device(gridData.device())
+                    .requires_grad(gridData.requires_grad());
+    auto optsIdx = torch::TensorOptions().dtype(torch::kInt64).device(gridData.device());
+
+    torch::Tensor gridDataReshape = featureCoalescedView(gridData).contiguous();
+    torch::Tensor outFeatures =
+        torch::zeros({points.rsize(0), gridDataReshape.size(1)}, opts).contiguous();
+    torch::Tensor outIndices = torch::full({points.rsize(0)}, int64_t(-1), optsIdx).contiguous();
+    auto outShape            = spliceShape({points.rsize(0)}, gridData, 1);
+
+    auto batchAcc             = gridBatchAccessor<DeviceTag>(batchHdl);
+    auto gridDataAcc          = tensorAccessor<DeviceTag, scalar_t, 2>(gridDataReshape);
+    auto outFeaturesAcc       = tensorAccessor<DeviceTag, scalar_t, 2>(outFeatures);
+    int64_t *outIndicesPtr    = outIndices.data_ptr<int64_t>();
+    const int64_t numChannels = gridDataReshape.size(1);
+
+    if constexpr (DeviceTag == torch::kCUDA || DeviceTag == torch::kPrivateUse1) {
+        auto dispatchForEach = [&](const auto &cb) {
+            if constexpr (DeviceTag == torch::kCUDA) {
+                forEachJaggedElementChannelCUDA<scalar_t, 2>(
+                    DEFAULT_BLOCK_DIM, int64_t(1), points, cb);
+            } else {
+                forEachJaggedElementChannelPrivateUse1<scalar_t, 2>(int64_t(1), points, cb);
+            }
+        };
+
+        if constexpr (std::is_same_v<scalar_t, float>) {
+            if (numChannels >= 4 && numChannels % 4 == 0 &&
+                reinterpret_cast<uintptr_t>(gridDataReshape.data_ptr<float>()) % 16 == 0 &&
+                reinterpret_cast<uintptr_t>(outFeatures.data_ptr<float>()) % 16 == 0) {
+                auto cb = [=] __device__(int32_t bidx,
+                                         int32_t eidx,
+                                         int32_t cidx,
+                                         JaggedRAcc64<float, 2> pts) {
+                    sampleNearestCallbackVec4<JaggedRAcc64, TorchRAcc64>(bidx,
+                                                                         eidx,
+                                                                         cidx,
+                                                                         pts,
+                                                                         gridDataAcc,
+                                                                         batchAcc,
+                                                                         outFeaturesAcc,
+                                                                         outIndicesPtr,
+                                                                         numChannels);
+                };
+                dispatchForEach(cb);
+            } else {
+                auto cb = [=] __device__(int32_t bidx,
+                                         int32_t eidx,
+                                         int32_t cidx,
+                                         JaggedRAcc64<float, 2> pts) {
+                    sampleNearestCallback<float, JaggedRAcc64, TorchRAcc64>(bidx,
+                                                                            eidx,
+                                                                            cidx,
+                                                                            pts,
+                                                                            gridDataAcc,
+                                                                            batchAcc,
+                                                                            outFeaturesAcc,
+                                                                            outIndicesPtr,
+                                                                            numChannels);
+                };
+                dispatchForEach(cb);
+            }
+        } else {
+            auto cb = [=] __device__(int32_t bidx,
+                                     int32_t eidx,
+                                     int32_t cidx,
+                                     JaggedRAcc64<scalar_t, 2> pts) {
+                sampleNearestCallback<scalar_t, JaggedRAcc64, TorchRAcc64>(bidx,
+                                                                           eidx,
+                                                                           cidx,
+                                                                           pts,
+                                                                           gridDataAcc,
+                                                                           batchAcc,
+                                                                           outFeaturesAcc,
+                                                                           outIndicesPtr,
+                                                                           numChannels);
+            };
+            dispatchForEach(cb);
+        }
+    } else {
+        auto cb = [=](int32_t bidx, int32_t eidx, int32_t cidx, JaggedAcc<scalar_t, 2> pts) {
+            sampleNearestCallback<scalar_t, JaggedAcc, TorchAcc>(bidx,
+                                                                 eidx,
+                                                                 cidx,
+                                                                 pts,
+                                                                 gridDataAcc,
+                                                                 batchAcc,
+                                                                 outFeaturesAcc,
+                                                                 outIndicesPtr,
+                                                                 numChannels);
+        };
+        forEachJaggedElementChannelCPU<scalar_t, 2>(int64_t(1), points, cb);
+    }
+
+    return {outFeatures.reshape(outShape), outIndices};
+}
+
+template <torch::DeviceType DeviceTag>
+std::vector<torch::Tensor>
+dispatchSampleGridNearest(const GridBatchData &batchHdl,
+                          const JaggedTensor &points,
+                          const torch::Tensor &gridData) {
+    return AT_DISPATCH_V2(
+        points.scalar_type(),
+        "SampleGridNearest",
+        AT_WRAP([&] { return SampleGridNearest<DeviceTag, scalar_t>(batchHdl, points, gridData); }),
+        AT_EXPAND(AT_FLOATING_TYPES),
+        c10::kHalf);
+}
+
+template std::vector<torch::Tensor> dispatchSampleGridNearest<torch::kCPU>(const GridBatchData &,
+                                                                           const JaggedTensor &,
+                                                                           const torch::Tensor &);
+template std::vector<torch::Tensor> dispatchSampleGridNearest<torch::kCUDA>(const GridBatchData &,
+                                                                            const JaggedTensor &,
+                                                                            const torch::Tensor &);
+template std::vector<torch::Tensor> dispatchSampleGridNearest<torch::kPrivateUse1>(
+    const GridBatchData &, const JaggedTensor &, const torch::Tensor &);
+
+std::vector<torch::Tensor>
+sampleNearest(const GridBatchData &batchHdl,
+              const JaggedTensor &points,
+              const torch::Tensor &gridData) {
+    batchHdl.checkNonEmptyGrid();
+    TORCH_CHECK_VALUE(points.device() == gridData.device(),
+                      "points and data must be on the same device");
+    batchHdl.checkDevice(points);
+    batchHdl.checkDevice(gridData);
+    points.check_valid();
+    TORCH_CHECK_TYPE(points.is_floating_point(), "points must have a floating point type");
+    TORCH_CHECK_TYPE(points.dtype() == gridData.dtype(), "all tensors must have the same type");
+    TORCH_CHECK_VALUE(points.rdim() == 2,
+                      "Expected points to have shape [B*M, 3] (wrong number of dimensions)");
+    TORCH_CHECK(points.numel() > 0, "Empty tensor (points)");
+    TORCH_CHECK(points.rsize(1) == 3, "points must have shape [B, M, 3] (points must be 3D)");
+    TORCH_CHECK_TYPE(gridData.is_floating_point(), "data must have a floating point type");
+    TORCH_CHECK_VALUE(gridData.dim() >= 2,
+                      "Expected data to have shape [N, *] (at least 2 dimensions)");
+    TORCH_CHECK(gridData.numel() > 0, "Empty tensor (data)");
+    TORCH_CHECK(gridData.size(0) == batchHdl.totalVoxels(),
+                "grid_data must have one value per voxel (shape [N, *]) (wrong first dimension)");
+    return FVDB_DISPATCH_KERNEL(points.device(), [&]() {
+        return dispatchSampleGridNearest<DeviceTag>(batchHdl, points, gridData);
+    });
+}
+
+} // namespace ops
+} // namespace detail
+} // namespace fvdb

--- a/src/fvdb/detail/ops/SampleNearest.h
+++ b/src/fvdb/detail/ops/SampleNearest.h
@@ -1,0 +1,36 @@
+// Copyright Contributors to the OpenVDB Project
+// SPDX-License-Identifier: Apache-2.0
+//
+#ifndef FVDB_DETAIL_OPS_SAMPLENEAREST_H
+#define FVDB_DETAIL_OPS_SAMPLENEAREST_H
+
+#include <fvdb/JaggedTensor.h>
+#include <fvdb/detail/GridBatchData.h>
+
+#include <torch/types.h>
+
+#include <vector>
+
+namespace fvdb {
+namespace detail {
+namespace ops {
+
+/// @brief Sample features on the grid batch using nearest-neighbor lookup.
+///
+/// Data is assumed to be defined at voxel centers.  For each query
+/// point, the 8 nearest voxel centers are checked and the value of
+/// the closest active one is returned.  When none of the 8 are active
+/// the output is zero (matching sample_trilinear boundary behaviour).
+///
+/// @return A two-element vector: [sampled_values, selected_indices].
+///         selected_indices contains the cumulative linear index of the
+///         chosen voxel for each point, or -1 when no active corner exists.
+std::vector<torch::Tensor> sampleNearest(const GridBatchData &batchHdl,
+                                         const JaggedTensor &points,
+                                         const torch::Tensor &gridData);
+
+} // namespace ops
+} // namespace detail
+} // namespace fvdb
+
+#endif // FVDB_DETAIL_OPS_SAMPLENEAREST_H

--- a/src/python/GridBatchOps.cpp
+++ b/src/python/GridBatchOps.cpp
@@ -14,6 +14,7 @@
 #include <fvdb/detail/ops/SampleBezier.h>
 #include <fvdb/detail/ops/SampleBezierWithGrad.h>
 #include <fvdb/detail/ops/SampleBezierWithGradBackward.h>
+#include <fvdb/detail/ops/SampleNearest.h>
 #include <fvdb/detail/ops/SampleTrilinear.h>
 #include <fvdb/detail/ops/SampleTrilinearWithGrad.h>
 #include <fvdb/detail/ops/SampleTrilinearWithGradBackward.h>
@@ -123,6 +124,9 @@ bind_grid_batch_ops(py::module &m) {
     // -----------------------------------------------------------------------
     // Interpolation: forward
     // -----------------------------------------------------------------------
+
+    m.def(
+        "sample_nearest", &ops::sampleNearest, py::arg("grid"), py::arg("points"), py::arg("data"));
 
     m.def("sample_trilinear",
           &ops::sampleTrilinear,

--- a/tests/unit/test_sample.py
+++ b/tests/unit/test_sample.py
@@ -95,7 +95,14 @@ def sample_nearest_naive(pts: JaggedTensor, corner_feats: torch.Tensor, grid: Gr
     base_ijk = torch.floor(grid_pts)
     frac = grid_pts - base_ijk
 
-    offsets = torch.tensor(list(itertools.product([0, 1], [0, 1], [0, 1])), device=device, dtype=torch.long)
+    # Corner ordering must match the C++ kernel's cache-friendly zigzag
+    # (SampleNearest.cu / TrilinearStencil.h) so that tie-breaking via
+    # argmin and strict-less-than give the same result.
+    offsets = torch.tensor(
+        [[0, 0, 0], [0, 0, 1], [0, 1, 1], [0, 1, 0], [1, 0, 0], [1, 0, 1], [1, 1, 1], [1, 1, 0]],
+        device=device,
+        dtype=torch.long,
+    )
 
     all_ijk = base_ijk.unsqueeze(1).long() + offsets.unsqueeze(0)  # [N, 8, 3]
     active_mask = grid.coords_in_grid(JaggedTensor(all_ijk.reshape(-1, 3))).jdata.reshape(-1, 8)
@@ -957,6 +964,13 @@ class TestSample(unittest.TestCase):
 
     @parameterized.expand(all_device_dtype_channel_combos)
     def test_nearest_sparse_onbound_vs_brute(self, device, dtype, num_channels):
+        if dtype == torch.half:
+            atol = 1e-2
+            rtol = 1e-2
+        else:
+            atol = 1e-5
+            rtol = 1e-5
+
         grid, grid_d, p = make_grid_batch_and_jagged_point_data(device, dtype, include_boundary_points=True)
 
         for test_grid in (grid, grid_d):
@@ -977,11 +991,11 @@ class TestSample(unittest.TestCase):
             features.grad.zero_()
 
             self.assertTrue(
-                torch.allclose(fv, fp, atol=1e-5, rtol=1e-5),
+                torch.allclose(fv, fp, atol=atol, rtol=rtol),
                 f"Forward max error is {torch.max(torch.abs(fv - fp))}",
             )
             self.assertTrue(
-                torch.allclose(gv, gp, atol=1e-5, rtol=1e-5),
+                torch.allclose(gv, gp, atol=atol, rtol=rtol),
                 f"Backward max error is {torch.max(torch.abs(gv - gp))}",
             )
 

--- a/tests/unit/test_sample.py
+++ b/tests/unit/test_sample.py
@@ -83,6 +83,39 @@ def sample_trilinear_naive(pts: JaggedTensor, corner_feats: torch.Tensor, grid: 
     return torch.sum(interpolated_feats, dim=1).to(dtype)
 
 
+def sample_nearest_naive(pts: JaggedTensor, corner_feats: torch.Tensor, grid: GridBatch) -> torch.Tensor:
+    device = corner_feats.device
+    dtype = corner_feats.dtype
+    feats_dim = corner_feats.shape[-1]
+
+    if pts.dtype == torch.half:
+        pts = pts.to(torch.float)
+
+    grid_pts = grid.world_to_voxel(pts).jdata
+    base_ijk = torch.floor(grid_pts)
+    frac = grid_pts - base_ijk
+
+    offsets = torch.tensor(list(itertools.product([0, 1], [0, 1], [0, 1])), device=device, dtype=torch.long)
+
+    all_ijk = base_ijk.unsqueeze(1).long() + offsets.unsqueeze(0)  # [N, 8, 3]
+    active_mask = grid.coords_in_grid(JaggedTensor(all_ijk.reshape(-1, 3))).jdata.reshape(-1, 8)
+    indices = grid.ijk_to_index(JaggedTensor(all_ijk.reshape(-1, 3))).jdata.reshape(-1, 8)
+
+    dist_components = offsets.float().unsqueeze(0) - frac.unsqueeze(1)  # [N, 8, 3]
+    sq_dist = (dist_components**2).sum(dim=-1)  # [N, 8]
+
+    sq_dist[~active_mask] = float("inf")
+    best_corner = sq_dist.argmin(dim=1)  # [N]
+
+    any_active = active_mask.any(dim=1)
+    best_indices = indices[torch.arange(indices.shape[0], device=device), best_corner]
+
+    output = torch.zeros(grid_pts.shape[0], feats_dim, device=device, dtype=dtype)
+    if any_active.any():
+        output[any_active] = corner_feats[best_indices[any_active]]
+    return output
+
+
 def _bezier(x: torch.Tensor):
     b1 = (x + 1.5) ** 2
     b2 = -2 * (x**2) + 1.5
@@ -886,6 +919,100 @@ class TestSample(unittest.TestCase):
         self.assertTrue(
             torch.allclose(gv, gp, atol=gatol, rtol=grtol),
             f"Max error is {torch.max(torch.abs(gv - gp))}",
+        )
+
+    # -----------------------------------------------------------------------
+    #  sample_nearest tests
+    # -----------------------------------------------------------------------
+
+    @parameterized.expand(all_device_dtype_channel_combos)
+    def test_nearest_sparse_vs_brute(self, device, dtype, num_channels):
+        grid, grid_d, p = make_grid_batch_and_jagged_point_data(device, dtype)
+
+        for test_grid in (grid, grid_d):
+            features = torch.rand((test_grid.total_voxels, num_channels), device=device, dtype=dtype)
+            features.requires_grad = True
+
+            fv = test_grid.sample_nearest(p, JaggedTensor(features)).jdata
+            grad_out = torch.rand_like(fv) + 0.1
+            fv.backward(grad_out)
+            assert features.grad is not None
+            gv = features.grad.clone()
+            features.grad.zero_()
+
+            fp = sample_nearest_naive(p, features, test_grid)
+            fp.backward(grad_out)
+            assert features.grad is not None
+            gp = features.grad.clone()
+            features.grad.zero_()
+
+            self.assertTrue(
+                torch.allclose(fv, fp, atol=1e-5, rtol=1e-5),
+                f"Forward max error is {torch.max(torch.abs(fv - fp))}",
+            )
+            self.assertTrue(
+                torch.allclose(gv, gp, atol=1e-5, rtol=1e-5),
+                f"Backward max error is {torch.max(torch.abs(gv - gp))}",
+            )
+
+    @parameterized.expand(all_device_dtype_channel_combos)
+    def test_nearest_sparse_onbound_vs_brute(self, device, dtype, num_channels):
+        grid, grid_d, p = make_grid_batch_and_jagged_point_data(device, dtype, include_boundary_points=True)
+
+        for test_grid in (grid, grid_d):
+            features = torch.rand((test_grid.total_voxels, num_channels), device=device, dtype=dtype)
+            features.requires_grad = True
+
+            fv = test_grid.sample_nearest(p, JaggedTensor(features)).jdata
+            grad_out = torch.rand_like(fv) + 0.1
+            fv.backward(grad_out)
+            assert features.grad is not None
+            gv = features.grad.clone()
+            features.grad.zero_()
+
+            fp = sample_nearest_naive(p, features, test_grid)
+            fp.backward(grad_out)
+            assert features.grad is not None
+            gp = features.grad.clone()
+            features.grad.zero_()
+
+            self.assertTrue(
+                torch.allclose(fv, fp, atol=1e-5, rtol=1e-5),
+                f"Forward max error is {torch.max(torch.abs(fv - fp))}",
+            )
+            self.assertTrue(
+                torch.allclose(gv, gp, atol=1e-5, rtol=1e-5),
+                f"Backward max error is {torch.max(torch.abs(gv - gp))}",
+            )
+
+    @parameterized.expand(all_device_dtype_channel_combos)
+    def test_nearest_at_voxel_centers(self, device, dtype, num_channels):
+        """Query at exact voxel centers must return the stored voxel value."""
+        grid, _, _ = make_grid_batch_and_jagged_point_data(device, dtype)
+        features = torch.rand((grid.total_voxels, num_channels), device=device, dtype=dtype)
+
+        ijk_float = grid.ijk.jdata.to(dtype)
+        centers_world = grid.voxel_to_world(JaggedTensor(ijk_float))
+        result = grid.sample_nearest(centers_world, JaggedTensor(features)).jdata
+
+        self.assertTrue(
+            torch.allclose(result, features, atol=1e-6, rtol=1e-6),
+            f"At voxel centers max error is {torch.max(torch.abs(result - features))}",
+        )
+
+    @parameterized.expand(all_device_dtype_combos)
+    def test_nearest_all_inactive(self, device, dtype):
+        """Points far outside the grid must return zero."""
+        grid, _, _ = make_grid_batch_and_jagged_point_data(device, dtype)
+        num_channels = 4
+        features = torch.rand((grid.total_voxels, num_channels), device=device, dtype=dtype)
+
+        far_points = torch.tensor([[1000.0, 1000.0, 1000.0], [-1000.0, -1000.0, -1000.0]], device=device, dtype=dtype)
+        result = grid.sample_nearest(JaggedTensor(far_points), JaggedTensor(features)).jdata
+
+        self.assertTrue(
+            torch.all(result == 0.0),
+            "Points far outside the grid should return zero",
         )
 
 


### PR DESCRIPTION
Implements the `sample_nearest` operator for `GridBatch` and `Grid`, providing nearest-neighbor sampling of voxel data at arbitrary world-space query positions. Fixes #612.

- **CUDA forward kernel** (`SampleNearest.cu/.h`): For each query point, transforms to voxel space, checks the 8 surrounding voxel centers via the NanoVDB accessor, and selects the closest active one by Euclidean distance. Returns zero when all 8 are inactive, consistent with `sample_trilinear` boundary behavior. Includes both scalar and vectorized `float4` dispatch paths, mirroring the existing trilinear kernel structure.
- **Python autograd** (`_SampleNearestFn` in `_interpolation.py`): The C++ kernel returns sampled values and the selected voxel index per query point. The backward pass uses `torch.index_add_` to scatter gradients back to the selected voxels, following the project's convention of keeping autograd in Python.
- **Public API**: `sample_nearest` on `GridBatch` and `Grid`, plus `sample_nearest_batch`/`sample_nearest_single` in `fvdb.functional`.
- **Tests**: Brute-force reference implementation plus 4 parameterized test cases covering correctness vs. reference (with gradients), boundary points, exact voxel-center queries, and fully-inactive regions.

## Test plan

- [x] `cd tests && pytest unit/test_sample.py -k "nearest" -v` -- all 4 new test methods pass across device/dtype/channel combinations
- [x] Existing `test_sample.py` tests still pass (no regressions to trilinear/bezier)
- [x] Build succeeds with `SampleNearest.cu` added to CMakeLists