### PR TITLE
Add Vec2 and double fast paths to `SampleGridTrilinear`

### DIFF
--- a/src/fvdb/detail/ops/SampleTrilinear.cu
+++ b/src/fvdb/detail/ops/SampleTrilinear.cu
@@ -64,23 +64,43 @@ sampleTrilinearStencilCallback(int32_t bidx,
     }
 }
 
-// Maps a scalar type to its matching 2-wide CUDA vector type. Only the types we
-// actually emit a Vec2 fast path for are specialized.
-template <typename T> struct Vec2Trait;
-template <> struct Vec2Trait<float> {
-    using type = float2;
-};
-template <> struct Vec2Trait<double> {
-    using type = double2;
+namespace {
+
+// Aligned wrapper around nanovdb::math::Vec2<T>. nanovdb's Vec2 stores a bare
+// T[2] without an alignas, so its natural alignment is alignof(T) (4B for
+// float, 8B for double). Reinterpreting a row as Vec2<T>* and dereferencing
+// would let nvcc split the access into two scalar loads. Bumping the alignment
+// to 2*sizeof(T) (8B for float, 16B for double) matches float2/double2 and is
+// the contract the runtime address checks (`aligned8`/`aligned16`) rely on to
+// guarantee a single LDG.64/LDG.128 transaction. Inheriting from Vec2 keeps
+// arithmetic operators (`+=`, `*scalar`, ...) usable without rewriting them.
+template <typename T> struct alignas(2 * sizeof(T)) AlignedVec2 : nanovdb::math::Vec2<T> {
+    using Base = nanovdb::math::Vec2<T>;
+    __hostdev__
+    AlignedVec2()
+        : Base(T(0), T(0)) {}
+    __hostdev__
+    AlignedVec2(const Base &b)
+        : Base(b) {}
 };
 
-// Maps a scalar type to its matching 4-wide CUDA vector type. Only float is
-// specialized: CUDA has no native 4-wide double vector with single-instruction
-// 16-byte load semantics (double2 is the widest aligned double vector type).
-template <typename T> struct Vec4Trait;
-template <> struct Vec4Trait<float> {
-    using type = float4;
+// Aligned wrapper around nanovdb::math::Vec4<T>. Same rationale as
+// AlignedVec2: nanovdb::math::Vec4 has alignof(T) (4B for float), but a single
+// LDG.128 needs the address (and the type) to be 16B aligned. Only
+// instantiated for float in this TU because CUDA has no native 4-wide double
+// vector with single-instruction 16-byte load semantics; doubles fall through
+// to the scalar path or the Vec2 fast path.
+template <typename T> struct alignas(4 * sizeof(T)) AlignedVec4 : nanovdb::math::Vec4<T> {
+    using Base = nanovdb::math::Vec4<T>;
+    __hostdev__
+    AlignedVec4()
+        : Base(T(0), T(0), T(0), T(0)) {}
+    __hostdev__
+    AlignedVec4(const Base &b)
+        : Base(b) {}
 };
+
+} // namespace
 
 // One-thread-per-point callback specialized for numChannels == 2. Resolves the
 // 8-corner stencil once, then issues a single 8-byte (float2) or 16-byte
@@ -99,7 +119,7 @@ sampleTrilinearStencilCallbackVec2(int32_t bidx,
                                    TensorAccessor<ScalarType, 2> gridData,
                                    BatchGridAccessor batchAccessor,
                                    TensorAccessor<ScalarType, 2> outFeatures) {
-    using Vec = typename Vec2Trait<ScalarType>::type;
+    using Vec = AlignedVec2<ScalarType>;
 
     const auto &pointsData               = points.data();
     const nanovdb::OnIndexGrid *grid     = batchAccessor.grid(bidx);
@@ -117,13 +137,11 @@ sampleTrilinearStencilCallbackVec2(int32_t bidx,
     if (activeMask == 0)
         return;
 
-    Vec accum{};
+    Vec accum;
 #pragma unroll
     for (int corner = 0; corner < 8; ++corner) {
-        const ScalarType wt = weights[corner];
-        const Vec val       = *reinterpret_cast<const Vec *>(&gridData[indices[corner]][0]);
-        accum.x += wt * val.x;
-        accum.y += wt * val.y;
+        const Vec val = *reinterpret_cast<const Vec *>(&gridData[indices[corner]][0]);
+        accum += val * weights[corner];
     }
     *reinterpret_cast<Vec *>(&outFeatures[eidx][0]) = accum;
 }
@@ -147,7 +165,7 @@ sampleTrilinearStencilCallbackVec4(int32_t bidx,
                                    BatchGridAccessor batchAccessor,
                                    TensorAccessor<ScalarType, 2> outFeatures,
                                    int64_t numChannels) {
-    using Vec = typename Vec4Trait<ScalarType>::type;
+    using Vec = AlignedVec4<ScalarType>;
 
     const auto &pointsData               = points.data();
     const nanovdb::OnIndexGrid *grid     = batchAccessor.grid(bidx);
@@ -169,18 +187,10 @@ sampleTrilinearStencilCallbackVec4(int32_t bidx,
     for (int64_t g = 0; g < numGroups; ++g) {
         const int64_t cBase = g * 4;
         Vec accum;
-        accum.x = ScalarType(0);
-        accum.y = ScalarType(0);
-        accum.z = ScalarType(0);
-        accum.w = ScalarType(0);
 #pragma unroll
         for (int corner = 0; corner < 8; ++corner) {
-            const ScalarType wt = weights[corner];
-            const Vec val       = *reinterpret_cast<const Vec *>(&gridData[indices[corner]][cBase]);
-            accum.x += wt * val.x;
-            accum.y += wt * val.y;
-            accum.z += wt * val.z;
-            accum.w += wt * val.w;
+            const Vec val = *reinterpret_cast<const Vec *>(&gridData[indices[corner]][cBase]);
+            accum += val * weights[corner];
         }
         *reinterpret_cast<Vec *>(&outFeatures[eidx][cBase]) = accum;
     }

--- a/src/fvdb/detail/ops/SampleTrilinear.cu
+++ b/src/fvdb/detail/ops/SampleTrilinear.cu
@@ -117,9 +117,7 @@ sampleTrilinearStencilCallbackVec2(int32_t bidx,
     if (activeMask == 0)
         return;
 
-    Vec accum;
-    accum.x = ScalarType(0);
-    accum.y = ScalarType(0);
+    Vec accum{};
 #pragma unroll
     for (int corner = 0; corner < 8; ++corner) {
         const ScalarType wt = weights[corner];

--- a/src/fvdb/detail/ops/SampleTrilinear.cu
+++ b/src/fvdb/detail/ops/SampleTrilinear.cu
@@ -64,31 +64,104 @@ sampleTrilinearStencilCallback(int32_t bidx,
     }
 }
 
-// One-thread-per-point callback: resolve the 8-corner stencil once, then iterate
-// channels in float4 groups with explicit 128-bit loads/stores. GPU only.
-template <template <typename T, int32_t D> typename JaggedAccessor,
+// Maps a scalar type to its matching 2-wide CUDA vector type. Only the types we
+// actually emit a Vec2 fast path for are specialized.
+template <typename T> struct Vec2Trait;
+template <> struct Vec2Trait<float> {
+    using type = float2;
+};
+template <> struct Vec2Trait<double> {
+    using type = double2;
+};
+
+// Maps a scalar type to its matching 4-wide CUDA vector type. Only float is
+// specialized: CUDA has no native 4-wide double vector with single-instruction
+// 16-byte load semantics (double2 is the widest aligned double vector type).
+template <typename T> struct Vec4Trait;
+template <> struct Vec4Trait<float> {
+    using type = float4;
+};
+
+// One-thread-per-point callback specialized for numChannels == 2. Resolves the
+// 8-corner stencil once, then issues a single 8-byte (float2) or 16-byte
+// (double2) vector load per corner, halving per-sample transactions relative
+// to the scalar path. GPU only. Caller is responsible for alignment checks.
+template <typename ScalarType,
+          template <typename T, int32_t D>
+          typename JaggedAccessor,
           template <typename T, int32_t D>
           typename TensorAccessor>
 __device__ void
-sampleTrilinearStencilCallbackVec4(int32_t bidx,
+sampleTrilinearStencilCallbackVec2(int32_t bidx,
                                    int32_t eidx,
                                    int32_t /*cidx*/,
-                                   JaggedAccessor<float, 2> points,
-                                   TensorAccessor<float, 2> gridData,
+                                   JaggedAccessor<ScalarType, 2> points,
+                                   TensorAccessor<ScalarType, 2> gridData,
                                    BatchGridAccessor batchAccessor,
-                                   TensorAccessor<float, 2> outFeatures,
-                                   int64_t numChannels) {
+                                   TensorAccessor<ScalarType, 2> outFeatures) {
+    using Vec = typename Vec2Trait<ScalarType>::type;
+
     const auto &pointsData               = points.data();
     const nanovdb::OnIndexGrid *grid     = batchAccessor.grid(bidx);
     const VoxelCoordTransform &transform = batchAccessor.primalTransform(bidx);
     const int64_t baseOffset             = batchAccessor.voxelOffset(bidx);
     auto gridAcc                         = grid->tree().getAccessor();
 
-    const nanovdb::math::Vec3<float> xyz =
+    const nanovdb::math::Vec3<ScalarType> xyz =
         transform.apply(pointsData[eidx][0], pointsData[eidx][1], pointsData[eidx][2]);
 
     int64_t indices[8] = {};
-    float weights[8];
+    ScalarType weights[8];
+    const uint8_t activeMask = resolveTrilinearStencil(xyz, gridAcc, baseOffset, indices, weights);
+
+    if (activeMask == 0)
+        return;
+
+    Vec accum;
+    accum.x = ScalarType(0);
+    accum.y = ScalarType(0);
+#pragma unroll
+    for (int corner = 0; corner < 8; ++corner) {
+        const ScalarType wt = weights[corner];
+        const Vec val       = *reinterpret_cast<const Vec *>(&gridData[indices[corner]][0]);
+        accum.x += wt * val.x;
+        accum.y += wt * val.y;
+    }
+    *reinterpret_cast<Vec *>(&outFeatures[eidx][0]) = accum;
+}
+
+// One-thread-per-point callback specialized for numChannels % 4 == 0. Resolves
+// the 8-corner stencil once, then iterates channels in 4-wide groups with a
+// single 16-byte (float4) vector load per corner per group, quartering
+// per-sample transactions relative to the scalar path. GPU only, float only.
+// Caller is responsible for alignment checks.
+template <typename ScalarType,
+          template <typename T, int32_t D>
+          typename JaggedAccessor,
+          template <typename T, int32_t D>
+          typename TensorAccessor>
+__device__ void
+sampleTrilinearStencilCallbackVec4(int32_t bidx,
+                                   int32_t eidx,
+                                   int32_t /*cidx*/,
+                                   JaggedAccessor<ScalarType, 2> points,
+                                   TensorAccessor<ScalarType, 2> gridData,
+                                   BatchGridAccessor batchAccessor,
+                                   TensorAccessor<ScalarType, 2> outFeatures,
+                                   int64_t numChannels) {
+    using Vec = typename Vec4Trait<ScalarType>::type;
+
+    const auto &pointsData               = points.data();
+    const nanovdb::OnIndexGrid *grid     = batchAccessor.grid(bidx);
+    const VoxelCoordTransform &transform = batchAccessor.primalTransform(bidx);
+    const int64_t baseOffset             = batchAccessor.voxelOffset(bidx);
+    auto gridAcc                         = grid->tree().getAccessor();
+
+    const nanovdb::math::Vec3<ScalarType> xyz =
+        transform.apply(pointsData[eidx][0], pointsData[eidx][1], pointsData[eidx][2]);
+
+    int64_t indices[8] = {};
+    ScalarType weights[8];
     const uint8_t activeMask = resolveTrilinearStencil(xyz, gridAcc, baseOffset, indices, weights);
 
     if (activeMask == 0)
@@ -97,17 +170,21 @@ sampleTrilinearStencilCallbackVec4(int32_t bidx,
     const int64_t numGroups = numChannels / 4;
     for (int64_t g = 0; g < numGroups; ++g) {
         const int64_t cBase = g * 4;
-        float4 accum        = make_float4(0.0f, 0.0f, 0.0f, 0.0f);
+        Vec accum;
+        accum.x = ScalarType(0);
+        accum.y = ScalarType(0);
+        accum.z = ScalarType(0);
+        accum.w = ScalarType(0);
 #pragma unroll
         for (int corner = 0; corner < 8; ++corner) {
-            const float wt   = weights[corner];
-            const float4 val = *reinterpret_cast<const float4 *>(&gridData[indices[corner]][cBase]);
+            const ScalarType wt = weights[corner];
+            const Vec val       = *reinterpret_cast<const Vec *>(&gridData[indices[corner]][cBase]);
             accum.x += wt * val.x;
             accum.y += wt * val.y;
             accum.z += wt * val.z;
             accum.w += wt * val.w;
         }
-        *reinterpret_cast<float4 *>(&outFeatures[eidx][cBase]) = accum;
+        *reinterpret_cast<Vec *>(&outFeatures[eidx][cBase]) = accum;
     }
 }
 
@@ -139,37 +216,58 @@ SampleGridTrilinear(const GridBatchData &batchHdl,
             }
         };
 
+        auto scalarCb = [=]
+            __device__(int32_t bidx, int32_t eidx, int32_t cidx, JaggedRAcc64<scalar_t, 2> pts) {
+                sampleTrilinearStencilCallback<scalar_t, JaggedRAcc64, TorchRAcc64>(
+                    bidx, eidx, cidx, pts, gridDataAcc, batchAcc, outFeaturesAcc, numChannels);
+            };
+
         if constexpr (std::is_same_v<scalar_t, float>) {
-            if (numChannels >= 4 && numChannels % 4 == 0 &&
-                reinterpret_cast<uintptr_t>(gridDataReshape.data_ptr<float>()) % 16 == 0 &&
-                reinterpret_cast<uintptr_t>(outFeatures.data_ptr<float>()) % 16 == 0) {
+            const auto gridDataAddr =
+                reinterpret_cast<uintptr_t>(gridDataReshape.data_ptr<float>());
+            const auto outAddr   = reinterpret_cast<uintptr_t>(outFeatures.data_ptr<float>());
+            const bool aligned8  = (gridDataAddr % 8 == 0) && (outAddr % 8 == 0);
+            const bool aligned16 = (gridDataAddr % 16 == 0) && (outAddr % 16 == 0);
+            if (numChannels == 2 && aligned8) {
                 auto cb = [=] __device__(int32_t bidx,
                                          int32_t eidx,
                                          int32_t cidx,
                                          JaggedRAcc64<float, 2> pts) {
-                    sampleTrilinearStencilCallbackVec4<JaggedRAcc64, TorchRAcc64>(
+                    sampleTrilinearStencilCallbackVec2<float, JaggedRAcc64, TorchRAcc64>(
+                        bidx, eidx, cidx, pts, gridDataAcc, batchAcc, outFeaturesAcc);
+                };
+                dispatchForEach(cb);
+            } else if (numChannels >= 4 && numChannels % 4 == 0 && aligned16) {
+                auto cb = [=] __device__(int32_t bidx,
+                                         int32_t eidx,
+                                         int32_t cidx,
+                                         JaggedRAcc64<float, 2> pts) {
+                    sampleTrilinearStencilCallbackVec4<float, JaggedRAcc64, TorchRAcc64>(
                         bidx, eidx, cidx, pts, gridDataAcc, batchAcc, outFeaturesAcc, numChannels);
                 };
                 dispatchForEach(cb);
             } else {
+                dispatchForEach(scalarCb);
+            }
+        } else if constexpr (std::is_same_v<scalar_t, double>) {
+            const auto gridDataAddr =
+                reinterpret_cast<uintptr_t>(gridDataReshape.data_ptr<double>());
+            const auto outAddr   = reinterpret_cast<uintptr_t>(outFeatures.data_ptr<double>());
+            const bool aligned16 = (gridDataAddr % 16 == 0) && (outAddr % 16 == 0);
+            if (numChannels == 2 && aligned16) {
                 auto cb = [=] __device__(int32_t bidx,
                                          int32_t eidx,
                                          int32_t cidx,
-                                         JaggedRAcc64<float, 2> pts) {
-                    sampleTrilinearStencilCallback<float, JaggedRAcc64, TorchRAcc64>(
-                        bidx, eidx, cidx, pts, gridDataAcc, batchAcc, outFeaturesAcc, numChannels);
+                                         JaggedRAcc64<double, 2> pts) {
+                    sampleTrilinearStencilCallbackVec2<double, JaggedRAcc64, TorchRAcc64>(
+                        bidx, eidx, cidx, pts, gridDataAcc, batchAcc, outFeaturesAcc);
                 };
                 dispatchForEach(cb);
+            } else {
+                dispatchForEach(scalarCb);
             }
         } else {
-            auto cb = [=] __device__(int32_t bidx,
-                                     int32_t eidx,
-                                     int32_t cidx,
-                                     JaggedRAcc64<scalar_t, 2> pts) {
-                sampleTrilinearStencilCallback<scalar_t, JaggedRAcc64, TorchRAcc64>(
-                    bidx, eidx, cidx, pts, gridDataAcc, batchAcc, outFeaturesAcc, numChannels);
-            };
-            dispatchForEach(cb);
+            dispatchForEach(scalarCb);
         }
     } else {
         auto cb = [=](int32_t bidx, int32_t eidx, int32_t cidx, JaggedAcc<scalar_t, 2> pts) {

--- a/src/fvdb/detail/ops/SampleTrilinear.cu
+++ b/src/fvdb/detail/ops/SampleTrilinear.cu
@@ -165,6 +165,11 @@ sampleTrilinearStencilCallbackVec4(int32_t bidx,
                                    BatchGridAccessor batchAccessor,
                                    TensorAccessor<ScalarType, 2> outFeatures,
                                    int64_t numChannels) {
+    static_assert(std::is_same_v<ScalarType, float>,
+                  "sampleTrilinearStencilCallbackVec4 is float-only: CUDA's widest "
+                  "vector load is 16B (ld.global.v4.f32 / v2.f64), so a 4-wide double "
+                  "group (32B) would split into two loads per corner and defeat the "
+                  "single-transaction-per-corner specialization.");
     using Vec = AlignedVec4<ScalarType>;
 
     const auto &pointsData               = points.data();

--- a/src/fvdb/detail/ops/SampleTrilinear.cu
+++ b/src/fvdb/detail/ops/SampleTrilinear.cu
@@ -13,6 +13,8 @@
 #include <c10/cuda/CUDAException.h>
 
 #include <cstdint>
+#include <new>
+#include <type_traits>
 
 namespace fvdb {
 namespace detail {
@@ -74,6 +76,14 @@ namespace {
 // the contract the runtime address checks (`aligned8`/`aligned16`) rely on to
 // guarantee a single LDG.64/LDG.128 transaction. Inheriting from Vec2 keeps
 // arithmetic operators (`+=`, `*scalar`, ...) usable without rewriting them.
+//
+// The wrappers must remain standard-layout and trivially-copyable: the
+// load/store sites view raw tensor storage through `std::launder` of a
+// reinterpret_cast, which under C++20's implicit-lifetime-type rules is
+// well-defined for standard-layout, trivially-copyable types occupying
+// suitably-aligned storage. The alignas/sizeof contract must also match what
+// the runtime alignment checks (`aligned8`/`aligned16`) promise, so we
+// static_assert all four properties below.
 template <typename T> struct alignas(2 * sizeof(T)) AlignedVec2 : nanovdb::math::Vec2<T> {
     using Base = nanovdb::math::Vec2<T>;
     __hostdev__
@@ -83,6 +93,20 @@ template <typename T> struct alignas(2 * sizeof(T)) AlignedVec2 : nanovdb::math:
     AlignedVec2(const Base &b)
         : Base(b) {}
 };
+
+static_assert(sizeof(AlignedVec2<float>) == 8, "AlignedVec2<float> must be 8B for LDG.64");
+static_assert(alignof(AlignedVec2<float>) == 8, "AlignedVec2<float> must be 8B-aligned");
+static_assert(std::is_standard_layout_v<AlignedVec2<float>>,
+              "AlignedVec2<float> must be standard-layout for implicit-lifetime view");
+static_assert(std::is_trivially_copyable_v<AlignedVec2<float>>,
+              "AlignedVec2<float> must be trivially-copyable for implicit-lifetime view");
+
+static_assert(sizeof(AlignedVec2<double>) == 16, "AlignedVec2<double> must be 16B for LDG.128");
+static_assert(alignof(AlignedVec2<double>) == 16, "AlignedVec2<double> must be 16B-aligned");
+static_assert(std::is_standard_layout_v<AlignedVec2<double>>,
+              "AlignedVec2<double> must be standard-layout for implicit-lifetime view");
+static_assert(std::is_trivially_copyable_v<AlignedVec2<double>>,
+              "AlignedVec2<double> must be trivially-copyable for implicit-lifetime view");
 
 // Aligned wrapper around nanovdb::math::Vec4<T>. Same rationale as
 // AlignedVec2: nanovdb::math::Vec4 has alignof(T) (4B for float), but a single
@@ -99,6 +123,13 @@ template <typename T> struct alignas(4 * sizeof(T)) AlignedVec4 : nanovdb::math:
     AlignedVec4(const Base &b)
         : Base(b) {}
 };
+
+static_assert(sizeof(AlignedVec4<float>) == 16, "AlignedVec4<float> must be 16B for LDG.128");
+static_assert(alignof(AlignedVec4<float>) == 16, "AlignedVec4<float> must be 16B-aligned");
+static_assert(std::is_standard_layout_v<AlignedVec4<float>>,
+              "AlignedVec4<float> must be standard-layout for implicit-lifetime view");
+static_assert(std::is_trivially_copyable_v<AlignedVec4<float>>,
+              "AlignedVec4<float> must be trivially-copyable for implicit-lifetime view");
 
 } // namespace
 
@@ -137,13 +168,20 @@ sampleTrilinearStencilCallbackVec2(int32_t bidx,
     if (activeMask == 0)
         return;
 
+    // Vec is standard-layout + trivially-copyable (asserted above) and has
+    // alignas == sizeof matching float2/double2, so under C++20 implicit-
+    // lifetime rules the cast accesses a Vec object that lives in the tensor
+    // storage. std::launder makes the object identity explicit so the
+    // dereference is well-defined under strict-aliasing, while still letting
+    // nvcc lower it to a single ld.global.v2 (LDG.64 for float2, LDG.128 for
+    // double2). Caller is responsible for the alignment precondition.
     Vec accum;
 #pragma unroll
     for (int corner = 0; corner < 8; ++corner) {
-        const Vec val = *reinterpret_cast<const Vec *>(&gridData[indices[corner]][0]);
+        const Vec val = *std::launder(reinterpret_cast<const Vec *>(&gridData[indices[corner]][0]));
         accum += val * weights[corner];
     }
-    *reinterpret_cast<Vec *>(&outFeatures[eidx][0]) = accum;
+    *std::launder(reinterpret_cast<Vec *>(&outFeatures[eidx][0])) = accum;
 }
 
 // One-thread-per-point callback specialized for numChannels % 4 == 0. Resolves
@@ -191,13 +229,18 @@ sampleTrilinearStencilCallbackVec4(int32_t bidx,
     const int64_t numGroups = numChannels / 4;
     for (int64_t g = 0; g < numGroups; ++g) {
         const int64_t cBase = g * 4;
+        // See comment in the Vec2 callback for the std::launder rationale: it
+        // makes the implicit-lifetime view of tensor storage as a Vec
+        // strict-aliasing-clean while preserving the single ld.global.v4.f32
+        // (LDG.128) lowering that we rely on here.
         Vec accum;
 #pragma unroll
         for (int corner = 0; corner < 8; ++corner) {
-            const Vec val = *reinterpret_cast<const Vec *>(&gridData[indices[corner]][cBase]);
+            const Vec val =
+                *std::launder(reinterpret_cast<const Vec *>(&gridData[indices[corner]][cBase]));
             accum += val * weights[corner];
         }
-        *reinterpret_cast<Vec *>(&outFeatures[eidx][cBase]) = accum;
+        *std::launder(reinterpret_cast<Vec *>(&outFeatures[eidx][cBase])) = accum;
     }
 }
 

--- a/tests/unit/test_sample.py
+++ b/tests/unit/test_sample.py
@@ -23,7 +23,7 @@ all_device_dtype_combos = [
 ]
 
 all_device_dtype_channel_combos = [
-    (*combo, nc) for combo, nc in itertools.product(all_device_dtype_combos, [1, 3, 4, 5, 16])
+    (*combo, nc) for combo, nc in itertools.product(all_device_dtype_combos, [1, 2, 3, 4, 5, 16])
 ]
 
 

--- a/tests/unit/test_sample.py
+++ b/tests/unit/test_sample.py
@@ -424,6 +424,55 @@ class TestSample(unittest.TestCase):
         )
 
     @parameterized.expand(all_device_dtype_channel_combos)
+    def test_trilinear_sparse_misaligned_input(self, device, dtype, num_channels):
+        # Exercise the misalignment fallback in the CUDA Vec2/Vec4 fast paths.
+        # The kernel selects a wide-load specialization only when both grid_data
+        # and out_features have aligned data_ptrs (8B for float Vec2, 16B for
+        # float Vec4 / double Vec2). torch.empty/zeros always returns 256-byte-
+        # aligned storage, so we manually construct a contiguous-but-misaligned
+        # view by slicing one element off the start of a flat buffer and
+        # viewing it back to 2D. data_ptr ends up at storage_base + sizeof(dtype),
+        # which fails every alignment check the kernel makes and forces the
+        # scalar fallback regardless of channel count.
+        if dtype == torch.half:
+            atol = 1e-3
+            rtol = 1e-3
+        else:
+            atol = 1e-5
+            rtol = 1e-8
+
+        grid, grid_d, p = make_grid_batch_and_jagged_point_data(device, dtype)
+
+        def make_misaligned(num_voxels: int) -> torch.Tensor:
+            buf = torch.empty(num_voxels * num_channels + 1, device=device, dtype=dtype)
+            buf.uniform_()
+            view = buf[1:].view(num_voxels, num_channels)
+            assert view.is_contiguous()
+            # Sanity: data_ptr must not satisfy the strictest alignment the
+            # fast paths look for. element_size is 2/4/8 for half/float/double;
+            # offsetting by one element guarantees we miss 16B alignment.
+            assert view.data_ptr() % 16 != 0
+            return view.detach().requires_grad_(True)
+
+        # Primal
+        primal_features = make_misaligned(grid.total_voxels)
+        fv = grid.sample_trilinear(p, JaggedTensor(primal_features)).jdata
+        fp = sample_trilinear_naive(p, primal_features, grid)
+        self.assertTrue(
+            torch.allclose(fv, fp, atol=atol, rtol=rtol),
+            f"Primal misaligned max error is {torch.max(torch.abs(fv - fp))}",
+        )
+
+        # Dual
+        dual_features = make_misaligned(grid_d.total_voxels)
+        fv = grid_d.sample_trilinear(p, JaggedTensor(dual_features)).jdata
+        fp = sample_trilinear_naive(p, dual_features, grid_d)
+        self.assertTrue(
+            torch.allclose(fv, fp, atol=atol, rtol=rtol),
+            f"Dual misaligned max error is {torch.max(torch.abs(fv - fp))}",
+        )
+
+    @parameterized.expand(all_device_dtype_channel_combos)
     def test_trilinear_with_grad_sparse_vs_brute(self, device, dtype, num_channels):
         if dtype == torch.half:
             atol = 1e-3

--- a/tests/unit/test_sample.py
+++ b/tests/unit/test_sample.py
@@ -447,11 +447,11 @@ class TestSample(unittest.TestCase):
             buf = torch.empty(num_voxels * num_channels + 1, device=device, dtype=dtype)
             buf.uniform_()
             view = buf[1:].view(num_voxels, num_channels)
-            assert view.is_contiguous()
+            self.assertTrue(view.is_contiguous())
             # Sanity: data_ptr must not satisfy the strictest alignment the
             # fast paths look for. element_size is 2/4/8 for half/float/double;
             # offsetting by one element guarantees we miss 16B alignment.
-            assert view.data_ptr() % 16 != 0
+            self.assertNotEqual(view.data_ptr() % 16, 0)
             return view.detach().requires_grad_(True)
 
         # Primal


### PR DESCRIPTION
## Add Vec2 and double fast paths to `SampleGridTrilinear`

Broaden the GPU trilinear-sampling fast paths so they cover more shapes:

- Introduce `AlignedVec2<T>` / `AlignedVec4<T>`: `alignas(2*sizeof(T))` / `alignas(4*sizeof(T))` subclasses of `nanovdb::math::Vec2<T>` / `nanovdb::math::Vec4<T>`. nanovdb's `Vec2`/`Vec4` only carry `alignof(T)` (4B for float, 8B for double), so reinterpreting a row as `Vec2<T>*`/`Vec4<T>*` would let nvcc split the access into multiple scalar loads. Bumping the alignment to match `float2`/`double2`/`float4` is what the runtime `aligned8`/`aligned16` checks rely on to guarantee a single `LDG.64` / `LDG.128` transaction. Subclassing keeps `+=`, `* scalar`, etc. usable without rewriting any arithmetic. No `AlignedVec4<double>` is used because CUDA has no single-instruction 16B vector load for doubles; the double path tops out at `Vec2`.
- Add `sampleTrilinearStencilCallbackVec2<ScalarType>`: one-thread-per-point callback for `numChannels == 2` that issues one 8-byte (float) or 16-byte (double) aligned vector load per stencil corner, halving per-sample memory transactions vs. the scalar path.
- Template the existing `sampleTrilinearStencilCallbackVec4` on `ScalarType` (instantiated for `float` only today; structurally generic).
- In `SampleGridTrilinear`'s GPU dispatcher, compute alignment once (`aligned8` / `aligned16`) and pick:
  - `float`  + `nc == 2`                + 8B  aligned -> Vec2 path
  - `float`  + `nc >= 4 && nc % 4 == 0` + 16B aligned -> Vec4 path
  - `double` + `nc == 2`                + 16B aligned -> Vec2 path
  - otherwise -> scalar callback

  The scalar callback is hoisted as a shared lambda so each branch just dispatches to the right specialization.

CPU paths and non-`{float,double}` scalar types continue to use the scalar callback unchanged; correctness is unaffected — this is a throughput optimization only.

## Tests

- Extended the existing `test_sample` matrix to include `num_channels == 2`, exercising the new Vec2 fast path for both float and double.
- Added `test_trilinear_sparse_misaligned_input`, which slices a flat buffer to produce a contiguous-but-misaligned `[N, C]` view (`data_ptr = storage_base + sizeof(dtype)`), defeating both the `aligned8` and `aligned16` checks. It sweeps the same `(device, dtype, num_channels)` matrix as the aligned tests, asserts parity with the naive reference, and guards against an accidental future re-alignment (e.g. an extra `.contiguous()`) silently neutering the fallback coverage.

## Performance

On a Blackwell RTX 6000 PRO, trilinear sampling of a 2-channel float feature in my application sees a ~21% speedup in trilinear-sampling time.
