### PR TITLE
ci(publish): set short cache-control and invalidate CloudFront on index uploads

### DIFF
--- a/.github/versions.json
+++ b/.github/versions.json
@@ -36,7 +36,8 @@
     "cpu_ami": "ami-0e14a711dad782a70",
     "gpu_ami": "ami-0f5c0b65fde08ae43",
     "subnet": "subnet-03f2320d6e6e0005b",
-    "security_group": "sg-0cd08bd89d6212223"
+    "security_group": "sg-0cd08bd89d6212223",
+    "cloudfront_distribution_domain": "d36m13axqqhiit.cloudfront.net"
   },
   "publish_matrix": {
     "python-version": ["3.10", "3.11", "3.12", "3.13"],

--- a/.github/workflows/load-versions.yml
+++ b/.github/workflows/load-versions.yml
@@ -54,6 +54,8 @@ on:
         value: ${{ jobs.load.outputs.aws-subnet }}
       aws-security-group:
         value: ${{ jobs.load.outputs.aws-security-group }}
+      aws-cloudfront-distribution-domain:
+        value: ${{ jobs.load.outputs.aws-cloudfront-distribution-domain }}
       publish-matrix:
         value: ${{ jobs.load.outputs.publish-matrix }}
       auditwheel-excludes:
@@ -87,6 +89,7 @@ jobs:
       aws-gpu-ami: ${{ steps.parse.outputs.aws-gpu-ami }}
       aws-subnet: ${{ steps.parse.outputs.aws-subnet }}
       aws-security-group: ${{ steps.parse.outputs.aws-security-group }}
+      aws-cloudfront-distribution-domain: ${{ steps.parse.outputs.aws-cloudfront-distribution-domain }}
       publish-matrix: ${{ steps.parse.outputs.publish-matrix }}
       auditwheel-excludes: ${{ steps.parse.outputs.auditwheel-excludes }}
       auditwheel-excludes-cuda-major: ${{ steps.parse.outputs.auditwheel-excludes-cuda-major }}
@@ -123,6 +126,7 @@ jobs:
             echo "aws-gpu-ami=$(jq -r '.aws.gpu_ami' $CFG)"
             echo "aws-subnet=$(jq -r '.aws.subnet' $CFG)"
             echo "aws-security-group=$(jq -r '.aws.security_group' $CFG)"
+            echo "aws-cloudfront-distribution-domain=$(jq -r '.aws.cloudfront_distribution_domain // ""' $CFG)"
             echo "publish-matrix=$(jq -c '.publish_matrix' $CFG)"
             echo "auditwheel-excludes=$(jq -c '.auditwheel_excludes' $CFG)"
             echo "auditwheel-excludes-cuda-major=$(jq -c '.auditwheel_excludes_cuda_major' $CFG)"

--- a/.github/workflows/nightly-publish.yml
+++ b/.github/workflows/nightly-publish.yml
@@ -354,7 +354,10 @@ jobs:
           echo "Generated index.html:"
           cat "$INDEX_FILE"
 
-          aws s3 cp "$INDEX_FILE" "s3://${S3_BUCKET}/${SIMPLE_PREFIX}/${{ steps.proj.outputs.normalized }}/index.html" --content-type text/html --only-show-errors
+          aws s3 cp "$INDEX_FILE" "s3://${S3_BUCKET}/${SIMPLE_PREFIX}/${{ steps.proj.outputs.normalized }}/index.html" \
+            --content-type text/html \
+            --cache-control "public, max-age=60, must-revalidate" \
+            --only-show-errors
           echo "Index uploaded successfully"
 
       - name: Generate root simple index.html
@@ -374,7 +377,35 @@ jobs:
             done;
             echo "</body></html>";
           } > "$ROOT_INDEX"
