### PR TITLE
More optimal prefetching for mGPU Gaussian splatting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ requires-python = ">=3.10"
 readme = "README.md"
 dependencies = [
     # Require torch; users will choose the correct CUDA build from PyTorch's index
-    "torch>=2.8,<2.12",
+    "torch>=2.8,<2.13",
     "numpy",
 ]
 optional-dependencies = {viewer = ["nanovdb-editor>=0.0.23,<0.2.0"]}

--- a/src/fvdb/detail/ops/gsplat/EvaluateSphericalHarmonicsBackward.cu
+++ b/src/fvdb/detail/ops/gsplat/EvaluateSphericalHarmonicsBackward.cu
@@ -712,13 +712,23 @@ dispatchEvaluateSphericalHarmonicsBwd<torch::kPrivateUse1>(
             return std::make_tuple(dLossDSh0Coeffs, dLossDShNCoeffs, dLossDViewDirs);
         }
 
+        std::vector<cudaEvent_t> events(c10::cuda::device_count());
         for (const auto deviceId: c10::irange(c10::cuda::device_count())) {
             C10_CUDA_CHECK(cudaSetDevice(deviceId));
             auto stream = c10::cuda::getCurrentCUDAStream(deviceId);
+            C10_CUDA_CHECK(cudaEventCreate(&events[deviceId], cudaEventDisableTiming));
+            C10_CUDA_CHECK(cudaEventRecord(events[deviceId], stream));
+        }
+
+        for (const auto deviceId: c10::irange(c10::cuda::device_count())) {
+            C10_CUDA_CHECK(cudaSetDevice(deviceId));
+            auto stream = c10::cuda::getStreamFromPool(false, deviceId);
+            C10_CUDA_CHECK(cudaStreamWaitEvent(stream, events[deviceId]));
 
             int64_t elementOffset, elementCount;
             std::tie(elementOffset, elementCount) = deviceChunk(N, deviceId);
 
+#if (CUDART_VERSION < 13000)
             nanovdb::util::cuda::memPrefetchAsync(
                 dLossDSh0Coeffs.data_ptr<scalar_t>() + elementOffset * dLossDSh0Coeffs.stride(0),
                 elementCount * dLossDSh0Coeffs.stride(0) * sizeof(scalar_t),
@@ -733,11 +743,49 @@ dispatchEvaluateSphericalHarmonicsBwd<torch::kPrivateUse1>(
                     deviceId,
                     stream);
             }
+#else
+            std::vector<void *> prefetchPtrs;
+            std::vector<size_t> prefetchSizes;
+            const cudaMemLocation location                 = {cudaMemLocationTypeDevice, deviceId};
+            std::vector<cudaMemLocation> prefetchLocations = {location};
+            std::vector<size_t> prefetchLocationIndices    = {0};
+
+            prefetchPtrs.emplace_back(dLossDSh0Coeffs.data_ptr<scalar_t>() +
+                                      elementOffset * dLossDSh0Coeffs.stride(0));
+            prefetchSizes.emplace_back(elementCount * dLossDSh0Coeffs.stride(0) * sizeof(scalar_t));
+            for (int cameraIndex = 0; cameraIndex < C; ++cameraIndex) {
+                prefetchPtrs.emplace_back(dLossDRenderQuantities.data_ptr<scalar_t>() +
+                                          cameraIndex * dLossDRenderQuantities.stride(0) +
+                                          elementOffset * dLossDRenderQuantities.stride(1));
+                prefetchSizes.emplace_back(elementCount * dLossDRenderQuantities.stride(1) *
+                                           sizeof(scalar_t));
+            }
+
+            C10_CUDA_CHECK(cudaMemPrefetchBatchAsync(prefetchPtrs.data(),
+                                                     prefetchSizes.data(),
+                                                     prefetchPtrs.size(),
+                                                     prefetchLocations.data(),
+                                                     prefetchLocationIndices.data(),
+                                                     prefetchLocations.size(),
+                                                     0,
+                                                     stream));
+#endif
             C10_CUDA_CHECK(cudaMemsetAsync(
                 dLossDSh0Coeffs.data_ptr<scalar_t>() + elementOffset * dLossDSh0Coeffs.stride(0),
                 0,
                 elementCount * dLossDSh0Coeffs.stride(0) * sizeof(scalar_t),
                 stream));
+            C10_CUDA_CHECK(cudaEventRecord(events[deviceId], stream));
+        }
+
+        for (const auto deviceId: c10::irange(c10::cuda::device_count())) {
+            C10_CUDA_CHECK(cudaSetDevice(deviceId));
+            auto stream = c10::cuda::getCurrentCUDAStream(deviceId);
+            C10_CUDA_CHECK(cudaStreamWaitEvent(stream, events[deviceId]));
+            C10_CUDA_CHECK(cudaEventDestroy(events[deviceId]));
+
+            int64_t elementOffset, elementCount;
+            std::tie(elementOffset, elementCount) = deviceChunk(N, deviceId);
 
             const auto NUM_BLOCKS = GET_BLOCKS(C * elementCount * D, DEFAULT_BLOCK_DIM);
 

--- a/src/fvdb/detail/ops/gsplat/EvaluateSphericalHarmonicsBackward.cu
+++ b/src/fvdb/detail/ops/gsplat/EvaluateSphericalHarmonicsBackward.cu
@@ -601,6 +601,15 @@ dispatchEvaluateSphericalHarmonicsBwd<torch::kPrivateUse1>(
                         stream);
                 }
             }
