### PR TITLE
Speed up builds with ccache, host PCH, and trimmed torch headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,18 +29,38 @@ message(STATUS "NVCC_THREADS: $ENV{NVCC_THREADS}")
 # the box.
 # ----------------------------------------------------------------------------
 option(FVDB_DISABLE_CCACHE "Disable ccache/sccache compiler caching" OFF)
-# Cache size cap applied via CCACHE_MAXSIZE in the per-invocation env so we
-# don't trample the user's global ccache.conf for other projects. One full
-# multi-arch wheel build is ~250 MB compressed; 10 GB retains roughly 15-40
-# builds depending on config, comfortably covering branch switches and a
-# day's worth of bisecting. Set to "0" (or empty) to inherit the user's
-# personal ccache.conf max_size.
+# We point ccache at a project-scoped CCACHE_DIR and apply CCACHE_MAXSIZE
+# against *that* directory, so the size cap can't evict entries belonging to
+# other projects sharing the user's global ~/.ccache. The directory is stable
+# across build trees (under XDG_CACHE_HOME / ~/.cache) so switching branches
+# or wiping `build/` still hits the cache. Set FVDB_CCACHE_DIR to "" (or "0")
+# to fall back to the user's global ccache; in that mode we also skip the
+# CCACHE_MAXSIZE override to avoid resizing a cache we don't own.
+#
+# One full multi-arch wheel build is ~250 MB compressed; 10 GB retains
+# roughly 15-40 builds, comfortably covering branch switches and a day's
+# worth of bisecting. Set FVDB_CCACHE_MAXSIZE to "0" (or "") to inherit the
+# user's personal ccache.conf max_size for the project-local dir.
+if(DEFINED ENV{XDG_CACHE_HOME} AND NOT "$ENV{XDG_CACHE_HOME}" STREQUAL "")
+    set(_FVDB_DEFAULT_CCACHE_DIR "$ENV{XDG_CACHE_HOME}/fvdb/ccache")
+elseif(DEFINED ENV{HOME} AND NOT "$ENV{HOME}" STREQUAL "")
+    set(_FVDB_DEFAULT_CCACHE_DIR "$ENV{HOME}/.cache/fvdb/ccache")
+else()
+    set(_FVDB_DEFAULT_CCACHE_DIR "")
+endif()
+set(FVDB_CCACHE_DIR "${_FVDB_DEFAULT_CCACHE_DIR}" CACHE PATH
+    "Project-scoped CCACHE_DIR. '' or '0' = use the user's global ccache (and skip MAXSIZE override).")
 set(FVDB_CCACHE_MAXSIZE "10G" CACHE STRING
     "Per-invocation CCACHE_MAXSIZE override (e.g. '20G'). '0' or '' = inherit user config.")
 
 if(NOT FVDB_DISABLE_CCACHE)
     find_program(FVDB_COMPILER_CACHE NAMES ccache sccache)
     if(FVDB_COMPILER_CACHE)
+        set(_fvdb_ccache_dir_active FALSE)
+        if(FVDB_CCACHE_DIR AND NOT FVDB_CCACHE_DIR STREQUAL "0")
+            set(_fvdb_ccache_dir_active TRUE)
+        endif()
+
         # PCH-aware launcher.
         #
         # ccache refuses direct-mode hits on TUs that include a PCH unless
@@ -52,23 +72,43 @@ if(NOT FVDB_DISABLE_CCACHE)
         set(_FVDB_CCACHE_LAUNCHER
             "${CMAKE_COMMAND}" "-E" "env"
             "CCACHE_SLOPPINESS=pch_defines,time_macros")
-        if(FVDB_CCACHE_MAXSIZE AND NOT FVDB_CCACHE_MAXSIZE STREQUAL "0")
+        if(_fvdb_ccache_dir_active)
+            file(MAKE_DIRECTORY "${FVDB_CCACHE_DIR}")
             list(APPEND _FVDB_CCACHE_LAUNCHER
-                "CCACHE_MAXSIZE=${FVDB_CCACHE_MAXSIZE}")
+                "CCACHE_DIR=${FVDB_CCACHE_DIR}")
+            # Only apply MAXSIZE when we own the cache directory; otherwise
+            # we'd be resizing the user's shared global cache.
+            if(FVDB_CCACHE_MAXSIZE AND NOT FVDB_CCACHE_MAXSIZE STREQUAL "0")
+                list(APPEND _FVDB_CCACHE_LAUNCHER
+                    "CCACHE_MAXSIZE=${FVDB_CCACHE_MAXSIZE}")
+            endif()
         endif()
         list(APPEND _FVDB_CCACHE_LAUNCHER "${FVDB_COMPILER_CACHE}")
 