-          aws s3 cp "$ROOT_INDEX" "s3://${S3_BUCKET}/${SIMPLE_PREFIX}/index.html" --content-type text/html --only-show-errors
+          aws s3 cp "$ROOT_INDEX" "s3://${S3_BUCKET}/${SIMPLE_PREFIX}/index.html" \
+            --content-type text/html \
+            --cache-control "public, max-age=60, must-revalidate" \
+            --only-show-errors
+
+      - name: Invalidate CloudFront cache for index.html files
+        run: |
+          set -euo pipefail
+          DOMAIN="${{ needs.versions.outputs.aws-cloudfront-distribution-domain }}"
+          if [ -z "$DOMAIN" ] || [ "$DOMAIN" = "null" ]; then
+            echo "No CloudFront distribution domain configured (aws.cloudfront_distribution_domain in versions.json); skipping invalidation"
+            exit 0
+          fi
+          DIST_ID=$(aws cloudfront list-distributions \
+            --query "DistributionList.Items[?DomainName=='$DOMAIN'].Id | [0]" \
+            --output text 2>/dev/null || echo "")
+          if [ -z "$DIST_ID" ] || [ "$DIST_ID" = "None" ]; then
+            echo "WARNING: Could not find CloudFront distribution for domain $DOMAIN; skipping invalidation"
+            echo "(IAM role may need cloudfront:ListDistributions permission)"
+            exit 0
+          fi
+          PROJECT_PATH="/${SIMPLE_PREFIX}/${{ steps.proj.outputs.normalized }}/index.html"
+          ROOT_PATH="/${SIMPLE_PREFIX}/index.html"
+          echo "Invalidating distribution $DIST_ID paths: $PROJECT_PATH, $ROOT_PATH"
+          aws cloudfront create-invalidation \
+            --distribution-id "$DIST_ID" \
+            --paths "$PROJECT_PATH" "$ROOT_PATH" \
+            --query 'Invalidation.{Id:Id,Status:Status,CreateTime:CreateTime}' \
+            --output table
 
   ##############################################################################
   # STOP EC2 BUILD RUNNERS

--- a/.github/workflows/nightly-publish.yml
+++ b/.github/workflows/nightly-publish.yml
@@ -382,7 +382,7 @@ jobs:
             --cache-control "public, max-age=60, must-revalidate" \
             --only-show-errors
 
-      - name: Invalidate CloudFront cache for index.html files
+      - name: Invalidate CloudFront cache for simple-index paths
         run: |
           set -euo pipefail
           DOMAIN="${{ needs.versions.outputs.aws-cloudfront-distribution-domain }}"
@@ -398,12 +398,21 @@ jobs:
             echo "(IAM role may need cloudfront:ListDistributions permission)"
             exit 0
           fi
-          PROJECT_PATH="/${SIMPLE_PREFIX}/${{ steps.proj.outputs.normalized }}/index.html"
-          ROOT_PATH="/${SIMPLE_PREFIX}/index.html"
-          echo "Invalidating distribution $DIST_ID paths: $PROJECT_PATH, $ROOT_PATH"
+          NORM="${{ steps.proj.outputs.normalized }}"
+          # Invalidate both the trailing-slash directory paths (what pip and
+          # browsers actually request) and the underlying index.html object
+          # paths. CloudFront caches each request URI independently, so
+          # invalidating only one form leaves the other stale.
+          PATHS=(
+            "/${SIMPLE_PREFIX}/"
+            "/${SIMPLE_PREFIX}/index.html"
+            "/${SIMPLE_PREFIX}/${NORM}/"
+            "/${SIMPLE_PREFIX}/${NORM}/index.html"
+          )
+          echo "Invalidating distribution $DIST_ID paths: ${PATHS[*]}"
           aws cloudfront create-invalidation \
             --distribution-id "$DIST_ID" \
-            --paths "$PROJECT_PATH" "$ROOT_PATH" \
+            --paths "${PATHS[@]}" \
             --query 'Invalidation.{Id:Id,Status:Status,CreateTime:CreateTime}' \
             --output table
 

--- a/.github/workflows/nightly-publish.yml
+++ b/.github/workflows/nightly-publish.yml
@@ -401,11 +401,15 @@ jobs:
           PROJECT_PATH="/${SIMPLE_PREFIX}/${{ steps.proj.outputs.normalized }}/index.html"
           ROOT_PATH="/${SIMPLE_PREFIX}/index.html"
           echo "Invalidating distribution $DIST_ID paths: $PROJECT_PATH, $ROOT_PATH"
