### PR TITLE
ci(nightly): anchor nightly version to upcoming release in pyproject.toml

### DIFF
--- a/.github/workflows/nightly-publish.yml
+++ b/.github/workflows/nightly-publish.yml
@@ -157,7 +157,16 @@ jobs:
         run: |
           TORCH_TAG="$(echo "${{ matrix.torch-version }}" | tr -d '.')"
           CUDA_TAG="$(echo "${{ matrix.cuda-version }}" | tr -d '.')"
-          NIGHTLY_VERSION="0.0.0.dev$(date -u '+%Y%m%d')+pt${TORCH_TAG}.cu${CUDA_TAG}"
+          # Anchor the nightly at the upcoming release recorded in pyproject.toml
+          # (e.g. 0.5.0.dev0 -> 0.5.0) so PEP 440 ordering puts nightlies between
+          # the previous final release and the next one.
+          CURRENT_VERSION=$(grep -E '^version *=' pyproject.toml | head -n1 | sed -E 's/^version *= *"([^"]+)".*/\1/')
+          BASE_VERSION=$(echo "${CURRENT_VERSION%%+*}" | sed -E 's/(\.dev[0-9]+|\.post[0-9]+|(a|b|c|rc)[0-9]+)+$//')
+          if [ -z "$BASE_VERSION" ]; then
+            echo "Failed to parse base version from pyproject.toml (got '$CURRENT_VERSION')" >&2
+            exit 1
+          fi
+          NIGHTLY_VERSION="${BASE_VERSION}.dev$(date -u '+%Y%m%d')+pt${TORCH_TAG}.cu${CUDA_TAG}"
           sed -i -E "s/^version *= *\"[^\"]+\"/version = \"${NIGHTLY_VERSION}\"/" pyproject.toml
           echo "Nightly version: $NIGHTLY_VERSION"
           grep '^version' pyproject.toml


### PR DESCRIPTION
Previously the nightly publish workflow hard-coded the base version as 0.0.0, producing wheels like 0.0.0.dev20260427+pt280.cu128. This made nightlies sort below every real release and gave no hint of which release cycle they belonged to.

Read the current `version` from pyproject.toml instead, strip any trailing pre/dev/post segment and local label, and use the resulting base release as the anchor. With pyproject.toml at 0.5.0.dev0 today's nightly becomes 0.5.0.dev20260427+pt280.cu128, which under PEP 440 sorts as:

    0.5.0.dev0  <  0.5.0.devYYYYMMDD+ptX.cuY  <  0.5.0

so `pip install --pre fvdb-core` tracks nightlies until 0.5.0 ships, prefers the final release once tagged, and resumes tracking nightlies after the next dev-cycle bump. Fails fast if the version string can't be parsed.