### PR TITLE
Promote GridBatchData to public header

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -50,7 +50,7 @@ set(FVDB_CPP_FILES
     fvdb/detail/utils/cuda/Prefetch.cpp
     fvdb/detail/io/SaveNanoVDB.cpp
     fvdb/detail/ops/jagged/JaggedReductions.cpp
-    fvdb/detail/TorchDeviceBuffer.cpp
+    fvdb/TorchDeviceBuffer.cpp
     fvdb/detail/viewer/GaussianSplat3dView.cpp
     fvdb/detail/viewer/Viewer.cpp
     fvdb/FVDB.cpp
@@ -58,7 +58,7 @@ set(FVDB_CPP_FILES
 )
 
 set(FVDB_CU_FILES
-    fvdb/detail/GridBatchData.cu
+    fvdb/GridBatchData.cu
     fvdb/detail/GridBatchDataFactory.cu
     fvdb/detail/ops/ActiveGridCoords.cu
     fvdb/detail/ops/ActiveVoxelsInBoundsMask.cu

--- a/src/benchmarks/convolution/gather_scatter_conv_benchmark.cu
+++ b/src/benchmarks/convolution/gather_scatter_conv_benchmark.cu
@@ -21,8 +21,8 @@
 #pragma nv_diag_suppress 177
 #endif
 
+#include <fvdb/GridBatchData.h>
 #include <fvdb/JaggedTensor.h>
-#include <fvdb/detail/GridBatchData.h>
 #include <fvdb/detail/ops/BuildGridFromIjk.h>
 #include <fvdb/detail/ops/convolution/GatherScatterDefault.h>
 

--- a/src/fvdb/FVDB.cpp
+++ b/src/fvdb/FVDB.cpp
@@ -45,20 +45,20 @@ volumeRender(const torch::Tensor &sigmas,
         sigmas, rgbs, deltaTs, ts, jOffsets, transmittanceThresh);
 }
 
-std::tuple<c10::intrusive_ptr<detail::GridBatchData>, JaggedTensor, std::vector<std::string>>
+std::tuple<c10::intrusive_ptr<GridBatchData>, JaggedTensor, std::vector<std::string>>
 from_nanovdb(nanovdb::GridHandle<nanovdb::HostBuffer> &handle) {
     return detail::io::fromNVDB(handle);
 }
 
 nanovdb::GridHandle<nanovdb::HostBuffer>
-to_nanovdb(const detail::GridBatchData &gridBatchData,
+to_nanovdb(const GridBatchData &gridBatchData,
            const std::optional<JaggedTensor> maybeData,
            const std::vector<std::string> &names) {
     return detail::io::toNVDB(gridBatchData, maybeData, names);
 }
 
-c10::intrusive_ptr<detail::GridBatchData>
-jcat(const std::vector<c10::intrusive_ptr<detail::GridBatchData>> &vec) {
+c10::intrusive_ptr<GridBatchData>
+jcat(const std::vector<c10::intrusive_ptr<GridBatchData>> &vec) {
     return detail::ops::concatenateGrids(vec);
 }
 
@@ -69,7 +69,7 @@ jcat(const std::vector<JaggedTensor> &vec, std::optional<int64_t> dim) {
 
 void
 save(const std::string &path,
-     const detail::GridBatchData &gridBatchData,
+     const GridBatchData &gridBatchData,
      const std::optional<JaggedTensor> maybeData,
      const std::vector<std::string> &names,
      bool compressed,
@@ -79,7 +79,7 @@ save(const std::string &path,
 
 void
 save(const std::string &path,
-     const detail::GridBatchData &gridBatchData,
+     const GridBatchData &gridBatchData,
      const std::optional<JaggedTensor> maybeData,
      const std::string &name,
      bool compressed,
@@ -93,7 +93,7 @@ save(const std::string &path,
     }
 }
 
-std::tuple<c10::intrusive_ptr<detail::GridBatchData>, JaggedTensor, std::vector<std::string>>
+std::tuple<c10::intrusive_ptr<GridBatchData>, JaggedTensor, std::vector<std::string>>
 load(const std::string &path,
      const std::vector<uint64_t> &indices,
      const torch::Device &device,
@@ -101,7 +101,7 @@ load(const std::string &path,
     return detail::io::loadNVDB(path, indices, device, verbose);
 }
 
-std::tuple<c10::intrusive_ptr<detail::GridBatchData>, JaggedTensor, std::vector<std::string>>
+std::tuple<c10::intrusive_ptr<GridBatchData>, JaggedTensor, std::vector<std::string>>
 load(const std::string &path,
      const std::vector<std::string> &names,
      const torch::Device &device,
@@ -109,33 +109,33 @@ load(const std::string &path,
     return detail::io::loadNVDB(path, names, device, verbose);
 }
 
-std::tuple<c10::intrusive_ptr<detail::GridBatchData>, JaggedTensor, std::vector<std::string>>
+std::tuple<c10::intrusive_ptr<GridBatchData>, JaggedTensor, std::vector<std::string>>
 load(const std::string &path, const torch::Device &device, bool verbose) {
     return detail::io::loadNVDB(path, device, verbose);
 }
 
-c10::intrusive_ptr<detail::GridBatchData>
+c10::intrusive_ptr<GridBatchData>
 gridbatch_from_points(const JaggedTensor &points,
                       const std::vector<nanovdb::Vec3d> &voxel_sizes,
                       const std::vector<nanovdb::Vec3d> &origins) {
     return detail::ops::buildGridFromPoints(points, voxel_sizes, origins);
 }
 
-c10::intrusive_ptr<detail::GridBatchData>
+c10::intrusive_ptr<GridBatchData>
 gridbatch_from_ijk(const JaggedTensor &ijk,
                    const std::vector<nanovdb::Vec3d> &voxel_sizes,
                    const std::vector<nanovdb::Vec3d> &origins) {
     return detail::ops::createNanoGridFromIJK(ijk, voxel_sizes, origins);
 }
 
-c10::intrusive_ptr<detail::GridBatchData>
+c10::intrusive_ptr<GridBatchData>
 gridbatch_from_nearest_voxels_to_points(const JaggedTensor &points,
                                         const std::vector<nanovdb::Vec3d> &voxel_sizes,
                                         const std::vector<nanovdb::Vec3d> &origins) {
     return detail::ops::buildGridFromNearestVoxelsToPoints(points, voxel_sizes, origins);
 }
 
-c10::intrusive_ptr<detail::GridBatchData>
+c10::intrusive_ptr<GridBatchData>
 gridbatch_from_dense(const int64_t numGrids,
                      const nanovdb::Coord &denseDims,
                      const nanovdb::Coord &ijkMin,
@@ -147,7 +147,7 @@ gridbatch_from_dense(const int64_t numGrids,
         numGrids, ijkMin, denseDims, device, mask, voxel_sizes, origins);
 }
 
-c10::intrusive_ptr<detail::GridBatchData>
+c10::intrusive_ptr<GridBatchData>
 gridbatch_from_mesh(const JaggedTensor &vertices,
                     const JaggedTensor &faces,
                     const std::vector<nanovdb::Vec3d> &voxel_sizes,

--- a/src/fvdb/FVDB.h
+++ b/src/fvdb/FVDB.h
@@ -4,8 +4,8 @@
 #ifndef FVDB_FVDB_H
 #define FVDB_FVDB_H
 
+#include <fvdb/GridBatchData.h>
 #include <fvdb/JaggedTensor.h>
-#include <fvdb/detail/GridBatchData.h>
 
 #include <vector>
 
@@ -23,8 +23,7 @@ std::vector<torch::Tensor> volumeRender(const torch::Tensor &sigmas,
 /// @brief Concatenate a list of grid batches into a single grid batch
 /// @param vec A list of grid batches to concatenate
 /// @return A GridBatchData representing the concatenated grid batch
-c10::intrusive_ptr<detail::GridBatchData>
-jcat(const std::vector<c10::intrusive_ptr<detail::GridBatchData>> &vec);
+c10::intrusive_ptr<GridBatchData> jcat(const std::vector<c10::intrusive_ptr<GridBatchData>> &vec);
 
 /// @brief Concatenate a list of JaggedTensor into a single JaggedTensor
 /// @param vec A list of JaggedTensor to concatenate
@@ -103,7 +102,7 @@ JaggedTensor jempty(const std::vector<std::vector<int64_t>> &lsizes,
 /// 0, 0] voxel
 ///                for each grid in the batch, or one origin for all grids
 /// @return A GridBatchData containing the created grid batch
-c10::intrusive_ptr<detail::GridBatchData>
+c10::intrusive_ptr<GridBatchData>
 gridbatch_from_points(const JaggedTensor &points,
                       const std::vector<nanovdb::Vec3d> &voxel_sizes,
                       const std::vector<nanovdb::Vec3d> &origins);
@@ -116,7 +115,7 @@ gridbatch_from_points(const JaggedTensor &points,
 /// @param origins A tensor of shape [B, 3] or [3,] containing the world space coordinate of the [0,
 /// 0, 0] voxel for each grid in the batch, or one origin for all grids
 /// @return A GridBatchData containing the created grid batch
-c10::intrusive_ptr<detail::GridBatchData>
+c10::intrusive_ptr<GridBatchData>
 gridbatch_from_nearest_voxels_to_points(const JaggedTensor &points,
                                         const std::vector<nanovdb::Vec3d> &voxel_sizes,
                                         const std::vector<nanovdb::Vec3d> &origins);
@@ -130,10 +129,9 @@ gridbatch_from_nearest_voxels_to_points(const JaggedTensor &points,
 /// 0, 0] voxel
 ///                for each grid in the batch, or one origin for all grids
 /// @return A GridBatchData containing the created grid batch
-c10::intrusive_ptr<detail::GridBatchData>
-gridbatch_from_ijk(const JaggedTensor &ijk,
-                   const std::vector<nanovdb::Vec3d> &voxel_sizes,
-                   const std::vector<nanovdb::Vec3d> &origins);
+c10::intrusive_ptr<GridBatchData> gridbatch_from_ijk(const JaggedTensor &ijk,
+                                                     const std::vector<nanovdb::Vec3d> &voxel_sizes,
+                                                     const std::vector<nanovdb::Vec3d> &origins);
 
 /// @brief Return a grid batch densely from ijkMin to ijkMin + size
 /// @param numGrids The number of grids to create in the batch
@@ -149,7 +147,7 @@ gridbatch_from_ijk(const JaggedTensor &ijk,
 ///             Note that the same mask will be re-used for all the grids in the batch.
 /// @param device Which device to build the grid batch on
 /// @return A GridBatchData containing a batch of dense grids
-c10::intrusive_ptr<detail::GridBatchData>
+c10::intrusive_ptr<GridBatchData>
 gridbatch_from_dense(const int64_t numGrids,
                      const nanovdb::Coord &denseDims,
                      const nanovdb::Coord &ijkMin,
@@ -168,7 +166,7 @@ gridbatch_from_dense(const int64_t numGrids,
 /// @param origins A tensor of shape [B, 3] or [3,] containing the world space coordinate of the [0,
 /// 0, 0] voxel for each grid in the batch, or one origin for all grids
 /// @return A GridBatchData containing the created grid batch
-c10::intrusive_ptr<detail::GridBatchData>
+c10::intrusive_ptr<GridBatchData>
 gridbatch_from_mesh(const JaggedTensor &vertices,
                     const JaggedTensor &faces,
                     const std::vector<nanovdb::Vec3d> &voxel_sizes,
@@ -180,7 +178,7 @@ gridbatch_from_mesh(const JaggedTensor &vertices,
 /// containing the converted grids,
 ///         data is a JaggedTensor containing the data of the grids, and names is a list of strings
 ///         containing the name of each grid
-std::tuple<c10::intrusive_ptr<detail::GridBatchData>, JaggedTensor, std::vector<std::string>>
+std::tuple<c10::intrusive_ptr<GridBatchData>, JaggedTensor, std::vector<std::string>>
 from_nanovdb(nanovdb::GridHandle<nanovdb::HostBuffer> &handle);
 
 /// @brief Return a nanovdb grid handle created from a grid batch, optional jagged tensor of data,
@@ -194,7 +192,7 @@ from_nanovdb(nanovdb::GridHandle<nanovdb::HostBuffer> &handle);
 /// @return A nanovdb grid handle, whose type is inferred from the data, containing the converted
 /// grids
 nanovdb::GridHandle<nanovdb::HostBuffer>
-to_nanovdb(const detail::GridBatchData &gridBatchData,
+to_nanovdb(const GridBatchData &gridBatchData,
            const std::optional<JaggedTensor> maybeData = std::nullopt,
            const std::vector<std::string> &names       = {});
 
@@ -208,7 +206,7 @@ to_nanovdb(const detail::GridBatchData &gridBatchData,
 /// @param compressed Whether to compress the stored grid using Blosc (https://www.blosc.org/)
 /// @param verbose Whether to print information about the saved grids
 void save(const std::string &path,
-          const detail::GridBatchData &gridBatchData,
+          const GridBatchData &gridBatchData,
           const std::optional<JaggedTensor> maybeData = std::nullopt,
           const std::vector<std::string> &names       = {},
           bool compressed                             = false,
@@ -224,7 +222,7 @@ void save(const std::string &path,
 /// @param compressed Whether to compress the stored grid using Blosc (https://www.blosc.org/)
 /// @param verbose Whether to print information about the saved grids
 void save(const std::string &path,
-          const detail::GridBatchData &gridBatchData,
+          const GridBatchData &gridBatchData,
           const std::optional<JaggedTensor> maybeData = std::nullopt,
           const std::string &name                     = std::string(),
           bool compressed                             = false,
@@ -236,7 +234,7 @@ void save(const std::string &path,
 /// @param device Which device to load the grid batch on
 /// @param verbose If set to true, print information about the loaded grids
 /// @return A triple (gridbatch_data, data, names)
-std::tuple<c10::intrusive_ptr<detail::GridBatchData>, JaggedTensor, std::vector<std::string>>
+std::tuple<c10::intrusive_ptr<GridBatchData>, JaggedTensor, std::vector<std::string>>
 load(const std::string &path,
      const std::vector<uint64_t> &indices,
      const torch::Device &device,
@@ -247,7 +245,7 @@ load(const std::string &path,
 /// @param device Which device to load the grid batch on
 /// @param verbose If set to true, print information about the loaded grids
 /// @return A triple (gridbatch_data, data, names)
-std::tuple<c10::intrusive_ptr<detail::GridBatchData>, JaggedTensor, std::vector<std::string>>
+std::tuple<c10::intrusive_ptr<GridBatchData>, JaggedTensor, std::vector<std::string>>
 load(const std::string &path,
      const std::vector<std::string> &names,
      const torch::Device &device,
@@ -257,7 +255,7 @@ load(const std::string &path,
 /// @param device Which device to load the grid batch on
 /// @param verbose If set to true, print information about the loaded grids
 /// @return A triple (gridbatch_data, data, names)
-std::tuple<c10::intrusive_ptr<detail::GridBatchData>, JaggedTensor, std::vector<std::string>>
+std::tuple<c10::intrusive_ptr<GridBatchData>, JaggedTensor, std::vector<std::string>>
 load(const std::string &path, const torch::Device &device, bool verbose = false);
 
 /// @brief Convert a tensor of ijk coordinates to a tensor of morton codes

--- a/src/fvdb/GridBatchData.cu
+++ b/src/fvdb/GridBatchData.cu
@@ -1,12 +1,78 @@
 // Copyright Contributors to the OpenVDB Project
 // SPDX-License-Identifier: Apache-2.0
 //
-#include <fvdb/detail/GridBatchData.h>
+#include <fvdb/GridBatchData.h>
 #include <fvdb/detail/GridBatchDataFactory.h>
 #include <fvdb/detail/ops/JIdxForGrid.h>
 
 namespace fvdb {
-namespace detail {
+
+// -----------------------------------------------------------------------
+// Methods that dereference mGridHdl (require complete TorchDeviceBuffer)
+// -----------------------------------------------------------------------
+
+const nanovdb::GridHandle<TorchDeviceBuffer> &
+GridBatchData::nanoGridHandle() const {
+    return *mGridHdl;
+}
+
+const c10::Device
+GridBatchData::device() const {
+    return mGridHdl->buffer().device();
+}
+
+bool
+GridBatchData::isEmpty() const {
+    return mGridHdl->buffer().isEmpty();
+}
+
+GridBatchData::Accessor
+GridBatchData::hostAccessor() const {
+    TORCH_CHECK(!isEmpty(), "Cannot access empty grid");
+    TORCH_CHECK(mGridHdl->template grid<nanovdb::ValueOnIndex>(),
+                "Failed to get host grid pointer");
+    return Accessor(mHostGridMetadata,
+                    mGridHdl->template grid<nanovdb::ValueOnIndex>(),
+                    mLeafBatchIndices.data_ptr<fvdb::JIdxType>(),
+                    mBatchMetadata.mTotalVoxels,
+                    mBatchMetadata.mTotalLeaves,
+                    mBatchMetadata.mMaxVoxels,
+                    mBatchMetadata.mMaxLeafCount,
+                    mBatchSize);
+}
+
+GridBatchData::Accessor
+GridBatchData::deviceAccessor() const {
+    TORCH_CHECK(!isEmpty(), "Cannot access empty grid");
+    TORCH_CHECK(device().is_cuda() || device().is_privateuseone(),
+                "Cannot access device accessor without a CUDA or PrivateUse1 device");
+    TORCH_CHECK(mGridHdl->template deviceGrid<nanovdb::ValueOnIndex>(),
+                "Failed to get device grid pointer");
+    return Accessor(mDeviceGridMetadata,
+                    mGridHdl->template deviceGrid<nanovdb::ValueOnIndex>(),
+                    mLeafBatchIndices.data_ptr<fvdb::JIdxType>(),
+                    mBatchMetadata.mTotalVoxels,
+                    mBatchMetadata.mTotalLeaves,
+                    mBatchMetadata.mMaxVoxels,
+                    mBatchMetadata.mMaxLeafCount,
+                    mBatchSize);
+}
+
+void
+GridBatchData::checkDevice(const torch::Tensor &t) const {
+    torch::Device hdlDevice = mGridHdl->buffer().device();
+    TORCH_CHECK(hdlDevice == t.device(),
+                "All tensors must be on the same device (" + hdlDevice.str() +
+                    ") as index grid but got " + t.device().str());
+}
+
+void
+GridBatchData::checkDevice(const JaggedTensor &t) const {
+    torch::Device hdlDevice = mGridHdl->buffer().device();
+    TORCH_CHECK(hdlDevice == t.device(),
+                "All tensors must be on the same device (" + hdlDevice.str() +
+                    ") as index grid but got " + t.device().str());
+}
 
 GridBatchData::~GridBatchData() {
     if (!mGridHdl) {
@@ -14,14 +80,14 @@ GridBatchData::~GridBatchData() {
     }
     const torch::Device dev = mGridHdl->buffer().device();
     if (dev.is_cpu() || dev.is_cuda()) {
-        freeHostGridMetadata(mHostGridMetadata);
+        fvdb::detail::freeHostGridMetadata(mHostGridMetadata);
         mHostGridMetadata = nullptr;
         if (dev.is_cuda()) {
-            freeDeviceGridMetadata(dev, mDeviceGridMetadata);
+            fvdb::detail::freeDeviceGridMetadata(dev, mDeviceGridMetadata);
             mDeviceGridMetadata = nullptr;
         }
     } else if (dev.is_privateuseone()) {
-        freeUnifiedMemoryGridMetadata(mDeviceGridMetadata);
+        fvdb::detail::freeUnifiedMemoryGridMetadata(mDeviceGridMetadata);
         mHostGridMetadata   = nullptr;
         mDeviceGridMetadata = nullptr;
     } else {
@@ -189,7 +255,7 @@ GridBatchData::totalBBoxTensor() const {
 
 const std::vector<VoxelCoordTransform>
 GridBatchData::primalTransforms() const {
-    std::vector<detail::VoxelCoordTransform> transforms;
+    std::vector<VoxelCoordTransform> transforms;
     transforms.reserve(batchSize());
     for (int64_t bi = 0; bi < batchSize(); ++bi) {
         transforms.push_back(primalTransformAt(bi));
@@ -199,7 +265,7 @@ GridBatchData::primalTransforms() const {
 
 const std::vector<VoxelCoordTransform>
 GridBatchData::dualTransforms() const {
-    std::vector<detail::VoxelCoordTransform> transforms;
+    std::vector<VoxelCoordTransform> transforms;
     transforms.reserve(batchSize());
     for (int64_t bi = 0; bi < batchSize(); ++bi) {
         transforms.push_back(dualTransformAt(bi));
@@ -263,7 +329,7 @@ GridBatchData::jaggedTensor(const torch::Tensor &data) const {
 
 torch::Tensor
 GridBatchData::jidx() const {
-    return ops::jIdxForGrid(*this);
+    return fvdb::detail::ops::jIdxForGrid(*this);
 }
 
 torch::Tensor
@@ -271,5 +337,4 @@ GridBatchData::jlidx() const {
     return mListIndices;
 }
 
-} // namespace detail
 } // namespace fvdb

--- a/src/fvdb/GridBatchData.h
+++ b/src/fvdb/GridBatchData.h
@@ -1,12 +1,12 @@
 // Copyright Contributors to the OpenVDB Project
 // SPDX-License-Identifier: Apache-2.0
 //
-#ifndef FVDB_DETAIL_GRIDBATCHDATA_H
-#define FVDB_DETAIL_GRIDBATCHDATA_H
+#ifndef FVDB_GRIDBATCHDATA_H
+#define FVDB_GRIDBATCHDATA_H
 
 #include <fvdb/JaggedTensor.h>
-#include <fvdb/detail/TorchDeviceBuffer.h>
-#include <fvdb/detail/VoxelCoordTransform.h>
+#include <fvdb/TorchDeviceBuffer.h>
+#include <fvdb/VoxelCoordTransform.h>
 
 #include <nanovdb/GridHandle.h>
 #include <nanovdb/NanoVDB.h>
@@ -21,7 +21,6 @@
 #endif
 
 namespace fvdb {
-namespace detail {
 
 struct GridBatchData : public torch::CustomClassHolder {
     static constexpr int64_t MAX_GRIDS_PER_BATCH = 1024; // Maximum number of grids in a batch
@@ -229,37 +228,8 @@ struct GridBatchData : public torch::CustomClassHolder {
     // -----------------------------------------------------------------------
     // Accessors
     // -----------------------------------------------------------------------
-    Accessor
-    hostAccessor() const {
-        TORCH_CHECK(!isEmpty(), "Cannot access empty grid");
-        TORCH_CHECK(mGridHdl->template grid<nanovdb::ValueOnIndex>(),
-                    "Failed to get host grid pointer");
-        return Accessor(mHostGridMetadata,
-                        mGridHdl->template grid<nanovdb::ValueOnIndex>(),
-                        mLeafBatchIndices.data_ptr<fvdb::JIdxType>(),
-                        mBatchMetadata.mTotalVoxels,
-                        mBatchMetadata.mTotalLeaves,
-                        mBatchMetadata.mMaxVoxels,
-                        mBatchMetadata.mMaxLeafCount,
-                        mBatchSize);
-    }
-
-    Accessor
-    deviceAccessor() const {
-        TORCH_CHECK(!isEmpty(), "Cannot access empty grid");
-        TORCH_CHECK(device().is_cuda() || device().is_privateuseone(),
-                    "Cannot access device accessor without a CUDA or PrivateUse1 device");
-        TORCH_CHECK(mGridHdl->template deviceGrid<nanovdb::ValueOnIndex>(),
-                    "Failed to get device grid pointer");
-        return Accessor(mDeviceGridMetadata,
-                        mGridHdl->template deviceGrid<nanovdb::ValueOnIndex>(),
-                        mLeafBatchIndices.data_ptr<fvdb::JIdxType>(),
-                        mBatchMetadata.mTotalVoxels,
-                        mBatchMetadata.mTotalLeaves,
-                        mBatchMetadata.mMaxVoxels,
-                        mBatchMetadata.mMaxLeafCount,
-                        mBatchSize);
-    }
+    Accessor hostAccessor() const;
+    Accessor deviceAccessor() const;
 
     // -----------------------------------------------------------------------
     // Scalar getters
@@ -302,20 +272,9 @@ struct GridBatchData : public torch::CustomClassHolder {
         return sum;
     }
 
-    const nanovdb::GridHandle<TorchDeviceBuffer> &
-    nanoGridHandle() const {
-        return *mGridHdl;
-    }
-
-    const c10::Device
-    device() const {
-        return mGridHdl->buffer().device();
-    }
-
-    bool
-    isEmpty() const {
-        return mGridHdl->buffer().isEmpty();
-    }
+    const nanovdb::GridHandle<TorchDeviceBuffer> &nanoGridHandle() const;
+    const c10::Device device() const;
+    bool isEmpty() const;
 
     bool
     isContiguous() const {
@@ -461,21 +420,8 @@ struct GridBatchData : public torch::CustomClassHolder {
         TORCH_CHECK(!isEmpty(), "Empty grid");
     }
 
-    void
-    checkDevice(const torch::Tensor &t) const {
-        torch::Device hdlDevice = mGridHdl->buffer().device();
-        TORCH_CHECK(hdlDevice == t.device(),
-                    "All tensors must be on the same device (" + hdlDevice.str() +
-                        ") as index grid but got " + t.device().str());
-    }
-
-    void
-    checkDevice(const JaggedTensor &t) const {
-        torch::Device hdlDevice = mGridHdl->buffer().device();
-        TORCH_CHECK(hdlDevice == t.device(),
-                    "All tensors must be on the same device (" + hdlDevice.str() +
-                        ") as index grid but got " + t.device().str());
-    }
+    void checkDevice(const torch::Tensor &t) const;
+    void checkDevice(const JaggedTensor &t) const;
 
     void
     checkDevice(const std::optional<torch::Tensor> t) const {
@@ -499,7 +445,6 @@ struct GridBatchData : public torch::CustomClassHolder {
 
 using BatchGridAccessor = typename GridBatchData::Accessor;
 
-} // namespace detail
 } // namespace fvdb
 
-#endif // FVDB_DETAIL_GRIDBATCHDATA_H
+#endif // FVDB_GRIDBATCHDATA_H

--- a/src/fvdb/JaggedTensor.h
+++ b/src/fvdb/JaggedTensor.h
@@ -4,10 +4,10 @@
 #ifndef FVDB_JAGGEDTENSOR_H
 #define FVDB_JAGGEDTENSOR_H
 
-#include <fvdb/detail/utils/Utils.h>
-
 #include <torch/custom_class.h>
 #include <torch/types.h>
+
+#include <dispatch/dispatch/macros.h>
 
 #include <optional>
 

--- a/src/fvdb/TorchDeviceBuffer.cpp
+++ b/src/fvdb/TorchDeviceBuffer.cpp
@@ -17,12 +17,10 @@ namespace nanovdb {
 template <>
 template <>
 GridHandle<fvdb::TorchDeviceBuffer>
-GridHandle<fvdb::TorchDeviceBuffer>::copy(
-    const fvdb::TorchDeviceBuffer &guide) const {
+GridHandle<fvdb::TorchDeviceBuffer>::copy(const fvdb::TorchDeviceBuffer &guide) const {
     if (mBuffer.isEmpty()) {
         fvdb::TorchDeviceBuffer retbuf(0, guide.device());
-        return GridHandle<fvdb::TorchDeviceBuffer>(
-            std::move(retbuf)); // return an empty handle
+        return GridHandle<fvdb::TorchDeviceBuffer>(std::move(retbuf)); // return an empty handle
     }
 
     const bool guideIsHost   = guide.device().is_cpu();

--- a/src/fvdb/TorchDeviceBuffer.cpp
+++ b/src/fvdb/TorchDeviceBuffer.cpp
@@ -1,7 +1,7 @@
 // Copyright Contributors to the OpenVDB Project
 // SPDX-License-Identifier: Apache-2.0
 //
-#include <fvdb/detail/TorchDeviceBuffer.h>
+#include <fvdb/TorchDeviceBuffer.h>
 
 #include <nanovdb/GridHandle.h>
 #include <nanovdb/cuda/DeviceBuffer.h>
@@ -16,12 +16,12 @@ namespace nanovdb {
 // TODO: Pass in synchronous option
 template <>
 template <>
-GridHandle<fvdb::detail::TorchDeviceBuffer>
-GridHandle<fvdb::detail::TorchDeviceBuffer>::copy(
-    const fvdb::detail::TorchDeviceBuffer &guide) const {
+GridHandle<fvdb::TorchDeviceBuffer>
+GridHandle<fvdb::TorchDeviceBuffer>::copy(
+    const fvdb::TorchDeviceBuffer &guide) const {
     if (mBuffer.isEmpty()) {
-        fvdb::detail::TorchDeviceBuffer retbuf(0, guide.device());
-        return GridHandle<fvdb::detail::TorchDeviceBuffer>(
+        fvdb::TorchDeviceBuffer retbuf(0, guide.device());
+        return GridHandle<fvdb::TorchDeviceBuffer>(
             std::move(retbuf)); // return an empty handle
     }
 
@@ -30,28 +30,28 @@ GridHandle<fvdb::detail::TorchDeviceBuffer>::copy(
     const bool guideIsDevice = !guideIsHost;
     const bool iAmDevice     = !iAmHost;
 
-    auto buffer = fvdb::detail::TorchDeviceBuffer::create(mBuffer.size(), &guide);
+    auto buffer = fvdb::TorchDeviceBuffer::create(mBuffer.size(), &guide);
 
     if (iAmHost && guideIsHost) {
         std::memcpy(buffer.data(),
                     mBuffer.data(),
                     mBuffer.size()); // deep copy of buffer in CPU RAM
-        return GridHandle<fvdb::detail::TorchDeviceBuffer>(std::move(buffer));
+        return GridHandle<fvdb::TorchDeviceBuffer>(std::move(buffer));
     } else if (iAmHost && guideIsDevice) {
         const at::cuda::CUDAGuard device_guard{guide.device()};
         cudaCheck(cudaMemcpy(
             buffer.deviceData(), mBuffer.data(), mBuffer.size(), cudaMemcpyHostToDevice));
-        return GridHandle<fvdb::detail::TorchDeviceBuffer>(std::move(buffer));
+        return GridHandle<fvdb::TorchDeviceBuffer>(std::move(buffer));
     } else if (iAmDevice && guideIsHost) {
         const at::cuda::CUDAGuard device_guard{mBuffer.device()};
         cudaCheck(cudaMemcpy(
             buffer.data(), mBuffer.deviceData(), mBuffer.size(), cudaMemcpyDeviceToHost));
-        return GridHandle<fvdb::detail::TorchDeviceBuffer>(std::move(buffer));
+        return GridHandle<fvdb::TorchDeviceBuffer>(std::move(buffer));
     } else if (iAmDevice && guideIsDevice) {
         const at::cuda::CUDAGuard device_guard{guide.device()};
         cudaCheck(cudaMemcpy(
             buffer.deviceData(), mBuffer.deviceData(), mBuffer.size(), cudaMemcpyDeviceToDevice));
-        return GridHandle<fvdb::detail::TorchDeviceBuffer>(std::move(buffer));
+        return GridHandle<fvdb::TorchDeviceBuffer>(std::move(buffer));
     } else {
         TORCH_CHECK(false, "All host/device combos exhausted. This should never happen.");
     }
@@ -60,7 +60,6 @@ GridHandle<fvdb::detail::TorchDeviceBuffer>::copy(
 } // namespace nanovdb
 
 namespace fvdb {
-namespace detail {
 
 TorchDeviceBuffer::TorchDeviceBuffer(uint64_t size /* = 0*/,
                                      const torch::Device &device /* = torch::kCPU*/)
@@ -221,5 +220,4 @@ TorchDeviceBuffer::create(uint64_t size, const TorchDeviceBuffer *proto, int dev
     }
 }
 
-} // namespace detail
 } // namespace fvdb

--- a/src/fvdb/TorchDeviceBuffer.h
+++ b/src/fvdb/TorchDeviceBuffer.h
@@ -1,8 +1,8 @@
 // Copyright Contributors to the OpenVDB Project
 // SPDX-License-Identifier: Apache-2.0
 //
-#ifndef FVDB_DETAIL_TORCHDEVICEBUFFER_H
-#define FVDB_DETAIL_TORCHDEVICEBUFFER_H
+#ifndef FVDB_TORCHDEVICEBUFFER_H
+#define FVDB_TORCHDEVICEBUFFER_H
 
 #include <nanovdb/GridHandle.h>
 #include <nanovdb/HostBuffer.h> // for BufferTraits
@@ -10,9 +10,6 @@
 #include <torch/types.h>
 
 namespace fvdb {
-namespace detail {
-
-// ----------------------------> TorchDeviceBuffer <--------------------------------------
 
 /// @brief Simple memory buffer using un-managed pinned host memory when compiled with NVCC.
 ///        Obviously this class is making explicit used of CUDA so replace it with your own memory
@@ -92,20 +89,19 @@ class TorchDeviceBuffer {
 
 }; // TorchDeviceBuffer class
 
-} // namespace detail
 } // namespace fvdb
 
 namespace nanovdb {
-template <> struct BufferTraits<fvdb::detail::TorchDeviceBuffer> {
+template <> struct BufferTraits<fvdb::TorchDeviceBuffer> {
     static const bool hasDeviceDual = true;
 };
 
 template <>
 template <>
-GridHandle<fvdb::detail::TorchDeviceBuffer>
-GridHandle<fvdb::detail::TorchDeviceBuffer>::copy<fvdb::detail::TorchDeviceBuffer>(
-    const fvdb::detail::TorchDeviceBuffer &guide) const;
+GridHandle<fvdb::TorchDeviceBuffer>
+GridHandle<fvdb::TorchDeviceBuffer>::copy<fvdb::TorchDeviceBuffer>(
+    const fvdb::TorchDeviceBuffer &guide) const;
 
 } // namespace nanovdb
 
-#endif // FVDB_DETAIL_TORCHDEVICEBUFFER_H
+#endif // FVDB_TORCHDEVICEBUFFER_H

--- a/src/fvdb/TypeTraits.h
+++ b/src/fvdb/TypeTraits.h
@@ -1,0 +1,30 @@
+// Copyright Contributors to the OpenVDB Project
+// SPDX-License-Identifier: Apache-2.0
+//
+#ifndef FVDB_TYPETRAITS_H
+#define FVDB_TYPETRAITS_H
+
+#include <c10/util/Half.h>
+
+#include <type_traits>
+
+namespace fvdb {
+
+/// @brief A helper struct to determine if a type is a floating-point type or a half-precision
+/// floating-point type.
+/// @tparam T The type to check.
+template <class T>
+struct is_floating_point_or_half
+    : std::integral_constant<bool,
+                             // Note: standard floating-point types
+                             std::is_same<float, typename std::remove_cv<T>::type>::value ||
+                                 std::is_same<double, typename std::remove_cv<T>::type>::value ||
+                                 std::is_same<long double, typename std::remove_cv<T>::type>::value
+                                 // Note: extended floating-point types (C++23, if supported)
+                                 ||
+                                 std::is_same<c10::Half, typename std::remove_cv<T>::type>::value> {
+};
+
+} // namespace fvdb
+
+#endif // FVDB_TYPETRAITS_H

--- a/src/fvdb/VoxelCoordTransform.h
+++ b/src/fvdb/VoxelCoordTransform.h
@@ -1,16 +1,15 @@
 // Copyright Contributors to the OpenVDB Project
 // SPDX-License-Identifier: Apache-2.0
 //
-#ifndef FVDB_DETAIL_VOXELCOORDTRANSFORM_H
-#define FVDB_DETAIL_VOXELCOORDTRANSFORM_H
+#ifndef FVDB_VOXELCOORDTRANSFORM_H
+#define FVDB_VOXELCOORDTRANSFORM_H
 
-#include <fvdb/detail/utils/Utils.h>
+#include <fvdb/TypeTraits.h>
 
 #include <nanovdb/NanoVDB.h>
 #include <nanovdb/math/Ray.h>
 
 namespace fvdb {
-namespace detail {
 
 /// @brief A class representing the the transformation from world space (xyz) to voxel space (ijk)
 ///        its inverse, and gradient. It can be applied to points, vectors and rays. It stores the
@@ -332,7 +331,6 @@ voxelTransformForSizeAndOrigin(const nanovdb::Vec3d &voxSize,
     outDual   = VoxelCoordTransform(invW, -tx / w + half);
 }
 
-} // namespace detail
 } // namespace fvdb
 
-#endif // FVDB_DETAIL_VOXELCOORDTRANSFORM_H
+#endif // FVDB_VOXELCOORDTRANSFORM_H

--- a/src/fvdb/detail/GridBatchDataFactory.cu
+++ b/src/fvdb/detail/GridBatchDataFactory.cu
@@ -13,7 +13,7 @@ namespace {
 __global__ void
 computeBatchOffsetsFromMetadata(
     uint32_t numGrids,
-    fvdb::detail::GridBatchData::GridMetadata *perGridMetadata,
+    fvdb::GridBatchData::GridMetadata *perGridMetadata,
     torch::PackedTensorAccessor64<fvdb::JOffsetsType, 1, torch::RestrictPtrTraits>
         outBatchOffsets) {
     if (numGrids == 0) {

--- a/src/fvdb/detail/GridBatchDataFactory.h
+++ b/src/fvdb/detail/GridBatchDataFactory.h
@@ -4,7 +4,7 @@
 #ifndef FVDB_DETAIL_GRIDBATCHDATAFACTORY_H
 #define FVDB_DETAIL_GRIDBATCHDATAFACTORY_H
 
-#include <fvdb/detail/GridBatchData.h>
+#include <fvdb/GridBatchData.h>
 
 #include <torch/types.h>
 

--- a/src/fvdb/detail/dispatch/ForEachActiveVoxel.cuh
+++ b/src/fvdb/detail/dispatch/ForEachActiveVoxel.cuh
@@ -25,7 +25,7 @@
 #include "dispatch/torch/for_each.h"
 #include "dispatch/with_value.h"
 
-#include <fvdb/detail/GridBatchData.h>
+#include <fvdb/GridBatchData.h>
 #include <fvdb/detail/dispatch/GridAccessor.h>
 
 #include <nanovdb/NanoVDB.h>

--- a/src/fvdb/detail/dispatch/GridAccessor.h
+++ b/src/fvdb/detail/dispatch/GridAccessor.h
@@ -16,7 +16,7 @@
 
 #include "dispatch/torch/dispatch.h"
 
-#include <fvdb/detail/GridBatchData.h>
+#include <fvdb/GridBatchData.h>
 
 namespace fvdb {
 namespace detail {

--- a/src/fvdb/detail/io/LoadNanovdb.cpp
+++ b/src/fvdb/detail/io/LoadNanovdb.cpp
@@ -1,7 +1,7 @@
 // Copyright Contributors to the OpenVDB Project
 // SPDX-License-Identifier: Apache-2.0
 //
-#include <fvdb/detail/GridBatchData.h>
+#include <fvdb/GridBatchData.h>
 #include <fvdb/detail/GridBatchDataFactory.h>
 #include <fvdb/detail/io/LoadNanovdb.h>
 #include <fvdb/detail/ops/CloneGrid.h>

--- a/src/fvdb/detail/io/LoadNanovdb.h
+++ b/src/fvdb/detail/io/LoadNanovdb.h
@@ -4,8 +4,8 @@
 #ifndef FVDB_DETAIL_IO_LOADNANOVDB_H
 #define FVDB_DETAIL_IO_LOADNANOVDB_H
 
+#include <fvdb/GridBatchData.h>
 #include <fvdb/JaggedTensor.h>
-#include <fvdb/detail/GridBatchData.h>
 
 #include <tuple>
 

--- a/src/fvdb/detail/io/SaveNanoVDB.h
+++ b/src/fvdb/detail/io/SaveNanoVDB.h
@@ -4,8 +4,8 @@
 #ifndef FVDB_DETAIL_IO_SAVENANOVDB_H
 #define FVDB_DETAIL_IO_SAVENANOVDB_H
 
+#include <fvdb/GridBatchData.h>
 #include <fvdb/JaggedTensor.h>
-#include <fvdb/detail/GridBatchData.h>
 
 #include <tuple>
 

--- a/src/fvdb/detail/ops/ActiveGridCoords.cu
+++ b/src/fvdb/detail/ops/ActiveGridCoords.cu
@@ -1,7 +1,7 @@
 // Copyright Contributors to the OpenVDB Project
 // SPDX-License-Identifier: Apache-2.0
 //
-#include <fvdb/detail/GridBatchData.h>
+#include <fvdb/GridBatchData.h>
 #include <fvdb/detail/ops/ActiveGridCoords.h>
 #include <fvdb/detail/utils/SimpleOpHelper.h>
 #include <fvdb/detail/utils/Utils.h>

--- a/src/fvdb/detail/ops/ActiveGridCoords.h
+++ b/src/fvdb/detail/ops/ActiveGridCoords.h
@@ -4,8 +4,8 @@
 #ifndef FVDB_DETAIL_OPS_ACTIVEGRIDCOORDS_H
 #define FVDB_DETAIL_OPS_ACTIVEGRIDCOORDS_H
 
+#include <fvdb/GridBatchData.h>
 #include <fvdb/JaggedTensor.h>
-#include <fvdb/detail/GridBatchData.h>
 
 namespace fvdb {
 namespace detail {

--- a/src/fvdb/detail/ops/ActiveVoxelsInBoundsMask.cu
+++ b/src/fvdb/detail/ops/ActiveVoxelsInBoundsMask.cu
@@ -1,7 +1,7 @@
 // Copyright Contributors to the OpenVDB Project
 // SPDX-License-Identifier: Apache-2.0
 //
-#include <fvdb/detail/GridBatchData.h>
+#include <fvdb/GridBatchData.h>
 #include <fvdb/detail/ops/ActiveVoxelsInBoundsMask.h>
 #include <fvdb/detail/utils/AccessorHelpers.cuh>
 #include <fvdb/detail/utils/ForEachCPU.h>

--- a/src/fvdb/detail/ops/ActiveVoxelsInBoundsMask.h
+++ b/src/fvdb/detail/ops/ActiveVoxelsInBoundsMask.h
@@ -4,8 +4,8 @@
 #ifndef FVDB_DETAIL_OPS_ACTIVEVOXELSINBOUNDSMASK_H
 #define FVDB_DETAIL_OPS_ACTIVEVOXELSINBOUNDSMASK_H
 
+#include <fvdb/GridBatchData.h>
 #include <fvdb/JaggedTensor.h>
-#include <fvdb/detail/GridBatchData.h>
 
 #include <vector>
 

--- a/src/fvdb/detail/ops/AvgPool.h
+++ b/src/fvdb/detail/ops/AvgPool.h
@@ -4,7 +4,7 @@
 #ifndef FVDB_DETAIL_OPS_AVGPOOL_H
 #define FVDB_DETAIL_OPS_AVGPOOL_H
 
-#include <fvdb/detail/GridBatchData.h>
+#include <fvdb/GridBatchData.h>
 
 #include <torch/types.h>
 

--- a/src/fvdb/detail/ops/BuildCoarseGridFromFine.cu
+++ b/src/fvdb/detail/ops/BuildCoarseGridFromFine.cu
@@ -1,7 +1,7 @@
 // Copyright Contributors to the OpenVDB Project
 // SPDX-License-Identifier: Apache-2.0
 //
-#include <fvdb/detail/GridBatchData.h>
+#include <fvdb/GridBatchData.h>
 #include <fvdb/detail/GridBatchDataFactory.h>
 #include <fvdb/detail/ops/BuildCoarseGridFromFine.h>
 #include <fvdb/detail/ops/BuildGridFromIjk.h>

--- a/src/fvdb/detail/ops/BuildCoarseGridFromFine.h
+++ b/src/fvdb/detail/ops/BuildCoarseGridFromFine.h
@@ -4,7 +4,7 @@
 #ifndef FVDB_DETAIL_OPS_BUILDCOARSEGRIDFROMFINE_H
 #define FVDB_DETAIL_OPS_BUILDCOARSEGRIDFROMFINE_H
 
-#include <fvdb/detail/GridBatchData.h>
+#include <fvdb/GridBatchData.h>
 
 namespace fvdb {
 namespace detail {

--- a/src/fvdb/detail/ops/BuildDenseGrid.cu
+++ b/src/fvdb/detail/ops/BuildDenseGrid.cu
@@ -1,7 +1,7 @@
 // Copyright Contributors to the OpenVDB Project
 // SPDX-License-Identifier: Apache-2.0
 //
-#include <fvdb/detail/GridBatchData.h>
+#include <fvdb/GridBatchData.h>
 #include <fvdb/detail/GridBatchDataFactory.h>
 #include <fvdb/detail/ops/BuildDenseGrid.h>
 #include <fvdb/detail/utils/AccessorHelpers.cuh>

--- a/src/fvdb/detail/ops/BuildDenseGrid.h
+++ b/src/fvdb/detail/ops/BuildDenseGrid.h
@@ -4,7 +4,7 @@
 #ifndef FVDB_DETAIL_OPS_BUILDDENSEGRID_H
 #define FVDB_DETAIL_OPS_BUILDDENSEGRID_H
 
-#include <fvdb/detail/GridBatchData.h>
+#include <fvdb/GridBatchData.h>
 
 #include <torch/types.h>
 

--- a/src/fvdb/detail/ops/BuildDilatedGrid.cu
+++ b/src/fvdb/detail/ops/BuildDilatedGrid.cu
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 #include <fvdb/detail/GridBatchDataFactory.h>
-#include <fvdb/detail/TorchDeviceBuffer.h>
+#include <fvdb/TorchDeviceBuffer.h>
 #include <fvdb/detail/ops/BuildDilatedGrid.h>
 #include <fvdb/detail/ops/CloneGrid.h>
 #include <fvdb/detail/utils/Utils.h>

--- a/src/fvdb/detail/ops/BuildDilatedGrid.cu
+++ b/src/fvdb/detail/ops/BuildDilatedGrid.cu
@@ -1,8 +1,8 @@
 // Copyright Contributors to the OpenVDB Project
 // SPDX-License-Identifier: Apache-2.0
 //
-#include <fvdb/detail/GridBatchDataFactory.h>
 #include <fvdb/TorchDeviceBuffer.h>
+#include <fvdb/detail/GridBatchDataFactory.h>
 #include <fvdb/detail/ops/BuildDilatedGrid.h>
 #include <fvdb/detail/ops/CloneGrid.h>
 #include <fvdb/detail/utils/Utils.h>

--- a/src/fvdb/detail/ops/BuildDilatedGrid.h
+++ b/src/fvdb/detail/ops/BuildDilatedGrid.h
@@ -4,7 +4,7 @@
 #ifndef FVDB_DETAIL_OPS_BUILDDILATEDGRID_H
 #define FVDB_DETAIL_OPS_BUILDDILATEDGRID_H
 
-#include <fvdb/detail/GridBatchData.h>
+#include <fvdb/GridBatchData.h>
 
 #include <cstdint>
 #include <vector>

--- a/src/fvdb/detail/ops/BuildFineGridFromCoarse.cu
+++ b/src/fvdb/detail/ops/BuildFineGridFromCoarse.cu
@@ -1,7 +1,7 @@
 // Copyright Contributors to the OpenVDB Project
 // SPDX-License-Identifier: Apache-2.0
 //
-#include <fvdb/detail/GridBatchData.h>
+#include <fvdb/GridBatchData.h>
 #include <fvdb/detail/GridBatchDataFactory.h>
 #include <fvdb/detail/ops/BuildFineGridFromCoarse.h>
 #include <fvdb/detail/ops/BuildGridFromIjk.h>

--- a/src/fvdb/detail/ops/BuildFineGridFromCoarse.h
+++ b/src/fvdb/detail/ops/BuildFineGridFromCoarse.h
@@ -4,8 +4,8 @@
 #ifndef FVDB_DETAIL_OPS_BUILDFINEGRIDFROMCOARSE_H
 #define FVDB_DETAIL_OPS_BUILDFINEGRIDFROMCOARSE_H
 
+#include <fvdb/GridBatchData.h>
 #include <fvdb/JaggedTensor.h>
-#include <fvdb/detail/GridBatchData.h>
 
 #include <optional>
 

--- a/src/fvdb/detail/ops/BuildGridForConv.cu
+++ b/src/fvdb/detail/ops/BuildGridForConv.cu
@@ -1,7 +1,7 @@
 // Copyright Contributors to the OpenVDB Project
 // SPDX-License-Identifier: Apache-2.0
 //
-#include <fvdb/detail/GridBatchData.h>
+#include <fvdb/GridBatchData.h>
 #include <fvdb/detail/GridBatchDataFactory.h>
 #include <fvdb/detail/ops/BuildGridForConv.h>
 #include <fvdb/detail/ops/BuildGridFromIjk.h>

--- a/src/fvdb/detail/ops/BuildGridForConv.h
+++ b/src/fvdb/detail/ops/BuildGridForConv.h
@@ -4,7 +4,7 @@
 #ifndef FVDB_DETAIL_OPS_BUILDGRIDFORCONV_H
 #define FVDB_DETAIL_OPS_BUILDGRIDFORCONV_H
 
-#include <fvdb/detail/GridBatchData.h>
+#include <fvdb/GridBatchData.h>
 
 namespace fvdb {
 namespace detail {

--- a/src/fvdb/detail/ops/BuildGridForConvTranspose.cu
+++ b/src/fvdb/detail/ops/BuildGridForConvTranspose.cu
@@ -1,7 +1,7 @@
 // Copyright Contributors to the OpenVDB Project
 // SPDX-License-Identifier: Apache-2.0
 //
-#include <fvdb/detail/GridBatchData.h>
+#include <fvdb/GridBatchData.h>
 #include <fvdb/detail/GridBatchDataFactory.h>
 #include <fvdb/detail/ops/BuildFineGridFromCoarse.h>
 #include <fvdb/detail/ops/BuildGridForConvTranspose.h>

--- a/src/fvdb/detail/ops/BuildGridForConvTranspose.h
+++ b/src/fvdb/detail/ops/BuildGridForConvTranspose.h
@@ -7,7 +7,7 @@
 #ifndef FVDB_DETAIL_OPS_BUILDGRIDFORCONVTRANSPOSE_H
 #define FVDB_DETAIL_OPS_BUILDGRIDFORCONVTRANSPOSE_H
 
-#include <fvdb/detail/GridBatchData.h>
+#include <fvdb/GridBatchData.h>
 
 namespace fvdb {
 namespace detail {

--- a/src/fvdb/detail/ops/BuildGridFromIjk.cu
+++ b/src/fvdb/detail/ops/BuildGridFromIjk.cu
@@ -1,7 +1,7 @@
 // Copyright Contributors to the OpenVDB Project
 // SPDX-License-Identifier: Apache-2.0
 //
-#include <fvdb/detail/GridBatchData.h>
+#include <fvdb/GridBatchData.h>
 #include <fvdb/detail/GridBatchDataFactory.h>
 #include <fvdb/detail/ops/BuildGridFromIjk.h>
 #include <fvdb/detail/utils/AccessorHelpers.cuh>

--- a/src/fvdb/detail/ops/BuildGridFromIjk.h
+++ b/src/fvdb/detail/ops/BuildGridFromIjk.h
@@ -4,8 +4,8 @@
 #ifndef FVDB_DETAIL_OPS_BUILDGRIDFROMIJK_H
 #define FVDB_DETAIL_OPS_BUILDGRIDFROMIJK_H
 
+#include <fvdb/GridBatchData.h>
 #include <fvdb/JaggedTensor.h>
-#include <fvdb/detail/GridBatchData.h>
 
 #include <vector>
 

--- a/src/fvdb/detail/ops/BuildGridFromMesh.cu
+++ b/src/fvdb/detail/ops/BuildGridFromMesh.cu
@@ -1,7 +1,7 @@
 // Copyright Contributors to the OpenVDB Project
 // SPDX-License-Identifier: Apache-2.0
 //
-#include <fvdb/detail/GridBatchData.h>
+#include <fvdb/GridBatchData.h>
 #include <fvdb/detail/GridBatchDataFactory.h>
 #include <fvdb/detail/ops/BuildGridFromIjk.h>
 #include <fvdb/detail/ops/BuildGridFromMesh.h>

--- a/src/fvdb/detail/ops/BuildGridFromMesh.h
+++ b/src/fvdb/detail/ops/BuildGridFromMesh.h
@@ -4,8 +4,8 @@
 #ifndef FVDB_DETAIL_OPS_BUILDGRIDFROMMESH_H
 #define FVDB_DETAIL_OPS_BUILDGRIDFROMMESH_H
 
+#include <fvdb/GridBatchData.h>
 #include <fvdb/JaggedTensor.h>
-#include <fvdb/detail/GridBatchData.h>
 
 #include <vector>
 

--- a/src/fvdb/detail/ops/BuildGridFromNearestVoxelsToPoints.cu
+++ b/src/fvdb/detail/ops/BuildGridFromNearestVoxelsToPoints.cu
@@ -1,7 +1,7 @@
 // Copyright Contributors to the OpenVDB Project
 // SPDX-License-Identifier: Apache-2.0
 //
-#include <fvdb/detail/GridBatchData.h>
+#include <fvdb/GridBatchData.h>
 #include <fvdb/detail/GridBatchDataFactory.h>
 #include <fvdb/detail/ops/BuildGridFromIjk.h>
 #include <fvdb/detail/ops/BuildGridFromNearestVoxelsToPoints.h>

--- a/src/fvdb/detail/ops/BuildGridFromNearestVoxelsToPoints.h
+++ b/src/fvdb/detail/ops/BuildGridFromNearestVoxelsToPoints.h
@@ -4,8 +4,8 @@
 #ifndef FVDB_DETAIL_OPS_BUILDGRIDFROMNEARESTVOXELSTOPOINTS_H
 #define FVDB_DETAIL_OPS_BUILDGRIDFROMNEARESTVOXELSTOPOINTS_H
 
+#include <fvdb/GridBatchData.h>
 #include <fvdb/JaggedTensor.h>
-#include <fvdb/detail/GridBatchData.h>
 
 #include <vector>
 

--- a/src/fvdb/detail/ops/BuildGridFromPoints.cu
+++ b/src/fvdb/detail/ops/BuildGridFromPoints.cu
@@ -1,7 +1,7 @@
 // Copyright Contributors to the OpenVDB Project
 // SPDX-License-Identifier: Apache-2.0
 //
-#include <fvdb/detail/GridBatchData.h>
+#include <fvdb/GridBatchData.h>
 #include <fvdb/detail/GridBatchDataFactory.h>
 #include <fvdb/detail/ops/BuildGridFromIjk.h>
 #include <fvdb/detail/ops/BuildGridFromPoints.h>

--- a/src/fvdb/detail/ops/BuildGridFromPoints.h
+++ b/src/fvdb/detail/ops/BuildGridFromPoints.h
@@ -4,8 +4,8 @@
 #ifndef FVDB_DETAIL_OPS_BUILDGRIDFROMPOINTS_H
 #define FVDB_DETAIL_OPS_BUILDGRIDFROMPOINTS_H
 
+#include <fvdb/GridBatchData.h>
 #include <fvdb/JaggedTensor.h>
-#include <fvdb/detail/GridBatchData.h>
 
 #include <vector>
 

--- a/src/fvdb/detail/ops/BuildMergedGrids.cu
+++ b/src/fvdb/detail/ops/BuildMergedGrids.cu
@@ -1,8 +1,8 @@
 // Copyright Contributors to the OpenVDB Project
 // SPDX-License-Identifier: Apache-2.0
 //
-#include <fvdb/detail/GridBatchDataFactory.h>
 #include <fvdb/TorchDeviceBuffer.h>
+#include <fvdb/detail/GridBatchDataFactory.h>
 #include <fvdb/detail/ops/BuildMergedGrids.h>
 #include <fvdb/detail/utils/Utils.h>
 

--- a/src/fvdb/detail/ops/BuildMergedGrids.cu
+++ b/src/fvdb/detail/ops/BuildMergedGrids.cu
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 #include <fvdb/detail/GridBatchDataFactory.h>
-#include <fvdb/detail/TorchDeviceBuffer.h>
+#include <fvdb/TorchDeviceBuffer.h>
 #include <fvdb/detail/ops/BuildMergedGrids.h>
 #include <fvdb/detail/utils/Utils.h>
 

--- a/src/fvdb/detail/ops/BuildMergedGrids.h
+++ b/src/fvdb/detail/ops/BuildMergedGrids.h
@@ -4,7 +4,7 @@
 #ifndef FVDB_DETAIL_OPS_BUILDMERGEDGRIDS_H
 #define FVDB_DETAIL_OPS_BUILDMERGEDGRIDS_H
 
-#include <fvdb/detail/GridBatchData.h>
+#include <fvdb/GridBatchData.h>
 
 namespace fvdb {
 namespace detail {

--- a/src/fvdb/detail/ops/BuildPaddedGrid.cu
+++ b/src/fvdb/detail/ops/BuildPaddedGrid.cu
@@ -1,7 +1,7 @@
 // Copyright Contributors to the OpenVDB Project
 // SPDX-License-Identifier: Apache-2.0
 //
-#include <fvdb/detail/GridBatchData.h>
+#include <fvdb/GridBatchData.h>
 #include <fvdb/detail/GridBatchDataFactory.h>
 #include <fvdb/detail/ops/BuildGridFromIjk.h>
 #include <fvdb/detail/ops/BuildPaddedGrid.h>

--- a/src/fvdb/detail/ops/BuildPaddedGrid.h
+++ b/src/fvdb/detail/ops/BuildPaddedGrid.h
@@ -4,7 +4,7 @@
 #ifndef FVDB_DETAIL_OPS_BUILDPADDEDGRID_H
 #define FVDB_DETAIL_OPS_BUILDPADDEDGRID_H
 
-#include <fvdb/detail/GridBatchData.h>
+#include <fvdb/GridBatchData.h>
 
 namespace fvdb {
 namespace detail {

--- a/src/fvdb/detail/ops/BuildPrunedGrid.cu
+++ b/src/fvdb/detail/ops/BuildPrunedGrid.cu
@@ -1,10 +1,10 @@
 // Copyright Contributors to the OpenVDB Project
 // SPDX-License-Identifier: Apache-2.0
 //
+#include <fvdb/GridBatchData.h>
 #include <fvdb/JaggedTensor.h>
-#include <fvdb/detail/GridBatchData.h>
 #include <fvdb/detail/GridBatchDataFactory.h>
-#include <fvdb/detail/TorchDeviceBuffer.h>
+#include <fvdb/TorchDeviceBuffer.h>
 #include <fvdb/detail/ops/BuildPrunedGrid.h>
 #include <fvdb/detail/utils/Utils.h>
 #include <fvdb/detail/utils/nanovdb/CreateEmptyGridHandle.h>

--- a/src/fvdb/detail/ops/BuildPrunedGrid.cu
+++ b/src/fvdb/detail/ops/BuildPrunedGrid.cu
@@ -3,8 +3,8 @@
 //
 #include <fvdb/GridBatchData.h>
 #include <fvdb/JaggedTensor.h>
-#include <fvdb/detail/GridBatchDataFactory.h>
 #include <fvdb/TorchDeviceBuffer.h>
+#include <fvdb/detail/GridBatchDataFactory.h>
 #include <fvdb/detail/ops/BuildPrunedGrid.h>
 #include <fvdb/detail/utils/Utils.h>
 #include <fvdb/detail/utils/nanovdb/CreateEmptyGridHandle.h>

--- a/src/fvdb/detail/ops/BuildPrunedGrid.h
+++ b/src/fvdb/detail/ops/BuildPrunedGrid.h
@@ -4,8 +4,8 @@
 #ifndef FVDB_DETAIL_OPS_BUILDPRUNEDGRID_H
 #define FVDB_DETAIL_OPS_BUILDPRUNEDGRID_H
 
+#include <fvdb/GridBatchData.h>
 #include <fvdb/JaggedTensor.h>
-#include <fvdb/detail/GridBatchData.h>
 
 namespace fvdb {
 namespace detail {

--- a/src/fvdb/detail/ops/ClipGrid.h
+++ b/src/fvdb/detail/ops/ClipGrid.h
@@ -4,8 +4,8 @@
 #ifndef FVDB_DETAIL_OPS_CLIPGRID_H
 #define FVDB_DETAIL_OPS_CLIPGRID_H
 
+#include <fvdb/GridBatchData.h>
 #include <fvdb/JaggedTensor.h>
-#include <fvdb/detail/GridBatchData.h>
 
 #include <nanovdb/NanoVDB.h>
 

--- a/src/fvdb/detail/ops/CloneGrid.h
+++ b/src/fvdb/detail/ops/CloneGrid.h
@@ -4,7 +4,7 @@
 #ifndef FVDB_DETAIL_OPS_CLONEGRID_H
 #define FVDB_DETAIL_OPS_CLONEGRID_H
 
-#include <fvdb/detail/GridBatchData.h>
+#include <fvdb/GridBatchData.h>
 
 namespace fvdb {
 namespace detail {

--- a/src/fvdb/detail/ops/CoarseIjkForFineGrid.h
+++ b/src/fvdb/detail/ops/CoarseIjkForFineGrid.h
@@ -4,8 +4,8 @@
 #ifndef FVDB_DETAIL_OPS_COARSEIJKFORFINEGRID_H
 #define FVDB_DETAIL_OPS_COARSEIJKFORFINEGRID_H
 
+#include <fvdb/GridBatchData.h>
 #include <fvdb/JaggedTensor.h>
-#include <fvdb/detail/GridBatchData.h>
 
 namespace fvdb {
 namespace detail {

--- a/src/fvdb/detail/ops/ConcatenateGrids.h
+++ b/src/fvdb/detail/ops/ConcatenateGrids.h
@@ -4,7 +4,7 @@
 #ifndef FVDB_DETAIL_OPS_CONCATENATEGRIDS_H
 #define FVDB_DETAIL_OPS_CONCATENATEGRIDS_H
 
-#include <fvdb/detail/GridBatchData.h>
+#include <fvdb/GridBatchData.h>
 
 #include <vector>
 

--- a/src/fvdb/detail/ops/CoordsInGrid.h
+++ b/src/fvdb/detail/ops/CoordsInGrid.h
@@ -4,8 +4,8 @@
 #ifndef FVDB_DETAIL_OPS_COORDSINGRID_H
 #define FVDB_DETAIL_OPS_COORDSINGRID_H
 
+#include <fvdb/GridBatchData.h>
 #include <fvdb/JaggedTensor.h>
-#include <fvdb/detail/GridBatchData.h>
 
 namespace fvdb {
 namespace detail {

--- a/src/fvdb/detail/ops/CubesInGrid.h
+++ b/src/fvdb/detail/ops/CubesInGrid.h
@@ -4,8 +4,8 @@
 #ifndef FVDB_DETAIL_OPS_CUBESINGRID_H
 #define FVDB_DETAIL_OPS_CUBESINGRID_H
 
+#include <fvdb/GridBatchData.h>
 #include <fvdb/JaggedTensor.h>
-#include <fvdb/detail/GridBatchData.h>
 #include <fvdb/detail/utils/Utils.h>
 
 #include <nanovdb/NanoVDB.h>

--- a/src/fvdb/detail/ops/GridEdgeNetwork.h
+++ b/src/fvdb/detail/ops/GridEdgeNetwork.h
@@ -4,8 +4,8 @@
 #ifndef FVDB_DETAIL_OPS_GRIDEDGENETWORK_H
 #define FVDB_DETAIL_OPS_GRIDEDGENETWORK_H
 
+#include <fvdb/GridBatchData.h>
 #include <fvdb/JaggedTensor.h>
-#include <fvdb/detail/GridBatchData.h>
 
 #include <vector>
 

--- a/src/fvdb/detail/ops/IjkForMesh.cu
+++ b/src/fvdb/detail/ops/IjkForMesh.cu
@@ -3,6 +3,7 @@
 //
 #include <fvdb/detail/ops/IjkForMesh.h>
 #include <fvdb/detail/utils/AccessorHelpers.cuh>
+#include <fvdb/detail/utils/Utils.h>
 #include <fvdb/detail/utils/cuda/ForEachCUDA.cuh>
 #include <fvdb/detail/utils/cuda/GridDim.h>
 #include <fvdb/detail/utils/cuda/RAIIRawDeviceBuffer.h>

--- a/src/fvdb/detail/ops/IjkForMesh.h
+++ b/src/fvdb/detail/ops/IjkForMesh.h
@@ -5,7 +5,7 @@
 #define FVDB_DETAIL_OPS_IJKFORMESH_H
 
 #include <fvdb/JaggedTensor.h>
-#include <fvdb/detail/VoxelCoordTransform.h>
+#include <fvdb/VoxelCoordTransform.h>
 
 #include <vector>
 

--- a/src/fvdb/detail/ops/IjkToIndex.h
+++ b/src/fvdb/detail/ops/IjkToIndex.h
@@ -4,8 +4,8 @@
 #ifndef FVDB_DETAIL_OPS_IJKTOINDEX_H
 #define FVDB_DETAIL_OPS_IJKTOINDEX_H
 
+#include <fvdb/GridBatchData.h>
 #include <fvdb/JaggedTensor.h>
-#include <fvdb/detail/GridBatchData.h>
 
 namespace fvdb {
 namespace detail {

--- a/src/fvdb/detail/ops/IjkToInvIndex.h
+++ b/src/fvdb/detail/ops/IjkToInvIndex.h
@@ -4,8 +4,8 @@
 #ifndef FVDB_DETAIL_OPS_IJKTOINVINDEX_H
 #define FVDB_DETAIL_OPS_IJKTOINVINDEX_H
 
+#include <fvdb/GridBatchData.h>
 #include <fvdb/JaggedTensor.h>
-#include <fvdb/detail/GridBatchData.h>
 
 namespace fvdb {
 namespace detail {

--- a/src/fvdb/detail/ops/IndexGrid.cu
+++ b/src/fvdb/detail/ops/IndexGrid.cu
@@ -9,8 +9,8 @@
 namespace {
 
 template <typename Indexable>
-c10::intrusive_ptr<fvdb::detail::GridBatchData>
-indexGridInternal(const fvdb::detail::GridBatchData &grid, const Indexable &idx, int64_t size) {
+c10::intrusive_ptr<fvdb::GridBatchData>
+indexGridInternal(const fvdb::GridBatchData &grid, const Indexable &idx, int64_t size) {
     using namespace fvdb::detail;
 
     if (size == 0) {
@@ -19,8 +19,8 @@ indexGridInternal(const fvdb::detail::GridBatchData &grid, const Indexable &idx,
     TORCH_CHECK(size >= 0,
                 "Indexing with negative size is not supported (this should never happen)");
 
-    GridBatchData::GridMetadata *hostMeta   = allocateHostGridMetadata(size);
-    GridBatchData::GridMetadata *deviceMeta = nullptr;
+    fvdb::GridBatchData::GridMetadata *hostMeta   = allocateHostGridMetadata(size);
+    fvdb::GridBatchData::GridMetadata *deviceMeta = nullptr;
 
     const torch::Device device = grid.device();
     if (device.is_cuda()) {
@@ -70,7 +70,7 @@ indexGridInternal(const fvdb::detail::GridBatchData &grid, const Indexable &idx,
         count += 1;
     }
 
-    GridBatchData::GridBatchMetadata batchMeta;
+    fvdb::GridBatchData::GridBatchMetadata batchMeta;
     batchMeta.mIsContiguous = isContiguous && (count == grid.batchSize());
     batchMeta.mTotalLeaves  = cumLeaves;
     batchMeta.mTotalVoxels  = cumVoxels;
@@ -96,14 +96,14 @@ indexGridInternal(const fvdb::detail::GridBatchData &grid, const Indexable &idx,
         listIndices = grid.mListIndices;
     }
 
-    return c10::make_intrusive<GridBatchData>(grid.mGridHdl,
-                                              hostMeta,
-                                              deviceMeta,
-                                              size,
-                                              std::move(batchMeta),
-                                              std::move(leafBatchIndices),
-                                              std::move(batchOffsets),
-                                              std::move(listIndices));
+    return c10::make_intrusive<fvdb::GridBatchData>(grid.mGridHdl,
+                                                    hostMeta,
+                                                    deviceMeta,
+                                                    size,
+                                                    std::move(batchMeta),
+                                                    std::move(leafBatchIndices),
+                                                    std::move(batchOffsets),
+                                                    std::move(listIndices));
 }
 
 struct RangeAccessor {

--- a/src/fvdb/detail/ops/IndexGrid.h
+++ b/src/fvdb/detail/ops/IndexGrid.h
@@ -4,7 +4,7 @@
 #ifndef FVDB_DETAIL_OPS_INDEXGRID_H
 #define FVDB_DETAIL_OPS_INDEXGRID_H
 
-#include <fvdb/detail/GridBatchData.h>
+#include <fvdb/GridBatchData.h>
 
 #include <cstdint>
 #include <vector>

--- a/src/fvdb/detail/ops/Inject.cu
+++ b/src/fvdb/detail/ops/Inject.cu
@@ -1,9 +1,9 @@
 // Copyright Contributors to the OpenVDB Project
 // SPDX-License-Identifier: Apache-2.0
 //
+#include <fvdb/GridBatchData.h>
 #include <fvdb/JaggedTensor.h>
-#include <fvdb/detail/GridBatchData.h>
-#include <fvdb/detail/TorchDeviceBuffer.h>
+#include <fvdb/TorchDeviceBuffer.h>
 #include <fvdb/detail/ops/Inject.h>
 #include <fvdb/detail/utils/Utils.h>
 #include <fvdb/detail/utils/cuda/Utils.cuh>

--- a/src/fvdb/detail/ops/Inject.h
+++ b/src/fvdb/detail/ops/Inject.h
@@ -4,8 +4,8 @@
 #ifndef FVDB_DETAIL_OPS_INJECT_H
 #define FVDB_DETAIL_OPS_INJECT_H
 
+#include <fvdb/GridBatchData.h>
 #include <fvdb/JaggedTensor.h>
-#include <fvdb/detail/GridBatchData.h>
 
 #include <torch/types.h>
 

--- a/src/fvdb/detail/ops/InjectFromDense.h
+++ b/src/fvdb/detail/ops/InjectFromDense.h
@@ -4,7 +4,7 @@
 #ifndef FVDB_DETAIL_OPS_INJECTFROMDENSE_H
 #define FVDB_DETAIL_OPS_INJECTFROMDENSE_H
 
-#include <fvdb/detail/GridBatchData.h>
+#include <fvdb/GridBatchData.h>
 
 #include <torch/types.h>
 

--- a/src/fvdb/detail/ops/InjectToDense.h
+++ b/src/fvdb/detail/ops/InjectToDense.h
@@ -4,7 +4,7 @@
 #ifndef FVDB_DETAIL_OPS_INJECTTODENSE_H
 #define FVDB_DETAIL_OPS_INJECTTODENSE_H
 
-#include <fvdb/detail/GridBatchData.h>
+#include <fvdb/GridBatchData.h>
 
 #include <torch/types.h>
 

--- a/src/fvdb/detail/ops/IntegrateTSDF.cu
+++ b/src/fvdb/detail/ops/IntegrateTSDF.cu
@@ -1,8 +1,8 @@
 // Copyright Contributors to the OpenVDB Project
 // SPDX-License-Identifier: Apache-2.0
 //
+#include <fvdb/GridBatchData.h>
 #include <fvdb/JaggedTensor.h>
-#include <fvdb/detail/GridBatchData.h>
 #include <fvdb/detail/ops/BuildDilatedGrid.h>
 #include <fvdb/detail/ops/BuildGridFromPoints.h>
 #include <fvdb/detail/ops/BuildMergedGrids.h>
@@ -107,8 +107,8 @@ integrateTSDFKernel(const ScalarDataType truncationMargin,
                     const fvdb::TorchRAcc64<ScalarDataType, 3> depthImages,
                     const fvdb::TorchRAcc64<FeatureScalarDataType, 4> featureImages,
                     const fvdb::TorchRAcc64<ScalarDataType, 3> weightImages,
-                    const fvdb::detail::BatchGridAccessor baseGridAcc,
-                    const fvdb::detail::BatchGridAccessor unionGridAcc,
+                    const fvdb::BatchGridAccessor baseGridAcc,
+                    const fvdb::BatchGridAccessor unionGridAcc,
                     const fvdb::JaggedRAcc64<ScalarDataType, 1> tsdfAcc,
                     const fvdb::JaggedRAcc64<ScalarDataType, 1> weightsAcc,
                     const fvdb::JaggedRAcc64<FeatureScalarDataType, 2> featuresAcc,

--- a/src/fvdb/detail/ops/IntegrateTSDF.h
+++ b/src/fvdb/detail/ops/IntegrateTSDF.h
@@ -4,8 +4,8 @@
 #ifndef FVDB_DETAIL_OPS_INTEGRATETSDF_H
 #define FVDB_DETAIL_OPS_INTEGRATETSDF_H
 
+#include <fvdb/GridBatchData.h>
 #include <fvdb/JaggedTensor.h>
-#include <fvdb/detail/GridBatchData.h>
 
 #include <torch/types.h>
 

--- a/src/fvdb/detail/ops/JIdxForGrid.cu
+++ b/src/fvdb/detail/ops/JIdxForGrid.cu
@@ -1,7 +1,7 @@
 // Copyright Contributors to the OpenVDB Project
 // SPDX-License-Identifier: Apache-2.0
 //
-#include <fvdb/detail/GridBatchData.h>
+#include <fvdb/GridBatchData.h>
 #include <fvdb/detail/ops/JIdxForGrid.h>
 #include <fvdb/detail/ops/JIdxForJOffsets.h>
 #include <fvdb/detail/utils/Utils.h>

--- a/src/fvdb/detail/ops/JIdxForGrid.h
+++ b/src/fvdb/detail/ops/JIdxForGrid.h
@@ -4,7 +4,7 @@
 #ifndef FVDB_DETAIL_OPS_JIDXFORGRID_H
 #define FVDB_DETAIL_OPS_JIDXFORGRID_H
 
-#include <fvdb/detail/GridBatchData.h>
+#include <fvdb/GridBatchData.h>
 
 #include <torch/types.h>
 

--- a/src/fvdb/detail/ops/MakeContiguous.h
+++ b/src/fvdb/detail/ops/MakeContiguous.h
@@ -4,7 +4,7 @@
 #ifndef FVDB_DETAIL_OPS_MAKECONTIGUOUS_H
 #define FVDB_DETAIL_OPS_MAKECONTIGUOUS_H
 
-#include <fvdb/detail/GridBatchData.h>
+#include <fvdb/GridBatchData.h>
 
 namespace fvdb {
 namespace detail {

--- a/src/fvdb/detail/ops/MarchingCubes.h
+++ b/src/fvdb/detail/ops/MarchingCubes.h
@@ -4,8 +4,8 @@
 #ifndef FVDB_DETAIL_OPS_MARCHINGCUBES_H
 #define FVDB_DETAIL_OPS_MARCHINGCUBES_H
 
+#include <fvdb/GridBatchData.h>
 #include <fvdb/JaggedTensor.h>
-#include <fvdb/detail/GridBatchData.h>
 
 #include <torch/types.h>
 

--- a/src/fvdb/detail/ops/MaxPool.h
+++ b/src/fvdb/detail/ops/MaxPool.h
@@ -4,7 +4,7 @@
 #ifndef FVDB_DETAIL_OPS_MAXPOOL_H
 #define FVDB_DETAIL_OPS_MAXPOOL_H
 
-#include <fvdb/detail/GridBatchData.h>
+#include <fvdb/GridBatchData.h>
 
 #include <torch/types.h>
 

--- a/src/fvdb/detail/ops/NearestIjkForPoints.cu
+++ b/src/fvdb/detail/ops/NearestIjkForPoints.cu
@@ -3,8 +3,8 @@
 //
 #include <fvdb/detail/ops/NearestIjkForPoints.h>
 #include <fvdb/detail/utils/AccessorHelpers.cuh>
-#include <fvdb/detail/utils/Utils.h>
 #include <fvdb/detail/utils/ForEachCPU.h>
+#include <fvdb/detail/utils/Utils.h>
 #include <fvdb/detail/utils/cuda/ForEachCUDA.cuh>
 #include <fvdb/detail/utils/cuda/RAIIRawDeviceBuffer.h>
 

--- a/src/fvdb/detail/ops/NearestIjkForPoints.cu
+++ b/src/fvdb/detail/ops/NearestIjkForPoints.cu
@@ -3,6 +3,7 @@
 //
 #include <fvdb/detail/ops/NearestIjkForPoints.h>
 #include <fvdb/detail/utils/AccessorHelpers.cuh>
+#include <fvdb/detail/utils/Utils.h>
 #include <fvdb/detail/utils/ForEachCPU.h>
 #include <fvdb/detail/utils/cuda/ForEachCUDA.cuh>
 #include <fvdb/detail/utils/cuda/RAIIRawDeviceBuffer.h>

--- a/src/fvdb/detail/ops/NearestIjkForPoints.h
+++ b/src/fvdb/detail/ops/NearestIjkForPoints.h
@@ -5,7 +5,7 @@
 #define FVDB_DETAIL_OPS_NEARESTIJKFORPOINTS_H
 
 #include <fvdb/JaggedTensor.h>
-#include <fvdb/detail/VoxelCoordTransform.h>
+#include <fvdb/VoxelCoordTransform.h>
 
 #include <vector>
 

--- a/src/fvdb/detail/ops/NeighborIndexes.h
+++ b/src/fvdb/detail/ops/NeighborIndexes.h
@@ -4,8 +4,8 @@
 #ifndef FVDB_DETAIL_OPS_NEIGHBORINDEXES_H
 #define FVDB_DETAIL_OPS_NEIGHBORINDEXES_H
 
+#include <fvdb/GridBatchData.h>
 #include <fvdb/JaggedTensor.h>
-#include <fvdb/detail/GridBatchData.h>
 
 #include <cstdint>
 

--- a/src/fvdb/detail/ops/PointsInGrid.h
+++ b/src/fvdb/detail/ops/PointsInGrid.h
@@ -4,8 +4,8 @@
 #ifndef FVDB_DETAIL_OPS_POINTSINGRID_H
 #define FVDB_DETAIL_OPS_POINTSINGRID_H
 
+#include <fvdb/GridBatchData.h>
 #include <fvdb/JaggedTensor.h>
-#include <fvdb/detail/GridBatchData.h>
 
 namespace fvdb {
 namespace detail {

--- a/src/fvdb/detail/ops/PopulateGridMetadata.cu
+++ b/src/fvdb/detail/ops/PopulateGridMetadata.cu
@@ -1,7 +1,7 @@
 // Copyright Contributors to the OpenVDB Project
 // SPDX-License-Identifier: Apache-2.0
 //
-#include <fvdb/detail/GridBatchData.h>
+#include <fvdb/GridBatchData.h>
 #include <fvdb/detail/ops/PopulateGridMetadata.h>
 #include <fvdb/detail/utils/AccessorHelpers.cuh>
 #include <fvdb/detail/utils/Utils.h>

--- a/src/fvdb/detail/ops/PopulateGridMetadata.h
+++ b/src/fvdb/detail/ops/PopulateGridMetadata.h
@@ -4,7 +4,7 @@
 #ifndef FVDB_DETAIL_OPS_POPULATEGRIDMETADATA_H
 #define FVDB_DETAIL_OPS_POPULATEGRIDMETADATA_H
 
-#include <fvdb/detail/GridBatchData.h>
+#include <fvdb/GridBatchData.h>
 
 #include <torch/types.h>
 

--- a/src/fvdb/detail/ops/RayImplicitIntersection.h
+++ b/src/fvdb/detail/ops/RayImplicitIntersection.h
@@ -4,8 +4,8 @@
 #ifndef FVDB_DETAIL_OPS_RAYIMPLICITINTERSECTION_H
 #define FVDB_DETAIL_OPS_RAYIMPLICITINTERSECTION_H
 
+#include <fvdb/GridBatchData.h>
 #include <fvdb/JaggedTensor.h>
-#include <fvdb/detail/GridBatchData.h>
 
 #include <torch/types.h>
 

--- a/src/fvdb/detail/ops/Refine.cu
+++ b/src/fvdb/detail/ops/Refine.cu
@@ -3,6 +3,7 @@
 //
 #include <fvdb/detail/ops/Refine.h>
 #include <fvdb/detail/utils/AccessorHelpers.cuh>
+#include <fvdb/detail/utils/Utils.h>
 #include <fvdb/detail/utils/ForEachCPU.h>
 #include <fvdb/detail/utils/cuda/ForEachCUDA.cuh>
 #include <fvdb/detail/utils/cuda/ForEachPrivateUse1.cuh>

--- a/src/fvdb/detail/ops/Refine.cu
+++ b/src/fvdb/detail/ops/Refine.cu
@@ -3,8 +3,8 @@
 //
 #include <fvdb/detail/ops/Refine.h>
 #include <fvdb/detail/utils/AccessorHelpers.cuh>
-#include <fvdb/detail/utils/Utils.h>
 #include <fvdb/detail/utils/ForEachCPU.h>
+#include <fvdb/detail/utils/Utils.h>
 #include <fvdb/detail/utils/cuda/ForEachCUDA.cuh>
 #include <fvdb/detail/utils/cuda/ForEachPrivateUse1.cuh>
 
@@ -59,8 +59,7 @@ upsampleNearestVoxelCallback(int32_t batchIdx,
 
 template <typename Dtype,
           torch::DeviceType DeviceTag,
-          template <typename T, int32_t D>
-          typename TensorAccessor>
+          template <typename T, int32_t D> typename TensorAccessor>
 __hostdev__ inline void
 upsampleNearestBackwardsVoxelCallback(int32_t batchIdx,
                                       int32_t leafIdx,

--- a/src/fvdb/detail/ops/Refine.cu
+++ b/src/fvdb/detail/ops/Refine.cu
@@ -59,7 +59,8 @@ upsampleNearestVoxelCallback(int32_t batchIdx,
 
 template <typename Dtype,
           torch::DeviceType DeviceTag,
-          template <typename T, int32_t D> typename TensorAccessor>
+          template <typename T, int32_t D>
+          typename TensorAccessor>
 __hostdev__ inline void
 upsampleNearestBackwardsVoxelCallback(int32_t batchIdx,
                                       int32_t leafIdx,

--- a/src/fvdb/detail/ops/Refine.h
+++ b/src/fvdb/detail/ops/Refine.h
@@ -4,7 +4,7 @@
 #ifndef FVDB_DETAIL_OPS_REFINE_H
 #define FVDB_DETAIL_OPS_REFINE_H
 
-#include <fvdb/detail/GridBatchData.h>
+#include <fvdb/GridBatchData.h>
 #include <fvdb/detail/utils/Utils.h>
 
 #include <torch/types.h>

--- a/src/fvdb/detail/ops/SampleBezier.h
+++ b/src/fvdb/detail/ops/SampleBezier.h
@@ -4,8 +4,8 @@
 #ifndef FVDB_DETAIL_OPS_SAMPLEBEZIER_H
 #define FVDB_DETAIL_OPS_SAMPLEBEZIER_H
 
+#include <fvdb/GridBatchData.h>
 #include <fvdb/JaggedTensor.h>
-#include <fvdb/detail/GridBatchData.h>
 
 #include <torch/types.h>
 

--- a/src/fvdb/detail/ops/SampleBezierWithGrad.h
+++ b/src/fvdb/detail/ops/SampleBezierWithGrad.h
@@ -4,8 +4,8 @@
 #ifndef FVDB_DETAIL_OPS_SAMPLEBEZIERWITHGRAD_H
 #define FVDB_DETAIL_OPS_SAMPLEBEZIERWITHGRAD_H
 
+#include <fvdb/GridBatchData.h>
 #include <fvdb/JaggedTensor.h>
-#include <fvdb/detail/GridBatchData.h>
 
 #include <torch/types.h>
 

--- a/src/fvdb/detail/ops/SampleBezierWithGradBackward.h
+++ b/src/fvdb/detail/ops/SampleBezierWithGradBackward.h
@@ -4,8 +4,8 @@
 #ifndef FVDB_DETAIL_OPS_SAMPLEBEZIERWITHGRADBACKWARD_H
 #define FVDB_DETAIL_OPS_SAMPLEBEZIERWITHGRADBACKWARD_H
 
+#include <fvdb/GridBatchData.h>
 #include <fvdb/JaggedTensor.h>
-#include <fvdb/detail/GridBatchData.h>
 
 #include <torch/types.h>
 

--- a/src/fvdb/detail/ops/SampleRaysUniform.h
+++ b/src/fvdb/detail/ops/SampleRaysUniform.h
@@ -4,8 +4,8 @@
 #ifndef FVDB_DETAIL_OPS_SAMPLERAYSUNIFORM_H
 #define FVDB_DETAIL_OPS_SAMPLERAYSUNIFORM_H
 
+#include <fvdb/GridBatchData.h>
 #include <fvdb/JaggedTensor.h>
-#include <fvdb/detail/GridBatchData.h>
 
 #include <torch/types.h>
 

--- a/src/fvdb/detail/ops/SampleTrilinear.h
+++ b/src/fvdb/detail/ops/SampleTrilinear.h
@@ -4,8 +4,8 @@
 #ifndef FVDB_DETAIL_OPS_SAMPLETRILINEAR_H
 #define FVDB_DETAIL_OPS_SAMPLETRILINEAR_H
 
+#include <fvdb/GridBatchData.h>
 #include <fvdb/JaggedTensor.h>
-#include <fvdb/detail/GridBatchData.h>
 
 #include <torch/types.h>
 

--- a/src/fvdb/detail/ops/SampleTrilinearWithGrad.h
+++ b/src/fvdb/detail/ops/SampleTrilinearWithGrad.h
@@ -4,8 +4,8 @@
 #ifndef FVDB_DETAIL_OPS_SAMPLETRILINEARWITHGRAD_H
 #define FVDB_DETAIL_OPS_SAMPLETRILINEARWITHGRAD_H
 
+#include <fvdb/GridBatchData.h>
 #include <fvdb/JaggedTensor.h>
-#include <fvdb/detail/GridBatchData.h>
 
 #include <torch/types.h>
 

--- a/src/fvdb/detail/ops/SampleTrilinearWithGradBackward.h
+++ b/src/fvdb/detail/ops/SampleTrilinearWithGradBackward.h
@@ -4,8 +4,8 @@
 #ifndef FVDB_DETAIL_OPS_SAMPLETRILINEARWITHGRADBACKWARD_H
 #define FVDB_DETAIL_OPS_SAMPLETRILINEARWITHGRADBACKWARD_H
 
+#include <fvdb/GridBatchData.h>
 #include <fvdb/JaggedTensor.h>
-#include <fvdb/detail/GridBatchData.h>
 
 #include <torch/types.h>
 

--- a/src/fvdb/detail/ops/SegmentsAlongRays.h
+++ b/src/fvdb/detail/ops/SegmentsAlongRays.h
@@ -4,8 +4,8 @@
 #ifndef FVDB_DETAIL_OPS_SEGMENTSALONGRAYS_H
 #define FVDB_DETAIL_OPS_SEGMENTSALONGRAYS_H
 
+#include <fvdb/GridBatchData.h>
 #include <fvdb/JaggedTensor.h>
-#include <fvdb/detail/GridBatchData.h>
 
 #include <torch/types.h>
 

--- a/src/fvdb/detail/ops/SerializeEncode.cu
+++ b/src/fvdb/detail/ops/SerializeEncode.cu
@@ -1,7 +1,7 @@
 // Copyright Contributors to the OpenVDB Project
 // SPDX-License-Identifier: Apache-2.0
 //
-#include <fvdb/detail/GridBatchData.h>
+#include <fvdb/GridBatchData.h>
 #include <fvdb/detail/ops/SerializeEncode.h>
 #include <fvdb/detail/utils/HilbertCode.h>
 #include <fvdb/detail/utils/MortonCode.h>

--- a/src/fvdb/detail/ops/SerializeEncode.h
+++ b/src/fvdb/detail/ops/SerializeEncode.h
@@ -4,9 +4,9 @@
 #ifndef FVDB_DETAIL_OPS_SERIALIZEENCODE_H
 #define FVDB_DETAIL_OPS_SERIALIZEENCODE_H
 
+#include <fvdb/GridBatchData.h>
 #include <fvdb/JaggedTensor.h>
 #include <fvdb/Types.h>
-#include <fvdb/detail/GridBatchData.h>
 
 namespace fvdb {
 namespace detail {

--- a/src/fvdb/detail/ops/SerializeGrid.h
+++ b/src/fvdb/detail/ops/SerializeGrid.h
@@ -4,7 +4,7 @@
 #ifndef FVDB_DETAIL_OPS_SERIALIZEGRID_H
 #define FVDB_DETAIL_OPS_SERIALIZEGRID_H
 
-#include <fvdb/detail/GridBatchData.h>
+#include <fvdb/GridBatchData.h>
 
 namespace fvdb {
 namespace detail {

--- a/src/fvdb/detail/ops/SplatBezier.h
+++ b/src/fvdb/detail/ops/SplatBezier.h
@@ -4,8 +4,8 @@
 #ifndef FVDB_DETAIL_OPS_SPLATBEZIER_H
 #define FVDB_DETAIL_OPS_SPLATBEZIER_H
 
+#include <fvdb/GridBatchData.h>
 #include <fvdb/JaggedTensor.h>
-#include <fvdb/detail/GridBatchData.h>
 
 #include <torch/types.h>
 

--- a/src/fvdb/detail/ops/SplatTrilinear.h
+++ b/src/fvdb/detail/ops/SplatTrilinear.h
@@ -4,8 +4,8 @@
 #ifndef FVDB_DETAIL_OPS_SPLATTRILINEAR_H
 #define FVDB_DETAIL_OPS_SPLATTRILINEAR_H
 
+#include <fvdb/GridBatchData.h>
 #include <fvdb/JaggedTensor.h>
-#include <fvdb/detail/GridBatchData.h>
 
 #include <torch/types.h>
 

--- a/src/fvdb/detail/ops/VoxelToWorld.h
+++ b/src/fvdb/detail/ops/VoxelToWorld.h
@@ -4,8 +4,8 @@
 #ifndef FVDB_DETAIL_OPS_VOXELTOWORLD_H
 #define FVDB_DETAIL_OPS_VOXELTOWORLD_H
 
+#include <fvdb/GridBatchData.h>
 #include <fvdb/JaggedTensor.h>
-#include <fvdb/detail/GridBatchData.h>
 
 #include <torch/types.h>
 

--- a/src/fvdb/detail/ops/VoxelsAlongRays.h
+++ b/src/fvdb/detail/ops/VoxelsAlongRays.h
@@ -4,8 +4,8 @@
 #ifndef FVDB_DETAIL_OPS_VOXELSALONGRAYS_H
 #define FVDB_DETAIL_OPS_VOXELSALONGRAYS_H
 
+#include <fvdb/GridBatchData.h>
 #include <fvdb/JaggedTensor.h>
-#include <fvdb/detail/GridBatchData.h>
 
 #include <torch/types.h>
 

--- a/src/fvdb/detail/ops/convolution/GatherScatterDefault.h
+++ b/src/fvdb/detail/ops/convolution/GatherScatterDefault.h
@@ -21,7 +21,7 @@
 #ifndef FVDB_DETAIL_OPS_CONVOLUTION_GATHERSCATTERDEFAULT_H
 #define FVDB_DETAIL_OPS_CONVOLUTION_GATHERSCATTERDEFAULT_H
 
-#include <fvdb/detail/GridBatchData.h>
+#include <fvdb/GridBatchData.h>
 
 #include <nanovdb/NanoVDB.h>
 

--- a/src/fvdb/detail/ops/convolution/PredGatherIGemm.h
+++ b/src/fvdb/detail/ops/convolution/PredGatherIGemm.h
@@ -16,7 +16,7 @@
 #ifndef FVDB_DETAIL_OPS_CONVOLUTION_PREDGATHERIGEMM_H
 #define FVDB_DETAIL_OPS_CONVOLUTION_PREDGATHERIGEMM_H
 
-#include <fvdb/detail/GridBatchData.h>
+#include <fvdb/GridBatchData.h>
 
 #include <torch/types.h>
 

--- a/src/fvdb/detail/utils/AccessorHelpers.cuh
+++ b/src/fvdb/detail/utils/AccessorHelpers.cuh
@@ -4,8 +4,8 @@
 #ifndef FVDB_DETAIL_UTILS_ACCESSORHELPERS_CUH
 #define FVDB_DETAIL_UTILS_ACCESSORHELPERS_CUH
 
+#include <fvdb/GridBatchData.h>
 #include <fvdb/JaggedTensor.h>
-#include <fvdb/detail/GridBatchData.h>
 
 #include <torch/types.h>
 
@@ -60,10 +60,10 @@ tensorAccessor(const torch::Tensor &tensor) {
 /// @brief Get an accessor for the given batched grid handle with scalar type T
 /// @tparam DeviceTag The device tag to use for the accessor (either torch::kCUDA or torch::kCPU)
 /// @param batchHdl The batched grid handle to get an accessor for
-/// @return A fvdb::detail::GridBatchData::Accessor of the given type on the appropriate device
+/// @return A fvdb::GridBatchData::Accessor of the given type on the appropriate device
 template <c10::DeviceType DeviceTag>
-typename fvdb::detail::GridBatchData::Accessor
-gridBatchAccessor(const fvdb::detail::GridBatchData &batchHdl) {
+typename fvdb::GridBatchData::Accessor
+gridBatchAccessor(const fvdb::GridBatchData &batchHdl) {
     if constexpr (DeviceTag == torch::kCUDA || DeviceTag == torch::kPrivateUse1) {
         return batchHdl.deviceAccessor();
     } else {

--- a/src/fvdb/detail/utils/ForEachCPU.h
+++ b/src/fvdb/detail/utils/ForEachCPU.h
@@ -4,8 +4,8 @@
 #ifndef FVDB_DETAIL_UTILS_FOREACHCPU_H
 #define FVDB_DETAIL_UTILS_FOREACHCPU_H
 
+#include <fvdb/GridBatchData.h>
 #include <fvdb/JaggedTensor.h>
-#include <fvdb/detail/GridBatchData.h>
 
 #include <nanovdb/NanoVDB.h>
 
@@ -14,7 +14,7 @@ namespace fvdb {
 /// @brief Run the given function on each leaf in the grid batch on the CPU.
 ///        The callback has the form:
 ///            void(int32_t bidx, int32_t lidx, int32_t cidx,
-///            fvdb::detail::GridBatchData::Accessor batchAcc, Args...)
+///            fvdb::GridBatchData::Accessor batchAcc, Args...)
 ///        Where:
 ///            - bidx is the batch index of the current leaf
 ///            - lidx is the index of the leaf within the bidx^th grid in the batch
@@ -22,7 +22,7 @@ namespace fvdb {
 /// @tparam Func The type of the callback function to run on each leaf. It must be a callable of the
 /// form
 ///         void(int32_t, int32_t, int32_t,
-///         fvdb::detail::GridBatchData::Accessor, Args...)
+///         fvdb::GridBatchData::Accessor, Args...)
 /// @tparam Args... The types of any extra arguments to pass to the callback function
 ///
 /// @param stream Which cuda stream to run the kernel on
@@ -34,7 +34,7 @@ namespace fvdb {
 template <typename Func, typename... Args>
 __host__ void
 forEachLeafCPU(int64_t channelsPerLeaf,
-               const fvdb::detail::GridBatchData &batchHdl,
+               const fvdb::GridBatchData &batchHdl,
                Func func,
                Args... args) {
     TORCH_CHECK(batchHdl.device().is_cpu(), "Grid batch must be on the CPU");
@@ -76,7 +76,7 @@ template <typename Func, typename... Args>
 void
 forEachLeafInOneGridCPU(int64_t numChannels,
                         int64_t batchIdx,
-                        const fvdb::detail::GridBatchData &batchHdl,
+                        const fvdb::GridBatchData &batchHdl,
                         Func func,
                         Args... args) {
     TORCH_CHECK(batchHdl.device().is_cpu(), "Grid batch must be on the CPU");
@@ -98,7 +98,7 @@ forEachLeafInOneGridCPU(int64_t numChannels,
 /// @brief Run the given function on each voxel in the grid batch on the CPU.
 ///        The callback has the form:
 ///            void(int32_t bidx, int32_t lidx, int32_t vidx, int32_t cidx,
-///            fvdb::detail::GridBatchData::Accessor batchAcc, Args...)
+///            fvdb::GridBatchData::Accessor batchAcc, Args...)
 ///         Where:
 ///             - bidx is the batch index of the current voxel
 ///             - lidx is the index of the leaf containing the voxelwithin the bidx^th grid in the
@@ -111,7 +111,7 @@ forEachLeafInOneGridCPU(int64_t numChannels,
 /// @tparam Func The type of the callback function to run on each voxel. It must be a callable of
 /// the form
 ///         void(int32_t, int32_t, int32_t, int32_t,
-///         fvdb::detail::GridBatchData::Accessor, Args...)
+///         fvdb::GridBatchData::Accessor, Args...)
 /// @tparam Args... The types of any extra arguments to pass to the callback function
 ///
 /// @param stream Which cuda stream to run the kernel on
@@ -122,10 +122,7 @@ forEachLeafInOneGridCPU(int64_t numChannels,
 /// @param args Any extra arguments to pass to the callback function
 template <typename Func, typename... Args>
 __host__ void
-forEachVoxelCPU(int64_t numChannels,
-                const fvdb::detail::GridBatchData &batchHdl,
-                Func func,
-                Args... args) {
+forEachVoxelCPU(int64_t numChannels, const fvdb::GridBatchData &batchHdl, Func func, Args... args) {
     TORCH_CHECK(batchHdl.device().is_cpu(), "Grid batch must be on the CPU");
     constexpr int64_t VOXELS_PER_LEAF =
         static_cast<int64_t>(nanovdb::OnIndexTree::LeafNodeType::NUM_VALUES);

--- a/src/fvdb/detail/utils/SimpleOpHelper.h
+++ b/src/fvdb/detail/utils/SimpleOpHelper.h
@@ -4,7 +4,7 @@
 #ifndef FVDB_DETAIL_UTILS_SIMPLEOPHELPER_H
 #define FVDB_DETAIL_UTILS_SIMPLEOPHELPER_H
 
-#include <fvdb/detail/GridBatchData.h>
+#include <fvdb/GridBatchData.h>
 #include <fvdb/detail/utils/AccessorHelpers.cuh>
 #include <fvdb/detail/utils/ForEachCPU.h>
 #include <fvdb/detail/utils/cuda/ForEachCUDA.cuh>

--- a/src/fvdb/detail/utils/Utils.h
+++ b/src/fvdb/detail/utils/Utils.h
@@ -4,18 +4,17 @@
 #ifndef FVDB_DETAIL_UTILS_UTILS_H
 #define FVDB_DETAIL_UTILS_UTILS_H
 
+#include <fvdb/TypeTraits.h>
 #include <fvdb/detail/utils/nanovdb/ActiveVoxelIterator.h>
 #include <fvdb/detail/utils/nanovdb/HDDAIterators.h>
 #include <fvdb/detail/utils/nanovdb/TorchNanoConversions.h>
 
 #include <ATen/Dispatch_v2.h>
-#include <c10/util/Half.h>
 #include <torch/types.h>
 #include <torch/version.h>
 
 #include <iostream>
 #include <memory>
-#include <type_traits>
 
 // A bunch of things defined to make intellisense work with nvcc
 #if defined(NDEVELOP_IDE_ONLY)
@@ -64,21 +63,6 @@ template <typename T> struct RestrictPtrTraits {
 
 namespace fvdb {
 namespace detail {
-
-/// @brief A helper struct to determine if a type is a floating-point type or a half-precision
-/// floating-point type.
-/// @tparam T The type to check.
-template <class T>
-struct is_floating_point_or_half
-    : std::integral_constant<bool,
-                             // Note: standard floating-point types
-                             std::is_same<float, typename std::remove_cv<T>::type>::value ||
-                                 std::is_same<double, typename std::remove_cv<T>::type>::value ||
-                                 std::is_same<long double, typename std::remove_cv<T>::type>::value
-                                 // Note: extended floating-point types (C++23, if supported)
-                                 ||
-                                 std::is_same<c10::Half, typename std::remove_cv<T>::type>::value> {
-};
 
 /// @brief Convert a 1d tensor of integer values into an std:vector<int64_t>
 /// @param shapeTensor a 1D tensor of integer values

--- a/src/fvdb/detail/utils/cuda/ForEachCUDA.cu
+++ b/src/fvdb/detail/utils/cuda/ForEachCUDA.cu
@@ -8,7 +8,7 @@ namespace fvdb {
 namespace _private {
 
 __global__ void
-voxelMetaIndexCUDAKernel(fvdb::detail::GridBatchData::Accessor gridAccessor,
+voxelMetaIndexCUDAKernel(fvdb::GridBatchData::Accessor gridAccessor,
                          TorchRAcc64<int64_t, 2> metaIndex) {
     constexpr int32_t VOXELS_PER_LEAF = nanovdb::OnIndexTree::LeafNodeType::NUM_VALUES;
     const int64_t lvIdx               = ((int64_t)blockIdx.x * (int64_t)blockDim.x) + threadIdx.x;

--- a/src/fvdb/detail/utils/cuda/ForEachCUDA.cuh
+++ b/src/fvdb/detail/utils/cuda/ForEachCUDA.cuh
@@ -5,8 +5,8 @@
 #define FVDB_DETAIL_UTILS_CUDA_FOREACHCUDA_CUH
 
 #include <fvdb/Config.h>
+#include <fvdb/GridBatchData.h>
 #include <fvdb/JaggedTensor.h>
-#include <fvdb/detail/GridBatchData.h>
 #include <fvdb/detail/utils/AccessorHelpers.cuh>
 #include <fvdb/detail/utils/cuda/GridDim.h>
 
@@ -20,7 +20,7 @@ namespace _private {
 
 template <typename Func, typename... Args>
 __global__ void
-forEachLeafCUDAKernel(fvdb::detail::GridBatchData::Accessor grid,
+forEachLeafCUDAKernel(fvdb::GridBatchData::Accessor grid,
                       const bool returnIfOutOfRange,
                       const int32_t channelsPerLeaf,
                       Func func,
@@ -46,7 +46,7 @@ forEachLeafCUDAKernel(fvdb::detail::GridBatchData::Accessor grid,
 
 template <typename Func, typename... Args>
 __global__ void
-forEachLeafSingleGridCUDAKernel(fvdb::detail::GridBatchData::Accessor batchAccessor,
+forEachLeafSingleGridCUDAKernel(fvdb::GridBatchData::Accessor batchAccessor,
                                 const bool returnIfOutOfRange,
                                 const int32_t channelsPerLeaf,
                                 const int32_t bidx,
@@ -70,12 +70,12 @@ forEachLeafSingleGridCUDAKernel(fvdb::detail::GridBatchData::Accessor batchAcces
     func(gpuGrid, leafIdx, channelIdx, args...);
 }
 
-__global__ void voxelMetaIndexCUDAKernel(fvdb::detail::GridBatchData::Accessor gridAccessor,
+__global__ void voxelMetaIndexCUDAKernel(fvdb::GridBatchData::Accessor gridAccessor,
                                          TorchRAcc64<int64_t, 2> metaIndex);
 
 template <typename Func, typename... Args>
 __global__ void
-forEachVoxelWithMetaCUDAKernel(fvdb::detail::GridBatchData::Accessor grid,
+forEachVoxelWithMetaCUDAKernel(fvdb::GridBatchData::Accessor grid,
                                TorchRAcc64<int64_t, 2> metaIndex,
                                const bool returnIfOutOfRange,
                                const int64_t channelsPerVoxel,
@@ -104,7 +104,7 @@ forEachVoxelWithMetaCUDAKernel(fvdb::detail::GridBatchData::Accessor grid,
 
 template <typename Func, typename... Args>
 __global__ void
-forEachVoxelCUDAKernel(fvdb::detail::GridBatchData::Accessor grid,
+forEachVoxelCUDAKernel(fvdb::GridBatchData::Accessor grid,
                        const bool returnIfOutOfRange,
                        const int64_t channelsPerVoxel,
                        Func func,
@@ -186,7 +186,7 @@ forEachTensorElementChannelCUDAKernel(TorchRAcc64<ScalarT, NDIMS> tensorAcc,
 /// @brief Run the given function on each leaf in the grid batch in parallel on the GPU.
 ///        The callback has the form:
 ///            void(int32_t bidx, int32_t lidx, int32_t cidx,
-///            fvdb::detail::GridBatchData::Accessor batchAcc, Args...)
+///            fvdb::GridBatchData::Accessor batchAcc, Args...)
 ///        Where:
 ///            - bidx is the batch index of the current leaf
 ///            - lidx is the index of the leaf within the bidx^th grid in the batch
@@ -194,7 +194,7 @@ forEachTensorElementChannelCUDAKernel(TorchRAcc64<ScalarT, NDIMS> tensorAcc,
 /// @tparam Func The type of the callback function to run on each leaf. It must be a callable of the
 /// form
 ///         void(int32_t, int32_t, int32_t,
-///         fvdb::detail::GridBatchData::Accessor, Args...)
+///         fvdb::GridBatchData::Accessor, Args...)
 /// @tparam Args... The types of any extra arguments to pass to the callback function
 ///
 /// @param stream Which cuda stream to run the kernel on
@@ -211,7 +211,7 @@ forEachLeafCUDA(const at::cuda::CUDAStream &stream,
                 const bool returnIfOutOfRange,
                 const int64_t numThreads,
                 const int64_t numChannels,
-                const fvdb::detail::GridBatchData &batchHdl,
+                const fvdb::GridBatchData &batchHdl,
                 Func func,
                 Args... args) {
     TORCH_CHECK(batchHdl.device().is_cuda(), "Grid batch must be on a CUDA device");
@@ -240,7 +240,7 @@ template <typename Func, typename... Args>
 void
 forEachLeafCUDA(const int64_t numThreads,
                 const int64_t numChannels,
-                const fvdb::detail::GridBatchData &batchHdl,
+                const fvdb::GridBatchData &batchHdl,
                 Func func,
                 Args... args) {
     TORCH_CHECK(batchHdl.device().is_cuda(), "Grid batch must be on a CUDA device");
@@ -280,7 +280,7 @@ forEachLeafInOneGridCUDA(const at::cuda::CUDAStream &stream,
                          const int64_t numThreads,
                          const int64_t numChannels,
                          const int64_t batchIdx,
-                         const fvdb::detail::GridBatchData &batchHdl,
+                         const fvdb::GridBatchData &batchHdl,
                          Func func,
                          Args... args) {
     TORCH_CHECK(batchHdl.device().is_cuda(), "Grid batch must be on a CUDA device");
@@ -312,7 +312,7 @@ void
 forEachLeafInOneGridCUDA(const int64_t numThreads,
                          const int64_t numChannels,
                          const int64_t batchIdx,
-                         const fvdb::detail::GridBatchData &batchHdl,
+                         const fvdb::GridBatchData &batchHdl,
                          Func func,
                          Args... args) {
     TORCH_CHECK(batchHdl.device().is_cuda(), "Grid batch must be on a CUDA device");
@@ -325,7 +325,7 @@ forEachLeafInOneGridCUDA(const int64_t numThreads,
 /// @brief Run the given function on each voxel in the grid batch in parallel on the GPU.
 ///        The callback has the form:
 ///            void(int32_t bidx, int32_t lidx, int32_t vidx, int32_t cidx,
-///            fvdb::detail::GridBatchData::Accessor batchAcc, Args...)
+///            fvdb::GridBatchData::Accessor batchAcc, Args...)
 ///         Where:
 ///             - bidx is the batch index of the current voxel
 ///             - lidx is the index of the leaf containing the voxelwithin the bidx^th grid in the
@@ -338,7 +338,7 @@ forEachLeafInOneGridCUDA(const int64_t numThreads,
 /// @tparam Func The type of the callback function to run on each voxel. It must be a callable of
 /// the form
 ///         void(int32_t, int32_t, int32_t, int32_t,
-///         fvdb::detail::GridBatchData::Accessor, Args...)
+///         fvdb::GridBatchData::Accessor, Args...)
 /// @tparam Args... The types of any extra arguments to pass to the callback function
 ///
 /// @param stream Which cuda stream to run the kernel on
@@ -358,7 +358,7 @@ forEachVoxelCUDA(const at::cuda::CUDAStream &stream,
                  const bool returnIfOutOfRange,
                  const int64_t numThreads,
                  const int64_t numChannels,
-                 const fvdb::detail::GridBatchData &batchHdl,
+                 const fvdb::GridBatchData &batchHdl,
                  Func func,
                  Args... args) {
     TORCH_CHECK(batchHdl.device().is_cuda(), "Grid batch must be on a CUDA device");
@@ -424,7 +424,7 @@ template <typename Func, typename... Args>
 void
 forEachVoxelCUDA(const int64_t numThreads,
                  const int64_t numChannels,
-                 const fvdb::detail::GridBatchData &batchHdl,
+                 const fvdb::GridBatchData &batchHdl,
                  Func func,
                  Args... args) {
     TORCH_CHECK(batchHdl.device().is_cuda(), "Grid batch must be on a CUDA device");

--- a/src/fvdb/detail/utils/cuda/ForEachPrivateUse1.cuh
+++ b/src/fvdb/detail/utils/cuda/ForEachPrivateUse1.cuh
@@ -5,8 +5,8 @@
 #define FVDB_DETAIL_UTILS_CUDA_FOREACHPRIVATEUSE1_CUH
 
 #include <fvdb/Config.h>
+#include <fvdb/GridBatchData.h>
 #include <fvdb/JaggedTensor.h>
-#include <fvdb/detail/GridBatchData.h>
 #include <fvdb/detail/utils/AccessorHelpers.cuh>
 #include <fvdb/detail/utils/cuda/GridDim.h>
 #include <fvdb/detail/utils/cuda/Utils.cuh>
@@ -23,7 +23,7 @@ template <typename Func, typename... Args>
 __global__ void
 forEachLeafPrivateUse1Kernel(int64_t leafChannelCount,
                              int64_t leafChannelOffset,
-                             fvdb::detail::GridBatchData::Accessor grid,
+                             fvdb::GridBatchData::Accessor grid,
                              const int32_t channelsPerLeaf,
                              Func func,
                              Args... args) {
@@ -45,7 +45,7 @@ template <typename Func, typename... Args>
 __global__ void
 forEachVoxelPrivateUse1Kernel(int64_t leafVoxelChannelCount,
                               int64_t leafVoxelChannelOffset,
-                              fvdb::detail::GridBatchData::Accessor grid,
+                              fvdb::GridBatchData::Accessor grid,
                               int64_t channelsPerVoxel,
                               Func func,
                               Args... args) {
@@ -112,7 +112,7 @@ forEachTensorElementChannelPrivateUse1Kernel(int64_t numel,
 template <typename Func, typename... Args>
 void
 forEachLeafPrivateUse1(int64_t numChannels,
-                       const fvdb::detail::GridBatchData &batchHdl,
+                       const fvdb::GridBatchData &batchHdl,
                        Func func,
                        Args... args) {
     TORCH_CHECK(batchHdl.device().is_privateuseone(), "Grid batch must be on a PrivateUse1 device");
@@ -155,7 +155,7 @@ forEachLeafPrivateUse1(int64_t numChannels,
 template <typename Func, typename... Args>
 void
 forEachVoxelPrivateUse1(int64_t numChannels,
-                        const fvdb::detail::GridBatchData &batchHdl,
+                        const fvdb::GridBatchData &batchHdl,
                         Func func,
                         Args... args) {
     TORCH_CHECK(batchHdl.device().is_privateuseone(), "Grid batch must be on a PrivateUse1 device");

--- a/src/fvdb/detail/utils/nanovdb/CreateEmptyGridHandle.h
+++ b/src/fvdb/detail/utils/nanovdb/CreateEmptyGridHandle.h
@@ -3,7 +3,7 @@
 //
 #ifndef FVDB_DETAIL_UTILS_NANOVDB_CREATEEMPTYGRIDHANDLE_H
 #define FVDB_DETAIL_UTILS_NANOVDB_CREATEEMPTYGRIDHANDLE_H
-#include <fvdb/detail/TorchDeviceBuffer.h>
+#include <fvdb/TorchDeviceBuffer.h>
 
 #include <nanovdb/NanoVDB.h>
 #include <nanovdb/tools/CreateNanoGrid.h>

--- a/src/python/Bindings.cpp
+++ b/src/python/Bindings.cpp
@@ -155,7 +155,7 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
 
     // Concatenate grids or jagged tensors
     m.def("jcat",
-          py::overload_cast<const std::vector<c10::intrusive_ptr<fvdb::detail::GridBatchData>> &>(
+          py::overload_cast<const std::vector<c10::intrusive_ptr<fvdb::GridBatchData>> &>(
               &fvdb::jcat),
           py::arg("grid_batches"));
     m.def("jcat",
@@ -374,7 +374,7 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
 
     m.def("save",
           py::overload_cast<const std::string &,
-                            const fvdb::detail::GridBatchData &,
+                            const fvdb::GridBatchData &,
                             const std::optional<fvdb::JaggedTensor>,
                             const std::vector<std::string> &,
                             bool,
@@ -387,7 +387,7 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
           py::arg("verbose")    = false);
     m.def("save",
           py::overload_cast<const std::string &,
-                            const fvdb::detail::GridBatchData &,
+                            const fvdb::GridBatchData &,
                             const std::optional<fvdb::JaggedTensor>,
                             const std::string &,
                             bool,
@@ -467,8 +467,8 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
 
     m.def(
         "gs_build_topology",
-        [](const fvdb::detail::GridBatchData &feature_grid,
-           const fvdb::detail::GridBatchData &output_grid,
+        [](const fvdb::GridBatchData &feature_grid,
+           const fvdb::GridBatchData &output_grid,
            const torch::Tensor &kernelSize,
            const torch::Tensor &stride) -> GSDTopo {
             return fvdb::detail::ops::gatherScatterDefaultSparseConvTopology(
@@ -509,8 +509,8 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
 
     m.def(
         "gs_build_transpose_topology",
-        [](const fvdb::detail::GridBatchData &feature_grid,
-           const fvdb::detail::GridBatchData &output_grid,
+        [](const fvdb::GridBatchData &feature_grid,
+           const fvdb::GridBatchData &output_grid,
            const torch::Tensor &kernelSize,
            const torch::Tensor &stride) -> GSDTopo {
             return fvdb::detail::ops::gatherScatterDefaultSparseConvTransposeTopology(
@@ -556,8 +556,8 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
         "pred_gather_igemm_conv",
         [](torch::Tensor features,
            torch::Tensor weights,
-           const fvdb::detail::GridBatchData &feature_grid,
-           const fvdb::detail::GridBatchData &output_grid,
+           const fvdb::GridBatchData &feature_grid,
+           const fvdb::GridBatchData &output_grid,
            int kernel_size,
            int stride) -> torch::Tensor {
             return fvdb::detail::ops::predGatherIGemmSparseConv(
@@ -574,7 +574,7 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
 
 TORCH_LIBRARY(fvdb, m) {
     m.class_<fvdb::JaggedTensor>("JaggedTensor");
-    m.class_<fvdb::detail::GridBatchData>("GridBatchData");
+    m.class_<fvdb::GridBatchData>("GridBatchData");
 
     m.def(
         "_fused_ssim(float C1, float C2, Tensor img1, Tensor img2, bool train) -> (Tensor, Tensor, Tensor, Tensor)");

--- a/src/python/GridBatchDataBinding.cpp
+++ b/src/python/GridBatchDataBinding.cpp
@@ -4,7 +4,7 @@
 
 #include <pybind11/stl.h>
 
-#include <fvdb/detail/GridBatchData.h>
+#include <fvdb/GridBatchData.h>
 #include <fvdb/detail/ops/CloneGrid.h>
 #include <fvdb/detail/ops/SerializeGrid.h>
 
@@ -12,7 +12,7 @@
 
 void
 bind_grid_batch_data(py::module &m) {
-    using GBI = fvdb::detail::GridBatchData;
+    using GBI = fvdb::GridBatchData;
 
     py::class_<GBI, c10::intrusive_ptr<GBI>>(m, "GridBatchData")
 

--- a/src/python/GridBatchOps.cpp
+++ b/src/python/GridBatchOps.cpp
@@ -4,9 +4,9 @@
 
 #include <pybind11/stl.h>
 
+#include <fvdb/GridBatchData.h>
 #include <fvdb/JaggedTensor.h>
 #include <fvdb/Types.h>
-#include <fvdb/detail/GridBatchData.h>
 
 #include <torch/extension.h>
 
@@ -116,7 +116,7 @@ vecsToCoords(const std::vector<std::vector<int32_t>> &vecs) {
 
 void
 bind_grid_batch_ops(py::module &m) {
-    using GBI     = fvdb::detail::GridBatchData;
+    using GBI     = fvdb::GridBatchData;
     using JT      = fvdb::JaggedTensor;
     namespace ops = fvdb::detail::ops;
 

--- a/src/tests/GatherScatterDefaultConvTest.cu
+++ b/src/tests/GatherScatterDefaultConvTest.cu
@@ -51,8 +51,8 @@
 // CPU and CUDA with float32 and float64.  A separate kernel-size test suite
 // exercises non-cubic and varied kernel dimensions.
 //
+#include <fvdb/GridBatchData.h>
 #include <fvdb/JaggedTensor.h>
-#include <fvdb/detail/GridBatchData.h>
 #include <fvdb/detail/GridBatchDataFactory.h>
 #include <fvdb/detail/ops/BuildGridForConv.h>
 #include <fvdb/detail/ops/BuildGridFromIjk.h>

--- a/src/tests/PredGatherIGemmTest.cu
+++ b/src/tests/PredGatherIGemmTest.cu
@@ -4,8 +4,8 @@
 // PredGatherIGemmTest.cu -- GTest for PredGatherIGemm sparse convolution,
 // validating against GatherScatterDefault as ground truth.
 
+#include <fvdb/GridBatchData.h>
 #include <fvdb/JaggedTensor.h>
-#include <fvdb/detail/GridBatchData.h>
 #include <fvdb/detail/ops/BuildGridFromIjk.h>
 #include <fvdb/detail/ops/convolution/GatherScatterDefault.h>
 #include <fvdb/detail/ops/convolution/PredGatherIGemm.h>


### PR DESCRIPTION
Move GridBatchData, TorchDeviceBuffer, VoxelCoordTransform, and TypeTraits out of fvdb::detail into the fvdb namespace as public headers. This was because `fvdb::detail::GridBatchData.h` was used in the public FVDB.h header but GridBatchData.h was in the private detail headers (ones we don't ship when building libfvdb making it impossible to use downstream)

Key changes:
- Move GridBatchData.{h,cu} from detail/ to fvdb/
- Move TorchDeviceBuffer.{h,cpp} from detail/ to fvdb/
- Move VoxelCoordTransform.h from detail/ to fvdb/
- Add new TypeTraits.h public header
- Move non-inlined GridBatchData methods (hostAccessor, deviceAccessor, nanoGridHandle, device, isEmpty, checkDevice) to the .cu file to keep the header lightweight
- Update all include paths and namespace references across detail/ops, detail/io, detail/utils, python bindings, tests, and benchmarks
- Add missing Utils.h includes in IjkForMesh.cu, NearestIjkForPoints.cu, and Refine.cu (AT_DISPATCH_V2 was previously resolved transitively)