### PR TITLE
Avoid repeated delta computation

### DIFF
--- a/src/fvdb/detail/utils/gsplat/GaussianRasterize.cuh
+++ b/src/fvdb/detail/utils/gsplat/GaussianRasterize.cuh
@@ -333,7 +333,7 @@ template <typename ScalarType, size_t NUM_CHANNELS, bool IS_PACKED> struct Raste
                  const ScalarType px,
                  const ScalarType py) const {
         const auto delta         = gaussian.delta(px, py);
-        const auto sigma         = gaussian.sigma(px, py);
+        const auto sigma         = gaussian.sigma(delta);
         const auto expMinusSigma = __expf(-sigma);
         const auto alpha         = min(ALPHA_THRESHOLD, gaussian.opacity * expMinusSigma);
 


### PR DESCRIPTION
Delta is already computed in the line above so we can use the equivalent `sigma(...)` overload to save a few FLOPs.