-          aws cloudfront create-invalidation \
+          if ! aws cloudfront create-invalidation \
             --distribution-id "$DIST_ID" \
             --paths "$PROJECT_PATH" "$ROOT_PATH" \
             --query 'Invalidation.{Id:Id,Status:Status,CreateTime:CreateTime}' \
-            --output table
+            --output table; then
+            echo "WARNING: Failed to create CloudFront invalidation for distribution $DIST_ID; continuing without failing publish"
+            echo "(IAM role may need cloudfront:CreateInvalidation permission)"
+            exit 0
+          fi
 
   ##############################################################################
   # STOP EC2 BUILD RUNNERS

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -551,11 +551,15 @@ jobs:
           PROJECT_PATH="/${SIMPLE_PREFIX}/${{ steps.proj.outputs.normalized }}/index.html"
           ROOT_PATH="/${SIMPLE_PREFIX}/index.html"
           echo "Invalidating distribution $DIST_ID paths: $PROJECT_PATH, $ROOT_PATH"
-          aws cloudfront create-invalidation \
+          if ! aws cloudfront create-invalidation \
             --distribution-id "$DIST_ID" \
             --paths "$PROJECT_PATH" "$ROOT_PATH" \
             --query 'Invalidation.{Id:Id,Status:Status,CreateTime:CreateTime}' \
-            --output table
+            --output table; then
+            echo "WARNING: Failed to create CloudFront invalidation for distribution $DIST_ID; skipping invalidation"
+            echo "(IAM role may need cloudfront:CreateInvalidation permission)"
+            exit 0
+          fi
 
   ##############################################################################
   # GPU VALIDATION: SMOKE TEST + UNIT TESTS

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -503,7 +503,10 @@ jobs:
           cat "$INDEX_FILE"
 
           echo "Uploading index.html to S3..."
-          aws s3 cp "$INDEX_FILE" "s3://${S3_BUCKET}/${SIMPLE_PREFIX}/${{ steps.proj.outputs.normalized }}/index.html" --content-type text/html --only-show-errors
+          aws s3 cp "$INDEX_FILE" "s3://${S3_BUCKET}/${SIMPLE_PREFIX}/${{ steps.proj.outputs.normalized }}/index.html" \
+            --content-type text/html \
+            --cache-control "public, max-age=60, must-revalidate" \
+            --only-show-errors
           echo "Index uploaded successfully"
 
       - name: Generate root simple index.html
@@ -524,7 +527,35 @@ jobs:
             done;
             echo "</body></html>";
           } > "$ROOT_INDEX"
-          aws s3 cp "$ROOT_INDEX" "s3://${S3_BUCKET}/${SIMPLE_PREFIX}/index.html" --content-type text/html --only-show-errors
+          aws s3 cp "$ROOT_INDEX" "s3://${S3_BUCKET}/${SIMPLE_PREFIX}/index.html" \
+            --content-type text/html \
+            --cache-control "public, max-age=60, must-revalidate" \
+            --only-show-errors
+
+      - name: Invalidate CloudFront cache for index.html files
+        run: |
+          set -euo pipefail
+          DOMAIN="${{ needs.versions.outputs.aws-cloudfront-distribution-domain }}"
+          if [ -z "$DOMAIN" ] || [ "$DOMAIN" = "null" ]; then
+            echo "No CloudFront distribution domain configured (aws.cloudfront_distribution_domain in versions.json); skipping invalidation"
+            exit 0
+          fi
+          DIST_ID=$(aws cloudfront list-distributions \
+            --query "DistributionList.Items[?DomainName=='$DOMAIN'].Id | [0]" \
+            --output text 2>/dev/null || echo "")
+          if [ -z "$DIST_ID" ] || [ "$DIST_ID" = "None" ]; then
+            echo "WARNING: Could not find CloudFront distribution for domain $DOMAIN; skipping invalidation"
+            echo "(IAM role may need cloudfront:ListDistributions permission)"
+            exit 0
+          fi
+          PROJECT_PATH="/${SIMPLE_PREFIX}/${{ steps.proj.outputs.normalized }}/index.html"
+          ROOT_PATH="/${SIMPLE_PREFIX}/index.html"
+          echo "Invalidating distribution $DIST_ID paths: $PROJECT_PATH, $ROOT_PATH"
+          aws cloudfront create-invalidation \
+            --distribution-id "$DIST_ID" \
+            --paths "$PROJECT_PATH" "$ROOT_PATH" \
+            --query 'Invalidation.{Id:Id,Status:Status,CreateTime:CreateTime}' \
+            --output table
 
   ##############################################################################
   # GPU VALIDATION: SMOKE TEST + UNIT TESTS

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -532,7 +532,7 @@ jobs:
             --cache-control "public, max-age=60, must-revalidate" \
             --only-show-errors
 
