### PR TITLE
CI: fix nightly wheel build

### DIFF
--- a/.github/workflows/nightly-publish.yml
+++ b/.github/workflows/nightly-publish.yml
@@ -81,7 +81,7 @@ jobs:
           mode: start
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
           ec2-image-id: ${{ needs.versions.outputs.aws-cpu-ami }}
-          ec2-instance-type: m6a.4xlarge
+          ec2-instance-type: r6a.4xlarge
           subnet-id: ${{ needs.versions.outputs.aws-subnet }}
           security-group-id: ${{ needs.versions.outputs.aws-security-group }}
           label: nightly-${{ matrix.python-version }}-pt${{ matrix.torch-version }}-cu${{ matrix.cuda-version }}-${{ github.run_id }}

--- a/.github/workflows/nightly-publish.yml
+++ b/.github/workflows/nightly-publish.yml
@@ -81,7 +81,7 @@ jobs:
           mode: start
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
           ec2-image-id: ${{ needs.versions.outputs.aws-cpu-ami }}
-          ec2-instance-type: t3a.large
+          ec2-instance-type: m6a.8xlarge
           subnet-id: ${{ needs.versions.outputs.aws-subnet }}
           security-group-id: ${{ needs.versions.outputs.aws-security-group }}
           label: nightly-${{ matrix.python-version }}-pt${{ matrix.torch-version }}-cu${{ matrix.cuda-version }}-${{ github.run_id }}

--- a/.github/workflows/nightly-publish.yml
+++ b/.github/workflows/nightly-publish.yml
@@ -81,7 +81,7 @@ jobs:
           mode: start
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
           ec2-image-id: ${{ needs.versions.outputs.aws-cpu-ami }}
-          ec2-instance-type: r6a.2xlarge
+          ec2-instance-type: m6a.4xlarge
           subnet-id: ${{ needs.versions.outputs.aws-subnet }}
           security-group-id: ${{ needs.versions.outputs.aws-security-group }}
           label: nightly-${{ matrix.python-version }}-pt${{ matrix.torch-version }}-cu${{ matrix.cuda-version }}-${{ github.run_id }}

--- a/.github/workflows/nightly-publish.yml
+++ b/.github/workflows/nightly-publish.yml
@@ -81,7 +81,7 @@ jobs:
           mode: start
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
           ec2-image-id: ${{ needs.versions.outputs.aws-cpu-ami }}
-          ec2-instance-type: m6a.2xlarge
+          ec2-instance-type: m6a.4xlarge
           subnet-id: ${{ needs.versions.outputs.aws-subnet }}
           security-group-id: ${{ needs.versions.outputs.aws-security-group }}
           label: nightly-${{ matrix.python-version }}-pt${{ matrix.torch-version }}-cu${{ matrix.cuda-version }}-${{ github.run_id }}

--- a/.github/workflows/nightly-publish.yml
+++ b/.github/workflows/nightly-publish.yml
@@ -81,7 +81,7 @@ jobs:
           mode: start
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
           ec2-image-id: ${{ needs.versions.outputs.aws-cpu-ami }}
-          ec2-instance-type: r6a.4xlarge
+          ec2-instance-type: r6a.2xlarge
           subnet-id: ${{ needs.versions.outputs.aws-subnet }}
           security-group-id: ${{ needs.versions.outputs.aws-security-group }}
           label: nightly-${{ matrix.python-version }}-pt${{ matrix.torch-version }}-cu${{ matrix.cuda-version }}-${{ github.run_id }}

--- a/.github/workflows/nightly-publish.yml
+++ b/.github/workflows/nightly-publish.yml
@@ -81,7 +81,7 @@ jobs:
           mode: start
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
           ec2-image-id: ${{ needs.versions.outputs.aws-cpu-ami }}
-          ec2-instance-type: m6a.8xlarge
+          ec2-instance-type: m6a.2xlarge
           subnet-id: ${{ needs.versions.outputs.aws-subnet }}
           security-group-id: ${{ needs.versions.outputs.aws-security-group }}
           label: nightly-${{ matrix.python-version }}-pt${{ matrix.torch-version }}-cu${{ matrix.cuda-version }}-${{ github.run_id }}

--- a/.github/workflows/nightly-publish.yml
+++ b/.github/workflows/nightly-publish.yml
@@ -81,7 +81,7 @@ jobs:
           mode: start
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
           ec2-image-id: ${{ needs.versions.outputs.aws-cpu-ami }}
-          ec2-instance-type: m6a.4xlarge
+          ec2-instance-type: m6a.xlarge
           subnet-id: ${{ needs.versions.outputs.aws-subnet }}
           security-group-id: ${{ needs.versions.outputs.aws-security-group }}
           label: nightly-${{ matrix.python-version }}-pt${{ matrix.torch-version }}-cu${{ matrix.cuda-version }}-${{ github.run_id }}


### PR DESCRIPTION
* The PR #549 downsized runner from `m6a.8xlarge` to `t3a.large` but since then fvdb buld failed with an error: "runner lost communication"

* Same happened after manually run with set:
```
      - name: Build fvdb
        env:
          CMAKE_BUILD_PARALLEL_LEVEL: "1"
          MAX_JOBS: "1"
```
* With reverted changes the job succeeded again:
https://github.com/openvdb/fvdb-core/actions/runs/24730340925

* Following table includes measured runs tested in this PR, sorted by estimated $/nightly:

| instance | vCPU / RAM | $/hr (on-demand) | min/cell | $/cell | **$/nightly** |
|---|---|---|---|---|---|
| `t3a.large` | 2 / 8 GiB | $0.075 | n/a (OOM) | n/a | n/a |
| `m6a.xlarge` | 4 / 16 GiB | $0.173 | ~75 | $0.22 | **~$1.73** |
| `r6a.large` | 2 / 16 GiB | $0.113 | ~130 | $0.24 | ~$1.96 |
| `c6a.4xlarge` | 16 / 32 GiB | $0.612 | ~28 | $0.29 | ~$2.28 |
| `m6a.2xlarge` | 8 / 32 GiB | $0.346 | ~55 (partial, some OOM) | ~$0.32 | ~$2.54 |
| `m7a.2xlarge` | 8 / 32 GiB | $0.44 | ~50 | $0.37 | ~$2.93 |
| **`m6a.4xlarge`** | **16 / 64 GiB** | **$0.691** | **39.5** | **$0.47** | **~$3.73** |
| `m6a.8xlarge` | 32 / 128 GiB | $1.38 | **22** | $0.51 | ~$4.05 |
| `r6a.2xlarge` | 8 / 64 GiB | $0.454 | **100.5** | $0.76 | ~$6.09 |

* Chosen configuration: `m6a.4xlarge`, running on cheaper instances would require changes to avoid OOM