-        set(CMAKE_CXX_COMPILER_LAUNCHER  "${_FVDB_CCACHE_LAUNCHER}"
-            CACHE STRING "Compiler launcher for CXX (auto-detected)" FORCE)
-        set(CMAKE_CUDA_COMPILER_LAUNCHER "${_FVDB_CCACHE_LAUNCHER}"
-            CACHE STRING "Compiler launcher for CUDA (auto-detected)" FORCE)
-        if(FVDB_CCACHE_MAXSIZE AND NOT FVDB_CCACHE_MAXSIZE STREQUAL "0")
-            message(STATUS "FVDB: compiler caching enabled via ${FVDB_COMPILER_CACHE} "
-                           "(max_size=${FVDB_CCACHE_MAXSIZE}, "
-                           "sloppiness=pch_defines,time_macros)")
+        if(NOT DEFINED CMAKE_CXX_COMPILER_LAUNCHER)
+            set(CMAKE_CXX_COMPILER_LAUNCHER "${_FVDB_CCACHE_LAUNCHER}"
+                CACHE STRING "Compiler launcher for CXX (auto-detected)")
+        endif()
+        if(NOT DEFINED CMAKE_CUDA_COMPILER_LAUNCHER)
+            set(CMAKE_CUDA_COMPILER_LAUNCHER "${_FVDB_CCACHE_LAUNCHER}"
+                CACHE STRING "Compiler launcher for CUDA (auto-detected)")
+        endif()
+
+        if(_fvdb_ccache_dir_active)
+            if(FVDB_CCACHE_MAXSIZE AND NOT FVDB_CCACHE_MAXSIZE STREQUAL "0")
+                message(STATUS "FVDB: compiler caching enabled via ${FVDB_COMPILER_CACHE} "
+                               "(dir=${FVDB_CCACHE_DIR}, "
+                               "max_size=${FVDB_CCACHE_MAXSIZE}, "
+                               "sloppiness=pch_defines,time_macros)")
+            else()
+                message(STATUS "FVDB: compiler caching enabled via ${FVDB_COMPILER_CACHE} "
+                               "(dir=${FVDB_CCACHE_DIR}, "
+                               "max_size=user ccache.conf, "
+                               "sloppiness=pch_defines,time_macros)")
+            endif()
         else()
             message(STATUS "FVDB: compiler caching enabled via ${FVDB_COMPILER_CACHE} "
-                           "(max_size=user ccache.conf, "
+                           "(dir=user global, max_size=user ccache.conf, "
                            "sloppiness=pch_defines,time_macros)")
         endif()
     else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,67 @@ find_package(Python3 COMPONENTS Development Interpreter)
 message(STATUS "CMAKE_BUILD_PARALLEL_LEVEL: $ENV{CMAKE_BUILD_PARALLEL_LEVEL}")
 message(STATUS "NVCC_THREADS: $ENV{NVCC_THREADS}")
 