-      - name: Invalidate CloudFront cache for index.html files
+      - name: Invalidate CloudFront cache for simple-index paths
         run: |
           set -euo pipefail
           DOMAIN="${{ needs.versions.outputs.aws-cloudfront-distribution-domain }}"
@@ -548,12 +548,21 @@ jobs:
             echo "(IAM role may need cloudfront:ListDistributions permission)"
             exit 0
           fi
-          PROJECT_PATH="/${SIMPLE_PREFIX}/${{ steps.proj.outputs.normalized }}/index.html"
-          ROOT_PATH="/${SIMPLE_PREFIX}/index.html"
-          echo "Invalidating distribution $DIST_ID paths: $PROJECT_PATH, $ROOT_PATH"
+          NORM="${{ steps.proj.outputs.normalized }}"
+          # Invalidate both the trailing-slash directory paths (what pip and
+          # browsers actually request) and the underlying index.html object
+          # paths. CloudFront caches each request URI independently, so
+          # invalidating only one form leaves the other stale.
+          PATHS=(
+            "/${SIMPLE_PREFIX}/"
+            "/${SIMPLE_PREFIX}/index.html"
+            "/${SIMPLE_PREFIX}/${NORM}/"
+            "/${SIMPLE_PREFIX}/${NORM}/index.html"
+          )
+          echo "Invalidating distribution $DIST_ID paths: ${PATHS[*]}"
           aws cloudfront create-invalidation \
             --distribution-id "$DIST_ID" \
-            --paths "$PROJECT_PATH" "$ROOT_PATH" \
+            --paths "${PATHS[@]}" \
             --query 'Invalidation.{Id:Id,Status:Status,CreateTime:CreateTime}' \
             --output table
 


### PR DESCRIPTION
The nightly and release publish workflows uploaded simple-index `index.html` files to S3 without a `Cache-Control` header and without invalidating the CloudFront distribution that fronts the bucket. As a result, after a successful publish the new wheels could remain hidden behind stale `index.html` for hours: pip's HTTP cache and the CloudFront edge cache both kept serving the previous index until their default TTLs expired. This made it look like the workflow had not run when in fact the wheels were already in S3.

Fix this for every project index the publish workflows touch (`simple-nightly/`, `simple-staging/`, `simple/`):

- Upload each `index.html` with `--cache-control "public, max-age=60, must-revalidate"` so pip and CloudFront refresh quickly even without explicit invalidation.
- Add a new step that resolves the CloudFront distribution by domain via cloudfront list-distributions and issues a cloudfront create-invalidation for the project and root simple-index paths in both their trailing-slash form (what pip actually requests) and their index.html object form (defensive), since CloudFront caches each request URI independently.
- Make the distribution domain configurable via a new `aws.cloudfront_distribution_domain` field in `.github/versions.json`, surfaced through `load-versions.yml` as `aws-cloudfront-distribution-domain`. Wheels themselves are immutable and are uploaded under new keys, so they don't need invalidation.
- Degrade gracefully: if the domain is unset or the IAM role lacks CloudFront permissions, the step logs a warning and exits 0 rather than failing the publish.

The GitHub Actions IAM role
(`openvdb-fvdb-github-actions-role`) needs to be granted `cloudfront:ListDistributions` (Resource: `*`) and `cloudfront:CreateInvalidation` on the distribution ARN before this step will actually invalidate;