### PR TITLE
Add warp level early exit for forward rasterization

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ requires-python = ">=3.10"
 readme = "README.md"
 dependencies = [
     # Require torch; users will choose the correct CUDA build from PyTorch's index
-    "torch>=2.8,<2.12",
+    "torch>=2.8,<2.13",
     "numpy",
 ]
 optional-dependencies = {viewer = ["nanovdb-editor>=0.0.23,<0.2.0"]}

--- a/src/fvdb/detail/ops/gsplat/RasterizeScreenSpaceGaussiansForward.cu
+++ b/src/fvdb/detail/ops/gsplat/RasterizeScreenSpaceGaussiansForward.cu
@@ -236,8 +236,10 @@ struct RasterizeForwardArgs {
                 // memory
                 __syncthreads();
 
-                // Volume render Gaussians in this batch
-                if (pixelIsActive) { // skip inactive sparse pixels
+                // Skip the per-Gaussian inner loop if every lane in this warp is
+                // already done (saturated or outside image bounds). Block-level
+                // __syncthreads_and above only fires once all 8 warps finish.
+                if (!__all_sync(0xffffffffu, done)) {
                     const uint32_t batchSize = min(blockSize, lastGaussianIdInBlock - batchStart);
                     for (uint32_t t = 0; (t < batchSize) && !done; ++t) {
                         const Gaussian2D<ScalarType> gaussian = sharedGaussians[t];


### PR DESCRIPTION
In addition to the block-level early exit, we can further improve the efficiency of the rasterization operator via a nested warp-level early exit. If each thread in the warp has completed, we can skip the per-Gaussian inner loop.