### PR TITLE
docs: fix marching_cubes return type (unique vertex indices, not normals)

### DIFF
--- a/fvdb/functional/_meshing.py
+++ b/fvdb/functional/_meshing.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 """Functional API for meshing and TSDF integration on sparse grids."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
@@ -36,7 +37,8 @@ def marching_cubes_batch(
     Returns:
         vertices (JaggedTensor): Mesh vertex positions, shape ``(B, -1, 3)``.
         faces (JaggedTensor): Triangle face indices.
-        normals (JaggedTensor): Per-vertex normals.
+        unique_vertex_ids (JaggedTensor): Unique vertex IDs with int64 values,
+            shape ``(B, -1, 3)``.
 
     .. seealso:: :func:`marching_cubes_single`
     """
@@ -60,7 +62,8 @@ def marching_cubes_single(
     Returns:
         vertices (torch.Tensor): Mesh vertex positions, shape ``(N, 3)``.
         faces (torch.Tensor): Triangle face indices.
-        normals (torch.Tensor): Per-vertex normals.
+        unique_vertex_ids (torch.Tensor): Unique vertex IDs with dtype ``torch.int64``,
+            shape ``(N, 3)``.
 
     .. seealso:: :func:`marching_cubes_batch`
     """

--- a/fvdb/functional/_meshing.py
+++ b/fvdb/functional/_meshing.py
@@ -37,8 +37,13 @@ def marching_cubes_batch(
     Returns:
         vertices (JaggedTensor): Mesh vertex positions, shape ``(B, -1, 3)``.
         faces (JaggedTensor): Triangle face indices.
-        unique_vertex_ids (JaggedTensor): Unique vertex IDs with int64 values,
-            shape ``(B, -1, 3)``.
+        vertex_edge_keys (JaggedTensor): Edge keys used to deduplicate mesh
+            vertices, dtype ``torch.int64``, shape ``(B, -1, 3)``. Each row
+            ``[batch_idx, voxel_a, voxel_b]`` identifies the grid edge on which
+            the vertex was interpolated, where ``voxel_a`` and ``voxel_b`` are
+            flat voxel indices of the two endpoint voxels (``voxel_a >=
+            voxel_b``). This can be used to map mesh vertices back to the grid
+            edges and voxels they originated from.
 
     .. seealso:: :func:`marching_cubes_single`
     """
@@ -62,8 +67,14 @@ def marching_cubes_single(
     Returns:
         vertices (torch.Tensor): Mesh vertex positions, shape ``(N, 3)``.
         faces (torch.Tensor): Triangle face indices.
-        unique_vertex_ids (torch.Tensor): Unique vertex IDs with dtype ``torch.int64``,
-            shape ``(N, 3)``.
+        vertex_edge_keys (torch.Tensor): Edge keys used to deduplicate mesh
+            vertices, dtype ``torch.int64``, shape ``(N, 3)``. Each row
+            ``[batch_idx, voxel_a, voxel_b]`` identifies the grid edge on which
+            the vertex was interpolated, where ``voxel_a`` and ``voxel_b`` are
+            flat voxel indices of the two endpoint voxels (``voxel_a >=
+            voxel_b``). This can be used to map mesh vertices back to the grid
+            edges and voxels they originated from. ``batch_idx`` is always
+            ``0`` for a single grid.
 
     .. seealso:: :func:`marching_cubes_batch`
     """

--- a/fvdb/grid.py
+++ b/fvdb/grid.py
@@ -1470,8 +1470,8 @@ class Grid:
                 ``(num_vertices, 3)``.
             faces (torch.Tensor): Triangle face indices of shape
                 ``(num_faces, 3)``.
-            normals (torch.Tensor): Vertex normals of shape
-                ``(num_vertices, 3)``.
+            unique_vertex_ids (torch.Tensor): Unique vertex IDs of shape
+                ``(num_vertices, 3)`` and dtype ``torch.int64``.
         """
         from . import functional
 

--- a/fvdb/grid.py
+++ b/fvdb/grid.py
@@ -1476,8 +1476,15 @@ class Grid:
                 ``(num_vertices, 3)``.
             faces (torch.Tensor): Triangle face indices of shape
                 ``(num_faces, 3)``.
-            unique_vertex_ids (torch.Tensor): Unique vertex IDs of shape
-                ``(num_vertices, 3)`` and dtype ``torch.int64``.
+            vertex_edge_keys (torch.Tensor): Edge keys used to deduplicate
+                mesh vertices, dtype ``torch.int64``, shape
+                ``(num_vertices, 3)``. Each row ``[batch_idx, voxel_a,
+                voxel_b]`` identifies the grid edge on which the vertex was
+                interpolated, where ``voxel_a`` and ``voxel_b`` are flat
+                voxel indices of the two endpoint voxels (``voxel_a >=
+                voxel_b``). This can be used to map mesh vertices back to the
+                grid edges and voxels they originated from. ``batch_idx`` is
+                always ``0`` for a single grid.
         """
         from . import functional
 

--- a/fvdb/grid_batch.py
+++ b/fvdb/grid_batch.py
@@ -1020,7 +1020,8 @@ class GridBatch:
         Returns:
             vertex_positions (JaggedTensor): Mesh vertex positions. Shape: ``(batch_size, num_vertices_for_grid_b, 3)``.
             face_indices (JaggedTensor): Triangle face indices. Shape: ``(batch_size, num_faces_for_grid_b, 3)``.
-            vertex_normals (JaggedTensor): Vertex normals. Shape: ``(batch_size, num_vertices_for_grid_b, 3)``.
+            unique_vertex_ids (JaggedTensor): Unique vertex IDs with int64 values.
+                Shape: ``(batch_size, num_vertices_for_grid_b, 3)``.
 
         .. seealso:: :meth:`Grid.marching_cubes`
         """

--- a/fvdb/grid_batch.py
+++ b/fvdb/grid_batch.py
@@ -1021,8 +1021,11 @@ class GridBatch:
         Returns:
             vertex_positions (JaggedTensor): Mesh vertex positions. Shape: ``(batch_size, num_vertices_for_grid_b, 3)``.
             face_indices (JaggedTensor): Triangle face indices. Shape: ``(batch_size, num_faces_for_grid_b, 3)``.
-            unique_vertex_ids (JaggedTensor): Unique vertex IDs with int64 values.
-                Shape: ``(batch_size, num_vertices_for_grid_b, 3)``.
+            vertex_edge_keys (JaggedTensor): Edge keys used to deduplicate mesh vertices, dtype ``torch.int64``.
+                Shape: ``(batch_size, num_vertices_for_grid_b, 3)``. Each row ``[batch_idx, voxel_a, voxel_b]``
+                identifies the grid edge on which the vertex was interpolated, where ``voxel_a`` and ``voxel_b``
+                are flat voxel indices of the two endpoint voxels (``voxel_a >= voxel_b``). This can be used to
+                map mesh vertices back to the grid edges and voxels they originated from.
 
         .. seealso:: :meth:`Grid.marching_cubes`
         """


### PR DESCRIPTION
## Summary

`marching_cubes` returns three values: vertices, faces, and an int64 tensor of unique vertex indices (the output of `torch.unique_dim` at `MarchingCubes.cu:357-385`). The docstrings in `fvdb/grid.py`, `fvdb/grid_batch.py`, and `fvdb/functional/_meshing.py` described the third return as "vertex normals", which the implementation does not produce.

## Why this matters

The docs led users to expect a normals tensor and write code like `vertices, faces, normals = ...`. The third value is actually `unqVertIdx` from the unique-vertex pass, which has a completely different shape (int64) and meaning.

## Changes

- `fvdb/grid.py`, `fvdb/grid_batch.py`, `fvdb/functional/_meshing.py` - update the docstring of `marching_cubes` at all four call sites to describe the third return as "unique vertex indices (int64)".

Fixes #422