+            for (int cameraIndex = 0; cameraIndex < C; ++cameraIndex) {
+                nanovdb::util::cuda::memPrefetchAsync(
+                    dLossDRenderQuantities.data_ptr<scalar_t>() +
+                        cameraIndex * dLossDRenderQuantities.stride(0) +
+                        elementOffset * dLossDRenderQuantities.stride(1),
+                    elementCount * dLossDRenderQuantities.stride(1) * sizeof(scalar_t),
+                    deviceId,
+                    stream);
+            }
 #else
             std::vector<void *> prefetchPtrs;
             std::vector<size_t> prefetchSizes;
@@ -622,6 +631,13 @@ dispatchEvaluateSphericalHarmonicsBwd<torch::kPrivateUse1>(
                     prefetchSizes.emplace_back(elementCount * dLossDViewDirs.stride(1) *
                                                sizeof(scalar_t));
                 }
+            }
+            for (int cameraIndex = 0; cameraIndex < C; ++cameraIndex) {
+                prefetchPtrs.emplace_back(dLossDRenderQuantities.data_ptr<scalar_t>() +
+                                          cameraIndex * dLossDRenderQuantities.stride(0) +
+                                          elementOffset * dLossDRenderQuantities.stride(1));
+                prefetchSizes.emplace_back(elementCount * dLossDRenderQuantities.stride(1) *
+                                           sizeof(scalar_t));
             }
 
             C10_CUDA_CHECK(cudaMemPrefetchBatchAsync(prefetchPtrs.data(),
@@ -708,6 +724,15 @@ dispatchEvaluateSphericalHarmonicsBwd<torch::kPrivateUse1>(
                 elementCount * dLossDSh0Coeffs.stride(0) * sizeof(scalar_t),
                 deviceId,
                 stream);
+            for (int cameraIndex = 0; cameraIndex < C; ++cameraIndex) {
+                nanovdb::util::cuda::memPrefetchAsync(
+                    dLossDRenderQuantities.data_ptr<scalar_t>() +
+                        cameraIndex * dLossDRenderQuantities.stride(0) +
+                        elementOffset * dLossDRenderQuantities.stride(1),
+                    elementCount * dLossDRenderQuantities.stride(1) * sizeof(scalar_t),
+                    deviceId,
+                    stream);
+            }
             C10_CUDA_CHECK(cudaMemsetAsync(
                 dLossDSh0Coeffs.data_ptr<scalar_t>() + elementOffset * dLossDSh0Coeffs.stride(0),
                 0,

--- a/src/fvdb/detail/ops/gsplat/EvaluateSphericalHarmonicsBackward.cu
+++ b/src/fvdb/detail/ops/gsplat/EvaluateSphericalHarmonicsBackward.cu
@@ -553,8 +553,8 @@ dispatchEvaluateSphericalHarmonicsBwd<torch::kPrivateUse1>(
 
     const auto tensorOptions = dLossDRenderQuantities.options();
     if (hasShNCoeffs && K > 1) {
-        torch::Tensor dLossDShNCoeffs = torch::zeros_like(shNCoeffs);
-        torch::Tensor dLossDSh0Coeffs = torch::zeros({N, 1, D}, tensorOptions);
+        torch::Tensor dLossDShNCoeffs = torch::empty_like(shNCoeffs);
+        torch::Tensor dLossDSh0Coeffs = torch::empty({N, 1, D}, tensorOptions);
         torch::Tensor dLossDViewDirs;
         if (computeDLossDViewDirs) {
             dLossDViewDirs = torch::empty_like(viewDirs);
@@ -571,16 +571,26 @@ dispatchEvaluateSphericalHarmonicsBwd<torch::kPrivateUse1>(
             C10_CUDA_CHECK(cudaEventRecord(events[deviceId], stream));
         }
 
-        if (computeDLossDViewDirs) {
-            for (const auto deviceId: c10::irange(c10::cuda::device_count())) {
-                C10_CUDA_CHECK(cudaSetDevice(deviceId));
-                auto stream = c10::cuda::getStreamFromPool(false, deviceId);
-                C10_CUDA_CHECK(cudaStreamWaitEvent(stream, events[deviceId]));
+        for (const auto deviceId: c10::irange(c10::cuda::device_count())) {
+            C10_CUDA_CHECK(cudaSetDevice(deviceId));
+            auto stream = c10::cuda::getStreamFromPool(false, deviceId);
+            C10_CUDA_CHECK(cudaStreamWaitEvent(stream, events[deviceId]));
 
-                int64_t elementOffset, elementCount;
-                std::tie(elementOffset, elementCount) = deviceChunk(N, deviceId);
+            int64_t elementOffset, elementCount;
+            std::tie(elementOffset, elementCount) = deviceChunk(N, deviceId);
 
 #if (CUDART_VERSION < 13000)
+            nanovdb::util::cuda::memPrefetchAsync(
+                dLossDSh0Coeffs.data_ptr<scalar_t>() + elementOffset * dLossDSh0Coeffs.stride(0),
+                elementCount * dLossDSh0Coeffs.stride(0) * sizeof(scalar_t),
+                deviceId,
+                stream);
+            nanovdb::util::cuda::memPrefetchAsync(
+                dLossDShNCoeffs.data_ptr<scalar_t>() + elementOffset * dLossDShNCoeffs.stride(0),
+                elementCount * dLossDShNCoeffs.stride(0) * sizeof(scalar_t),
+                deviceId,
+                stream);
+            if (computeDLossDViewDirs) {
                 for (int cameraIndex = 0; cameraIndex < C; ++cameraIndex) {
                     nanovdb::util::cuda::memPrefetchAsync(
                         dLossDViewDirs.data_ptr<scalar_t>() +
@@ -590,13 +600,21 @@ dispatchEvaluateSphericalHarmonicsBwd<torch::kPrivateUse1>(
                         deviceId,
                         stream);
                 }
+            }
 #else
-                std::vector<void *> prefetchPtrs;
-                std::vector<size_t> prefetchSizes;
-                const cudaMemLocation location = {cudaMemLocationTypeDevice, deviceId};
-                std::vector<cudaMemLocation> prefetchLocations = {location};
-                std::vector<size_t> prefetchLocationIndices    = {0};
+            std::vector<void *> prefetchPtrs;
+            std::vector<size_t> prefetchSizes;
+            const cudaMemLocation location                 = {cudaMemLocationTypeDevice, deviceId};
+            std::vector<cudaMemLocation> prefetchLocations = {location};
+            std::vector<size_t> prefetchLocationIndices    = {0};
 
+            prefetchPtrs.emplace_back(dLossDSh0Coeffs.data_ptr<scalar_t>() +
+                                      elementOffset * dLossDSh0Coeffs.stride(0));
+            prefetchSizes.emplace_back(elementCount * dLossDSh0Coeffs.stride(0) * sizeof(scalar_t));
+            prefetchPtrs.emplace_back(dLossDShNCoeffs.data_ptr<scalar_t>() +
+                                      elementOffset * dLossDShNCoeffs.stride(0));
+            prefetchSizes.emplace_back(elementCount * dLossDShNCoeffs.stride(0) * sizeof(scalar_t));
+            if (computeDLossDViewDirs) {
                 for (int cameraIndex = 0; cameraIndex < C; ++cameraIndex) {
                     prefetchPtrs.emplace_back(dLossDViewDirs.data_ptr<scalar_t>() +
                                               cameraIndex * dLossDViewDirs.stride(0) +
@@ -604,16 +622,28 @@ dispatchEvaluateSphericalHarmonicsBwd<torch::kPrivateUse1>(
                     prefetchSizes.emplace_back(elementCount * dLossDViewDirs.stride(1) *
                                                sizeof(scalar_t));
                 }
+            }
 
-                C10_CUDA_CHECK(cudaMemPrefetchBatchAsync(prefetchPtrs.data(),
-                                                         prefetchSizes.data(),
-                                                         prefetchPtrs.size(),
-                                                         prefetchLocations.data(),
-                                                         prefetchLocationIndices.data(),
-                                                         prefetchLocations.size(),
-                                                         0,
-                                                         stream));
+            C10_CUDA_CHECK(cudaMemPrefetchBatchAsync(prefetchPtrs.data(),
+                                                     prefetchSizes.data(),
+                                                     prefetchPtrs.size(),
+                                                     prefetchLocations.data(),
+                                                     prefetchLocationIndices.data(),
+                                                     prefetchLocations.size(),
+                                                     0,
+                                                     stream));
 #endif
+            C10_CUDA_CHECK(cudaMemsetAsync(
+                dLossDSh0Coeffs.data_ptr<scalar_t>() + elementOffset * dLossDSh0Coeffs.stride(0),
+                0,
+                elementCount * dLossDSh0Coeffs.stride(0) * sizeof(scalar_t),
+                stream));
+            C10_CUDA_CHECK(cudaMemsetAsync(
+                dLossDShNCoeffs.data_ptr<scalar_t>() + elementOffset * dLossDShNCoeffs.stride(0),
+                0,
+                elementCount * dLossDShNCoeffs.stride(0) * sizeof(scalar_t),
+                stream));
+            if (computeDLossDViewDirs) {
                 for (int cameraIndex = 0; cameraIndex < C; ++cameraIndex) {
                     C10_CUDA_CHECK(
                         cudaMemsetAsync(dLossDViewDirs.data_ptr<scalar_t>() +
@@ -623,8 +653,8 @@ dispatchEvaluateSphericalHarmonicsBwd<torch::kPrivateUse1>(
                                         elementCount * dLossDViewDirs.stride(1) * sizeof(scalar_t),
                                         stream));
                 }
-                C10_CUDA_CHECK(cudaEventRecord(events[deviceId], stream));
             }
+            C10_CUDA_CHECK(cudaEventRecord(events[deviceId], stream));
         }
 
         for (const auto deviceId: c10::irange(c10::cuda::device_count())) {
@@ -659,7 +689,7 @@ dispatchEvaluateSphericalHarmonicsBwd<torch::kPrivateUse1>(
 
         return std::make_tuple(dLossDSh0Coeffs, dLossDShNCoeffs, dLossDViewDirs);
     } else {
-        torch::Tensor dLossDSh0Coeffs = torch::zeros({N, 1, D}, tensorOptions);
+        torch::Tensor dLossDSh0Coeffs = torch::empty({N, 1, D}, tensorOptions);
         torch::Tensor dLossDShNCoeffs;
         torch::Tensor dLossDViewDirs;
         if (N == 0) {
@@ -672,6 +702,17 @@ dispatchEvaluateSphericalHarmonicsBwd<torch::kPrivateUse1>(
 
             int64_t elementOffset, elementCount;
             std::tie(elementOffset, elementCount) = deviceChunk(N, deviceId);
+
+            nanovdb::util::cuda::memPrefetchAsync(
+                dLossDSh0Coeffs.data_ptr<scalar_t>() + elementOffset * dLossDSh0Coeffs.stride(0),
+                elementCount * dLossDSh0Coeffs.stride(0) * sizeof(scalar_t),
+                deviceId,
+                stream);
+            C10_CUDA_CHECK(cudaMemsetAsync(
+                dLossDSh0Coeffs.data_ptr<scalar_t>() + elementOffset * dLossDSh0Coeffs.stride(0),
+                0,
+                elementCount * dLossDSh0Coeffs.stride(0) * sizeof(scalar_t),
+                stream));
 
             const auto NUM_BLOCKS = GET_BLOCKS(C * elementCount * D, DEFAULT_BLOCK_DIM);
 

--- a/src/fvdb/detail/ops/gsplat/IntersectGaussianTiles.cu
+++ b/src/fvdb/detail/ops/gsplat/IntersectGaussianTiles.cu
@@ -849,12 +849,26 @@ intersectGaussianTilesPrivateUse1Impl(
                     intersectionsOffset;
 
                 if (intersectionsCount > 0) {
-                    FVDB_CUB_WRAPPER(cub::DeviceMergeSort::SortPairs,
-                                     intersectionKeys.data_ptr<int64_t>() + intersectionsOffset,
-                                     intersectionValues.data_ptr<int32_t>() + intersectionsOffset,
-                                     intersectionsCount,
-                                     cuda::std::less<>{},
-                                     stream);
+                    size_t tempStorageBytes = 0;
+                    void *tempStorage       = nullptr;
+                    C10_CUDA_CHECK(cub::DeviceMergeSort::SortPairs(
+                        tempStorage,
+                        tempStorageBytes,
+                        intersectionKeys.data_ptr<int64_t>() + intersectionsOffset,
+                        intersectionValues.data_ptr<int32_t>() + intersectionsOffset,
+                        intersectionsCount,
+                        cuda::std::less<>{},
+                        stream));
+                    C10_CUDA_CHECK(cudaMallocAsync(&tempStorage, tempStorageBytes, stream));
+                    C10_CUDA_CHECK(cub::DeviceMergeSort::SortPairs(
+                        tempStorage,
+                        tempStorageBytes,
+                        intersectionKeys.data_ptr<int64_t>() + intersectionsOffset,
+                        intersectionValues.data_ptr<int32_t>() + intersectionsOffset,
+                        intersectionsCount,
+                        cuda::std::less<>{},
+                        stream));
+                    C10_CUDA_CHECK(cudaFreeAsync(tempStorage, stream));
                 }
             }
         }
@@ -878,11 +892,6 @@ intersectGaussianTilesPrivateUse1Impl(
                 intersectionsOffset;
 
             if (intersectionsCount > 0) {
-                C10_CUDA_CHECK(nanovdb::util::cuda::memPrefetchAsync(
-                    intersectionValues.const_data_ptr<int32_t>() + intersectionsOffset,
-                    intersectionsCount * sizeof(int32_t),
-                    deviceId,
-                    stream));
                 const int NUM_BLOCKS_2 = cuda::ceil_div(intersectionsCount, NUM_THREADS);
                 computeTileOffsets<<<NUM_BLOCKS_2, NUM_THREADS, 0, stream>>>(
                     intersectionsOffset,

--- a/src/fvdb/detail/ops/gsplat/ProjectGaussiansAnalyticBackward.cu
+++ b/src/fvdb/detail/ops/gsplat/ProjectGaussiansAnalyticBackward.cu
@@ -125,31 +125,22 @@ projectionBackwardKernel(const int32_t offset,
             nanovdb::math::Vec2<T>(dLossDMeans2d[0], dLossDMeans2d[1]),
             dLossDDepths[0]);
 
-    // write out results with warp-level reduction
-    auto warp         = cg::tiled_partition<32>(cg::this_thread_block());
-    auto warp_group_g = cg::labeled_partition(warp, gId);
     if (outDLossDMeans != nullptr) {
-        warpSum(dLossDPoint, warp_group_g);
-        if (warp_group_g.thread_rank() == 0) {
-            outDLossDMeans += gId * 3;
+        outDLossDMeans += gId * 3;
 #pragma unroll
-            for (uint32_t i = 0; i < 3; i++) {
-                gpuAtomicAdd(outDLossDMeans + i, dLossDPoint[i]);
-            }
+        for (uint32_t i = 0; i < 3; i++) {
+            gpuAtomicAdd(outDLossDMeans + i, dLossDPoint[i]);
         }
     }
     if (outDLossDCovars != nullptr) {
         // Output gradients w.r.t. the covariance matrix
-        warpSum(dLossDCovar, warp_group_g);
-        if (warp_group_g.thread_rank() == 0) {
-            outDLossDCovars += gId * 6;
-            gpuAtomicAdd(outDLossDCovars, dLossDCovar[0][0]);
-            gpuAtomicAdd(outDLossDCovars + 1, dLossDCovar[0][1] + dLossDCovar[1][0]);
-            gpuAtomicAdd(outDLossDCovars + 2, dLossDCovar[0][2] + dLossDCovar[2][0]);
-            gpuAtomicAdd(outDLossDCovars + 3, dLossDCovar[1][1]);
-            gpuAtomicAdd(outDLossDCovars + 4, dLossDCovar[1][2] + dLossDCovar[2][1]);
-            gpuAtomicAdd(outDLossDCovars + 5, dLossDCovar[2][2]);
-        }
+        outDLossDCovars += gId * 6;
+        gpuAtomicAdd(outDLossDCovars, dLossDCovar[0][0]);
+        gpuAtomicAdd(outDLossDCovars + 1, dLossDCovar[0][1] + dLossDCovar[1][0]);
+        gpuAtomicAdd(outDLossDCovars + 2, dLossDCovar[0][2] + dLossDCovar[2][0]);
+        gpuAtomicAdd(outDLossDCovars + 3, dLossDCovar[1][1]);
+        gpuAtomicAdd(outDLossDCovars + 4, dLossDCovar[1][2] + dLossDCovar[2][1]);
+        gpuAtomicAdd(outDLossDCovars + 5, dLossDCovar[2][2]);
     } else {
         // Directly output gradients w.r.t. the quaternion and log_scale
         const nanovdb::math::Mat3<T> &rotmat = quaternionToRotationMatrix<T>(quat);
@@ -160,21 +151,18 @@ projectionBackwardKernel(const int32_t offset,
             quaternionAndScaleToCovarianceVectorJacobianProduct<T, true>(
                 quat, scale, rotmat, dLossDCovar);
 
-        warpSum(dLossDQuat, warp_group_g);
-        warpSum(dLossDLogScale, warp_group_g);
-        if (warp_group_g.thread_rank() == 0) {
-            outDLossDQuats += gId * 4;
-            outDLossDScales += gId * 3;
-            gpuAtomicAdd(outDLossDQuats, dLossDQuat[0]);
-            gpuAtomicAdd(outDLossDQuats + 1, dLossDQuat[1]);
-            gpuAtomicAdd(outDLossDQuats + 2, dLossDQuat[2]);
-            gpuAtomicAdd(outDLossDQuats + 3, dLossDQuat[3]);
-            gpuAtomicAdd(outDLossDScales, dLossDLogScale[0]);
-            gpuAtomicAdd(outDLossDScales + 1, dLossDLogScale[1]);
-            gpuAtomicAdd(outDLossDScales + 2, dLossDLogScale[2]);
-        }
+        outDLossDQuats += gId * 4;
+        outDLossDScales += gId * 3;
+        gpuAtomicAdd(outDLossDQuats, dLossDQuat[0]);
+        gpuAtomicAdd(outDLossDQuats + 1, dLossDQuat[1]);
+        gpuAtomicAdd(outDLossDQuats + 2, dLossDQuat[2]);
+        gpuAtomicAdd(outDLossDQuats + 3, dLossDQuat[3]);
+        gpuAtomicAdd(outDLossDScales, dLossDLogScale[0]);
+        gpuAtomicAdd(outDLossDScales + 1, dLossDLogScale[1]);
+        gpuAtomicAdd(outDLossDScales + 2, dLossDLogScale[2]);
     }
     if (outDLossDWorldToCamMatrices != nullptr) {
+        auto warp         = cg::tiled_partition<32>(cg::this_thread_block());
         auto warp_group_c = cg::labeled_partition(warp, cId);
         warpSum(dLossDRotation, warp_group_c);
         warpSum(dLossDTranslation, warp_group_c);
@@ -445,22 +433,124 @@ dispatchProjectGaussiansAnalyticBwd<torch::kPrivateUse1>(
     const uint32_t N = means.size(0);                      // number of gaussians
     const uint32_t C = worldToCamMatrices.size(0);         // number of cameras
 
-    torch::Tensor dLossDMeans = torch::zeros_like(means);
+    torch::Tensor dLossDMeans = torch::empty_like(means);
     torch::Tensor dLossDCovars, dLossDQuats, dLossDScales; // optional
     if (covars.has_value()) {
-        dLossDCovars = torch::zeros_like(covars.value());
+        dLossDCovars = torch::empty_like(covars.value());
     } else {
-        dLossDQuats  = torch::zeros_like(quats);
-        dLossDScales = torch::zeros_like(logScales);
+        dLossDQuats  = torch::empty_like(quats);
+        dLossDScales = torch::empty_like(logScales);
     }
     torch::Tensor dLossDWorldToCamMatrices;
     if (worldToCamMatricesRequiresGrad) {
         dLossDWorldToCamMatrices = torch::zeros_like(worldToCamMatrices);
     }
     if (C && N) {
+        std::vector<cudaEvent_t> events(c10::cuda::device_count());
         for (const auto deviceId: c10::irange(c10::cuda::device_count())) {
             C10_CUDA_CHECK(cudaSetDevice(deviceId));
             auto stream = c10::cuda::getCurrentCUDAStream(deviceId);
+            C10_CUDA_CHECK(cudaEventCreate(&events[deviceId], cudaEventDisableTiming));
+            C10_CUDA_CHECK(cudaEventRecord(events[deviceId], stream));
+        }
+
+        for (const auto deviceId: c10::irange(c10::cuda::device_count())) {
+            C10_CUDA_CHECK(cudaSetDevice(deviceId));
+            auto stream = c10::cuda::getStreamFromPool(false, deviceId);
+            C10_CUDA_CHECK(cudaStreamWaitEvent(stream, events[deviceId]));
+
+            int64_t elementOffset, elementCount;
+            std::tie(elementOffset, elementCount) = deviceChunk(N, deviceId);
+
+#if (CUDART_VERSION < 13000)
+            nanovdb::util::cuda::memPrefetchAsync(
+                dLossDMeans.data_ptr<float>() + elementOffset * dLossDMeans.stride(0),
+                elementCount * dLossDMeans.stride(0) * sizeof(float),
+                deviceId,
+                stream);
+            if (covars.has_value()) {
+                nanovdb::util::cuda::memPrefetchAsync(
+                    dLossDCovars.data_ptr<float>() + elementOffset * dLossDCovars.stride(0),
+                    elementCount * dLossDCovars.stride(0) * sizeof(float),
+                    deviceId,
+                    stream);
+            } else {
+                nanovdb::util::cuda::memPrefetchAsync(
+                    dLossDQuats.data_ptr<float>() + elementOffset * dLossDQuats.stride(0),
+                    elementCount * dLossDQuats.stride(0) * sizeof(float),
+                    deviceId,
+                    stream);
+                nanovdb::util::cuda::memPrefetchAsync(
+                    dLossDScales.data_ptr<float>() + elementOffset * dLossDScales.stride(0),
+                    elementCount * dLossDScales.stride(0) * sizeof(float),
+                    deviceId,
+                    stream);
+            }
+#else
+            std::vector<void *> prefetchPtrs;
+            std::vector<size_t> prefetchSizes;
+            const cudaMemLocation location                 = {cudaMemLocationTypeDevice, deviceId};
+            std::vector<cudaMemLocation> prefetchLocations = {location};
+            std::vector<size_t> prefetchLocationIndices    = {0};
+
+            prefetchPtrs.emplace_back(dLossDMeans.data_ptr<float>() +
+                                      elementOffset * dLossDMeans.stride(0));
+            prefetchSizes.emplace_back(elementCount * dLossDMeans.stride(0) * sizeof(float));
+            if (covars.has_value()) {
+                prefetchPtrs.emplace_back(dLossDCovars.data_ptr<float>() +
+                                          elementOffset * dLossDCovars.stride(0));
+                prefetchSizes.emplace_back(elementCount * dLossDCovars.stride(0) *
+                                           sizeof(float));
+            } else {
+                prefetchPtrs.emplace_back(dLossDQuats.data_ptr<float>() +
+                                          elementOffset * dLossDQuats.stride(0));
+                prefetchSizes.emplace_back(elementCount * dLossDQuats.stride(0) * sizeof(float));
+                prefetchPtrs.emplace_back(dLossDScales.data_ptr<float>() +
+                                          elementOffset * dLossDScales.stride(0));
+                prefetchSizes.emplace_back(elementCount * dLossDScales.stride(0) *
+                                           sizeof(float));
+            }
+
+            C10_CUDA_CHECK(cudaMemPrefetchBatchAsync(prefetchPtrs.data(),
+                                                     prefetchSizes.data(),
+                                                     prefetchPtrs.size(),
+                                                     prefetchLocations.data(),
+                                                     prefetchLocationIndices.data(),
+                                                     prefetchLocations.size(),
+                                                     0,
+                                                     stream));
+#endif
+            C10_CUDA_CHECK(cudaMemsetAsync(dLossDMeans.data_ptr<float>() +
+                                               elementOffset * dLossDMeans.stride(0),
+                                           0,
+                                           elementCount * dLossDMeans.stride(0) * sizeof(float),
+                                           stream));
+            if (covars.has_value()) {
+                C10_CUDA_CHECK(cudaMemsetAsync(
+                    dLossDCovars.data_ptr<float>() + elementOffset * dLossDCovars.stride(0),
+                    0,
+                    elementCount * dLossDCovars.stride(0) * sizeof(float),
+                    stream));
+            } else {
+                C10_CUDA_CHECK(cudaMemsetAsync(
+                    dLossDQuats.data_ptr<float>() + elementOffset * dLossDQuats.stride(0),
+                    0,
+                    elementCount * dLossDQuats.stride(0) * sizeof(float),
+                    stream));
+                C10_CUDA_CHECK(cudaMemsetAsync(
+                    dLossDScales.data_ptr<float>() + elementOffset * dLossDScales.stride(0),
+                    0,
+                    elementCount * dLossDScales.stride(0) * sizeof(float),
+                    stream));
+            }
+            C10_CUDA_CHECK(cudaEventRecord(events[deviceId], stream));
+        }
+
+        for (const auto deviceId: c10::irange(c10::cuda::device_count())) {
+            C10_CUDA_CHECK(cudaSetDevice(deviceId));
+            auto stream = c10::cuda::getCurrentCUDAStream(deviceId);
+            C10_CUDA_CHECK(cudaStreamWaitEvent(stream, events[deviceId]));
+            C10_CUDA_CHECK(cudaEventDestroy(events[deviceId]));
 
             int64_t deviceProblemOffset, deviceProblemSize;
             std::tie(deviceProblemOffset, deviceProblemSize) = deviceChunk(N, deviceId);

--- a/src/fvdb/detail/ops/gsplat/ProjectGaussiansAnalyticBackward.cu
+++ b/src/fvdb/detail/ops/gsplat/ProjectGaussiansAnalyticBackward.cu
@@ -499,16 +499,14 @@ dispatchProjectGaussiansAnalyticBwd<torch::kPrivateUse1>(
             if (covars.has_value()) {
                 prefetchPtrs.emplace_back(dLossDCovars.data_ptr<float>() +
                                           elementOffset * dLossDCovars.stride(0));
-                prefetchSizes.emplace_back(elementCount * dLossDCovars.stride(0) *
-                                           sizeof(float));
+                prefetchSizes.emplace_back(elementCount * dLossDCovars.stride(0) * sizeof(float));
             } else {
                 prefetchPtrs.emplace_back(dLossDQuats.data_ptr<float>() +
                                           elementOffset * dLossDQuats.stride(0));
                 prefetchSizes.emplace_back(elementCount * dLossDQuats.stride(0) * sizeof(float));
                 prefetchPtrs.emplace_back(dLossDScales.data_ptr<float>() +
                                           elementOffset * dLossDScales.stride(0));
-                prefetchSizes.emplace_back(elementCount * dLossDScales.stride(0) *
-                                           sizeof(float));
+                prefetchSizes.emplace_back(elementCount * dLossDScales.stride(0) * sizeof(float));
             }
 
             C10_CUDA_CHECK(cudaMemPrefetchBatchAsync(prefetchPtrs.data(),
@@ -532,11 +530,11 @@ dispatchProjectGaussiansAnalyticBwd<torch::kPrivateUse1>(
                     elementCount * dLossDCovars.stride(0) * sizeof(float),
                     stream));
             } else {
-                C10_CUDA_CHECK(cudaMemsetAsync(
-                    dLossDQuats.data_ptr<float>() + elementOffset * dLossDQuats.stride(0),
-                    0,
-                    elementCount * dLossDQuats.stride(0) * sizeof(float),
-                    stream));
+                C10_CUDA_CHECK(cudaMemsetAsync(dLossDQuats.data_ptr<float>() +
+                                                   elementOffset * dLossDQuats.stride(0),
+                                               0,
+                                               elementCount * dLossDQuats.stride(0) * sizeof(float),
+                                               stream));
                 C10_CUDA_CHECK(cudaMemsetAsync(
                     dLossDScales.data_ptr<float>() + elementOffset * dLossDScales.stride(0),
                     0,

--- a/src/fvdb/detail/ops/gsplat/RasterizeScreenSpaceGaussiansBackward.cu
+++ b/src/fvdb/detail/ops/gsplat/RasterizeScreenSpaceGaussiansBackward.cu
@@ -1172,13 +1172,13 @@ callRasterizeBackwardPrivateUse1(
     const std::optional<torch::Tensor> &pixelMap        = std::nullopt) {
     TORCH_CHECK(tileSize > 0, "Tile size must be greater than 0");
 
-    torch::Tensor outDLossDMeans2d   = torch::zeros_like(means2d);
-    torch::Tensor outDLossDConics    = torch::zeros_like(conics);
-    torch::Tensor outDLossDFeatures  = torch::zeros_like(features);
-    torch::Tensor outDLossDOpacities = torch::zeros_like(opacities);
+    torch::Tensor outDLossDMeans2d   = torch::empty_like(means2d);
+    torch::Tensor outDLossDConics    = torch::empty_like(conics);
+    torch::Tensor outDLossDFeatures  = torch::empty_like(features);
+    torch::Tensor outDLossDOpacities = torch::empty_like(opacities);
     torch::Tensor outDLossDMeans2dAbs;
     if (absGrad) {
-        outDLossDMeans2dAbs = torch::zeros_like(means2d);
+        outDLossDMeans2dAbs = torch::empty_like(means2d);
     }
 
     // Just return empty tensors if there are no gaussians, cameras, or intersections
@@ -1255,6 +1255,13 @@ callRasterizeBackwardPrivateUse1(
                 tensors.emplace_back(outDLossDMeans2dAbs);
             }
             perCameraPrefetchBatchAsync(tensors, cameraOffset, cameraCount, deviceId, stream);
+
+            // Zero the outputs of the operator that need to be accumulated.
+            tensors = {outDLossDMeans2d, outDLossDConics, outDLossDFeatures, outDLossDOpacities};
+            if (absGrad) {
+                tensors.emplace_back(outDLossDMeans2dAbs);
+            }
+            perCameraMemsetAsync(tensors, cameraOffset, cameraCount, 0, stream);
         }
         C10_CUDA_CHECK(cudaEventRecord(events[deviceId], stream));
     }

--- a/src/fvdb/detail/ops/gsplat/RasterizeScreenSpaceGaussiansForward.cu
+++ b/src/fvdb/detail/ops/gsplat/RasterizeScreenSpaceGaussiansForward.cu
@@ -693,10 +693,8 @@ launchRasterizeForwardKernels(
         C10_CUDA_CHECK(cudaEventRecord(events[deviceId], stream));
     }
 
-    auto reshapedAlphas =
-        outAlphas.jdata().view({C, renderWindow.height, renderWindow.width, 1});
-    auto reshapedLastIds =
-        outLastIds.jdata().view({C, renderWindow.height, renderWindow.width});
+    auto reshapedAlphas  = outAlphas.jdata().view({C, renderWindow.height, renderWindow.width, 1});
+    auto reshapedLastIds = outLastIds.jdata().view({C, renderWindow.height, renderWindow.width});
     auto reshapedFeatures =
         outFeatures.jdata().view({C, renderWindow.height, renderWindow.width, channels});
 

--- a/src/fvdb/detail/ops/gsplat/RasterizeScreenSpaceGaussiansForward.cu
+++ b/src/fvdb/detail/ops/gsplat/RasterizeScreenSpaceGaussiansForward.cu
@@ -693,6 +693,22 @@ launchRasterizeForwardKernels(
         C10_CUDA_CHECK(cudaEventRecord(events[deviceId], stream));
     }
 
+    auto reshapedAlphas =
+        outAlphas.jdata().view({C, renderWindow.height, renderWindow.width, 1});
+    auto reshapedLastIds =
+        outLastIds.jdata().view({C, renderWindow.height, renderWindow.width});
+    auto reshapedFeatures =
+        outFeatures.jdata().view({C, renderWindow.height, renderWindow.width, channels});
+
+    std::vector<torch::Tensor> tensors = {means2d,
+                                          conics,
+                                          features,
+                                          opacities,
+                                          tileOffsets,
+                                          reshapedAlphas,
+                                          reshapedLastIds,
+                                          reshapedFeatures};
+
     for (const auto deviceId: c10::irange(c10::cuda::device_count())) {
         C10_CUDA_CHECK(cudaSetDevice(deviceId));
         auto stream = c10::cuda::getStreamFromPool(false, deviceId);
@@ -705,21 +721,6 @@ launchRasterizeForwardKernels(
             cuda::ceil_div(deviceTileOffset + deviceTileCount, (tileExtentH * tileExtentW)) -
             cameraOffset;
         if (deviceTileCount) {
-            auto reshapedAlphas =
-                outAlphas.jdata().view({C, renderWindow.height, renderWindow.width, 1});
-            auto reshapedLastIds =
-                outLastIds.jdata().view({C, renderWindow.height, renderWindow.width});
-            auto reshapedFeatures =
-                outFeatures.jdata().view({C, renderWindow.height, renderWindow.width, channels});
-
-            std::vector<torch::Tensor> tensors = {means2d,
-                                                  conics,
-                                                  features,
-                                                  opacities,
-                                                  tileOffsets,
-                                                  reshapedAlphas,
-                                                  reshapedLastIds,
-                                                  reshapedFeatures};
             perCameraPrefetchBatchAsync(tensors, cameraOffset, cameraCount, deviceId, stream);
         }
         C10_CUDA_CHECK(cudaEventRecord(events[deviceId], stream));

--- a/src/fvdb/detail/utils/cuda/Prefetch.cpp
+++ b/src/fvdb/detail/utils/cuda/Prefetch.cpp
@@ -78,5 +78,25 @@ perCameraPrefetchBatchAsync(const torch::TensorList &tensors,
 #endif
 }
 
+void
+perCameraMemsetAsync(const torch::TensorList &tensors,
+                     uint32_t cameraOffset,
+                     uint32_t cameraCount,
+                     int value,
+                     cudaStream_t stream) {
+    for (size_t i = 0; i < tensors.size(); ++i) {
+        const auto &tensor = tensors[i];
+        TORCH_CHECK(tensor.is_contiguous(), "Tensor to prefetch is not contiguous");
+        TORCH_CHECK(cameraOffset + cameraCount <= tensor.size(0),
+                    "Tensor does not have a batched first dimension");
+        size_t scalarSize = c10::elementSize(tensor.scalar_type());
+        C10_CUDA_CHECK(cudaMemsetAsync(static_cast<uint8_t *>(tensor.data_ptr()) +
+                                           cameraOffset * tensor.stride(0) * scalarSize,
+                                       value,
+                                       cameraCount * tensor.stride(0) * scalarSize,
+                                       stream));
+    }
+}
+
 } // namespace detail
 } // namespace fvdb

--- a/src/fvdb/detail/utils/cuda/Prefetch.h
+++ b/src/fvdb/detail/utils/cuda/Prefetch.h
@@ -29,6 +29,15 @@ void perCameraPrefetchBatchAsync(const torch::TensorList &tensors,
                                  int deviceId,
                                  cudaStream_t stream);
 
+/// Given a list of contiguous tensors each with dimensions [C, ...] where C is the number of
+/// cameras, we memset the slices [cameraOffset : cameraCount, ...] to the specified value
+/// on the input stream.
+void perCameraMemsetAsync(const torch::TensorList &tensors,
+                          uint32_t cameraOffset,
+                          uint32_t cameraCount,
+                          int value,
+                          cudaStream_t stream);
+
 } // namespace detail
 } // namespace fvdb
 


### PR DESCRIPTION
This PR improves and optimizes prefetching for mGPU Gaussian splatting.

1. Prefetching is batched via `cudaMemPrefetchBatchAsync` when possible. This amortizes the syscall overhead across multiple prefetches.
2. Instead of calling `zeros`, we call `empty` instead followed by a (batched) prefetch and memset.

In addition, this PR includes two cleanup changes:

1. Remove `warp_group_g in` backwards projection. `g` is guaranteed to be unique for each thread in the warp, so the warp sum is unnecessary.
2. Allocate CUB temporaries on the mGPU path using `cudaMallocAsync/cudaFreeAsync` as opposed to the built-in PyTorch CUDA block allocator. This prevents memory contention between the PyTorch block allocator and built-in CUDA mempool.
