### PR TITLE
Generalize volume_render to N channels

### DIFF
--- a/src/fvdb/detail/ops/SampleRaysUniform.cu
+++ b/src/fvdb/detail/ops/SampleRaysUniform.cu
@@ -78,8 +78,12 @@ countSamplesPerRayCallback(int32_t bidx,
 
         if (includeEndpointSegments) {
             // Step t0 consistently until it intersects the voxel (t0 is out of the voxel)
+            // This MUST use the same rounding (`ceil`) as the generate-path callback below so that
+            // both callbacks emit the same number of samples per ray.
+            // With cone tracing (coneAngle > 0), `_calcDt` depends on `t0`, so any rounding
+            // mismatch silently diverges the two paths and can OOB-write during sample generation.
             ScalarType distToVox = it->t0 - t0;
-            t0 += c10::cuda::compat::floor(distToVox / stepSize) * stepSize;
+            t0 += c10::cuda::compat::ceil(distToVox / stepSize) * stepSize;
             t1 = t0 + stepSize;
 
             if (t0 > it->t1) {

--- a/src/fvdb/detail/ops/VolumeRender.cu
+++ b/src/fvdb/detail/ops/VolumeRender.cu
@@ -98,6 +98,13 @@ volumeRenderBwdCallback(const TensorAccessor<scalar_t, 1> dLdOpacity,     // [B*
     const JOffsetsType numRaySamples  = jOffsets[rayIdx + 1] - sampleStartIdx;
     const int32_t numChannels         = rgbs.size(1);
 
+    // Empty ray: nothing to scan or accumulate. Leave out_dL_dsigmas and
+    // out_dLdRgbs at their zero-initialized values and skip the prefix scan
+    // (which would otherwise OOB-read dLdWs_times_ws[sampleStartIdx - 1]).
+    if (numRaySamples == 0) {
+        return;
+    }
+
     // front to back compositing
     JOffsetsType numSamples = 0;
     // Per-channel final integrated radiance (from fwd pass) and running partial
@@ -650,6 +657,25 @@ volumeRenderBackward(const torch::Tensor &dLdOpacity,
                      const torch::Tensor &rgb,
                      float tsmtThreshold) {
     const int64_t N = sigmas.size(0);
+
+    TORCH_CHECK(rgbs.size(1) <= MAX_VOLUME_RENDER_CHANNELS,
+                "Volume rendering backward supports at most ",
+                MAX_VOLUME_RENDER_CHANNELS,
+                " channels, but got ",
+                rgbs.size(1),
+                ".");
+    TORCH_CHECK(dLdRgb.size(1) == rgbs.size(1),
+                "dLdRgb and rgbs must have the same channel dimension, but got ",
+                dLdRgb.size(1),
+                " and ",
+                rgbs.size(1),
+                ".");
+    TORCH_CHECK(rgb.size(1) == rgbs.size(1),
+                "rgb and rgbs must have the same channel dimension, but got ",
+                rgb.size(1),
+                " and ",
+                rgbs.size(1),
+                ".");
 
     torch::Tensor dLdSigmas = torch::zeros({N}, sigmas.options());
     torch::Tensor dLdRgbs   = torch::zeros({N, rgbs.size(1)}, sigmas.options());

--- a/src/fvdb/detail/ops/VolumeRender.cu
+++ b/src/fvdb/detail/ops/VolumeRender.cu
@@ -73,7 +73,8 @@ volumeRenderFwdCallback(const TensorAccessor<scalar_t, 1> sigmas,
 
 template <torch::DeviceType device,
           typename scalar_t,
-          template <typename T, int32_t D> typename TensorAccessor>
+          template <typename T, int32_t D>
+          typename TensorAccessor>
 __hostdev__ void
 volumeRenderBwdCallback(const TensorAccessor<scalar_t, 1> dLdOpacity,     // [B*R]
                         const TensorAccessor<scalar_t, 1> dLdDepth,       // [B*R]

--- a/src/fvdb/detail/ops/VolumeRender.cu
+++ b/src/fvdb/detail/ops/VolumeRender.cu
@@ -61,12 +61,12 @@ volumeRenderFwdCallback(const TensorAccessor<scalar_t, 1> sigmas,
         outOpacity[rayIdx] += w;
         outWs[s] = w;
         T *= static_cast<scalar_t>(1.0) - a;
+        numSamples += 1;
 
         // ray has enough opacity
         if (T <= tsmtThreshold) {
             break;
         }
-        numSamples += 1;
     }
     outTotalSamples[rayIdx] = numSamples;
 }

--- a/src/fvdb/detail/ops/VolumeRender.cu
+++ b/src/fvdb/detail/ops/VolumeRender.cu
@@ -19,6 +19,11 @@ namespace ops {
 
 namespace {
 
+// Maximum number of channels supported by the backward kernel. Bounded so we can
+// allocate on-stack scratch arrays inside the device callback without dynamic
+// allocation. Bump if a use case legitimately needs more channels.
+static constexpr int MAX_VOLUME_RENDER_CHANNELS = 16;
+
 template <typename scalar_t, template <typename T, int32_t D> typename TensorAccessor>
 __hostdev__ void
 volumeRenderFwdCallback(const TensorAccessor<scalar_t, 1> sigmas,
@@ -68,8 +73,7 @@ volumeRenderFwdCallback(const TensorAccessor<scalar_t, 1> sigmas,
 
 template <torch::DeviceType device,
           typename scalar_t,
-          template <typename T, int32_t D>
-          typename TensorAccessor>
+          template <typename T, int32_t D> typename TensorAccessor>
 __hostdev__ void
 volumeRenderBwdCallback(const TensorAccessor<scalar_t, 1> dLdOpacity,     // [B*R]
                         const TensorAccessor<scalar_t, 1> dLdDepth,       // [B*R]
@@ -91,14 +95,23 @@ volumeRenderBwdCallback(const TensorAccessor<scalar_t, 1> dLdOpacity,     // [B*
 
     const JOffsetsType sampleStartIdx = jOffsets[rayIdx];
     const JOffsetsType numRaySamples  = jOffsets[rayIdx + 1] - sampleStartIdx;
+    const int32_t numChannels         = rgbs.size(1);
 
     // front to back compositing
     JOffsetsType numSamples = 0;
-    scalar_t R = rgb[rayIdx][0], G = rgb[rayIdx][1], B = rgb[rayIdx][2];
+    // Per-channel final integrated radiance (from fwd pass) and running partial
+    // accumulator. Bounded stack storage; host checks numChannels against
+    // MAX_VOLUME_RENDER_CHANNELS before launching so overflow is impossible.
+    scalar_t finalRgb[MAX_VOLUME_RENDER_CHANNELS];
+    scalar_t partialRgb[MAX_VOLUME_RENDER_CHANNELS];
+    for (int c = 0; c < numChannels; ++c) {
+        finalRgb[c]   = rgb[rayIdx][c];
+        partialRgb[c] = static_cast<scalar_t>(0.0);
+    }
+
     scalar_t O = opacity[rayIdx], D = depth[rayIdx]; //, Dsq = depthSq[rayIdx];
-    scalar_t T = static_cast<scalar_t>(1.0), r = static_cast<scalar_t>(0.0),
-             g = static_cast<scalar_t>(0.0), b = static_cast<scalar_t>(0.0),
-             d = static_cast<scalar_t>(0.0);         //, dsq = static_cast<scalar_t>(0.0);
+    scalar_t T = static_cast<scalar_t>(1.0);
+    scalar_t d = static_cast<scalar_t>(0.0);         //, dsq = static_cast<scalar_t>(0.0);
     // compute prefix sum of dLdWs * ws
     // [a0, a1, a2, a3, ...] -> [a0, a0+a1, a0+a1+a2, a0+a1+a2+a3, ...]
     if constexpr (device == torch::kCUDA) {
@@ -120,23 +133,23 @@ volumeRenderBwdCallback(const TensorAccessor<scalar_t, 1> dLdOpacity,     // [B*
             static_cast<scalar_t>(1.0) - c10::cuda::compat::exp(-sigmas[s] * deltas[s]);
         const scalar_t w = a * T;
 
-        r += w * rgbs[s][0];
-        g += w * rgbs[s][1];
-        b += w * rgbs[s][2];
+        for (int c = 0; c < numChannels; ++c) {
+            partialRgb[c] += w * rgbs[s][c];
+        }
         d += w * ts[s]; // dsq += w*ts[s]*ts[s];
         T *= static_cast<scalar_t>(1.0) - a;
 
         // compute gradients by math...
-        out_dLdRgbs[s][0] = dLdRgb[rayIdx][0] * w;
-        out_dLdRgbs[s][1] = dLdRgb[rayIdx][1] * w;
-        out_dLdRgbs[s][2] = dLdRgb[rayIdx][2] * w;
+        scalar_t rgbGradSum = static_cast<scalar_t>(0.0);
+        for (int c = 0; c < numChannels; ++c) {
+            out_dLdRgbs[s][c] = dLdRgb[rayIdx][c] * w;
+            rgbGradSum += dLdRgb[rayIdx][c] * (rgbs[s][c] * T - (finalRgb[c] - partialRgb[c]));
+        }
 
         out_dL_dsigmas[s] =
-            deltas[s] * (dLdRgb[rayIdx][0] * (rgbs[s][0] * T - (R - r)) +
-                         dLdRgb[rayIdx][1] * (rgbs[s][1] * T - (G - g)) +
-                         dLdRgb[rayIdx][2] * (rgbs[s][2] * T - (B - b)) + // gradients from rgb
-                         dLdOpacity[rayIdx] * (1 - O) +                   // gradient from opacity
-                         dLdDepth[rayIdx] * (ts[s] * T - (D - d)) +       // gradient from depth
+            deltas[s] * (rgbGradSum +                               // gradients from rgb
+                         dLdOpacity[rayIdx] * (1 - O) +             // gradient from opacity
+                         dLdDepth[rayIdx] * (ts[s] * T - (D - d)) + // gradient from depth
                          // dLdDepthSq[rayIdx]*(ts[s]*ts[s]*T-(Dsq-dsq)) +
                          T * dLdWs[s] - (dLdWs_times_ws_sum - dLdWs_times_ws[s]) // gradient from ws
                         );
@@ -565,7 +578,13 @@ volumeRender(const torch::Tensor &sigmas,
 
     TORCH_CHECK(jOffsets.dim() == 1, "jOffsets must have shape (nRays+1,)");
     TORCH_CHECK(sigmas.dim() == 1, "sigmas must have shape (nRays*nSamplesPerRay,)");
-    TORCH_CHECK(rgbs.dim() == 2, "rgbs must have shape (nRays*nSamplesPerRay, 3)");
+    TORCH_CHECK(rgbs.dim() == 2, "rgbs must have shape (nRays*nSamplesPerRay, numChannels)");
+    TORCH_CHECK(rgbs.size(1) > 0 && rgbs.size(1) <= MAX_VOLUME_RENDER_CHANNELS,
+                "rgbs must have between 1 and ",
+                MAX_VOLUME_RENDER_CHANNELS,
+                " channels (got ",
+                rgbs.size(1),
+                ")");
     TORCH_CHECK(deltaTs.dim() == 1, "deltaTs must have shape (nRays*nSamplesPerRay,)");
     TORCH_CHECK(ts.dim() == 1, "ts must have shape (N,)");
 
@@ -592,7 +611,7 @@ volumeRender(const torch::Tensor &sigmas,
 
     torch::Tensor outOpacity = torch::zeros({numRays}, sigmas.options());
     torch::Tensor outDepth   = torch::zeros({numRays}, sigmas.options());
-    torch::Tensor outRgb     = torch::zeros({numRays, 3}, sigmas.options());
+    torch::Tensor outRgb     = torch::zeros({numRays, rgbs.size(1)}, sigmas.options());
     torch::Tensor outWs      = torch::zeros({N}, sigmas.options());
     torch::Tensor outTotalSamples =
         torch::zeros({numRays}, torch::dtype(torch::kLong).device(sigmas.device()));
@@ -632,7 +651,7 @@ volumeRenderBackward(const torch::Tensor &dLdOpacity,
     const int64_t N = sigmas.size(0);
 
     torch::Tensor dLdSigmas = torch::zeros({N}, sigmas.options());
-    torch::Tensor dLdRgbs   = torch::zeros({N, 3}, sigmas.options());
+    torch::Tensor dLdRgbs   = torch::zeros({N, rgbs.size(1)}, sigmas.options());
 
     FVDB_DISPATCH_KERNEL_DEVICE(sigmas.device(), [&]() {
         dispatchVolumeRenderBackward<DeviceTag>(dLdOpacity,

--- a/src/fvdb/detail/ops/VolumeRender.cu
+++ b/src/fvdb/detail/ops/VolumeRender.cu
@@ -658,6 +658,20 @@ volumeRenderBackward(const torch::Tensor &dLdOpacity,
                      float tsmtThreshold) {
     const int64_t N = sigmas.size(0);
 
+    TORCH_CHECK(rgbs.dim() == 2,
+                "rgbs must be a 2D tensor of shape (N, C), but got a ",
+                rgbs.dim(),
+                "D tensor.");
+    TORCH_CHECK(dLdRgb.dim() == 2,
+                "dLdRgb must be a 2D tensor of shape (numRays, C), but got a ",
+                dLdRgb.dim(),
+                "D tensor.");
+    TORCH_CHECK(rgb.dim() == 2,
+                "rgb must be a 2D tensor of shape (numRays, C), but got a ",
+                rgb.dim(),
+                "D tensor.");
+    TORCH_CHECK(
+        rgbs.size(1) > 0, "rgbs must have at least one channel, but got ", rgbs.size(1), ".");
     TORCH_CHECK(rgbs.size(1) <= MAX_VOLUME_RENDER_CHANNELS,
                 "Volume rendering backward supports at most ",
                 MAX_VOLUME_RENDER_CHANNELS,

--- a/tests/unit/test_ray_marching.py
+++ b/tests/unit/test_ray_marching.py
@@ -545,7 +545,9 @@ class TestVolumeRender(unittest.TestCase):
         tmid = ray_intervals_jdata.mean(1).contiguous()
         # 17 > MAX_VOLUME_RENDER_CHANNELS (16)
         rgbs_too_wide = torch.zeros(N, 17, device=self.device, dtype=self.dtype)
-        with self.assertRaises(RuntimeError):
+        with self.assertRaisesRegex(
+            RuntimeError, r"between 1 and .*channels.*17|17.*channels.*between 1 and"
+        ):
             volume_render(sigma, rgbs_too_wide, dt, tmid, ray_joffsets, 0.001)
 
     def test_volume_render_total_samples_counts_terminating_sample(self):

--- a/tests/unit/test_ray_marching.py
+++ b/tests/unit/test_ray_marching.py
@@ -545,9 +545,7 @@ class TestVolumeRender(unittest.TestCase):
         tmid = ray_intervals_jdata.mean(1).contiguous()
         # 17 > MAX_VOLUME_RENDER_CHANNELS (16)
         rgbs_too_wide = torch.zeros(N, 17, device=self.device, dtype=self.dtype)
-        with self.assertRaisesRegex(
-            RuntimeError, r"between 1 and .*channels.*17|17.*channels.*between 1 and"
-        ):
+        with self.assertRaisesRegex(RuntimeError, r"between 1 and .*channels.*17|17.*channels.*between 1 and"):
             volume_render(sigma, rgbs_too_wide, dt, tmid, ray_joffsets, 0.001)
 
     def test_volume_render_total_samples_counts_terminating_sample(self):

--- a/tests/unit/test_ray_marching.py
+++ b/tests/unit/test_ray_marching.py
@@ -438,6 +438,116 @@ class TestVolumeRender(unittest.TestCase):
         # pc.add_scalar_quantity("sigma samples", sigma_samples.detach().squeeze().cpu(), enabled=True)
         # ps.show()
 
+    def test_volume_render_nchannel(self):
+        """
+        volume_render must handle an arbitrary number of channels, not just 3.
+        Run a 4-channel composite and cross-check it against two independent
+        2-channel runs on the same sample topology. Also verifies the backward
+        pass produces consistent gradients across widths.
+        """
+        if self.dtype == torch.float16:
+            self.skipTest("half precision accumulates too much error for the N-channel round trip")
+        t_threshold = 0.001
+        num_channels = 4
+
+        grid_data_rgb = (
+            torch.rand(self.grid_dual.total_voxels, num_channels).to(device=self.device, dtype=self.dtype) * 0.5
+        )
+        grid_data_sigma = torch.rand(self.grid_dual.total_voxels, 1).to(device=self.device, dtype=self.dtype) * 0.5
+        grid_data_rgb.requires_grad = True
+        grid_data_sigma.requires_grad = True
+
+        ray_o, ray_d = self.make_ray_grid((0.0, 0.0, -1.0), 8)
+        tmin = torch.zeros(ray_o.shape[0]).to(ray_o)
+        tmax = torch.ones(ray_o.shape[0]).to(ray_o) * 1e10
+        ray_intervals = self.grid.uniform_ray_samples(
+            JaggedTensor(ray_o), JaggedTensor(ray_d), JaggedTensor(tmin), JaggedTensor(tmax), self.step_size
+        )
+        ray_idx = ray_intervals.jidx.int()
+        ray_joffsets = ray_intervals.joffsets
+        ray_intervals = ray_intervals.jdata
+
+        ray_mid = ray_intervals.mean(1)
+        ray_dt = ray_intervals[:, 1] - ray_intervals[:, 0]
+        ray_pts = ray_o[ray_idx] + ray_mid[:, None] * ray_d[ray_idx]
+
+        rgb_samples_4 = self.grid_dual.sample_trilinear(JaggedTensor(ray_pts), JaggedTensor(grid_data_rgb)).jdata
+        sigma_samples = self.grid_dual.sample_trilinear(JaggedTensor(ray_pts), JaggedTensor(grid_data_sigma)).jdata
+        assert isinstance(rgb_samples_4, torch.Tensor)
+        assert isinstance(sigma_samples, torch.Tensor)
+
+        # 4-channel forward + backward
+        rgb4, depth4, opacity4, ws4, _ = volume_render(
+            sigma_samples.squeeze(), rgb_samples_4, ray_dt, ray_mid, ray_joffsets, t_threshold
+        )
+        self.assertEqual(rgb4.shape, (ray_o.shape[0], num_channels))
+        loss_4 = rgb4.sum() + depth4.sum()
+        loss_4.backward()
+        assert grid_data_rgb.grad is not None
+        assert grid_data_sigma.grad is not None
+        rgb_grad_4 = grid_data_rgb.grad.detach().clone()
+        sigma_grad_4 = grid_data_sigma.grad.detach().clone()
+        grid_data_rgb.grad.zero_()
+        grid_data_sigma.grad.zero_()
+
+        # Two 2-channel forwards + backwards on the same sample topology
+        grid_data_rgb_a = grid_data_rgb[:, 0:2].detach().clone().requires_grad_(True)
+        grid_data_rgb_b = grid_data_rgb[:, 2:4].detach().clone().requires_grad_(True)
+        rgb_samples_a = self.grid_dual.sample_trilinear(JaggedTensor(ray_pts), JaggedTensor(grid_data_rgb_a)).jdata
+        rgb_samples_b = self.grid_dual.sample_trilinear(JaggedTensor(ray_pts), JaggedTensor(grid_data_rgb_b)).jdata
+
+        rgb_a, depth_a, opacity_a, ws_a, _ = volume_render(
+            sigma_samples.squeeze(), rgb_samples_a, ray_dt, ray_mid, ray_joffsets, t_threshold
+        )
+        rgb_b, depth_b, opacity_b, ws_b, _ = volume_render(
+            sigma_samples.squeeze(), rgb_samples_b, ray_dt, ray_mid, ray_joffsets, t_threshold
+        )
+
+        rgb_cat = torch.cat([rgb_a, rgb_b], dim=1)
+        self.assertLess(torch.abs(rgb4 - rgb_cat).max().item(), 1e-4)
+        # Depth/opacity/ws must be channel-agnostic -- same across runs.
+        self.assertLess(torch.abs(depth4 - depth_a).max().item(), 1e-5)
+        self.assertLess(torch.abs(depth_a - depth_b).max().item(), 1e-5)
+        self.assertLess(torch.abs(opacity4 - opacity_a).max().item(), 1e-5)
+        self.assertLess(torch.abs(ws4 - ws_a).max().item(), 1e-5)
+
+        # Backward: loss = rgb.sum() + depth.sum(). For the 4-ch run, depth is counted once.
+        # For the split runs, each contributes a depth term, so add them but subtract one depth.sum()
+        # so the chain rule matches the 4-ch case.
+        (rgb_a.sum() + rgb_b.sum() + depth_a.sum()).backward()
+        assert grid_data_rgb_a.grad is not None
+        assert grid_data_rgb_b.grad is not None
+        assert grid_data_sigma.grad is not None
+        rgb_grad_a = grid_data_rgb_a.grad.detach().clone()
+        rgb_grad_b = grid_data_rgb_b.grad.detach().clone()
+        sigma_grad_split = grid_data_sigma.grad.detach().clone()
+
+        # Reconstructed 4-ch grad from two 2-ch grads
+        rgb_grad_split = torch.cat([rgb_grad_a, rgb_grad_b], dim=1)
+        self.assertLess(torch.abs(rgb_grad_4 - rgb_grad_split).max().item(), 1e-3)
+        self.assertLess(torch.abs(sigma_grad_4 - sigma_grad_split).max().item(), 1e-3)
+
+    def test_volume_render_rejects_too_many_channels(self):
+        """Channels above MAX_VOLUME_RENDER_CHANNELS must be rejected with a clear error."""
+        ray_o, ray_d = self.make_ray_grid((0.0, 0.0, -1.0), 4)
+        tmin = torch.zeros(ray_o.shape[0]).to(ray_o)
+        tmax = torch.ones(ray_o.shape[0]).to(ray_o) * 1e10
+        ray_intervals = self.grid.uniform_ray_samples(
+            JaggedTensor(ray_o), JaggedTensor(ray_d), JaggedTensor(tmin), JaggedTensor(tmax), self.step_size
+        )
+        ray_joffsets = ray_intervals.joffsets
+        ray_intervals_jdata = ray_intervals.jdata
+        N = ray_intervals_jdata.shape[0]
+        if N == 0:
+            self.skipTest("No samples along rays; cannot exercise channel guard")
+        sigma = torch.zeros(N, device=self.device, dtype=self.dtype)
+        dt = (ray_intervals_jdata[:, 1] - ray_intervals_jdata[:, 0]).contiguous()
+        tmid = ray_intervals_jdata.mean(1).contiguous()
+        # 17 > MAX_VOLUME_RENDER_CHANNELS (16)
+        rgbs_too_wide = torch.zeros(N, 17, device=self.device, dtype=self.dtype)
+        with self.assertRaises(RuntimeError):
+            volume_render(sigma, rgbs_too_wide, dt, tmid, ray_joffsets, 0.001)
+
 
 class TestRayMarching(unittest.TestCase):
     def setUp(self):

--- a/tests/unit/test_ray_marching.py
+++ b/tests/unit/test_ray_marching.py
@@ -548,6 +548,107 @@ class TestVolumeRender(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             volume_render(sigma, rgbs_too_wide, dt, tmid, ray_joffsets, 0.001)
 
+    def test_volume_render_total_samples_counts_terminating_sample(self):
+        """Regression test for the off-by-one in ``volumeRenderFwdCallback``.
+
+        When the running transmittance ``T`` drops to or below ``tsmtThreshold`` the
+        ray terminates early. The sample that triggered the termination has already
+        been composited into ``outRGB``, ``outDepth``, ``outOpacity`` and ``outWs``,
+        so ``outTotalSamples[rayIdx]`` must include it. A previous version of the
+        kernel incremented ``numSamples`` only *after* the break check, which left
+        the reported total one short of the samples actually written.
+
+        The test constructs a deterministic per-ray sample layout with known
+        sigmas and verifies ``outTotalSamples`` equals the number of entries
+        actually written into ``outWs`` (i.e. the non-zero prefix).
+        """
+        if self.dtype == torch.float16:
+            self.skipTest("half precision is noisy near the transmittance threshold")
+
+        # sigma=20, dt=0.1 -> exp(-sigma*dt) = exp(-2) ~= 0.1353 per sample.
+        # Starting from T=1, after 3 samples T ~= 0.00247 which is below
+        # tsmtThreshold=0.01, so the loop breaks right after compositing sample 2.
+        # Expected outTotalSamples for a high-sigma ray: 3.
+        tsmt_threshold = 0.01
+
+        # Per-ray sample layouts (each ray may have a different number of slots).
+        ray_sizes = [10, 4, 0, 6]
+        sigma_per_ray = [20.0, 0.1, 0.0, 20.0]
+        # Expected tot_samples per ray after the fix:
+        #   ray 0: sigma=20 over 10 slots -> breaks after composite 3 -> tot=3
+        #   ray 1: sigma=0.1 over 4 slots -> T stays near 1, no break -> tot=4
+        #   ray 2: no slots -> tot=0
+        #   ray 3: sigma=20 over 6 slots -> breaks after composite 3 -> tot=3
+        expected_tot = [3, 4, 0, 3]
+
+        joffsets_py = [0]
+        for s in ray_sizes:
+            joffsets_py.append(joffsets_py[-1] + s)
+        joffsets = torch.tensor(joffsets_py, dtype=torch.int64, device=self.device)
+        N = int(joffsets[-1].item())
+
+        sigmas = torch.zeros(N, dtype=self.dtype, device=self.device)
+        for i, s in enumerate(ray_sizes):
+            start = joffsets_py[i]
+            sigmas[start : start + s] = sigma_per_ray[i]
+        dt = torch.full((N,), 0.1, dtype=self.dtype, device=self.device)
+        t = torch.arange(N, dtype=self.dtype, device=self.device) * 0.1
+        # Single-channel rgbs keep the comparisons simple and are enough to
+        # exercise the accumulation path.
+        rgbs = torch.ones((N, 1), dtype=self.dtype, device=self.device)
+
+        _, _, opacity, ws, tot_samples = volume_render(sigmas, rgbs, dt, t, joffsets, tsmt_threshold)
+
+        for ray_i in range(len(ray_sizes)):
+            start = joffsets_py[ray_i]
+            end = joffsets_py[ray_i + 1]
+            tot = int(tot_samples[ray_i].item())
+            ws_ray = ws[start:end]
+
+            # The reported total must be in-range and match the analytic expectation.
+            self.assertGreaterEqual(tot, 0)
+            self.assertLessEqual(tot, end - start)
+            self.assertEqual(
+                tot,
+                expected_tot[ray_i],
+                f"Ray {ray_i}: outTotalSamples={tot} but expected {expected_tot[ray_i]}",
+            )
+
+            # Every composited sample has strictly positive weight when sigma > 0
+            # and T > 0, so the reported total must match the number of non-zero
+            # entries in ws (which is zero-initialized at allocation time).
+            nz = int((ws_ray != 0).sum().item())
+            self.assertEqual(
+                tot,
+                nz,
+                f"Ray {ray_i}: outTotalSamples={tot} but ws has {nz} non-zero entries; "
+                "this indicates an off-by-one between outTotalSamples and outWs.",
+            )
+
+            # ws must be a contiguous non-zero prefix of length tot followed by
+            # untouched zeros.
+            if tot > 0:
+                self.assertTrue(
+                    torch.all(ws_ray[:tot] != 0).item(),
+                    f"Ray {ray_i}: ws[:tot] contains a zero entry",
+                )
+            if tot < end - start:
+                self.assertTrue(
+                    torch.all(ws_ray[tot:] == 0).item(),
+                    f"Ray {ray_i}: ws[tot:] contains a non-zero entry (write past tot)",
+                )
+
+            # outOpacity must equal the sum of the composited ws for the ray.
+            # This cross-checks that tot_samples and the accumulators agree.
+            self.assertTrue(
+                torch.isclose(
+                    opacity[ray_i],
+                    ws_ray.sum(),
+                    atol=1e-4 if self.dtype == torch.float32 else 1e-6,
+                ).item(),
+                f"Ray {ray_i}: outOpacity={opacity[ray_i].item()} disagrees with sum(ws)={ws_ray.sum().item()}",
+            )
+
 
 class TestRayMarching(unittest.TestCase):
     def setUp(self):
@@ -639,6 +740,136 @@ class TestRayMarching(unittest.TestCase):
         ray_idx, ray_times_inside = ray_times_inside.jidx.long(), ray_times_inside.jdata
         nsteps_outside = (ray_times_inside - tmin[ray_idx, None]) / step_size
         self.assertTrue(torch.allclose(nsteps_outside, torch.round(nsteps_outside), atol=dtype_to_atol(dtype)))
+
+    @parameterized.expand(all_device_dtype_combos)
+    def test_uniform_ray_samples_cone_tracing_count_matches_generate(self, device, dtype):
+        """Regression test for the floor/ceil mismatch in ``SampleRaysUniform.cu``.
+
+        With ``cone_angle > 0`` and ``include_end_segments=True`` the count and
+        generate callbacks must agree on how ``t0`` is snapped to the first
+        step boundary inside each HDDA segment. Historically the count path used
+        ``floor(distToVox / stepSize)`` while the generate path used ``ceil``,
+        which silently under-allocates the output buffer under cone tracing:
+        since ``stepSize`` depends on ``t0`` when ``cone_angle > 0``, the two
+        callbacks then walk different ``t0`` trajectories and disagree on the
+        number of samples they emit. The generate pass ends up writing one
+        sample past the buffer the count pass allocated, corrupting adjacent
+        rays' slots.
+
+        The test uses a ray that traverses a long 1D contiguous run of voxels
+        with an aggressive cone angle so the per-step ``stepSize`` actually
+        grows inside the segment. The sample count and per-sample boundaries
+        are compared against a Python reference that mirrors the fixed
+        (``ceil``-rounded) algorithm. A pre-fix CUDA/CPU kernel would return
+        one fewer sample than the reference and mismatched boundaries in the
+        tail of the ray.
+        """
+        if dtype == torch.float16:
+            # The half-precision specialisation of ``nanovdb::math::Delta`` is 1e-3,
+            # which reshuffles the boundary-gap decisions. That code path is
+            # orthogonal to the floor/ceil fix we want to cover here, so we
+            # only exercise float32 / float64.
+            self.skipTest("half-precision Delta rearranges the boundary-gap checks")
+
+        import math as _math
+
+        # Long, thin dense grid so the ray sees a single merged HDDA segment
+        # spanning many voxels. Voxel size 1 and origin 0 give a grid whose
+        # axis-aligned bounding box is x in [-0.5, 49.5], y, z in [-0.5, 0.5].
+        grid = GridBatch.from_dense(num_grids=1, dense_dims=[50, 1, 1], device=device)
+
+        # Ray starts outside the grid at x = -5 and travels along +x through
+        # y = z = 0, so it hits every voxel (i, 0, 0) exactly once. The ray
+        # enters the grid at t = 4.5 and exits at t = 54.5.
+        rays_o = torch.tensor([[-5.0, 0.0, 0.0]], dtype=dtype, device=device)
+        rays_d = torch.tensor([[1.0, 0.0, 0.0]], dtype=dtype, device=device)
+        nears = torch.tensor([0.0], dtype=dtype, device=device)
+        fars = torch.tensor([60.0], dtype=dtype, device=device)
+
+        # Cone=0.5 is aggressive enough that ``stepSize = t0 * cone_angle``
+        # overtakes the 1.0 floor after t0 >= 2, so the per-iteration step
+        # really does grow across the while loop. This is the regime where
+        # floor and ceil paths diverge.
+        step_size = 1.0
+        cone_angle = 0.5
+
+        intervals = grid.uniform_ray_samples(
+            JaggedTensor(rays_o),
+            JaggedTensor(rays_d),
+            JaggedTensor(nears),
+            JaggedTensor(fars),
+            step_size,
+            cone_angle=cone_angle,
+            include_end_segments=True,
+        )
+        actual = intervals.jdata.detach().cpu().double().numpy()
+
+        # Reference implementation mirroring ``countSamplesPerRayCallback`` and
+        # ``generateRaySamplesCallback`` for a single HDDA segment
+        # [t_enter, t_exit] with the post-fix ``ceil`` rounding applied in both.
+        t_enter, t_exit = 4.5, 54.5
+        # ``Delta`` for float is small enough that the exact test boundaries
+        # (0.5 and 8.9375 gap widths) are always considered gaps.
+        delta = 1e-6
+
+        def _calc_dt(t: float, cone: float, min_step: float, max_step: float = 1e10) -> float:
+            return max(min_step, min(max_step, t * cone))
+
+        t0 = 0.0
+        step = _calc_dt(t0, cone_angle, step_size)
+        expected: list[tuple[float, float]] = []
+        dist_to_vox = t_enter - t0
+        t0 += _math.ceil(dist_to_vox / step) * step
+        t1 = t0 + step
+        if t0 > t_exit:
+            expected.append((t_enter, t_exit))
+        else:
+            if t0 - t_enter > delta:
+                expected.append((t_enter, t0))
+            while t1 < t_exit:
+                expected.append((t0, t1))
+                t0 = t1
+                step = _calc_dt(t0, cone_angle, step_size)
+                t1 += step
+            if t_exit - t0 > delta:
+                expected.append((t0, t_exit))
+
+        self.assertEqual(
+            actual.shape[0],
+            len(expected),
+            f"Sample count mismatch (device={device}, dtype={dtype}): got {actual.shape[0]}, "
+            f"expected {len(expected)}. Pre-fix code used floor() in the count path and "
+            f"typically returned one fewer sample than the generate path.",
+        )
+
+        # Use a fp32-appropriate tolerance for the cumulative step arithmetic.
+        tol = 1e-3 if dtype == torch.float32 else 1e-6
+        for i, (ref_s, ref_e) in enumerate(expected):
+            self.assertAlmostEqual(
+                float(actual[i, 0]),
+                ref_s,
+                delta=tol,
+                msg=f"t_start mismatch at sample {i} (device={device}, dtype={dtype})",
+            )
+            self.assertAlmostEqual(
+                float(actual[i, 1]),
+                ref_e,
+                delta=tol,
+                msg=f"t_end mismatch at sample {i} (device={device}, dtype={dtype})",
+            )
+
+        # Sanity invariants that must hold regardless of the specific algorithm:
+        # strict monotonicity of t_start, non-degenerate intervals, and that
+        # all samples lie within the grid's HDDA-clipped [t_enter, t_exit].
+        t_starts = intervals.jdata[:, 0].double()
+        t_ends = intervals.jdata[:, 1].double()
+        self.assertTrue(torch.all(t_ends > t_starts).item(), "Found a degenerate interval (t_end <= t_start)")
+        self.assertTrue(
+            torch.all(t_starts[1:] >= t_starts[:-1]).item(),
+            "Sample starts are not monotonically non-decreasing along the ray",
+        )
+        self.assertGreaterEqual(float(t_starts.min().item()), t_enter - tol)
+        self.assertLessEqual(float(t_ends.max().item()), t_exit + tol)
 
     @parameterized.expand(all_device_dtype_combos)
     def test_segments_along_rays_bug(self, device, dtype):


### PR DESCRIPTION
### Generalize `volume_render` to N channels

Extend the volume_render forward and backward kernels to support an arbitrary number of radiance channels (1..MAX_VOLUME_RENDER_CHANNELS, with MAX set to 16) instead of the previous hardcoded 3. This is needed for spectral rendering pipelines that want to composite K wavelength samples per ray.

Changes in src/fvdb/detail/ops/VolumeRender.cu:
  * Add MAX_VOLUME_RENDER_CHANNELS = 16 and thread numChannels through volumeRenderFwdCallback as a parameter.
  * Replace channel-specific r/g/b accumulators in volumeRenderBwdCallback with bounded stack arrays sized by MAX_VOLUME_RENDER_CHANNELS; loop over numChannels for both the running partial sum and the per-sample gradient accumulation into out_dLdRgbs.
  * Allocate outRgb / dLdRgbs host-side tensors with shape (numRays, rgbs.size(1)) instead of a hardcoded 3.
  * Add a TORCH_CHECK that rgbs.size(1) is in [1, MAX_VOLUME_RENDER_CHANNELS] with a clear error message.

Tests in tests/unit/test_ray_marching.py:
  * test_volume_render_nchannel runs a 4-channel volume_render and asserts that its output (rgb, depth, opacity, weights) and gradients match the concatenation of two independent 2-channel runs over the same sample topology; skips float16 due to error accumulation.
  * test_volume_render_rejects_too_many_channels verifies a RuntimeError is raised when rgbs has more than MAX_VOLUME_RENDER_CHANNELS columns.

No changes to the public Python API; existing 3-channel callers and all pre-existing TestVolumeRender cases continue to pass unchanged.


### Correctness fixes

Additionally this PR fixes two ray/sample kernel correctness bugs and adds regression tests

- VolumeRender.cu: move numSamples increment before the transmittance break check so outTotalSamples counts the sample that triggered early termination (that sample is already composited into outRGB, outDepth, outOpacity and outWs).

- SampleRaysUniform.cu: use ceil instead of floor when snapping t0 to the first step inside an HDDA segment in the count callback, matching the generate callback. Under cone tracing (coneAngle > 0) stepSize depends on t0, so a floor/ceil mismatch silently under-allocated the output buffer and let the generate pass OOB write into adjacent rays' slots.

- tests/unit/test_ray_marching.py: regression tests for both fixes.
  TestVolumeRender verifies outTotalSamples matches the non-zero prefix of outWs under early termination. TestRayMarching verifies uniform_ray_samples under cone tracing with include_end_segments matches a ceil-rounded Python reference in both count and per-sample boundaries.