### PR TITLE
CI: Revert failing drop cache step

### DIFF
--- a/.github/workflows/nightly-publish.yml
+++ b/.github/workflows/nightly-publish.yml
@@ -162,9 +162,6 @@ jobs:
           echo "Nightly version: $NIGHTLY_VERSION"
           grep '^version' pyproject.toml
 
-      - name: Drop page cache to free RAM before build
-        run: sync && echo 3 > /proc/sys/vm/drop_caches
-
       - name: Build fvdb
         run: |
           source .venv/bin/activate


### PR DESCRIPTION
The `Drop page cache to free RAM before build` step in `nightly-publish.yml` (added in #574) has failed on every nightly matrix job that entered the build container since 2026-03-31.

Inside the `nvidia/cuda:<tag>-cudnn-devel-rockylinux8` container on the EC2 self-hosted runner, `/proc/sys` is bind-mounted read-only, so the write returns **EROFS** and the job fails before `Build fvdb` ever runs.

No nightly wheel has been published since 2026-03-30; "green" days in between are `check-new-commits` gate skips, not successful builds.

#549: moved `nightly-publish` from `m6a.8xlarge` → `t3a.large`.