### PR TITLE
Add `__launch_bounds__` to forEach CUDA kernels

### DIFF
--- a/src/fvdb/detail/ops/ActiveVoxelsInBoundsMask.cu
+++ b/src/fvdb/detail/ops/ActiveVoxelsInBoundsMask.cu
@@ -64,7 +64,7 @@ GetActiveVoxelsInBoundsMask(const GridBatchData &gridBatch,
             activeGridVoxelInBoundsMaskCallback<TorchRAcc64>(
                 batchIdx, leafIdx, voxelIdx, gridAccessor, bboxAcc, outMaskAcc);
         };
-        forEachVoxelCUDA(1024, 1, gridBatch, cb);
+        forEachVoxelCUDA<1024>(1, gridBatch, cb);
     } else {
         auto cb = [=](int32_t batchIdx,
                       int32_t leafIdx,

--- a/src/fvdb/detail/ops/AvgPool.cu
+++ b/src/fvdb/detail/ops/AvgPool.cu
@@ -170,7 +170,7 @@ DownsampleGridAvgPool(const GridBatchData &fineBatchHdl,
                                                                 stride,
                                                                 static_cast<scalar_t>(avgFactor));
                 };
-                forEachVoxelCUDA(384, outCoarseData.size(1), coarseBatchHdl, avgPoolPerVoxel);
+                forEachVoxelCUDA<384>(outCoarseData.size(1), coarseBatchHdl, avgPoolPerVoxel);
             } else {
                 auto avgPoolPerVoxel = [=](int32_t batchIdx,
                                            int32_t leafIdx,
@@ -252,7 +252,7 @@ DownsampleGridAvgPoolBackward(const GridBatchData &coarseBatchHdl,
                                    stride,
                                    static_cast<scalar_t>(avgFactor));
                            };
-                           forEachVoxelCUDA(384, fineData.size(1), coarseBatchHdl, cb);
+                           forEachVoxelCUDA<384>(fineData.size(1), coarseBatchHdl, cb);
                        } else {
                            auto cb = [=](int32_t batchIdx,
                                          int32_t leafIdx,

--- a/src/fvdb/detail/ops/BuildFineGridFromCoarse.cu
+++ b/src/fvdb/detail/ops/BuildFineGridFromCoarse.cu
@@ -177,7 +177,7 @@ dispatchFineIJKForCoarseGrid<torch::kCUDA>(const GridBatchData &batchHdl,
                                               maskPrefixSumAcc);
         };
 
-        forEachVoxelCUDA(DEFAULT_BLOCK_DIM, 1, batchHdl, cb);
+        forEachVoxelCUDA(1, batchHdl, cb);
 
         at::cuda::CUDAStream stream  = at::cuda::getCurrentCUDAStream(batchHdl.device().index());
         torch::Tensor outVoxelCounts = torch::zeros_like(batchHdl.voxelOffsets());
@@ -232,7 +232,7 @@ dispatchFineIJKForCoarseGrid<torch::kCUDA>(const GridBatchData &batchHdl,
                 bidx, lidx, vidx, cidx, bacc, upsamplingFactor, outIJKAcc, outIJKBIdxAcc);
         };
 
-        forEachVoxelCUDA(DEFAULT_BLOCK_DIM, 1, batchHdl, cb);
+        forEachVoxelCUDA(1, batchHdl, cb);
 
         return JaggedTensor::from_data_offsets_and_list_ids(
             outIJK, batchHdl.voxelOffsets() * totalPadAmount, batchHdl.jlidx());

--- a/src/fvdb/detail/ops/BuildGridForConv.cu
+++ b/src/fvdb/detail/ops/BuildGridForConv.cu
@@ -175,7 +175,7 @@ convIJKForGrid(const GridBatchData &batchHdl,
                                outIJKBIdxAcc,
                                outMaskAcc);
     };
-    forEachVoxelCUDA(256, 1, batchHdl, cb);
+    forEachVoxelCUDA(1, batchHdl, cb);
 
     outIJK     = outIJK.index({outMask});
     outIJKBIdx = outIJKBIdx.index({outMask});

--- a/src/fvdb/detail/ops/BuildGridForConvTranspose.cu
+++ b/src/fvdb/detail/ops/BuildGridForConvTranspose.cu
@@ -173,7 +173,7 @@ convTransposeIJKForGrid(const GridBatchData &batchHdl,
                                         outIJKAcc,
                                         outIJKBIdxAcc);
     };
-    forEachVoxelCUDA(256, 1, batchHdl, cb);
+    forEachVoxelCUDA(1, batchHdl, cb);
 
     return JaggedTensor::from_data_indices_and_list_ids(
         outIJK, outIJKBIdx, batchHdl.jlidx(), batchHdl.batchSize());

--- a/src/fvdb/detail/ops/BuildGridFromPoints.cu
+++ b/src/fvdb/detail/ops/BuildGridFromPoints.cu
@@ -76,7 +76,7 @@ ijkForPoints(const JaggedTensor &jaggedPoints, const std::vector<VoxelCoordTrans
                                      JaggedRAcc64<scalar_t, 2> pacc) {
                 ijkForPointsCallback(bidx, eidx, pacc, transformDevPtr, outIJKAcc);
             };
-            forEachJaggedElementChannelCUDA<scalar_t, 2>(1024, 1, jaggedPoints, cb);
+            forEachJaggedElementChannelCUDA<scalar_t, 2, 1024>(1, jaggedPoints, cb);
         }),
         AT_EXPAND(AT_FLOATING_TYPES),
         c10::kHalf);

--- a/src/fvdb/detail/ops/BuildPaddedGrid.cu
+++ b/src/fvdb/detail/ops/BuildPaddedGrid.cu
@@ -222,7 +222,7 @@ paddedIJKForGrid(const GridBatchData &batchHdl, const nanovdb::CoordBBox &bbox) 
     };
 
     if constexpr (DeviceTag == torch::kCUDA) {
-        forEachVoxelCUDA(DEFAULT_BLOCK_DIM, 1, batchHdl, cb);
+        forEachVoxelCUDA(1, batchHdl, cb);
     } else if constexpr (DeviceTag == torch::kPrivateUse1) {
         forEachVoxelPrivateUse1(1, batchHdl, cb);
     }
@@ -253,7 +253,7 @@ paddedIJKForGridWithoutBorder(const GridBatchData &batchHdl, const nanovdb::Coor
         ijkForGridVoxelCallbackWithoutBorderCount(
             bidx, lidx, vidx, cidx, bacc, bbox, outCounterAcc);
     };
-    forEachVoxelCUDA(512, 1, batchHdl, cb);
+    forEachVoxelCUDA<512>(1, batchHdl, cb);
 
     torch::Tensor cumCounts    = torch::cumsum(outCounter, 0);
     int64_t numVoxels          = cumCounts[-1].item<int64_t>();
@@ -281,7 +281,7 @@ paddedIJKForGridWithoutBorder(const GridBatchData &batchHdl, const nanovdb::Coor
         ijkForGridVoxelCallbackWithoutBorder(
             bidx, lidx, vidx, cidx, bacc, bbox, packInfoBaseAcc, outIJKAcc, outIJKBIdxAcc);
     };
-    forEachVoxelCUDA(512, 1, batchHdl, cb2);
+    forEachVoxelCUDA<512>(1, batchHdl, cb2);
 
     return JaggedTensor::from_data_indices_and_list_ids(
         outIJK, outIJKBIdx, batchHdl.jlidx(), batchHdl.batchSize());

--- a/src/fvdb/detail/ops/CoarseIjkForFineGrid.cu
+++ b/src/fvdb/detail/ops/CoarseIjkForFineGrid.cu
@@ -74,7 +74,7 @@ dispatchCoarseIJKForFineGrid<torch::kCUDA>(const GridBatchData &batchHdl,
             bidx, lidx, vidx, cidx, bacc, coarseningFactor, outIJKAcc, outIJKBIdxAcc);
     };
 
-    forEachVoxelCUDA(1024, 1, batchHdl, cb);
+    forEachVoxelCUDA<1024>(1, batchHdl, cb);
 
     return JaggedTensor::from_data_offsets_and_list_ids(
         outIJK, batchHdl.voxelOffsets(), batchHdl.jlidx());

--- a/src/fvdb/detail/ops/CoordsInGrid.cu
+++ b/src/fvdb/detail/ops/CoordsInGrid.cu
@@ -63,7 +63,7 @@ CoordsInGrid(const GridBatchData &batchHdl, const JaggedTensor &ijk) {
                                coordsInGridCallback<scalar_t, JaggedRAcc64, TorchRAcc64>(
                                    bidx, eidx, ijkAcc, outMaskAccessor, batchAcc);
                            };