+# ----------------------------------------------------------------------------
+# Compiler caching (ccache / sccache)
+#
+# Wraps every CXX and CUDA invocation so unchanged TUs are pulled from cache.
+# Set FVDB_DISABLE_CCACHE=ON to opt out (e.g. for CI nodes without persistent
+# cache storage). The launcher variables are CACHE entries so they propagate
+# into the src/ subproject's separate project() scope.
+#
+# Cold builds are unaffected; subsequent rebuilds and most touched-header
+# scenarios drop from minutes to seconds. ccache 4.6+ recognizes nvcc out of
+# the box.
+# ----------------------------------------------------------------------------
+option(FVDB_DISABLE_CCACHE "Disable ccache/sccache compiler caching" OFF)
+# Cache size cap applied via CCACHE_MAXSIZE in the per-invocation env so we
+# don't trample the user's global ccache.conf for other projects. One full
+# multi-arch wheel build is ~250 MB compressed; 10 GB retains roughly 15-40
+# builds depending on config, comfortably covering branch switches and a
+# day's worth of bisecting. Set to "0" (or empty) to inherit the user's
+# personal ccache.conf max_size.
+set(FVDB_CCACHE_MAXSIZE "10G" CACHE STRING
+    "Per-invocation CCACHE_MAXSIZE override (e.g. '20G'). '0' or '' = inherit user config.")
+
+if(NOT FVDB_DISABLE_CCACHE)
+    find_program(FVDB_COMPILER_CACHE NAMES ccache sccache)
+    if(FVDB_COMPILER_CACHE)
+        # PCH-aware launcher.
+        #
+        # ccache refuses direct-mode hits on TUs that include a PCH unless
+        # `time_macros` sloppiness is set (the PCH was preprocessed at build-PCH
+        # time, so __TIME__/__DATE__ would always differ from the consuming TU).
+        # `pch_defines` lets us survive minor -D flag changes that don't affect
+        # the PCH contents. We bake both into the launcher via `cmake -E env`
+        # so users get cache hits without needing a personal ccache.conf.
+        set(_FVDB_CCACHE_LAUNCHER
+            "${CMAKE_COMMAND}" "-E" "env"
+            "CCACHE_SLOPPINESS=pch_defines,time_macros")
+        if(FVDB_CCACHE_MAXSIZE AND NOT FVDB_CCACHE_MAXSIZE STREQUAL "0")
+            list(APPEND _FVDB_CCACHE_LAUNCHER
+                "CCACHE_MAXSIZE=${FVDB_CCACHE_MAXSIZE}")
+        endif()
+        list(APPEND _FVDB_CCACHE_LAUNCHER "${FVDB_COMPILER_CACHE}")
+
+        set(CMAKE_CXX_COMPILER_LAUNCHER  "${_FVDB_CCACHE_LAUNCHER}"
+            CACHE STRING "Compiler launcher for CXX (auto-detected)" FORCE)
+        set(CMAKE_CUDA_COMPILER_LAUNCHER "${_FVDB_CCACHE_LAUNCHER}"
+            CACHE STRING "Compiler launcher for CUDA (auto-detected)" FORCE)
+        if(FVDB_CCACHE_MAXSIZE AND NOT FVDB_CCACHE_MAXSIZE STREQUAL "0")
+            message(STATUS "FVDB: compiler caching enabled via ${FVDB_COMPILER_CACHE} "
+                           "(max_size=${FVDB_CCACHE_MAXSIZE}, "
+                           "sloppiness=pch_defines,time_macros)")
+        else()
+            message(STATUS "FVDB: compiler caching enabled via ${FVDB_COMPILER_CACHE} "
+                           "(max_size=user ccache.conf, "
+                           "sloppiness=pch_defines,time_macros)")
+        endif()
+    else()
+        message(STATUS "FVDB: ccache/sccache not found on PATH; "
+                       "install one to speed up incremental builds")
+    endif()
+endif()
+
 include(${CMAKE_CURRENT_SOURCE_DIR}/src/cmake/get_cpm.cmake)
 include(${CMAKE_CURRENT_SOURCE_DIR}/src/cmake/get_nvtx.cmake)
 include(${CMAKE_CURRENT_SOURCE_DIR}/src/cmake/get_torch.cmake)
