### PR TITLE
Disambiguate CI job names and fix Torch CMake header path

### DIFF
--- a/.github/workflows/cu128.yml
+++ b/.github/workflows/cu128.yml
@@ -1,4 +1,4 @@
-name: fVDB CUDA 12.8.1 Build and Test
+name: fVDB pip CUDA 12.8 Build and Test
 
 on:
   pull_request_target:
@@ -62,7 +62,7 @@ jobs:
   # BUILD FVDB
   ##############################################################################
   fvdb-build:
-    name: fVDB Build
+    name: fVDB Build (pip CUDA 12.8)
     needs: [start-build-runner, versions]
     runs-on: ${{ needs.start-build-runner.outputs.label }}
     container:
@@ -246,7 +246,7 @@ jobs:
   ##############################################################################
   fvdb-gtests:
     needs: [start-tests-gpu-runner, versions] # required to start the main job when the runner is ready
-    name: fVDB GTests
+    name: fVDB GTests (pip CUDA 12.8)
     runs-on: ${{ needs.start-tests-gpu-runner.outputs.label }} # run the job on the newly created runner
     container:
       image: nvidia/cuda:${{ needs.versions.outputs.cuda-128-patch }}-cudnn-runtime-${{ needs.versions.outputs.docker-os-ubuntu }}
@@ -346,7 +346,7 @@ jobs:
   ##############################################################################
   fvdb-unit-test:
     needs: [start-tests-gpu-runner, versions] # required to start the main job when the runner is ready
-    name: fVDB PyTests
+    name: fVDB Unit Tests (pip CUDA 12.8)
     runs-on: ${{ needs.start-tests-gpu-runner.outputs.label }} # run the job on the newly created runner
     container:
       image: nvidia/cuda:${{ needs.versions.outputs.cuda-128-patch }}-cudnn-devel-${{ needs.versions.outputs.docker-os-ubuntu }}
@@ -443,7 +443,7 @@ jobs:
   ##############################################################################
   fvdb-docs-test:
     needs: [start-tests-gpu-runner, versions] # required to start the main job when the runner is ready
-    name: fVDB Documentation Tests
+    name: fVDB Doc Tests (pip CUDA 12.8)
     runs-on: ${{ needs.start-tests-gpu-runner.outputs.label }} # run the job on the newly created runner
     container:
       image: nvidia/cuda:${{ needs.versions.outputs.cuda-128-patch }}-cudnn-runtime-${{ needs.versions.outputs.docker-os-ubuntu }}

--- a/.github/workflows/cu130.yml
+++ b/.github/workflows/cu130.yml
@@ -1,4 +1,4 @@
-name: fVDB CUDA 13.0.2 Build and Test
+name: fVDB pip CUDA 13.0 Build and Test
 
 on:
   pull_request_target:
@@ -62,7 +62,7 @@ jobs:
   # BUILD FVDB
   ##############################################################################
   fvdb-build:
-    name: fVDB Build
+    name: fVDB Build (pip CUDA 13.0)
     needs: [start-build-runner, versions]
     runs-on: ${{ needs.start-build-runner.outputs.label }}
     container:
@@ -246,7 +246,7 @@ jobs:
   ##############################################################################
   fvdb-gtests:
     needs: [start-tests-gpu-runner, versions] # required to start the main job when the runner is ready
-    name: fVDB GTests
+    name: fVDB GTests (pip CUDA 13.0)
     runs-on: ${{ needs.start-tests-gpu-runner.outputs.label }} # run the job on the newly created runner
     container:
       image: nvidia/cuda:${{ needs.versions.outputs.cuda-130-patch }}-cudnn-runtime-${{ needs.versions.outputs.docker-os-ubuntu }}
@@ -346,7 +346,7 @@ jobs:
   ##############################################################################
   fvdb-unit-test:
     needs: [start-tests-gpu-runner, versions] # required to start the main job when the runner is ready
-    name: fVDB PyTests
+    name: fVDB Unit Tests (pip CUDA 13.0)
     runs-on: ${{ needs.start-tests-gpu-runner.outputs.label }} # run the job on the newly created runner
     container:
       image: nvidia/cuda:${{ needs.versions.outputs.cuda-130-patch }}-cudnn-devel-${{ needs.versions.outputs.docker-os-ubuntu }}
@@ -443,7 +443,7 @@ jobs:
   ##############################################################################
   fvdb-docs-test:
     needs: [start-tests-gpu-runner, versions] # required to start the main job when the runner is ready