-                           forEachJaggedElementChannelCUDA<scalar_t, 2>(1024, 1, ijk, cb);
+                           forEachJaggedElementChannelCUDA<scalar_t, 2, 1024>(1, ijk, cb);
                        } else {
                            auto cb = [=](int32_t bidx,
                                          int32_t eidx,

--- a/src/fvdb/detail/ops/CubesInGrid.cu
+++ b/src/fvdb/detail/ops/CubesInGrid.cu
@@ -102,7 +102,7 @@ CubesInGrid(const GridBatchData &batchHdl,
                                cubesInGridCallback<scalar_t, IsTouch, JaggedRAcc64, TorchRAcc64>(
                                    bidx, eidx, ptsA, outMaskAccessor, batchAcc, dstart, dend);
                            };
-                           forEachJaggedElementChannelCUDA<scalar_t, 2>(512, 1, cubeCenters, cb);
+                           forEachJaggedElementChannelCUDA<scalar_t, 2, 512>(1, cubeCenters, cb);
                        } else {
                            auto cb = [=](int32_t bidx,
                                          int32_t eidx,

--- a/src/fvdb/detail/ops/GridEdgeNetwork.cu
+++ b/src/fvdb/detail/ops/GridEdgeNetwork.cu
@@ -127,7 +127,7 @@ GridEdgeNetwork(const GridBatchData &batchHdl, bool returnVoxelCoordinates) {
                                                  outEBidxAcc,
                                                  returnVoxelCoordinates);
         };
-        forEachVoxelCUDA(1024, 1, batchHdl, cb);
+        forEachVoxelCUDA<1024>(1, batchHdl, cb);
     } else {
         auto cb = [=](int32_t batchIdx,
                       int32_t leafIdx,

--- a/src/fvdb/detail/ops/IjkForMesh.cu
+++ b/src/fvdb/detail/ops/IjkForMesh.cu
@@ -233,7 +233,7 @@ dispatchIJKForMesh<torch::kCUDA>(const JaggedTensor &meshVertices,
                         countVoxelsPerTriToCheck<scalar_f, scalar_i>(
                             bidx, eidx, transformDevPtr, verticesAcc, facesAcc, samplesPerTriAcc);
                     };
-                    forEachJaggedElementChannelCUDA<scalar_i, 2>(1024, 1, meshFaces, cb);
+                    forEachJaggedElementChannelCUDA<scalar_i, 2, 1024>(1, meshFaces, cb);
 
                     // Compute the cumulative sum of the number of samples per triangle so each
                     // thread can figure out which triangle it's in

--- a/src/fvdb/detail/ops/IjkToIndex.cu
+++ b/src/fvdb/detail/ops/IjkToIndex.cu
@@ -69,7 +69,7 @@ IjkToIndex(const GridBatchData &batchHdl, const JaggedTensor &ijk, bool cumulati
                                ijkToIndexCallback<scalar_t, JaggedRAcc64, TorchRAcc64>(
                                    bidx, eidx, batchAcc, ijkAcc, outIndexAcc, cumulative);
                            };
-                           forEachJaggedElementChannelCUDA<scalar_t, 2>(512, 1, ijk, cb);
+                           forEachJaggedElementChannelCUDA<scalar_t, 2, 512>(1, ijk, cb);
                        } else if constexpr (DeviceTag == torch::kPrivateUse1) {
                            auto cb = [=] __device__(fvdb::JIdxType bidx,
                                                     int64_t eidx,

--- a/src/fvdb/detail/ops/IjkToInvIndex.cu
+++ b/src/fvdb/detail/ops/IjkToInvIndex.cu
@@ -68,7 +68,7 @@ IjkToInvIndex(const GridBatchData &batchHdl, const JaggedTensor &ijk, bool cumul
                                ijkToInvIndexCallback<scalar_t, JaggedRAcc64, TorchRAcc64>(
                                    bidx, eidx, batchAcc, ijkAcc, outInvIndexAcc, cumulative);
                            };
-                           forEachJaggedElementChannelCUDA<scalar_t, 2>(512, 1, ijk, cb);
+                           forEachJaggedElementChannelCUDA<scalar_t, 2, 512>(1, ijk, cb);
                        } else {
                            auto cb = [=](fvdb::JIdxType bidx,
                                          int64_t eidx,

--- a/src/fvdb/detail/ops/Inject.cu
+++ b/src/fvdb/detail/ops/Inject.cu
@@ -1,11 +1,13 @@
 // Copyright Contributors to the OpenVDB Project
 // SPDX-License-Identifier: Apache-2.0
 //
+
 #include <fvdb/GridBatchData.h>
 #include <fvdb/JaggedTensor.h>
 #include <fvdb/TorchDeviceBuffer.h>
 #include <fvdb/detail/ops/Inject.h>
 #include <fvdb/detail/utils/Utils.h>
+#include <fvdb/detail/utils/cuda/GridDim.h>
 #include <fvdb/detail/utils/cuda/Utils.cuh>
 #include <fvdb/detail/utils/nanovdb/ActiveVoxelIterator.h>
 
@@ -105,7 +107,7 @@ template <typename ValueType, int64_t Offset = -1> struct InjectGridPytorchFunct
     // with the source are left unchanged NOTE: If the source voxels are not a subset of the
     // destination voxels, the injection will be from the intersection of the two active voxel sets
     // into the destination This version presumes a runtime dimension parameter for input features
-    static constexpr int MaxThreadsPerBlock         = 256;
+    static constexpr int MaxThreadsPerBlock         = DEFAULT_BLOCK_DIM;
     static constexpr int MinBlocksPerMultiprocessor = 1;
 
     __device__ void

--- a/src/fvdb/detail/ops/InjectFromDense.cu
+++ b/src/fvdb/detail/ops/InjectFromDense.cu
@@ -177,7 +177,7 @@ injectFromDenseCminorCUDA(const GridBatchData &batchHdl,
                 injectFromDenseCminorVoxelCallback<scalar_t>(
                     bidx, lidx, vidx, cidx, batchAcc, inDenseAcc, denseOriginsAcc, outSparseAcc);
             };
-            forEachVoxelCUDA(1024, outSparseTensor.size(1), batchHdl, callback);
+            forEachVoxelCUDA<1024>(outSparseTensor.size(1), batchHdl, callback);
         }),
         AT_EXPAND(AT_FLOATING_TYPES),
         c10::kHalf,
@@ -258,7 +258,7 @@ injectFromDenseCmajorCUDA(const GridBatchData &batchHdl,
                 injectFromDenseCmajorVoxelCallback<scalar_t>(
                     bidx, lidx, vidx, cidx, batchAcc, inDenseAcc, denseOriginsAcc, outSparseAcc);
             };
-            forEachVoxelCUDA(1024, outSparseTensor.size(1), batchHdl, callback);
+            forEachVoxelCUDA<1024>(outSparseTensor.size(1), batchHdl, callback);
         }),
         AT_EXPAND(AT_FLOATING_TYPES),
         c10::kHalf,

--- a/src/fvdb/detail/ops/InjectToDense.cu
+++ b/src/fvdb/detail/ops/InjectToDense.cu
@@ -181,7 +181,7 @@ injectToDenseCminorCUDA(const GridBatchData &batchHdl,
                 injectToDenseCminorVoxelCallback<scalar_t>(
                     bidx, lidx, vidx, cidx, batchAcc, denseOriginsAcc, inGridDataAcc, outDenseAcc);
             };
-            forEachVoxelCUDA(1024, inGridData.size(1), batchHdl, callback);
+            forEachVoxelCUDA<1024>(inGridData.size(1), batchHdl, callback);
         }),
         AT_EXPAND(AT_FLOATING_TYPES),
         c10::kHalf,
@@ -262,7 +262,7 @@ injectToDenseCmajorCUDA(const GridBatchData &batchHdl,
                 injectToDenseCmajorVoxelCallback<scalar_t>(
                     bidx, lidx, vidx, cidx, batchAcc, denseOriginsAcc, inGridDataAcc, outDenseAcc);
             };
-            forEachVoxelCUDA(1024, inGridData.size(1), batchHdl, callback);
+            forEachVoxelCUDA<1024>(inGridData.size(1), batchHdl, callback);
         }),
         AT_EXPAND(AT_FLOATING_TYPES),
         c10::kHalf,

--- a/src/fvdb/detail/ops/MarchingCubes.cu
+++ b/src/fvdb/detail/ops/MarchingCubes.cu
@@ -264,7 +264,7 @@ MarchingCubes(const GridBatchData &batchHdl, const torch::Tensor &sdf, double le
                                                                  static_cast<scalar_t>(level),
                                                                  nVerticesAcc);
                 };
-                forEachVoxelCUDA(128, 1, batchHdl, cb);
+                forEachVoxelCUDA<128>(1, batchHdl, cb);
             } else {
                 auto cb = [=](int32_t bidx,
                               int32_t lidx,
@@ -323,7 +323,7 @@ MarchingCubes(const GridBatchData &batchHdl, const torch::Tensor &sdf, double le
                                                                    trianglesAcc,
                                                                    vertIdsAcc);
                     };
-                    forEachVoxelCUDA(128, 1, batchHdl, cb);
+                    forEachVoxelCUDA<128>(1, batchHdl, cb);
                 } else {
                     auto cb = [=](int32_t bidx,
                                   int32_t lidx,

--- a/src/fvdb/detail/ops/MaxPool.cu
+++ b/src/fvdb/detail/ops/MaxPool.cu
@@ -182,7 +182,7 @@ DownsampleGridMaxPool(const GridBatchData &fineBatchHdl,
                                                                 poolingFactor,
                                                                 stride);
                 };
-                forEachVoxelCUDA(384, outCoarseData.size(1), coarseBatchHdl, maxPoolPerVoxel);
+                forEachVoxelCUDA<384>(outCoarseData.size(1), coarseBatchHdl, maxPoolPerVoxel);
             } else if constexpr (DeviceTag == torch::kPrivateUse1) {
                 auto maxPoolPerVoxel = [=] __device__(int32_t batchIdx,
                                                       int32_t leafIdx,
@@ -276,7 +276,7 @@ DownsampleGridMaxPoolBackward(const GridBatchData &coarseBatchHdl,
                                                                         poolingFactor,
                                                                         stride);
                 };
-                forEachVoxelCUDA(384, fineData.size(1), coarseBatchHdl, cb);
+                forEachVoxelCUDA<384>(fineData.size(1), coarseBatchHdl, cb);
             } else if constexpr (DeviceTag == torch::kPrivateUse1) {
                 auto cb = [=] __device__(int32_t batchIdx,
                                          int32_t leafIdx,

--- a/src/fvdb/detail/ops/NearestIjkForPoints.cu
+++ b/src/fvdb/detail/ops/NearestIjkForPoints.cu
@@ -94,7 +94,7 @@ dispatchNearestNeighborIJKForPoints<torch::kCUDA>(
                     bidx, eidx, pacc, transformDevPtr, outIJKAcc, outIJKBIdxAcc);
             };
 
-            forEachJaggedElementChannelCUDA<scalar_t, 2>(256, 1, jaggedPoints, cb);
+            forEachJaggedElementChannelCUDA<scalar_t, 2>(1, jaggedPoints, cb);
         }),
         AT_EXPAND(AT_FLOATING_TYPES),
         c10::kHalf);

--- a/src/fvdb/detail/ops/NeighborIndexes.cu
+++ b/src/fvdb/detail/ops/NeighborIndexes.cu
@@ -88,7 +88,7 @@ VoxelNeighborhood(const GridBatchData &batchHdl,
                     neighborIndexesCallback<scalar_t, JaggedRAcc64, TorchRAcc64>(
                         bidx, eidx, ptsA, outIndexAcc, batchAcc, extentMin, extentMax, shift);
                 };