@@ -91,6 +152,20 @@ target_compile_definitions(_fvdb_cpp PRIVATE
 
 # Configure the pybind11 module with PyTorch compatibility settings
 configure_torch_pybind11(_fvdb_cpp)
+
+# All bindings TUs include <torch/types.h> + pybind11. Pre-compile both so the
+# 30+ s ATen+pybind parse cost is paid once. Honors the same opt-out flag as
+# the fvdb library above.
+if(NOT FVDB_DISABLE_PCH)
+    target_precompile_headers(_fvdb_cpp PRIVATE
+        <torch/types.h>
+        <pybind11/pybind11.h>
+        <pybind11/stl.h>
+        <vector>
+        <memory>
+        <optional>
+        <string>)
+endif()
 
 # Add linker flags for Debug builds to preserve symbols
 if(CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ message(STATUS "NVCC_THREADS: $ENV{NVCC_THREADS}")
 # Compiler caching (ccache / sccache)
 #
 # Wraps every CXX and CUDA invocation so unchanged TUs are pulled from cache.
-# Set FVDB_DISABLE_CCACHE=ON to opt out (e.g. for CI nodes without persistent
+# Set FVDB_ENABLE_CCACHE=OFF to opt out (e.g. for CI nodes without persistent
 # cache storage). The launcher variables are CACHE entries so they propagate
 # into the src/ subproject's separate project() scope.
 #
@@ -28,7 +28,7 @@ message(STATUS "NVCC_THREADS: $ENV{NVCC_THREADS}")
 # scenarios drop from minutes to seconds. ccache 4.6+ recognizes nvcc out of
 # the box.
 # ----------------------------------------------------------------------------
-option(FVDB_DISABLE_CCACHE "Disable ccache/sccache compiler caching" OFF)
+option(FVDB_ENABLE_CCACHE "Enable ccache/sccache compiler caching" ON)
 # We point ccache at a project-scoped CCACHE_DIR and apply CCACHE_MAXSIZE
 # against *that* directory, so the size cap can't evict entries belonging to
 # other projects sharing the user's global ~/.ccache. The directory is stable
@@ -53,7 +53,7 @@ set(FVDB_CCACHE_DIR "${_FVDB_DEFAULT_CCACHE_DIR}" CACHE PATH
 set(FVDB_CCACHE_MAXSIZE "10G" CACHE STRING
     "Per-invocation CCACHE_MAXSIZE override (e.g. '20G'). '0' or '' = inherit user config.")
 
-if(NOT FVDB_DISABLE_CCACHE)
+if(FVDB_ENABLE_CCACHE)
     find_program(FVDB_COMPILER_CACHE NAMES ccache sccache)
     if(FVDB_COMPILER_CACHE)
         set(_fvdb_ccache_dir_active FALSE)
@@ -194,9 +194,9 @@ target_compile_definitions(_fvdb_cpp PRIVATE
 configure_torch_pybind11(_fvdb_cpp)
 
 # All bindings TUs include <torch/types.h> + pybind11. Pre-compile both so the
-# 30+ s ATen+pybind parse cost is paid once. Honors the same opt-out flag as
-# the fvdb library above.
-if(NOT FVDB_DISABLE_PCH)
+# 30+ s ATen+pybind parse cost is paid once. Honors the same opt-in flag as
+# the fvdb library above (FVDB_ENABLE_PCH, default ON).
+if(FVDB_ENABLE_PCH)
     target_precompile_headers(_fvdb_cpp PRIVATE
         <torch/types.h>
         <pybind11/pybind11.h>

--- a/env/dev_environment.yml
+++ b/env/dev_environment.yml
@@ -6,6 +6,7 @@ dependencies:
   - blas=*=mkl
   - boto3
   - ca-certificates
+  - ccache
   - certifi
   - clang-18
   - clang-format-18

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -223,9 +223,9 @@ target_link_libraries(fvdb PRIVATE
 #
 # The fvdb target is a CXX/CUDA mix; nvcc does not support PCH. We scope the
 # precompiled headers to CXX via the COMPILE_LANGUAGE generator expression so
-# only the .cpp sources benefit. The chosen headers are the universal heavy
-# hitters -- libtorch's umbrella alias header plus the two fvdb headers that
-# show up in nearly every TU.
+# only the .cpp sources benefit. The current PCH set is intentionally small:
+# torch/types.h plus a few common C++ standard library headers used across many
+# translation units.
 #
 # Disable with FVDB_DISABLE_PCH=ON for diagnostic builds where you want to see
 # precise per-TU header dependencies.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -218,6 +218,28 @@ target_compile_options(fvdb PRIVATE
 target_link_libraries(fvdb PRIVATE
     ${TORCH_LIBRARIES} tinyply cutlass blosc::blosc dispatch)
 
+# ----------------------------------------------------------------------------
+# Precompiled headers (host C++ only)
+#
+# The fvdb target is a CXX/CUDA mix; nvcc does not support PCH. We scope the
+# precompiled headers to CXX via the COMPILE_LANGUAGE generator expression so
+# only the .cpp sources benefit. The chosen headers are the universal heavy
+# hitters -- libtorch's umbrella alias header plus the two fvdb headers that
+# show up in nearly every TU.
+#
+# Disable with FVDB_DISABLE_PCH=ON for diagnostic builds where you want to see
+# precise per-TU header dependencies.
+# ----------------------------------------------------------------------------
+option(FVDB_DISABLE_PCH "Disable precompiled headers for the fvdb target" OFF)
+if(NOT FVDB_DISABLE_PCH)
+    target_precompile_headers(fvdb PRIVATE
+        "$<$<COMPILE_LANGUAGE:CXX>:<torch/types.h>>"
+        "$<$<COMPILE_LANGUAGE:CXX>:<vector>>"
+        "$<$<COMPILE_LANGUAGE:CXX>:<memory>>"
+        "$<$<COMPILE_LANGUAGE:CXX>:<optional>>"
+        "$<$<COMPILE_LANGUAGE:CXX>:<string>>")
+endif()
+
 # Add linker flags for Debug builds to preserve symbols
 if(CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
     target_link_options(fvdb PRIVATE "-rdynamic")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -227,11 +227,11 @@ target_link_libraries(fvdb PRIVATE
 # torch/types.h plus a few common C++ standard library headers used across many
 # translation units.
 #
-# Disable with FVDB_DISABLE_PCH=ON for diagnostic builds where you want to see
+# Set FVDB_ENABLE_PCH=OFF for diagnostic builds where you want to see
 # precise per-TU header dependencies.
 # ----------------------------------------------------------------------------
-option(FVDB_DISABLE_PCH "Disable precompiled headers for the fvdb target" OFF)
-if(NOT FVDB_DISABLE_PCH)
+option(FVDB_ENABLE_PCH "Enable precompiled headers for the fvdb target" ON)
+if(FVDB_ENABLE_PCH)
     target_precompile_headers(fvdb PRIVATE
         "$<$<COMPILE_LANGUAGE:CXX>:<torch/types.h>>"
         "$<$<COMPILE_LANGUAGE:CXX>:<vector>>"

--- a/src/fvdb/detail/ops/convolution/GatherScatterDefault.cu
+++ b/src/fvdb/detail/ops/convolution/GatherScatterDefault.cu
@@ -23,7 +23,7 @@
 #include <fvdb/detail/dispatch/TensorChecks.h>
 #include <fvdb/detail/ops/convolution/GatherScatterDefault.h>
 
-#include <torch/torch.h>
+#include <torch/types.h>
 
 #include <algorithm>
 #include <cmath>

--- a/src/fvdb/detail/viewer/Viewer.h
+++ b/src/fvdb/detail/viewer/Viewer.h
@@ -8,7 +8,8 @@
 #include <fvdb/detail/viewer/CameraView.h>
 #include <fvdb/detail/viewer/GaussianSplat3dView.h>
 
-#include <torch/torch.h>
+#include <c10/util/Exception.h>
+#include <torch/types.h>
 
 #include <nanovdb_editor/putil/Editor.h>
 


### PR DESCRIPTION
Speeds up incremental builds without changing runtime behavior. Three independent but complementary changes:

* ccache: auto-detect ccache (or sccache) and wrap every CXX and CUDA compile via `cmake -E env`. The wrapper bakes in `CCACHE_SLOPPINESS=pch_defines,time_macros`, which is required for ccache to take direct-mode hits on PCH-using TUs. By default the launcher also pins ccache to a project-scoped `CCACHE_DIR` (`$XDG_CACHE_HOME/fvdb/ccache`, falling back to `~/.cache/fvdb/ccache`) and applies `CCACHE_MAXSIZE` against *that* directory, so the project's size cap can't evict entries belonging to other projects sharing the user's global `~/.ccache`. The directory is stable across build trees, so wiping `build/` or switching branches still hits the cache. Set `-DFVDB_CCACHE_DIR=` (empty or `0`) to fall back to the user's global ccache; in that mode the `CCACHE_MAXSIZE` override is also skipped so we never resize a cache we don't own. Disable end-to-end with `-DFVDB_ENABLE_CCACHE=OFF`. ccache is added to `env/dev_environment.yml` so dev shells pick it up automatically.

* Host-only precompiled headers: precompile the universal heavy hitters (`<torch/types.h>` plus a few std headers, with pybind11 added on the bindings target) for `fvdb` and `_fvdb_cpp`. The PCH is scoped via `$<COMPILE_LANGUAGE:CXX>` so nvcc TUs are skipped (nvcc has no PCH support). Disable with `-DFVDB_ENABLE_PCH=OFF` for diagnostic builds where exact per-TU header dependencies matter.

* `<torch/torch.h>` quarantine: replace the umbrella header in the two production locations that still used it (`src/fvdb/detail/viewer/Viewer.h` and `src/fvdb/detail/ops/convolution/GatherScatterDefault.cu`) with `<torch/types.h>` (plus `<c10/util/Exception.h>` where `TORCH_CHECK` is needed). `<torch/torch.h>` drags in the entire nn / optim stack and contributes ~16s of parse time per including TU; neither file uses any of it.

Single-TU verification after these changes:

  * `Viewer.cpp` rebuild after `touch`:    33.4s -> 0.41s (ccache hit)
  * `GatherScatterDefault.cu` ccache hit:  0.09s
  * ccache direct-mode hit rate:           100% on cacheable calls

New CMake knobs:
  * `FVDB_ENABLE_CCACHE`    (BOOL,   default ON)
  * `FVDB_CCACHE_DIR`       (PATH,   default `$XDG_CACHE_HOME/fvdb/ccache`; '' or '0' = use the user's global ccache and skip the MAXSIZE override)
  * `FVDB_CCACHE_MAXSIZE`   (STRING, default "10G", "0" = inherit)
  * `FVDB_ENABLE_PCH`       (BOOL,   default ON)


Note:  On the CI this cut 26s (~5%) off the build time, likely attributable to the torch.h 'quarantine' and the PCH for the host headers.  The ccache changes have been a bigger win for me doing iterative local development.