-    name: fVDB Documentation Tests
+    name: fVDB Doc Tests (pip CUDA 13.0)
     runs-on: ${{ needs.start-tests-gpu-runner.outputs.label }} # run the job on the newly created runner
     container:
       image: nvidia/cuda:${{ needs.versions.outputs.cuda-130-patch }}-cudnn-runtime-${{ needs.versions.outputs.docker-os-ubuntu }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-name: fVDB Unit Tests
+name: fVDB Conda Build and Test
 
 on:
   pull_request_target:
@@ -64,7 +64,7 @@ jobs:
           subnet-id: ${{ needs.versions.outputs.aws-subnet }}
           security-group-id: ${{ needs.versions.outputs.aws-security-group }}
   fvdb-build:
-    name: fVDB Build
+    name: fVDB Build (Conda)
     needs: [start-build-runner, versions] # required to start the main job when the runner is ready
     runs-on: ${{ needs.start-build-runner.outputs.label }} # run the job on the newly created runner
     container:
@@ -210,7 +210,7 @@ jobs:
   ##############################################################################
   fvdb-gtests:
     needs: [start-tests-gpu-runner, versions] # required to start the main job when the runner is ready
-    name: fVDB GTests
+    name: fVDB GTests (Conda)
     runs-on: ${{ needs.start-tests-gpu-runner.outputs.label }} # run the job on the newly created runner
     container:
       image: nvidia/cuda:${{ needs.versions.outputs.cuda-130-patch }}-base-${{ needs.versions.outputs.docker-os-rocky }}
@@ -276,7 +276,7 @@ jobs:
   ##############################################################################
   fvdb-unit-tests:
     needs: [start-tests-gpu-runner, versions] # required to start the main job when the runner is ready
-    name: fVDB Unit Tests
+    name: fVDB Unit Tests (Conda)
     runs-on: ${{ needs.start-tests-gpu-runner.outputs.label }} # run the job on the newly created runner
     container:
       image: nvidia/cuda:${{ needs.versions.outputs.cuda-130-patch }}-base-${{ needs.versions.outputs.docker-os-rocky }}
@@ -346,7 +346,7 @@ jobs:
   ##############################################################################
   fvdb-docs-test:
     needs: [start-tests-gpu-runner, versions] # required to start the main job when the runner is ready
-    name: fVDB Documentation Tests
+    name: fVDB Doc Tests (Conda)
     runs-on: ${{ needs.start-tests-gpu-runner.outputs.label }} # run the job on the newly created runner
     container:
       image: nvidia/cuda:${{ needs.versions.outputs.cuda-130-patch }}-base-${{ needs.versions.outputs.docker-os-rocky }}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -171,7 +171,10 @@ target_include_directories(fvdb PUBLIC
     $<BUILD_INTERFACE:${nvtx3_SOURCE_DIR}/include>
     $<BUILD_INTERFACE:${NANOVDB_EDITOR_INCLUDE_DIR}>
     $<INSTALL_INTERFACE:include>)
-target_include_directories(fvdb SYSTEM PUBLIC ${TORCH_INCLUDE_DIRS})
+foreach(_torch_inc_dir IN LISTS TORCH_INCLUDE_DIRS)
+    target_include_directories(fvdb SYSTEM PUBLIC
+        $<BUILD_INTERFACE:${_torch_inc_dir}>)
+endforeach()
 target_include_directories(fvdb PRIVATE
     ${TORCH_SOURCE_INCLUDE_DIRS}
     ${tinyply_SOURCE_DIR}/source)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -168,10 +168,10 @@ message(STATUS "fvdb: TORCH_INCLUDE_DIRS: ${TORCH_INCLUDE_DIRS}")
 target_include_directories(fvdb PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
     $<BUILD_INTERFACE:${nanovdb_SOURCE_DIR}/nanovdb>
-    $<BUILD_INTERFACE:${TORCH_INCLUDE_DIRS}>
     $<BUILD_INTERFACE:${nvtx3_SOURCE_DIR}/include>
     $<BUILD_INTERFACE:${NANOVDB_EDITOR_INCLUDE_DIR}>
     $<INSTALL_INTERFACE:include>)
+target_include_directories(fvdb SYSTEM PUBLIC ${TORCH_INCLUDE_DIRS})
 target_include_directories(fvdb PRIVATE
     ${TORCH_SOURCE_INCLUDE_DIRS}
     ${tinyply_SOURCE_DIR}/source)


### PR DESCRIPTION
Add environment qualifiers (Conda, pip CUDA 12.8, pip CUDA 13.0) to all workflow and job names so each check is uniquely identifiable in GitHub branch protection rules. Standardize "PyTests" / "Unit Tests" naming inconsistency across workflows.

Mark Torch include directories as SYSTEM to fix include pathing in pip builds.