-                forEachJaggedElementChannelCUDA<scalar_t, 2>(256, 1, ijk, cb);
+                forEachJaggedElementChannelCUDA<scalar_t, 2>(1, ijk, cb);
             } else {
                 auto cb =
                     [=](int32_t bidx, int32_t eidx, int32_t cidx, JaggedAcc<scalar_t, 2> ptsA) {

--- a/src/fvdb/detail/ops/PointsInGrid.cu
+++ b/src/fvdb/detail/ops/PointsInGrid.cu
@@ -52,7 +52,7 @@ PointsInGrid(const GridBatchData &batchHdl, const JaggedTensor &points) {
                 pointsInGridCallback<scalar_t, JaggedRAcc64, TorchRAcc64>(
                     bidx, eidx, ptsA, outMaskAccessor, batchAcc);
             };
-        forEachJaggedElementChannelCUDA<scalar_t, 2>(1024, 1, points, cb);
+        forEachJaggedElementChannelCUDA<scalar_t, 2, 1024>(1, points, cb);
     } else if constexpr (DeviceTag == torch::kPrivateUse1) {
         auto cb = [=]
             __device__(int32_t bidx, int32_t eidx, int32_t cidx, JaggedRAcc64<scalar_t, 2> ptsA) {

--- a/src/fvdb/detail/ops/RayImplicitIntersection.cu
+++ b/src/fvdb/detail/ops/RayImplicitIntersection.cu
@@ -148,11 +148,6 @@ RayImplicitIntersection(const GridBatchData &batchHdl,
         rayO.scalar_type(),
         "RayImplicitIntersection",
         AT_WRAP([&]() {
-            int64_t numThreads = 256 + 128;
-            if constexpr (nanovdb::util::is_same<scalar_t, double>::value) {
-                numThreads = 256;
-            }
-
             auto batchAcc       = gridBatchAccessor<DeviceTag>(batchHdl);
             auto rayDAcc        = jaggedAccessor<DeviceTag, scalar_t, 2>(rayD);
             auto gridScalarsAcc = jaggedAccessor<DeviceTag, scalar_t, 1>(gridScalars);
@@ -166,7 +161,7 @@ RayImplicitIntersection(const GridBatchData &batchHdl,
                     rayImplicitCallback<scalar_t, JaggedRAcc64, TorchRAcc64>(
                         bidx, eidx, rOA, rayDAcc, gridScalarsAcc, batchAcc, outTimesAcc, eps);
                 };
-                forEachJaggedElementChannelCUDA<scalar_t, 2>(numThreads, 1, rayO, cb);
+                forEachJaggedElementChannelCUDA<scalar_t, 2>(1, rayO, cb);
             } else {
                 auto cb =
                     [=](int32_t bidx, int32_t eidx, int32_t cidx, JaggedAcc<scalar_t, 2> rOA) {

--- a/src/fvdb/detail/ops/Refine.cu
+++ b/src/fvdb/detail/ops/Refine.cu
@@ -159,7 +159,7 @@ UpsampleGridNearest(const GridBatchData &coarseBatchAccessor,
                                                                         outFineDataAcc,
                                                                         upsamplingFactor);
                 };
-                forEachVoxelCUDA(640, outFineData.size(1), fineBatchAccessor, callback);
+                forEachVoxelCUDA<640>(outFineData.size(1), fineBatchAccessor, callback);
             } else if constexpr (DeviceTag == torch::kPrivateUse1) {
                 auto callback = [=] __device__(int32_t batchIdx,
                                                int32_t leafIdx,
@@ -244,7 +244,7 @@ UpsampleGridNearestBackward(const GridBatchData &fineBatchAccessor,
                         outCoarseDataAcc,
                         upsamplingFactor);
                 };
-                forEachVoxelCUDA(640, outGradInReshape.size(1), fineBatchAccessor, callback);
+                forEachVoxelCUDA<640>(outGradInReshape.size(1), fineBatchAccessor, callback);
             } else if constexpr (DeviceTag == torch::kPrivateUse1) {
                 auto callback = [=] __device__(int32_t batchIdx,
                                                int32_t leafIdx,

--- a/src/fvdb/detail/ops/SampleBezier.cu
+++ b/src/fvdb/detail/ops/SampleBezier.cu
@@ -83,8 +83,7 @@ SampleGridBezier(const GridBatchData &batchHdl,
                     sampleBezierCallback<scalar_t, JaggedRAcc64, TorchRAcc64>(
                         bidx, eidx, cidx, pts, gridDataAcc, batchAcc, outFeaturesAcc);
                 };
-                forEachJaggedElementChannelCUDA<scalar_t, 2>(
-                    256, gridDataReshape.size(1), points, cb);
+                forEachJaggedElementChannelCUDA<scalar_t, 2>(gridDataReshape.size(1), points, cb);
             } else {
                 auto cb =
                     [=](int32_t bidx, int32_t eidx, int32_t cidx, JaggedAcc<scalar_t, 2> pts) {

--- a/src/fvdb/detail/ops/SampleBezierWithGrad.cu
+++ b/src/fvdb/detail/ops/SampleBezierWithGrad.cu
@@ -105,8 +105,7 @@ SampleGridBezierWithGrad(const GridBatchData &batchHdl,
                         outFeaturesAcc,
                         outGradFeaturesAcc);
                 };
-                forEachJaggedElementChannelCUDA<scalar_t, 2>(
-                    256, gridDataReshape.size(1), points, cb);
+                forEachJaggedElementChannelCUDA<scalar_t, 2>(gridDataReshape.size(1), points, cb);
             } else {
                 auto cb = [=](int32_t bidx,
                               int32_t eidx,

--- a/src/fvdb/detail/ops/SampleBezierWithGradBackward.cu
+++ b/src/fvdb/detail/ops/SampleBezierWithGradBackward.cu
@@ -107,7 +107,7 @@ SampleGridBezierWithGradBackward(const GridBatchData &batchHdl,
                                                                       batchAcc,
                                                                       outGridDataAcc);
                 };
-                forEachJaggedElementChannelCUDA<scalar_t, 2>(256, outGrad.size(1), points, cb);
+                forEachJaggedElementChannelCUDA<scalar_t, 2>(outGrad.size(1), points, cb);
             } else {
                 auto cb = [=](int32_t bidx,
                               int32_t eidx,

--- a/src/fvdb/detail/ops/SampleNearest.cu
+++ b/src/fvdb/detail/ops/SampleNearest.cu
@@ -206,8 +206,7 @@ SampleGridNearest(const GridBatchData &batchHdl,
     if constexpr (DeviceTag == torch::kCUDA || DeviceTag == torch::kPrivateUse1) {
         auto dispatchForEach = [&](const auto &cb) {
             if constexpr (DeviceTag == torch::kCUDA) {
-                forEachJaggedElementChannelCUDA<scalar_t, 2>(
-                    DEFAULT_BLOCK_DIM, int64_t(1), points, cb);
+                forEachJaggedElementChannelCUDA<scalar_t, 2>(int64_t(1), points, cb);
             } else {
                 forEachJaggedElementChannelPrivateUse1<scalar_t, 2>(int64_t(1), points, cb);
             }

--- a/src/fvdb/detail/ops/SampleRaysUniform.cu
+++ b/src/fvdb/detail/ops/SampleRaysUniform.cu
@@ -22,10 +22,8 @@ _calcDt(ScalarType t, ScalarType coneAngle, ScalarType minStepSize, const Scalar
 }
 
 template <typename ScalarType,
-          template <typename T, int32_t D>
-          typename JaggedAccessor,
-          template <typename T, int32_t D>
-          typename TensorAccessor>
+          template <typename T, int32_t D> typename JaggedAccessor,
+          template <typename T, int32_t D> typename TensorAccessor>
 __hostdev__ void
 countSamplesPerRayCallback(int32_t bidx,
                            int32_t eidx,
@@ -129,10 +127,8 @@ countSamplesPerRayCallback(int32_t bidx,
 }
 
 template <typename ScalarType,
-          template <typename T, int32_t D>
-          typename JaggedAccessor,
-          template <typename T, int32_t D>
-          typename TensorAccessor>
+          template <typename T, int32_t D> typename JaggedAccessor,
+          template <typename T, int32_t D> typename TensorAccessor>
 __hostdev__ void
 generateRaySamplesCallback(int32_t bidx,
                            int32_t rayIdx,
@@ -344,10 +340,6 @@ UniformRaySamples(const GridBatchData &batchHdl,
         rayOrigins.scalar_type(),
         "UniformRaySamples",
         AT_WRAP([&]() -> JaggedTensor {
-            int64_t numThreads = 256 + 128;
-            if constexpr (nanovdb::util::is_same<scalar_t, double>::value) {
-                numThreads = 256;
-            }
             const auto optsF =
                 torch::TensorOptions().dtype(rayOrigins.dtype()).device(rayOrigins.device());
             const auto optsI32 =
@@ -385,7 +377,7 @@ UniformRaySamples(const GridBatchData &batchHdl,
                         includeEndpointSegments,
                         eps);
                 };
-                forEachJaggedElementChannelCUDA<scalar_t, 2>(numThreads, 1, rayOrigins, cb);
+                forEachJaggedElementChannelCUDA<scalar_t, 2, 384>(1, rayOrigins, cb);
             } else {
                 auto cb = [=](int32_t bidx,
                               int32_t eidx,
@@ -452,7 +444,7 @@ UniformRaySamples(const GridBatchData &batchHdl,
                         returnMidpoint,
                         eps);
                 };
-                forEachJaggedElementChannelCUDA<scalar_t, 2>(numThreads, 1, rayOrigins, cb);
+                forEachJaggedElementChannelCUDA<scalar_t, 2, 384>(1, rayOrigins, cb);
             } else {
                 auto cb = [=](int32_t bidx,
                               int32_t eidx,

--- a/src/fvdb/detail/ops/SampleRaysUniform.cu
+++ b/src/fvdb/detail/ops/SampleRaysUniform.cu
@@ -22,8 +22,10 @@ _calcDt(ScalarType t, ScalarType coneAngle, ScalarType minStepSize, const Scalar
 }
 
 template <typename ScalarType,
-          template <typename T, int32_t D> typename JaggedAccessor,
-          template <typename T, int32_t D> typename TensorAccessor>
+          template <typename T, int32_t D>
+          typename JaggedAccessor,
+          template <typename T, int32_t D>
+          typename TensorAccessor>
 __hostdev__ void
 countSamplesPerRayCallback(int32_t bidx,
                            int32_t eidx,
@@ -127,8 +129,10 @@ countSamplesPerRayCallback(int32_t bidx,
 }
 
 template <typename ScalarType,
-          template <typename T, int32_t D> typename JaggedAccessor,
-          template <typename T, int32_t D> typename TensorAccessor>
+          template <typename T, int32_t D>
+          typename JaggedAccessor,
+          template <typename T, int32_t D>
+          typename TensorAccessor>
 __hostdev__ void
 generateRaySamplesCallback(int32_t bidx,
                            int32_t rayIdx,
@@ -377,7 +381,7 @@ UniformRaySamples(const GridBatchData &batchHdl,
                         includeEndpointSegments,
                         eps);
                 };
-                forEachJaggedElementChannelCUDA<scalar_t, 2, 384>(1, rayOrigins, cb);
+                forEachJaggedElementChannelCUDA<scalar_t, 2>(1, rayOrigins, cb);
             } else {
                 auto cb = [=](int32_t bidx,
                               int32_t eidx,
@@ -444,7 +448,7 @@ UniformRaySamples(const GridBatchData &batchHdl,
                         returnMidpoint,
                         eps);
                 };
-                forEachJaggedElementChannelCUDA<scalar_t, 2, 384>(1, rayOrigins, cb);
+                forEachJaggedElementChannelCUDA<scalar_t, 2>(1, rayOrigins, cb);
             } else {
                 auto cb = [=](int32_t bidx,
                               int32_t eidx,

--- a/src/fvdb/detail/ops/SampleTrilinear.cu
+++ b/src/fvdb/detail/ops/SampleTrilinear.cu
@@ -133,8 +133,7 @@ SampleGridTrilinear(const GridBatchData &batchHdl,
     if constexpr (DeviceTag == torch::kCUDA || DeviceTag == torch::kPrivateUse1) {
         auto dispatchForEach = [&](const auto &cb) {
             if constexpr (DeviceTag == torch::kCUDA) {
-                forEachJaggedElementChannelCUDA<scalar_t, 2>(
-                    DEFAULT_BLOCK_DIM, int64_t(1), points, cb);
+                forEachJaggedElementChannelCUDA<scalar_t, 2>(int64_t(1), points, cb);
             } else {
                 forEachJaggedElementChannelPrivateUse1<scalar_t, 2>(int64_t(1), points, cb);
             }

--- a/src/fvdb/detail/ops/SampleTrilinearWithGrad.cu
+++ b/src/fvdb/detail/ops/SampleTrilinearWithGrad.cu
@@ -175,8 +175,7 @@ SampleGridTrilinearWithGrad(const GridBatchData &batchHdl,
     if constexpr (DeviceTag == torch::kCUDA || DeviceTag == torch::kPrivateUse1) {
         auto dispatchForEach = [&](const auto &cb) {
             if constexpr (DeviceTag == torch::kCUDA) {
-                forEachJaggedElementChannelCUDA<scalar_t, 2>(
-                    DEFAULT_BLOCK_DIM, int64_t(1), points, cb);
+                forEachJaggedElementChannelCUDA<scalar_t, 2>(int64_t(1), points, cb);
             } else {
                 forEachJaggedElementChannelPrivateUse1<scalar_t, 2>(int64_t(1), points, cb);
             }

--- a/src/fvdb/detail/ops/SampleTrilinearWithGradBackward.cu
+++ b/src/fvdb/detail/ops/SampleTrilinearWithGradBackward.cu
@@ -185,8 +185,7 @@ SampleGridTrilinearWithGradBackward(const GridBatchData &batchHdl,
     if constexpr (DeviceTag == torch::kCUDA || DeviceTag == torch::kPrivateUse1) {
         auto dispatchForEach = [&](const auto &cb) {
             if constexpr (DeviceTag == torch::kCUDA) {
-                forEachJaggedElementChannelCUDA<scalar_t, 2>(
-                    DEFAULT_BLOCK_DIM, int64_t(1), points, cb);
+                forEachJaggedElementChannelCUDA<scalar_t, 2>(int64_t(1), points, cb);
             } else {
                 forEachJaggedElementChannelPrivateUse1<scalar_t, 2>(int64_t(1), points, cb);
             }

--- a/src/fvdb/detail/ops/SegmentsAlongRays.cu
+++ b/src/fvdb/detail/ops/SegmentsAlongRays.cu
@@ -170,10 +170,6 @@ SegmentsAlongRays(const GridBatchData &batchHdl,
         rayOrigins.scalar_type(),
         "SegmentsAlongRays",
         AT_WRAP([&]() -> JaggedTensor {
-            int64_t numThreads = 384;
-            if constexpr (nanovdb::util::is_same<scalar_t, double>::value) {
-                numThreads = 256;
-            }
             const auto optsF =
                 torch::TensorOptions().dtype(rayOrigins.dtype()).device(rayOrigins.device());
             const auto optsI32 =
@@ -203,7 +199,7 @@ SegmentsAlongRays(const GridBatchData &batchHdl,
                         maxSegments,
                         eps);
                 };
-                forEachJaggedElementChannelCUDA<scalar_t, 2>(numThreads, 1, rayOrigins, cb1);
+                forEachJaggedElementChannelCUDA<scalar_t, 2>(1, rayOrigins, cb1);
             } else {
                 auto cb1 = [=](int32_t bidx,
                                int32_t eidx,
@@ -261,7 +257,7 @@ SegmentsAlongRays(const GridBatchData &batchHdl,
                                                                                    maxSegments,
                                                                                    eps);
                 };
-                forEachJaggedElementChannelCUDA<scalar_t, 2>(numThreads, 1, rayOrigins, cb2);
+                forEachJaggedElementChannelCUDA<scalar_t, 2>(1, rayOrigins, cb2);
             } else {
                 auto cb2 = [=](int32_t bidx,
                                int32_t eidx,

--- a/src/fvdb/detail/ops/SplatBezier.cu
+++ b/src/fvdb/detail/ops/SplatBezier.cu
@@ -95,7 +95,7 @@ SplatIntoGridBezier(const GridBatchData &batchHdl,
                     splatBezierCallback<DeviceTag, scalar_t, JaggedRAcc64, TorchRAcc64>(
                         bidx, eidx, cidx, ptsA, pointsDataAcc, batchAcc, outGridDataAcc);
                 };
-                forEachJaggedElementChannelCUDA<scalar_t, 2>(256, pointsData.size(1), points, cb);
+                forEachJaggedElementChannelCUDA<scalar_t, 2>(pointsData.size(1), points, cb);
             } else {
                 auto cb =
                     [=](int32_t bidx, int32_t eidx, int32_t cidx, JaggedAcc<scalar_t, 2> ptsA) {

--- a/src/fvdb/detail/ops/SplatTrilinear.cu
+++ b/src/fvdb/detail/ops/SplatTrilinear.cu
@@ -159,8 +159,7 @@ SplatIntoGridTrilinear(const GridBatchData &batchHdl,
     if constexpr (DeviceTag == torch::kCUDA || DeviceTag == torch::kPrivateUse1) {
         auto dispatchForEach = [&](const auto &cb) {
             if constexpr (DeviceTag == torch::kCUDA) {
-                forEachJaggedElementChannelCUDA<scalar_t, 2>(
-                    DEFAULT_BLOCK_DIM, int64_t(1), points, cb);
+                forEachJaggedElementChannelCUDA<scalar_t, 2>(int64_t(1), points, cb);
             } else {
                 forEachJaggedElementChannelPrivateUse1<scalar_t, 2>(int64_t(1), points, cb);
             }

--- a/src/fvdb/detail/ops/VoxelToWorld.cu
+++ b/src/fvdb/detail/ops/VoxelToWorld.cu
@@ -122,7 +122,7 @@ TransformPointsToGrid(const GridBatchData &batchHdl, const JaggedTensor &points,
                 voxelToWorldCallback<scalar_t, JaggedRAcc64, TorchRAcc64>(
                     bidx, eidx, ptsA, outCoordsAcc, batchAcc, isPrimal);
             };
-        forEachJaggedElementChannelCUDA<scalar_t, 2>(512, 1, points, cb);
+        forEachJaggedElementChannelCUDA<scalar_t, 2, 512>(1, points, cb);
     } else if constexpr (DeviceTag == torch::kPrivateUse1) {
         auto cb = [=]
             __device__(int32_t bidx, int32_t eidx, int32_t cidx, JaggedRAcc64<scalar_t, 2> ptsA) {
@@ -161,7 +161,7 @@ InvTransformPointsToGrid(const GridBatchData &batchHdl, const JaggedTensor &poin
                 worldToVoxelCallback<scalar_t, JaggedRAcc64, TorchRAcc64>(
                     bidx, eidx, ptsA, outCoordsAcc, batchAcc, isPrimal);
             };
-        forEachJaggedElementChannelCUDA<scalar_t, 2>(512, 1, points, cb);
+        forEachJaggedElementChannelCUDA<scalar_t, 2, 512>(1, points, cb);
     } else if constexpr (DeviceTag == torch::kPrivateUse1) {
         auto cb = [=]
             __device__(int32_t bidx, int32_t eidx, int32_t cidx, JaggedRAcc64<scalar_t, 2> ptsA) {
@@ -195,7 +195,7 @@ TransformPointsToGridBackward(const GridBatchData &batchHdl,
                 voxelToWorldBackwardCallback<scalar_t, JaggedRAcc64, TorchRAcc64>(
                     bidx, eidx, ptsA, outGradInAcc, batchAcc, isPrimal);
             };
-        forEachJaggedElementChannelCUDA<scalar_t, 2>(512, 1, gradOut, cb);
+        forEachJaggedElementChannelCUDA<scalar_t, 2, 512>(1, gradOut, cb);
     } else if constexpr (DeviceTag == torch::kPrivateUse1) {
         auto cb = [=]
             __device__(int32_t bidx, int32_t eidx, int32_t cidx, JaggedRAcc64<scalar_t, 2> ptsA) {
@@ -229,7 +229,7 @@ InvTransformPointsToGridBackward(const GridBatchData &batchHdl,
                 worldToVoxelBackwardCallback<scalar_t, JaggedRAcc64, TorchRAcc64>(
                     bidx, eidx, ptsA, outGradInAcc, batchAcc, isPrimal);
             };
-        forEachJaggedElementChannelCUDA<scalar_t, 2>(512, 1, gradOut, cb);
+        forEachJaggedElementChannelCUDA<scalar_t, 2, 512>(1, gradOut, cb);
     } else if constexpr (DeviceTag == torch::kPrivateUse1) {
         auto cb = [=]
             __device__(int32_t bidx, int32_t eidx, int32_t cidx, JaggedRAcc64<scalar_t, 2> ptsA) {

--- a/src/fvdb/detail/ops/VoxelsAlongRays.cu
+++ b/src/fvdb/detail/ops/VoxelsAlongRays.cu
@@ -210,10 +210,6 @@ VoxelsAlongRays(const GridBatchData &batchHdl,
         rayOrigins.scalar_type(),
         "VoxelsAlongRays",
         AT_WRAP([&]() -> std::vector<JaggedTensor> {
-            int64_t numThreads = 384;
-            if constexpr (nanovdb::util::is_same<scalar_t, double>::value) {
-                numThreads = 256;
-            }
             const auto optsF =
                 torch::TensorOptions().dtype(rayOrigins.dtype()).device(rayOrigins.device());
             const auto optsI32 =
@@ -236,7 +232,7 @@ VoxelsAlongRays(const GridBatchData &batchHdl,
                     countVoxelsAlongRaysCallback<scalar_t, JaggedRAcc64, TorchRAcc64>(
                         bidx, eidx, rOA, rayDirectionsAcc, outCountsAcc, batchAcc, maxVox, eps);
                 };
-                forEachJaggedElementChannelCUDA<scalar_t, 2>(numThreads, 1, rayOrigins, cb1);
+                forEachJaggedElementChannelCUDA<scalar_t, 2>(1, rayOrigins, cb1);
             } else {
                 auto cb1 =
                     [=](int32_t bidx, int32_t eidx, int32_t cidx, JaggedAcc<scalar_t, 2> rOA) {
@@ -311,9 +307,9 @@ VoxelsAlongRays(const GridBatchData &batchHdl,
                 };
 
                 if (returnIjk) {
-                    forEachJaggedElementChannelCUDA<scalar_t, 2>(numThreads, 1, rayOrigins, cbIjk);
+                    forEachJaggedElementChannelCUDA<scalar_t, 2>(1, rayOrigins, cbIjk);
                 } else {
-                    forEachJaggedElementChannelCUDA<scalar_t, 2>(numThreads, 1, rayOrigins, cbIdx);
+                    forEachJaggedElementChannelCUDA<scalar_t, 2>(1, rayOrigins, cbIdx);
                 }
             } else {
                 auto cbIjk = [=](int32_t bidx,

--- a/src/fvdb/detail/ops/gsplat/IntersectGaussianTiles.cu
+++ b/src/fvdb/detail/ops/gsplat/IntersectGaussianTiles.cu
@@ -5,6 +5,7 @@
 #include <fvdb/detail/ops/gsplat/IntersectGaussianTiles.h>
 #include <fvdb/detail/utils/Nvtx.h>
 #include <fvdb/detail/utils/Utils.h>
+#include <fvdb/detail/utils/cuda/GridDim.h>
 #include <fvdb/detail/utils/cuda/Utils.cuh>
 
 #include <nanovdb/util/cuda/Util.h>
@@ -33,7 +34,7 @@ namespace ops {
 
 namespace {
 
-#define NUM_THREADS 256
+#define NUM_THREADS DEFAULT_BLOCK_DIM
 
 // Compute the number of 2d image tiles intersected by a set of 2D projected Gaussians.
 //

--- a/src/fvdb/detail/ops/gsplat/ProjectGaussiansUnscentedForward.cu
+++ b/src/fvdb/detail/ops/gsplat/ProjectGaussiansUnscentedForward.cu
@@ -438,7 +438,7 @@ template <typename ScalarType, typename Camera> struct ProjectionForwardUT {
 ///
 /// Each thread processes multiple (camera, gaussian) pairs in a grid-stride loop.
 template <typename ScalarType, typename Camera>
-__global__ __launch_bounds__(256) void
+__global__ __launch_bounds__(DEFAULT_BLOCK_DIM) void
 projectionForwardUTKernel(int64_t offset,
                           int64_t count,
                           ProjectionForwardUT<ScalarType, Camera> projectionForward) {
@@ -567,7 +567,7 @@ dispatchProjectGaussiansUnscentedFwd<torch::kCUDA>(
 
     using scalar_t = float;
 
-    const size_t NUM_BLOCKS = GET_BLOCKS(C * N, 256);
+    const size_t NUM_BLOCKS = GET_BLOCKS(C * N, DEFAULT_BLOCK_DIM);
     if (cameraModel == DistortionModel::ORTHOGRAPHIC) {
         OrthographicWithDistortionCamera<scalar_t> camera(worldToCamMatricesStart,
                                                           worldToCamMatricesEnd,
@@ -602,7 +602,8 @@ dispatchProjectGaussiansUnscentedFwd<torch::kCUDA>(
             outConics,
             outCompensations);
         projectionForwardUTKernel<scalar_t, OrthographicWithDistortionCamera<scalar_t>>
-            <<<NUM_BLOCKS, 256, SHARED_MEM_SIZE, stream>>>(0, C * N, projectionForward);
+            <<<NUM_BLOCKS, DEFAULT_BLOCK_DIM, SHARED_MEM_SIZE, stream>>>(
+                0, C * N, projectionForward);
     } else {
         PerspectiveWithDistortionCamera<scalar_t> camera(worldToCamMatricesStart,
                                                          worldToCamMatricesEnd,
@@ -640,7 +641,8 @@ dispatchProjectGaussiansUnscentedFwd<torch::kCUDA>(
             outConics,
             outCompensations);
         projectionForwardUTKernel<scalar_t, PerspectiveWithDistortionCamera<scalar_t>>
-            <<<NUM_BLOCKS, 256, SHARED_MEM_SIZE, stream>>>(0, C * N, projectionForward);
+            <<<NUM_BLOCKS, DEFAULT_BLOCK_DIM, SHARED_MEM_SIZE, stream>>>(
+                0, C * N, projectionForward);
     }
     C10_CUDA_KERNEL_LAUNCH_CHECK();
 

--- a/src/fvdb/detail/ops/jagged/JaggedSort.cu
+++ b/src/fvdb/detail/ops/jagged/JaggedSort.cu
@@ -123,7 +123,7 @@ JaggedArgsort(const JaggedTensor &jt) {
                         qsortCallback<scalar_t, TorchRAcc64>(
                             ridx, offsetAcc, dataAcc, idxAccessor, stackAccessor);
                     };
-                forEachTensorElementChannelCUDA<int64_t, 2>(256, 1, offsets, cb);
+                forEachTensorElementChannelCUDA<int64_t, 2>(1, offsets, cb);
             } else {
                 auto cb = [=](int32_t ridx, int32_t cidx, TorchAcc<int64_t, 2> offsetAcc) {
                     qsortCallback<scalar_t, TorchAcc>(

--- a/src/fvdb/detail/utils/SimpleOpHelper.h
+++ b/src/fvdb/detail/utils/SimpleOpHelper.h
@@ -211,19 +211,16 @@ struct BasePerActiveVoxelProcessor {
         }
     }
 
+    template <int NumThreads = 1024>
     JaggedTensor
     execute(GridBatchData const &grid_batch,
-            OutElementType const &out_element = OutElementType{},
-            int const num_threads             = 1024) const {
+            OutElementType const &out_element = OutElementType{}) const {
         auto out_tensor =
             makeOutTensorFromGridBatch<DeviceTag, OutElementType>(grid_batch, out_element);
         auto out_accessor = makeAccessor<DeviceTag, OutElementType>(out_tensor);
         if constexpr (DeviceTag == torch::kCUDA) {
-            forEachVoxelCUDA(num_threads, // num threads
-                             1,
-                             grid_batch,
-                             *static_cast<Derived const *>(this),
-                             out_accessor);
+            forEachVoxelCUDA<NumThreads>(
+                1, grid_batch, *static_cast<Derived const *>(this), out_accessor);
         } else if constexpr (DeviceTag == torch::kPrivateUse1) {
             forEachVoxelPrivateUse1(
                 1, grid_batch, *static_cast<Derived const *>(this), out_accessor);
@@ -300,21 +297,21 @@ struct BasePerElementProcessor {
         static_cast<Derived const *>(this)->perElement(element_idx, in_accessor, out_accessor);
     }
 
+    template <int NumThreads = 1024>
     torch::Tensor
     execute(torch::Tensor const &in_tensor,
-            OutElementType const &out_element = OutElementType{},
-            int const num_threads             = 1024) const {
+            OutElementType const &out_element = OutElementType{}) const {
         auto out_tensor =
             makeOutTensorFromTensor<DeviceTag, OutElementType>(in_tensor, out_element);
         auto out_accessor         = makeAccessor<DeviceTag, OutElementType>(out_tensor);
         constexpr size_t IN_NDIMS = 1 + InElementType::NDIMS;
         using IN_T                = typename InElementType::value_type;
         if constexpr (DeviceTag == torch::kCUDA) {
-            forEachTensorElementChannelCUDA<IN_T, IN_NDIMS>(num_threads,
-                                                            1, // num channels, ignored
-                                                            in_tensor,
-                                                            *static_cast<Derived const *>(this),
-                                                            out_accessor);
+            forEachTensorElementChannelCUDA<IN_T, IN_NDIMS, NumThreads>(
+                1, // num channels, ignored
+                in_tensor,
+                *static_cast<Derived const *>(this),
+                out_accessor);
         } else if constexpr (DeviceTag == torch::kPrivateUse1) {
             forEachTensorElementChannelPrivateUse1<IN_T, IN_NDIMS>(
                 1, in_tensor, *static_cast<Derived const *>(this), out_accessor);

--- a/src/fvdb/detail/utils/cuda/ForEachCUDA.cuh
+++ b/src/fvdb/detail/utils/cuda/ForEachCUDA.cuh
@@ -18,8 +18,8 @@ namespace fvdb {
 
 namespace _private {
 
-template <typename Func, typename... Args>
-__global__ void
+template <int NumThreads, typename Func, typename... Args>
+__global__ void __launch_bounds__(NumThreads)
 forEachLeafCUDAKernel(fvdb::GridBatchData::Accessor grid,
                       const bool returnIfOutOfRange,
                       const int32_t channelsPerLeaf,
@@ -44,8 +44,8 @@ forEachLeafCUDAKernel(fvdb::GridBatchData::Accessor grid,
     func(batchIdx, leafIdx, channelIdx, grid, args...);
 }
 
-template <typename Func, typename... Args>
-__global__ void
+template <int NumThreads, typename Func, typename... Args>
+__global__ void __launch_bounds__(NumThreads)
 forEachLeafSingleGridCUDAKernel(fvdb::GridBatchData::Accessor batchAccessor,
                                 const bool returnIfOutOfRange,
                                 const int32_t channelsPerLeaf,
@@ -73,8 +73,8 @@ forEachLeafSingleGridCUDAKernel(fvdb::GridBatchData::Accessor batchAccessor,
 __global__ void voxelMetaIndexCUDAKernel(fvdb::GridBatchData::Accessor gridAccessor,
                                          TorchRAcc64<int64_t, 2> metaIndex);
 
-template <typename Func, typename... Args>
-__global__ void
+template <int NumThreads, typename Func, typename... Args>
+__global__ void __launch_bounds__(NumThreads)
 forEachVoxelWithMetaCUDAKernel(fvdb::GridBatchData::Accessor grid,
                                TorchRAcc64<int64_t, 2> metaIndex,
                                const bool returnIfOutOfRange,
@@ -102,8 +102,8 @@ forEachVoxelWithMetaCUDAKernel(fvdb::GridBatchData::Accessor grid,
     func(batchIdx, leafIdx, leafVoxelIdx, channelIdx, grid, args...);
 }
 
-template <typename Func, typename... Args>
-__global__ void
+template <int NumThreads, typename Func, typename... Args>
+__global__ void __launch_bounds__(NumThreads)
 forEachVoxelCUDAKernel(fvdb::GridBatchData::Accessor grid,
                        const bool returnIfOutOfRange,
                        const int64_t channelsPerVoxel,
@@ -134,8 +134,8 @@ forEachVoxelCUDAKernel(fvdb::GridBatchData::Accessor grid,
     func(batchIdx, leafIdx, leafVoxelIdx, channelIdx, grid, args...);
 }
 
-template <int32_t NDIMS, typename ScalarT, typename Func, typename... Args>
-__global__ void __launch_bounds__(1024)
+template <typename ScalarT, int32_t NDIMS, int NumThreads, typename Func, typename... Args>
+__global__ void __launch_bounds__(NumThreads)
 forEachJaggedElementChannelCUDAKernel(JaggedRAcc64<ScalarT, NDIMS> jaggedAcc,
                                       const bool returnIfOutOfRange,
                                       const int64_t channelsPerElement,
@@ -158,8 +158,8 @@ forEachJaggedElementChannelCUDAKernel(JaggedRAcc64<ScalarT, NDIMS> jaggedAcc,
     func(batchIdx, elementIdx, channelIdx, jaggedAcc, args...);
 }
 
-template <int32_t NDIMS, typename ScalarT, typename Func, typename... Args>
-__global__ void
+template <typename ScalarT, int32_t NDIMS, int NumThreads, typename Func, typename... Args>
+__global__ void __launch_bounds__(NumThreads)
 forEachTensorElementChannelCUDAKernel(TorchRAcc64<ScalarT, NDIMS> tensorAcc,
                                       const bool returnIfOutOfRange,
                                       const int64_t channelsPerElement,
@@ -199,17 +199,15 @@ forEachTensorElementChannelCUDAKernel(TorchRAcc64<ScalarT, NDIMS> tensorAcc,
 ///
 /// @param stream Which cuda stream to run the kernel on
 /// @param sharedMemBytes The amount of shared memory to use for the kernel. If 0, no shared memory
-/// @param numThreads The number of threads per block to use
 /// @param numChannels The number of channels per item in each leaf being parallelized over
 /// @param batchHdl A batch of index grids
 /// @param func The callback function to run on each leaf
 /// @param args Any extra arguments to pass to the callback function
-template <typename Func, typename... Args>
+template <int NumThreads = DEFAULT_BLOCK_DIM, typename Func, typename... Args>
 void
 forEachLeafCUDA(const at::cuda::CUDAStream &stream,
                 const size_t sharedMemBytes,
                 const bool returnIfOutOfRange,
-                const int64_t numThreads,
                 const int64_t numChannels,
                 const fvdb::GridBatchData &batchHdl,
                 Func func,
@@ -217,11 +215,11 @@ forEachLeafCUDA(const at::cuda::CUDAStream &stream,
     TORCH_CHECK(batchHdl.device().is_cuda(), "Grid batch must be on a CUDA device");
     TORCH_CHECK(batchHdl.device().has_index(), "Grid batch device must have an index");
     c10::cuda::CUDAGuard deviceGuard(batchHdl.device());
-    const int64_t numBlocks = GET_BLOCKS(batchHdl.totalLeaves() * numChannels, numThreads);
+    const int64_t numBlocks = GET_BLOCKS(batchHdl.totalLeaves() * numChannels, NumThreads);
     TORCH_INTERNAL_ASSERT(numBlocks < (int64_t)(4294967295), "Too many blocks");
     if (numBlocks > 0) {
         if (sharedMemBytes > 0) {
-            if (cudaFuncSetAttribute(_private::forEachLeafCUDAKernel<Func, Args...>,
+            if (cudaFuncSetAttribute(_private::forEachLeafCUDAKernel<NumThreads, Func, Args...>,
                                      cudaFuncAttributeMaxDynamicSharedMemorySize,
                                      sharedMemBytes) != cudaSuccess) {
                 AT_ERROR(
@@ -231,23 +229,23 @@ forEachLeafCUDA(const at::cuda::CUDAStream &stream,
             }
         }
         auto batchAccessor = batchHdl.deviceAccessor();
-        _private::forEachLeafCUDAKernel<<<numBlocks, numThreads, sharedMemBytes, stream>>>(
-            batchAccessor, returnIfOutOfRange, numChannels, func, args...);
+        _private::forEachLeafCUDAKernel<NumThreads>
+            <<<numBlocks, NumThreads, sharedMemBytes, stream>>>(
+                batchAccessor, returnIfOutOfRange, numChannels, func, args...);
         C10_CUDA_KERNEL_LAUNCH_CHECK();
     }
 }
-template <typename Func, typename... Args>
+template <int NumThreads = DEFAULT_BLOCK_DIM, typename Func, typename... Args>
 void
-forEachLeafCUDA(const int64_t numThreads,
-                const int64_t numChannels,
+forEachLeafCUDA(const int64_t numChannels,
                 const fvdb::GridBatchData &batchHdl,
                 Func func,
                 Args... args) {
     TORCH_CHECK(batchHdl.device().is_cuda(), "Grid batch must be on a CUDA device");
     TORCH_CHECK(batchHdl.device().has_index(), "Grid batch device must have an index");
     at::cuda::CUDAStream stream = at::cuda::getCurrentCUDAStream(batchHdl.device().index());
-    return forEachLeafCUDA<Func, Args...>(
-        stream, 0, true, numThreads, numChannels, batchHdl, func, args...);
+    return forEachLeafCUDA<NumThreads, Func, Args...>(
+        stream, 0, true, numChannels, batchHdl, func, args...);
 }
 
 /// @brief Run the given function on each leaf in the specified grid (at index batchIdx) in the
@@ -266,18 +264,16 @@ forEachLeafCUDA(const int64_t numThreads,
 /// @param returnIfOutOfRange Whether to skip the callback if the element is out of range. If false,
 ///                           the callback will be run with -1 for the batchIdx, leafIdx, and
 ///                           channelIdx
-/// @param numThreads The number of threads per block to use
 /// @param numChannels The number of channels per item in each leaf being parallelized over
 /// @param batchIdx The index of the grid in the batch to run the callback on
 /// @param batchHdl A batch of index grids
 /// @param func The callback function to run on each leaf
 /// @param args Any extra arguments to pass to the callback function
-template <typename Func, typename... Args>
+template <int NumThreads = DEFAULT_BLOCK_DIM, typename Func, typename... Args>
 void
 forEachLeafInOneGridCUDA(const at::cuda::CUDAStream &stream,
                          const size_t sharedMemBytes,
                          const bool returnIfOutOfRange,
-                         const int64_t numThreads,
                          const int64_t numChannels,
                          const int64_t batchIdx,
                          const fvdb::GridBatchData &batchHdl,
@@ -287,13 +283,14 @@ forEachLeafInOneGridCUDA(const at::cuda::CUDAStream &stream,
     TORCH_CHECK(batchHdl.device().has_index(), "Grid batch device must have an index");
     c10::cuda::CUDAGuard deviceGuard(batchHdl.device());
     TORCH_CHECK(batchIdx >= 0 && batchIdx < batchHdl.batchSize(), "Batch index out of range");
-    const int64_t numBlocks = GET_BLOCKS(batchHdl.numLeavesAt(batchIdx) * numChannels, numThreads);
+    const int64_t numBlocks = GET_BLOCKS(batchHdl.numLeavesAt(batchIdx) * numChannels, NumThreads);
     TORCH_INTERNAL_ASSERT(numBlocks < (int64_t)(4294967295), "Too many blocks");
     if (numBlocks > 0) {
         if (sharedMemBytes > 0) {
-            if (cudaFuncSetAttribute(_private::forEachLeafSingleGridCUDAKernel<Func, Args...>,
-                                     cudaFuncAttributeMaxDynamicSharedMemorySize,
-                                     sharedMemBytes) != cudaSuccess) {
+            if (cudaFuncSetAttribute(
+                    _private::forEachLeafSingleGridCUDAKernel<NumThreads, Func, Args...>,
+                    cudaFuncAttributeMaxDynamicSharedMemorySize,
+                    sharedMemBytes) != cudaSuccess) {
                 AT_ERROR(
                     "Failed to set maximum shared memory size for forEachLeafSingleGridCUDAKernel (requested ",
                     sharedMemBytes,
@@ -301,16 +298,15 @@ forEachLeafInOneGridCUDA(const at::cuda::CUDAStream &stream,
             }
         }
         auto batchAccessor = batchHdl.deviceAccessor();
-        _private::
-            forEachLeafSingleGridCUDAKernel<<<numBlocks, numThreads, sharedMemBytes, stream>>>(
+        _private::forEachLeafSingleGridCUDAKernel<NumThreads>
+            <<<numBlocks, NumThreads, sharedMemBytes, stream>>>(
                 batchAccessor, returnIfOutOfRange, numChannels, batchIdx, func, args...);
         C10_CUDA_KERNEL_LAUNCH_CHECK();
     }
 }
-template <typename Func, typename... Args>
+template <int NumThreads = DEFAULT_BLOCK_DIM, typename Func, typename... Args>
 void
-forEachLeafInOneGridCUDA(const int64_t numThreads,
-                         const int64_t numChannels,
+forEachLeafInOneGridCUDA(const int64_t numChannels,
                          const int64_t batchIdx,
                          const fvdb::GridBatchData &batchHdl,
                          Func func,
@@ -318,8 +314,8 @@ forEachLeafInOneGridCUDA(const int64_t numThreads,
     TORCH_CHECK(batchHdl.device().is_cuda(), "Grid batch must be on a CUDA device");
     TORCH_CHECK(batchHdl.device().has_index(), "Grid batch device must have an index");
     at::cuda::CUDAStream stream = at::cuda::getCurrentCUDAStream(batchHdl.device().index());
-    return forEachLeafInOneGridCUDA<Func, Args...>(
-        stream, 0, true, numThreads, numChannels, batchIdx, batchHdl, func, args...);
+    return forEachLeafInOneGridCUDA<NumThreads, Func, Args...>(
+        stream, 0, true, numChannels, batchIdx, batchHdl, func, args...);
 }
 
 /// @brief Run the given function on each voxel in the grid batch in parallel on the GPU.
@@ -346,17 +342,15 @@ forEachLeafInOneGridCUDA(const int64_t numThreads,
 /// @param returnIfOutOfRange Whether to skip the callback if the element is out of range. If false,
 ///                           the callback will be run with -1 for the batchIdx, leafIdx, voxelIdx,
 ///                           and channelIdx
-/// @param numThreads The number of threads per block to use
 /// @param numChannels The number of channels per item in each leaf being parallelized over
 /// @param batchHdl A batch of index grids
 /// @param func The callback function to run on each leaf
 /// @param args Any extra arguments to pass to the callback function
-template <typename Func, typename... Args>
+template <int NumThreads = DEFAULT_BLOCK_DIM, typename Func, typename... Args>
 void
 forEachVoxelCUDA(const at::cuda::CUDAStream &stream,
                  const size_t sharedMemBytes,
                  const bool returnIfOutOfRange,
-                 const int64_t numThreads,
                  const int64_t numChannels,
                  const fvdb::GridBatchData &batchHdl,
                  Func func,
@@ -384,29 +378,31 @@ forEachVoxelCUDA(const at::cuda::CUDAStream &stream,
         C10_CUDA_KERNEL_LAUNCH_CHECK();
 
         if (sharedMemBytes > 0) {
-            if (cudaFuncSetAttribute(_private::forEachVoxelWithMetaCUDAKernel<Func, Args...>,
-                                     cudaFuncAttributeMaxDynamicSharedMemorySize,
-                                     sharedMemBytes) != cudaSuccess) {
+            if (cudaFuncSetAttribute(
+                    _private::forEachVoxelWithMetaCUDAKernel<NumThreads, Func, Args...>,
+                    cudaFuncAttributeMaxDynamicSharedMemorySize,
+                    sharedMemBytes) != cudaSuccess) {
                 AT_ERROR(
                     "Failed to set maximum shared memory size for forEachVoxelWithMetaCUDAKernel (requested ",
                     sharedMemBytes,
                     " bytes), try lowering sharedMemBytes.");
             }
         }
-        const int64_t numBlocks = GET_BLOCKS(numVoxels * numChannels, numThreads);
+        const int64_t numBlocks = GET_BLOCKS(numVoxels * numChannels, NumThreads);
         TORCH_INTERNAL_ASSERT(numBlocks < (int64_t)(4294967295),
                               "Too many blocks in forEachVoxelCUDA");
-        _private::forEachVoxelWithMetaCUDAKernel<<<numBlocks, numThreads, sharedMemBytes, stream>>>(
-            batchAccessor, metaIndexAcc, returnIfOutOfRange, numChannels, func, args...);
+        _private::forEachVoxelWithMetaCUDAKernel<NumThreads>
+            <<<numBlocks, NumThreads, sharedMemBytes, stream>>>(
+                batchAccessor, metaIndexAcc, returnIfOutOfRange, numChannels, func, args...);
         C10_CUDA_KERNEL_LAUNCH_CHECK();
 
     } else {
-        const int64_t numBlocks = GET_BLOCKS(numLeaves * VOXELS_PER_LEAF * numChannels, numThreads);
+        const int64_t numBlocks = GET_BLOCKS(numLeaves * VOXELS_PER_LEAF * numChannels, NumThreads);
         TORCH_INTERNAL_ASSERT(numBlocks < (int64_t)(4294967295),
                               "Too many blocks in forEachVoxelCUDA");
 
         if (sharedMemBytes > 0) {
-            if (cudaFuncSetAttribute(_private::forEachVoxelCUDAKernel<Func, Args...>,
+            if (cudaFuncSetAttribute(_private::forEachVoxelCUDAKernel<NumThreads, Func, Args...>,
                                      cudaFuncAttributeMaxDynamicSharedMemorySize,
                                      sharedMemBytes) != cudaSuccess) {
                 AT_ERROR(
@@ -415,23 +411,23 @@ forEachVoxelCUDA(const at::cuda::CUDAStream &stream,
                     " bytes), try lowering sharedMemBytes.");
             }
         }
-        _private::forEachVoxelCUDAKernel<<<numBlocks, numThreads, sharedMemBytes, stream>>>(
-            batchAccessor, returnIfOutOfRange, numChannels, func, args...);
+        _private::forEachVoxelCUDAKernel<NumThreads>
+            <<<numBlocks, NumThreads, sharedMemBytes, stream>>>(
+                batchAccessor, returnIfOutOfRange, numChannels, func, args...);
         C10_CUDA_KERNEL_LAUNCH_CHECK();
     }
 }
-template <typename Func, typename... Args>
+template <int NumThreads = DEFAULT_BLOCK_DIM, typename Func, typename... Args>
 void
-forEachVoxelCUDA(const int64_t numThreads,
-                 const int64_t numChannels,
+forEachVoxelCUDA(const int64_t numChannels,
                  const fvdb::GridBatchData &batchHdl,
                  Func func,
                  Args... args) {
     TORCH_CHECK(batchHdl.device().is_cuda(), "Grid batch must be on a CUDA device");
     TORCH_CHECK(batchHdl.device().has_index(), "Grid batch device must have an index");
     at::cuda::CUDAStream stream = at::cuda::getCurrentCUDAStream(batchHdl.device().index());
-    return forEachVoxelCUDA<Func, Args...>(
-        stream, 0, true, numThreads, numChannels, batchHdl, func, args...);
+    return forEachVoxelCUDA<NumThreads, Func, Args...>(
+        stream, 0, true, numChannels, batchHdl, func, args...);
 }
 
 /// @brief Run the given function on each element in the jagged tensor on the GPU
@@ -453,18 +449,20 @@ forEachVoxelCUDA(const int64_t numThreads,
 /// @param returnIfOutOfRange Whether to skip the callback if the element is out of range. If false,
 ///                           the callback will be called with -1 for the batchIdx, elementIdx, and
 ///                           channelIdx
-/// @param numThreads The number of threads to use per block
 /// @param numChannels The number of channels per item in each jagged element being parallelized
 /// over
 /// @param jaggedTensor The jagged tensor to parallelize over
 /// @param func The callback function to run on each element
 /// @param ...args Any extra arguments to pass to the callback function
-template <typename ScalarT, int32_t NDIMS, typename Func, typename... Args>
+template <typename ScalarT,
+          int32_t NDIMS,
+          int NumThreads = DEFAULT_BLOCK_DIM,
+          typename Func,
+          typename... Args>
 void
 forEachJaggedElementChannelCUDA(const at::cuda::CUDAStream &stream,
                                 const size_t sharedMemBytes,
                                 const bool returnIfOutOfRange,
-                                const int64_t numThreads,
                                 const int64_t numChannels,
                                 const JaggedTensor &jaggedTensor,
                                 Func func,
@@ -473,21 +471,24 @@ forEachJaggedElementChannelCUDA(const at::cuda::CUDAStream &stream,
     TORCH_CHECK(jaggedTensor.device().has_index(), "JaggedTensor device must have an index");
     c10::cuda::CUDAGuard deviceGuard(jaggedTensor.device());
     const int64_t numElements = jaggedTensor.element_count();
-    const int64_t numBlocks   = GET_BLOCKS(numElements * numChannels, numThreads);
+    const int64_t numBlocks   = GET_BLOCKS(numElements * numChannels, NumThreads);
     if (numBlocks > 0) {
         if (sharedMemBytes > 0) {
-            if (cudaFuncSetAttribute(
-                    _private::forEachJaggedElementChannelCUDAKernel<NDIMS, ScalarT, Func, Args...>,
-                    cudaFuncAttributeMaxDynamicSharedMemorySize,
-                    sharedMemBytes) != cudaSuccess) {
+            if (cudaFuncSetAttribute(_private::forEachJaggedElementChannelCUDAKernel<ScalarT,
+                                                                                     NDIMS,
+                                                                                     NumThreads,
+                                                                                     Func,
+                                                                                     Args...>,
+                                     cudaFuncAttributeMaxDynamicSharedMemorySize,
+                                     sharedMemBytes) != cudaSuccess) {
                 AT_ERROR(
                     "Failed to set maximum shared memory size for forEachJaggedElementChannelCUDAKernel (requested ",
                     sharedMemBytes,
                     " bytes), try lowering sharedMemBytes.");
             }
         }
-        _private::forEachJaggedElementChannelCUDAKernel<NDIMS, ScalarT, Func, Args...>
-            <<<numBlocks, numThreads, sharedMemBytes, stream>>>(
+        _private::forEachJaggedElementChannelCUDAKernel<ScalarT, NDIMS, NumThreads, Func, Args...>
+            <<<numBlocks, NumThreads, sharedMemBytes, stream>>>(
                 jaggedTensor.packed_accessor64<ScalarT, NDIMS, torch::RestrictPtrTraits>(),
                 returnIfOutOfRange,
                 numChannels,
@@ -496,18 +497,21 @@ forEachJaggedElementChannelCUDA(const at::cuda::CUDAStream &stream,
         C10_CUDA_KERNEL_LAUNCH_CHECK();
     }
 }
-template <typename ScalarT, int32_t NDIMS, typename Func, typename... Args>
+template <typename ScalarT,
+          int32_t NDIMS,
+          int NumThreads = DEFAULT_BLOCK_DIM,
+          typename Func,
+          typename... Args>
 void
-forEachJaggedElementChannelCUDA(const int64_t numThreads,
-                                const int64_t numChannels,
+forEachJaggedElementChannelCUDA(const int64_t numChannels,
                                 const JaggedTensor &jaggedTensor,
                                 Func func,
                                 Args... args) {
     TORCH_CHECK(jaggedTensor.device().is_cuda(), "JaggedTensor must be on a CUDA device");
     TORCH_CHECK(jaggedTensor.device().has_index(), "JaggedTensor device must have an index");
     at::cuda::CUDAStream stream = at::cuda::getCurrentCUDAStream(jaggedTensor.device().index());
-    return forEachJaggedElementChannelCUDA<ScalarT, NDIMS, Func, Args...>(
-        stream, 0, true, numThreads, numChannels, jaggedTensor, func, args...);
+    return forEachJaggedElementChannelCUDA<ScalarT, NDIMS, NumThreads, Func, Args...>(
+        stream, 0, true, numChannels, jaggedTensor, func, args...);
 }
 
 /// @brief Run the given function on each element in the tensor (first dimension) on the GPU
@@ -527,18 +531,20 @@ forEachJaggedElementChannelCUDA(const int64_t numThreads,
 /// @param sharedMemBytes The amount of shared memory to use for the kernel. If 0, no shared memory
 /// @param returnIfOutOfRange Whether to skip the callback if the element is out of range. If false,
 ///                           the callback will be called with -1 for the elementIdx and channelIdx
-/// @param numThreads The number of threads to use per block
 /// @param numChannels The number of channels per item in each tensor element being parallelized
 /// over
 /// @param tensor The tensor to parallelize over
 /// @param func The callback function to run on each element
 /// @param ...args Any extra arguments to pass to the callback function
-template <typename ScalarT, int32_t NDIMS, typename Func, typename... Args>
+template <typename ScalarT,
+          int32_t NDIMS,
+          int NumThreads = DEFAULT_BLOCK_DIM,
+          typename Func,
+          typename... Args>
 void
 forEachTensorElementChannelCUDA(const at::cuda::CUDAStream &stream,
                                 const size_t sharedMemBytes,
                                 const bool returnIfOutOfRange,
-                                const int64_t numThreads,
                                 const int64_t numChannels,
                                 const torch::Tensor &tensor,
                                 Func func,
@@ -547,21 +553,24 @@ forEachTensorElementChannelCUDA(const at::cuda::CUDAStream &stream,
     TORCH_CHECK(tensor.device().has_index(), "Tensor device must have an index");
     c10::cuda::CUDAGuard deviceGuard(tensor.device());
     const int64_t numElements = tensor.size(0);
-    const int64_t numBlocks   = GET_BLOCKS(numElements * numChannels, numThreads);
+    const int64_t numBlocks   = GET_BLOCKS(numElements * numChannels, NumThreads);
     if (numBlocks > 0) {
         if (sharedMemBytes > 0) {
-            if (cudaFuncSetAttribute(
-                    _private::forEachTensorElementChannelCUDAKernel<NDIMS, ScalarT, Func, Args...>,
-                    cudaFuncAttributeMaxDynamicSharedMemorySize,
-                    sharedMemBytes) != cudaSuccess) {
+            if (cudaFuncSetAttribute(_private::forEachTensorElementChannelCUDAKernel<ScalarT,
+                                                                                     NDIMS,
+                                                                                     NumThreads,
+                                                                                     Func,
+                                                                                     Args...>,
+                                     cudaFuncAttributeMaxDynamicSharedMemorySize,
+                                     sharedMemBytes) != cudaSuccess) {
                 AT_ERROR(
                     "Failed to set maximum shared memory size for forEachTensorElementChannelCUDAKernel (requested ",
                     sharedMemBytes,
                     " bytes), try lowering sharedMemBytes.");
             }
         }
-        _private::forEachTensorElementChannelCUDAKernel<NDIMS, ScalarT, Func, Args...>
-            <<<numBlocks, numThreads, sharedMemBytes, stream>>>(
+        _private::forEachTensorElementChannelCUDAKernel<ScalarT, NDIMS, NumThreads, Func, Args...>
+            <<<numBlocks, NumThreads, sharedMemBytes, stream>>>(
                 tensor.packed_accessor64<ScalarT, NDIMS, torch::RestrictPtrTraits>(),
                 returnIfOutOfRange,
                 numChannels,
@@ -570,18 +579,21 @@ forEachTensorElementChannelCUDA(const at::cuda::CUDAStream &stream,
         C10_CUDA_KERNEL_LAUNCH_CHECK();
     }
 }
-template <typename ScalarT, int32_t NDIMS, typename Func, typename... Args>
+template <typename ScalarT,
+          int32_t NDIMS,
+          int NumThreads = DEFAULT_BLOCK_DIM,
+          typename Func,
+          typename... Args>
 void
-forEachTensorElementChannelCUDA(const int64_t numThreads,
-                                const int64_t numChannels,
+forEachTensorElementChannelCUDA(const int64_t numChannels,
                                 const torch::Tensor &tensor,
                                 Func func,
                                 Args... args) {
     TORCH_CHECK(tensor.device().is_cuda(), "Tensor must be on a CUDA device");
     TORCH_CHECK(tensor.device().has_index(), "Tensor device must have an index");
     at::cuda::CUDAStream stream = at::cuda::getCurrentCUDAStream(tensor.device().index());
-    return forEachTensorElementChannelCUDA<ScalarT, NDIMS, Func, Args...>(
-        stream, 0, true, numThreads, numChannels, tensor, func, args...);
+    return forEachTensorElementChannelCUDA<ScalarT, NDIMS, NumThreads, Func, Args...>(
+        stream, 0, true, numChannels, tensor, func, args...);
 }
 
 } // namespace fvdb

--- a/src/fvdb/detail/utils/cuda/ForEachPrivateUse1.cuh
+++ b/src/fvdb/detail/utils/cuda/ForEachPrivateUse1.cuh
@@ -19,8 +19,8 @@ namespace fvdb {
 
 namespace _private {
 
-template <typename Func, typename... Args>
-__global__ void
+template <int NumThreads, typename Func, typename... Args>
+__global__ void __launch_bounds__(NumThreads)
 forEachLeafPrivateUse1Kernel(int64_t leafChannelCount,
                              int64_t leafChannelOffset,
                              fvdb::GridBatchData::Accessor grid,
@@ -41,8 +41,8 @@ forEachLeafPrivateUse1Kernel(int64_t leafChannelCount,
     }
 }
 
-template <typename Func, typename... Args>
-__global__ void
+template <int NumThreads, typename Func, typename... Args>
+__global__ void __launch_bounds__(NumThreads)
 forEachVoxelPrivateUse1Kernel(int64_t leafVoxelChannelCount,
                               int64_t leafVoxelChannelOffset,
                               fvdb::GridBatchData::Accessor grid,
@@ -70,8 +70,8 @@ forEachVoxelPrivateUse1Kernel(int64_t leafVoxelChannelCount,
     }
 }
 
-template <int32_t NDIMS, typename ScalarT, typename Func, typename... Args>
-__global__ void
+template <typename ScalarT, int32_t NDIMS, int NumThreads, typename Func, typename... Args>
+__global__ void __launch_bounds__(NumThreads)
 forEachJaggedElementChannelPrivateUse1Kernel(int64_t numel,
                                              int64_t offset,
                                              JaggedRAcc64<ScalarT, NDIMS> jaggedAcc,
@@ -89,8 +89,8 @@ forEachJaggedElementChannelPrivateUse1Kernel(int64_t numel,
     }
 }
 
-template <int32_t NDIMS, typename ScalarT, typename Func, typename... Args>
-__global__ void
+template <typename ScalarT, int32_t NDIMS, int NumThreads, typename Func, typename... Args>
+__global__ void __launch_bounds__(NumThreads)
 forEachTensorElementChannelPrivateUse1Kernel(int64_t numel,
                                              int64_t offset,
                                              TorchRAcc64<ScalarT, NDIMS> tensorAcc,
@@ -109,7 +109,7 @@ forEachTensorElementChannelPrivateUse1Kernel(int64_t numel,
 
 } // namespace _private
 
-template <typename Func, typename... Args>
+template <int NumThreads = DEFAULT_BLOCK_DIM, typename Func, typename... Args>
 void
 forEachLeafPrivateUse1(int64_t numChannels,
                        const fvdb::GridBatchData &batchHdl,
@@ -132,19 +132,18 @@ forEachLeafPrivateUse1(int64_t numChannels,
         const auto deviceLeafChannelCount  = deviceLeafCount * numChannels;
         const auto deviceLeafChannelOffset = deviceLeafOffset * numChannels;
 
-        const int64_t deviceNumBlocks = GET_BLOCKS(deviceLeafChannelCount, DEFAULT_BLOCK_DIM);
+        const int64_t deviceNumBlocks = GET_BLOCKS(deviceLeafChannelCount, NumThreads);
         TORCH_INTERNAL_ASSERT(deviceNumBlocks <
                                   static_cast<int64_t>(std::numeric_limits<unsigned int>::max()),
                               "Too many blocks in forEachLeafPrivateUse1");
         if (deviceNumBlocks > 0) {
-            _private::
-                forEachLeafPrivateUse1Kernel<<<deviceNumBlocks, DEFAULT_BLOCK_DIM, 0, stream>>>(
-                    deviceLeafChannelCount,
-                    deviceLeafChannelOffset,
-                    batchAccessor,
-                    numChannels,
-                    func,
-                    args...);
+            _private::forEachLeafPrivateUse1Kernel<NumThreads, Func, Args...>
+                <<<deviceNumBlocks, NumThreads, 0, stream>>>(deviceLeafChannelCount,
+                                                             deviceLeafChannelOffset,
+                                                             batchAccessor,
+                                                             numChannels,
+                                                             func,
+                                                             args...);
             C10_CUDA_KERNEL_LAUNCH_CHECK();
         }
     }
@@ -152,7 +151,7 @@ forEachLeafPrivateUse1(int64_t numChannels,
     fvdb::detail::mergeStreams();
 }
 
-template <typename Func, typename... Args>
+template <int NumThreads = DEFAULT_BLOCK_DIM, typename Func, typename... Args>
 void
 forEachVoxelPrivateUse1(int64_t numChannels,
                         const fvdb::GridBatchData &batchHdl,
@@ -177,20 +176,19 @@ forEachVoxelPrivateUse1(int64_t numChannels,
         const auto deviceLeafVoxelChannelCount  = deviceLeafCount * VOXELS_PER_LEAF * numChannels;
         const auto deviceLeafVoxelChannelOffset = deviceLeafOffset * VOXELS_PER_LEAF * numChannels;
 
-        const int64_t deviceNumBlocks = GET_BLOCKS(deviceLeafVoxelChannelCount, DEFAULT_BLOCK_DIM);
+        const int64_t deviceNumBlocks = GET_BLOCKS(deviceLeafVoxelChannelCount, NumThreads);
         TORCH_INTERNAL_ASSERT(deviceNumBlocks <
                                   static_cast<int64_t>(std::numeric_limits<unsigned int>::max()),
                               "Too many blocks in forEachVoxelPrivateUse1");
 
         if (deviceNumBlocks > 0) {
-            _private::
-                forEachVoxelPrivateUse1Kernel<<<deviceNumBlocks, DEFAULT_BLOCK_DIM, 0, stream>>>(
-                    deviceLeafVoxelChannelCount,
-                    deviceLeafVoxelChannelOffset,
-                    batchAccessor,
-                    numChannels,
-                    func,
-                    args...);
+            _private::forEachVoxelPrivateUse1Kernel<NumThreads, Func, Args...>
+                <<<deviceNumBlocks, NumThreads, 0, stream>>>(deviceLeafVoxelChannelCount,
+                                                             deviceLeafVoxelChannelOffset,
+                                                             batchAccessor,
+                                                             numChannels,
+                                                             func,
+                                                             args...);
             C10_CUDA_KERNEL_LAUNCH_CHECK();
         }
     }
@@ -198,7 +196,11 @@ forEachVoxelPrivateUse1(int64_t numChannels,
     fvdb::detail::mergeStreams();
 }
 
-template <typename ScalarT, int32_t NDIMS, typename Func, typename... Args>
+template <typename ScalarT,
+          int32_t NDIMS,
+          int NumThreads = DEFAULT_BLOCK_DIM,
+          typename Func,
+          typename... Args>
 void
 forEachJaggedElementChannelPrivateUse1(int64_t numChannels,
                                        const JaggedTensor &jaggedTensor,
@@ -215,10 +217,14 @@ forEachJaggedElementChannelPrivateUse1(int64_t numChannels,
         std::tie(deviceElementOffset, deviceElementCount) =
             fvdb::detail::deviceChunk(jaggedTensor.element_count(), deviceId);
 
-        const int64_t deviceNumBlocks = GET_BLOCKS(deviceElementCount, DEFAULT_BLOCK_DIM);
+        const int64_t deviceNumBlocks = GET_BLOCKS(deviceElementCount, NumThreads);
         if (deviceNumBlocks > 0) {
-            _private::forEachJaggedElementChannelPrivateUse1Kernel<NDIMS, ScalarT, Func, Args...>
-                <<<deviceNumBlocks, DEFAULT_BLOCK_DIM, 0, stream>>>(
+            _private::forEachJaggedElementChannelPrivateUse1Kernel<ScalarT,
+                                                                   NDIMS,
+                                                                   NumThreads,
+                                                                   Func,
+                                                                   Args...>
+                <<<deviceNumBlocks, NumThreads, 0, stream>>>(
                     deviceElementCount,
                     deviceElementOffset,
                     jaggedTensor.packed_accessor64<ScalarT, NDIMS, torch::RestrictPtrTraits>(),
@@ -232,7 +238,11 @@ forEachJaggedElementChannelPrivateUse1(int64_t numChannels,
     fvdb::detail::mergeStreams();
 }
 
-template <typename ScalarT, int32_t NDIMS, typename Func, typename... Args>
+template <typename ScalarT,
+          int32_t NDIMS,
+          int NumThreads = DEFAULT_BLOCK_DIM,
+          typename Func,
+          typename... Args>
 void
 forEachTensorElementChannelPrivateUse1(int64_t numChannels,
                                        const torch::Tensor &tensor,
@@ -248,10 +258,14 @@ forEachTensorElementChannelPrivateUse1(int64_t numChannels,
         std::tie(deviceElementOffset, deviceElementCount) =
             fvdb::detail::deviceChunk(tensor.size(0), deviceId);
 
-        const int64_t deviceNumBlocks = GET_BLOCKS(deviceElementCount, DEFAULT_BLOCK_DIM);
+        const int64_t deviceNumBlocks = GET_BLOCKS(deviceElementCount, NumThreads);
         if (deviceNumBlocks > 0) {
-            _private::forEachTensorElementChannelPrivateUse1Kernel<NDIMS, ScalarT, Func, Args...>
-                <<<deviceNumBlocks, DEFAULT_BLOCK_DIM, 0, stream>>>(
+            _private::forEachTensorElementChannelPrivateUse1Kernel<ScalarT,
+                                                                   NDIMS,
+                                                                   NumThreads,
+                                                                   Func,
+                                                                   Args...>
+                <<<deviceNumBlocks, NumThreads, 0, stream>>>(
                     deviceElementCount,
                     deviceElementOffset,
                     tensor.packed_accessor64<ScalarT, NDIMS, torch::RestrictPtrTraits>(),

--- a/src/fvdb/detail/utils/cuda/GridDim.h
+++ b/src/fvdb/detail/utils/cuda/GridDim.h
@@ -18,7 +18,7 @@ constexpr int DEFAULT_BLOCK_DIM = 256;
 /// @param N The number of elements to parallelize over
 /// @param maxThreadsPer dBlock The maximum number of threads per block
 /// @return The number of blocks for a CUDA kernel launch
-static int
+inline int
 GET_BLOCKS(const int64_t N, const int64_t maxThreadsPerBlock) {
     if (N <= 0) {
         return 0;


### PR DESCRIPTION
## Summary

- Replace the runtime `numThreads` function argument in `ForEachCUDA.cuh` and `ForEachPrivateUse1.cuh` with a compile-time `NumThreads` template parameter (defaulting to `DEFAULT_BLOCK_DIM` = 256), enabling `__launch_bounds__` on all `__global__` kernels for better register allocation and occupancy tuning.
- For jagged/tensor forEach families, template params are ordered `<ScalarT, NDIMS, NumThreads=DEFAULT_BLOCK_DIM, ...>` so existing call sites like `<scalar_t, 2>` work unchanged and a non-default block size can be appended as `<scalar_t, 2, 512>`.
- Update ~40 `.cu` call sites to remove the former runtime `numThreads` argument; callers needing non-default block sizes now specify them as a trailing template arg.
- Remove erroneous `__launch_bounds__` from `__device__`/`__hostdev__` callback functions that were causing compiler errors.
- Convert `SimpleOpHelper.h` runtime `num_threads` parameter to a template parameter on both `execute()` overloads.
- Fix `GridDim.h` `GET_BLOCKS` from `static` to `inline` to avoid `-Wunused-function` errors in translation units that include the header but don't call it.

In my experience, this has given me a free 5% speed gain in kernels like `SampleRaysUniform`.

## Test plan

- [x] Full build completes without warnings or errors (`./build.sh`)
- [x] C++ test suite passes (`./build.sh ctest`)
- [x] Python test suite passes (`cd tests && pytest unit -v`)
- [x] Spot-check that kernels using non-default block sizes (e.g. 384, 512, 1024) still launch correctly