### PR TITLE
Improve parity with gsplat for dense rasterization

### DIFF
--- a/fvdb/__init__.py
+++ b/fvdb/__init__.py
@@ -239,20 +239,10 @@ def gaussian_render_jagged(
         render_quantities = torch.cat([render_quantities, depths[gaussian_ids].unsqueeze(-1)], dim=-1)
 
     # --- Non-differentiable tile intersection ---
-    # Jagged render is packed by construction: means2d / radii / depths /
-    # conics are flat [nnz, ...] arrays with a per-element camera_ids; fvdb's
-    # intersect_gaussian_tiles takes that layout when camera_ids is provided.
     num_tiles_h = math.ceil(image_height / tile_size)
     num_tiles_w = math.ceil(image_width / tile_size)
     tile_offsets, tile_gaussian_ids_t = _C.intersect_gaussian_tiles(
-        means2d.contiguous(),
-        radii.contiguous(),
-        depths.contiguous(),
-        ccz,
-        tile_size,
-        num_tiles_h,
-        num_tiles_w,
-        camera_ids=camera_ids,
+        means2d, radii, depths, ccz, tile_size, num_tiles_h, num_tiles_w, camera_ids
     )
     if return_debug_info:
         debug_info["tile_offsets"] = tile_offsets

--- a/fvdb/__init__.py
+++ b/fvdb/__init__.py
@@ -213,7 +213,7 @@ def gaussian_render_jagged(
             None,
             sh0.permute(1, 0, 2),  # [nnz, 1, D]
             None,
-            radii.unsqueeze(0),  # [1, nnz]
+            radii.unsqueeze(0),  # [1, nnz, 2] (per-axis)
         )
     else:
         sh0 = sh_coeffs_batched[0, :, :].unsqueeze(0)  # [1, nnz, D]
@@ -231,7 +231,7 @@ def gaussian_render_jagged(
             dirs.unsqueeze(0),  # [1, nnz, 3]
             sh0.permute(1, 0, 2),  # [nnz, 1, D]
             shN.permute(1, 0, 2),  # [nnz, K-1, D]
-            radii.unsqueeze(0),  # [1, nnz]
+            radii.unsqueeze(0),  # [1, nnz, 2] (per-axis)
         )
     render_quantities = render_quantities.squeeze(0)  # [nnz, D]
 
@@ -239,10 +239,20 @@ def gaussian_render_jagged(
         render_quantities = torch.cat([render_quantities, depths[gaussian_ids].unsqueeze(-1)], dim=-1)
 
     # --- Non-differentiable tile intersection ---
+    # Jagged render is packed by construction: means2d / radii / depths /
+    # conics are flat [nnz, ...] arrays with a per-element camera_ids; fvdb's
+    # intersect_gaussian_tiles takes that layout when camera_ids is provided.
     num_tiles_h = math.ceil(image_height / tile_size)
     num_tiles_w = math.ceil(image_width / tile_size)
     tile_offsets, tile_gaussian_ids_t = _C.intersect_gaussian_tiles(
-        means2d, radii, depths, ccz, tile_size, num_tiles_h, num_tiles_w, camera_ids
+        means2d.contiguous(),
+        radii.contiguous(),
+        depths.contiguous(),
+        ccz,
+        tile_size,
+        num_tiles_h,
+        num_tiles_w,
+        camera_ids=camera_ids,
     )
     if return_debug_info:
         debug_info["tile_offsets"] = tile_offsets
@@ -289,8 +299,8 @@ def evaluate_spherical_harmonics(
         sh_degree: Degree of spherical harmonics to use (0-3 typically).
         num_cameras: Number of camera views (C).
         sh0: DC term coefficients with shape [N, 1, D].
-        radii: Projected radii with shape [C, N] (int32). Points with radii <= 0
-               will output zeros.
+        radii: Per-axis projected radii with shape [C, N, 2] (int32). A point
+               is masked out unless both axes are positive.
         shN: Higher-order SH coefficients with shape [N, K-1, D] where
              K = (sh_degree+1)^2. Required when sh_degree > 0.
         view_directions: Unnormalized view directions with shape [C, N, 3].
@@ -303,8 +313,8 @@ def evaluate_spherical_harmonics(
         raise ValueError(f"sh0 must be 3-dimensional [N, 1, D], got {sh0.ndim}D")
     if sh0.shape[1] != 1:
         raise ValueError(f"sh0.shape[1] must be 1, got {sh0.shape[1]}")
-    if radii.ndim != 2:
-        raise ValueError(f"radii must be 2-dimensional [C, N], got {radii.ndim}D")
+    if radii.ndim != 3 or radii.shape[-1] != 2:
+        raise ValueError(f"radii must be shape [C, N, 2], got {tuple(radii.shape)}")
     if sh0.shape[0] != radii.shape[1]:
         raise ValueError(f"sh0.shape[0] ({sh0.shape[0]}) must match radii.shape[1] ({radii.shape[1]})")
     if sh_degree > 0 and view_directions is None:

--- a/fvdb/_gaussian_autograd.py
+++ b/fvdb/_gaussian_autograd.py
@@ -303,10 +303,8 @@ class _EvaluateGaussianSHFn(torch.autograd.Function):
         view_dirs: torch.Tensor,  # [C, N, 3] or empty
         sh0_coeffs: torch.Tensor,  # [N, 1, D]
         shN_coeffs: torch.Tensor,  # [N, K-1, D] or empty
-        radii: torch.Tensor,  # [C, N] or [C, N, 2]
+        radii: torch.Tensor,  # [C, N, 2]
     ) -> torch.Tensor:
-        if radii.dim() == 3:
-            radii = radii.amin(dim=-1).contiguous()
         render_quantities = _C.evaluate_spherical_harmonics_fwd(
             sh_degree_to_use,
             num_cameras,

--- a/fvdb/_gaussian_autograd.py
+++ b/fvdb/_gaussian_autograd.py
@@ -19,6 +19,7 @@ from . import _fvdb_cpp as _C
 from ._fvdb_cpp import JaggedTensor as JaggedTensorCpp
 from .jagged_tensor import JaggedTensor
 
+
 # ---------------------------------------------------------------------------
 #  Projection (analytic)
 # ---------------------------------------------------------------------------
@@ -47,7 +48,10 @@ class _ProjectGaussiansFn(torch.autograd.Function):
         accum_step_counts: torch.Tensor | None = None,
         accum_max_radii: torch.Tensor | None = None,
     ):
-        result = _C.project_gaussians_analytic_fwd(
+        # fvdb's kernel takes raw log_scales (it exps internally) — the
+        # binding's argument name "scales" is a misnomer carried over from
+        # the gsplat-aligned signature.
+        radii, means2d, depths, conics, compensations = _C.project_gaussians_analytic_fwd(
             means,
             quats,
             log_scales,
@@ -62,13 +66,18 @@ class _ProjectGaussiansFn(torch.autograd.Function):
             calc_compensations,
             ortho,
         )
-        radii: torch.Tensor = result[0]
-        means2d: torch.Tensor = result[1]
-        depths: torch.Tensor = result[2]
-        conics: torch.Tensor = result[3]
-        compensations: torch.Tensor | None = result[4] if calc_compensations else None
+        if not calc_compensations:
+            compensations = None
 
-        to_save = [means, quats, log_scales, world_to_cam, projection_matrices, radii, conics]
+        to_save = [
+            means,
+            quats,
+            log_scales,
+            world_to_cam,
+            projection_matrices,
+            radii,
+            conics,
+        ]
         if compensations is not None:
             to_save.append(compensations)
         ctx.save_for_backward(*to_save)
@@ -118,7 +127,11 @@ class _ProjectGaussiansFn(torch.autograd.Function):
         assert grad_means2d is not None
         assert grad_depths is not None
         assert grad_conics is not None
-        d_means, _, d_quats, d_scales, d_w2c = _C.project_gaussians_analytic_bwd(
+        viewmats_requires_grad = ctx.needs_input_grad[3]
+        # fvdb's kernel takes raw log_scales and returns dL/d(log_scales)
+        # directly (chain rule applied internally), despite the parameter
+        # being named "scales" in the binding.
+        d_means, _d_covars, d_quats, d_log_scales, d_w2c = _C.project_gaussians_analytic_bwd(
             means,
             quats,
             log_scales,
@@ -134,7 +147,7 @@ class _ProjectGaussiansFn(torch.autograd.Function):
             grad_depths,
             grad_conics,
             grad_compensations,
-            ctx.needs_input_grad[3],
+            viewmats_requires_grad,
             ctx.ortho,
             ctx.accum_grad_norms,
             ctx.accum_max_radii,
@@ -144,7 +157,7 @@ class _ProjectGaussiansFn(torch.autograd.Function):
         return (
             d_means,
             d_quats,
-            d_scales,
+            d_log_scales,
             d_w2c,
             None,
             None,
@@ -303,18 +316,26 @@ class _EvaluateGaussianSHFn(torch.autograd.Function):
         view_dirs: torch.Tensor,  # [C, N, 3] or empty
         sh0_coeffs: torch.Tensor,  # [N, 1, D]
         shN_coeffs: torch.Tensor,  # [N, K-1, D] or empty
-        radii: torch.Tensor,  # [C, N]
+        radii: torch.Tensor,  # [C, N, 2]
     ) -> torch.Tensor:
+        # fvdb's SH kernel expects scalar [C, N] radii (it checks >0 per
+        # (cam, gaussian)); collapse the per-axis input by taking the min so
+        # the visibility check is "both axes positive".
+        if radii.dim() == 3:
+            radii_scalar = radii.amin(dim=-1).contiguous()
+        else:
+            radii_scalar = radii.contiguous()
+
         render_quantities = _C.evaluate_spherical_harmonics_fwd(
             sh_degree_to_use,
             num_cameras,
             view_dirs,
             sh0_coeffs,
             shN_coeffs,
-            radii,
+            radii_scalar,
         )
 
-        ctx.save_for_backward(view_dirs, shN_coeffs, radii)
+        ctx.save_for_backward(view_dirs, shN_coeffs, radii_scalar)
         ctx.sh_degree_to_use = sh_degree_to_use
         ctx.num_cameras = num_cameras
         ctx.num_gaussians = sh0_coeffs.size(0)
@@ -328,7 +349,7 @@ class _EvaluateGaussianSHFn(torch.autograd.Function):
             return (None, None, None, None, None, None)
         d_loss_d_colors = d_loss_d_colors.contiguous()
 
-        view_dirs, shN_coeffs, radii = ctx.saved_tensors
+        view_dirs, shN_coeffs, radii_scalar = ctx.saved_tensors
 
         compute_d_loss_d_view_dirs = view_dirs.numel() > 0 and view_dirs.requires_grad
 
@@ -339,7 +360,7 @@ class _EvaluateGaussianSHFn(torch.autograd.Function):
             view_dirs,
             shN_coeffs,
             d_loss_d_colors,
-            radii,
+            radii_scalar,
             compute_d_loss_d_view_dirs,
         )
 
@@ -372,7 +393,7 @@ class _RasterizeScreenSpaceGaussiansFn(torch.autograd.Function):
         backgrounds: torch.Tensor | None,
         masks: torch.Tensor | None,
     ):
-        result = _C.rasterize_screen_space_gaussians_fwd(
+        rendered_colors, rendered_alphas, last_ids = _C.rasterize_screen_space_gaussians_fwd(
             means2d,
             conics,
             colors,
@@ -388,9 +409,6 @@ class _RasterizeScreenSpaceGaussiansFn(torch.autograd.Function):
             backgrounds,
             masks,
         )
-        rendered_colors = result[0]
-        rendered_alphas = result[1]
-        last_ids = result[2]
 
         to_save = [means2d, conics, colors, opacities, tile_offsets, tile_gaussian_ids, rendered_alphas, last_ids]
         if backgrounds is not None:
@@ -412,7 +430,7 @@ class _RasterizeScreenSpaceGaussiansFn(torch.autograd.Function):
         ctx.tile_size = tile_size
         ctx.absgrad = absgrad
 
-        return rendered_colors, rendered_alphas
+        return rendered_colors, rendered_alphas.float()
 
     @staticmethod
     def backward(ctx: Any, *grad_outputs: torch.Tensor | None) -> tuple[torch.Tensor | None, ...]:
@@ -439,7 +457,7 @@ class _RasterizeScreenSpaceGaussiansFn(torch.autograd.Function):
 
         assert d_loss_d_rendered_colors is not None
         assert d_loss_d_rendered_alphas is not None
-        result = _C.rasterize_screen_space_gaussians_bwd(
+        _abs_d_means2d, d_means2d, d_conics, d_colors, d_opacities = _C.rasterize_screen_space_gaussians_bwd(
             means2d,
             conics,
             colors,
@@ -460,10 +478,6 @@ class _RasterizeScreenSpaceGaussiansFn(torch.autograd.Function):
             backgrounds,
             masks,
         )
-        d_means2d = result[1]
-        d_conics = result[2]
-        d_colors = result[3]
-        d_opacities = result[4]
 
         return (
             d_means2d,

--- a/fvdb/_gaussian_autograd.py
+++ b/fvdb/_gaussian_autograd.py
@@ -19,7 +19,6 @@ from . import _fvdb_cpp as _C
 from ._fvdb_cpp import JaggedTensor as JaggedTensorCpp
 from .jagged_tensor import JaggedTensor
 
-
 # ---------------------------------------------------------------------------
 #  Projection (analytic)
 # ---------------------------------------------------------------------------
@@ -48,10 +47,7 @@ class _ProjectGaussiansFn(torch.autograd.Function):
         accum_step_counts: torch.Tensor | None = None,
         accum_max_radii: torch.Tensor | None = None,
     ):
-        # fvdb's kernel takes raw log_scales (it exps internally) — the
-        # binding's argument name "scales" is a misnomer carried over from
-        # the gsplat-aligned signature.
-        radii, means2d, depths, conics, compensations = _C.project_gaussians_analytic_fwd(
+        result = _C.project_gaussians_analytic_fwd(
             means,
             quats,
             log_scales,
@@ -66,18 +62,13 @@ class _ProjectGaussiansFn(torch.autograd.Function):
             calc_compensations,
             ortho,
         )
-        if not calc_compensations:
-            compensations = None
+        radii: torch.Tensor = result[0]
+        means2d: torch.Tensor = result[1]
+        depths: torch.Tensor = result[2]
+        conics: torch.Tensor = result[3]
+        compensations: torch.Tensor | None = result[4] if calc_compensations else None
 
-        to_save = [
-            means,
-            quats,
-            log_scales,
-            world_to_cam,
-            projection_matrices,
-            radii,
-            conics,
-        ]
+        to_save = [means, quats, log_scales, world_to_cam, projection_matrices, radii, conics]
         if compensations is not None:
             to_save.append(compensations)
         ctx.save_for_backward(*to_save)
@@ -127,11 +118,7 @@ class _ProjectGaussiansFn(torch.autograd.Function):
         assert grad_means2d is not None
         assert grad_depths is not None
         assert grad_conics is not None
-        viewmats_requires_grad = ctx.needs_input_grad[3]
-        # fvdb's kernel takes raw log_scales and returns dL/d(log_scales)
-        # directly (chain rule applied internally), despite the parameter
-        # being named "scales" in the binding.
-        d_means, _d_covars, d_quats, d_log_scales, d_w2c = _C.project_gaussians_analytic_bwd(
+        d_means, _, d_quats, d_scales, d_w2c = _C.project_gaussians_analytic_bwd(
             means,
             quats,
             log_scales,
@@ -147,7 +134,7 @@ class _ProjectGaussiansFn(torch.autograd.Function):
             grad_depths,
             grad_conics,
             grad_compensations,
-            viewmats_requires_grad,
+            ctx.needs_input_grad[3],
             ctx.ortho,
             ctx.accum_grad_norms,
             ctx.accum_max_radii,
@@ -157,7 +144,7 @@ class _ProjectGaussiansFn(torch.autograd.Function):
         return (
             d_means,
             d_quats,
-            d_log_scales,
+            d_scales,
             d_w2c,
             None,
             None,
@@ -316,26 +303,20 @@ class _EvaluateGaussianSHFn(torch.autograd.Function):
         view_dirs: torch.Tensor,  # [C, N, 3] or empty
         sh0_coeffs: torch.Tensor,  # [N, 1, D]
         shN_coeffs: torch.Tensor,  # [N, K-1, D] or empty
-        radii: torch.Tensor,  # [C, N, 2]
+        radii: torch.Tensor,  # [C, N] or [C, N, 2]
     ) -> torch.Tensor:
-        # fvdb's SH kernel expects scalar [C, N] radii (it checks >0 per
-        # (cam, gaussian)); collapse the per-axis input by taking the min so
-        # the visibility check is "both axes positive".
         if radii.dim() == 3:
-            radii_scalar = radii.amin(dim=-1).contiguous()
-        else:
-            radii_scalar = radii.contiguous()
-
+            radii = radii.amin(dim=-1).contiguous()
         render_quantities = _C.evaluate_spherical_harmonics_fwd(
             sh_degree_to_use,
             num_cameras,
             view_dirs,
             sh0_coeffs,
             shN_coeffs,
-            radii_scalar,
+            radii,
         )
 
-        ctx.save_for_backward(view_dirs, shN_coeffs, radii_scalar)
+        ctx.save_for_backward(view_dirs, shN_coeffs, radii)
         ctx.sh_degree_to_use = sh_degree_to_use
         ctx.num_cameras = num_cameras
         ctx.num_gaussians = sh0_coeffs.size(0)
@@ -349,7 +330,7 @@ class _EvaluateGaussianSHFn(torch.autograd.Function):
             return (None, None, None, None, None, None)
         d_loss_d_colors = d_loss_d_colors.contiguous()
 
-        view_dirs, shN_coeffs, radii_scalar = ctx.saved_tensors
+        view_dirs, shN_coeffs, radii = ctx.saved_tensors
 
         compute_d_loss_d_view_dirs = view_dirs.numel() > 0 and view_dirs.requires_grad
 
@@ -360,7 +341,7 @@ class _EvaluateGaussianSHFn(torch.autograd.Function):
             view_dirs,
             shN_coeffs,
             d_loss_d_colors,
-            radii_scalar,
+            radii,
             compute_d_loss_d_view_dirs,
         )
 
@@ -393,7 +374,7 @@ class _RasterizeScreenSpaceGaussiansFn(torch.autograd.Function):
         backgrounds: torch.Tensor | None,
         masks: torch.Tensor | None,
     ):
-        rendered_colors, rendered_alphas, last_ids = _C.rasterize_screen_space_gaussians_fwd(
+        result = _C.rasterize_screen_space_gaussians_fwd(
             means2d,
             conics,
             colors,
@@ -409,6 +390,9 @@ class _RasterizeScreenSpaceGaussiansFn(torch.autograd.Function):
             backgrounds,
             masks,
         )
+        rendered_colors = result[0]
+        rendered_alphas = result[1]
+        last_ids = result[2]
 
         to_save = [means2d, conics, colors, opacities, tile_offsets, tile_gaussian_ids, rendered_alphas, last_ids]
         if backgrounds is not None:
@@ -430,7 +414,7 @@ class _RasterizeScreenSpaceGaussiansFn(torch.autograd.Function):
         ctx.tile_size = tile_size
         ctx.absgrad = absgrad
 
-        return rendered_colors, rendered_alphas.float()
+        return rendered_colors, rendered_alphas
 
     @staticmethod
     def backward(ctx: Any, *grad_outputs: torch.Tensor | None) -> tuple[torch.Tensor | None, ...]:
@@ -457,7 +441,7 @@ class _RasterizeScreenSpaceGaussiansFn(torch.autograd.Function):
 
         assert d_loss_d_rendered_colors is not None
         assert d_loss_d_rendered_alphas is not None
-        _abs_d_means2d, d_means2d, d_conics, d_colors, d_opacities = _C.rasterize_screen_space_gaussians_bwd(
+        result = _C.rasterize_screen_space_gaussians_bwd(
             means2d,
             conics,
             colors,
@@ -478,6 +462,10 @@ class _RasterizeScreenSpaceGaussiansFn(torch.autograd.Function):
             backgrounds,
             masks,
         )
+        d_means2d = result[1]
+        d_conics = result[2]
+        d_colors = result[3]
+        d_opacities = result[4]
 
         return (
             d_means2d,

--- a/fvdb/gaussian_splatting.py
+++ b/fvdb/gaussian_splatting.py
@@ -275,12 +275,13 @@ class ProjectedGaussianSplats:
     @property
     def radii(self) -> torch.Tensor:
         """
-        Return the 2D radii (in pixels) of each projected Gaussian in each image plane. The radius of a Gaussian is the maximum extent
-        of the Gaussian along any direction in the image plane.
+        Return the per-axis 2D radii (in pixels) of each projected Gaussian in each image plane.
+        Entry ``(c, n, 0)`` is the half-width of the AABB along x and ``(c, n, 1)`` is the
+        half-width along y. A Gaussian is considered visible iff both axes are positive.
 
         Returns:
-            radii (torch.Tensor): A tensor of shape ``(C, N)`` representing the 2D radius of each projected Gaussian, where
-                ``C`` is the number of image planes, and ``N`` is the number of projected Gaussians.
+            radii (torch.Tensor): A tensor of shape ``(C, N, 2)`` representing the per-axis 2D
+                radius of each projected Gaussian.
         """
         return self._radii
 
@@ -1658,9 +1659,9 @@ class GaussianSplat3d:
         num_tiles_h = math.ceil(H / tile_size)
         num_tiles_w = math.ceil(W / tile_size)
         tile_offsets, tile_gaussian_ids = _C.intersect_gaussian_tiles(
-            means2d,
-            radii,
-            depths,
+            means2d.contiguous(),
+            radii.contiguous(),
+            depths.contiguous(),
             C,
             tile_size,
             num_tiles_h,
@@ -2475,9 +2476,9 @@ class GaussianSplat3d:
             num_tiles_h = math.ceil(raster_h / tile_size)
             num_tiles_w = math.ceil(raster_w / tile_size)
             tile_offsets, tile_gaussian_ids = _C.intersect_gaussian_tiles(
-                pg.means2d,
-                pg.radii,
-                pg.depths,
+                pg.means2d.contiguous(),
+                pg.radii.contiguous(),
+                pg.depths.contiguous(),
                 C,
                 tile_size,
                 num_tiles_h,

--- a/fvdb/gaussian_splatting.py
+++ b/fvdb/gaussian_splatting.py
@@ -1659,9 +1659,9 @@ class GaussianSplat3d:
         num_tiles_h = math.ceil(H / tile_size)
         num_tiles_w = math.ceil(W / tile_size)
         tile_offsets, tile_gaussian_ids = _C.intersect_gaussian_tiles(
-            means2d.contiguous(),
-            radii.contiguous(),
-            depths.contiguous(),
+            means2d,
+            radii,
+            depths,
             C,
             tile_size,
             num_tiles_h,
@@ -2476,9 +2476,9 @@ class GaussianSplat3d:
             num_tiles_h = math.ceil(raster_h / tile_size)
             num_tiles_w = math.ceil(raster_w / tile_size)
             tile_offsets, tile_gaussian_ids = _C.intersect_gaussian_tiles(
-                pg.means2d.contiguous(),
-                pg.radii.contiguous(),
-                pg.depths.contiguous(),
+                pg.means2d,
+                pg.radii,
+                pg.depths,
                 C,
                 tile_size,
                 num_tiles_h,

--- a/src/cmake/get_test_data.cmake
+++ b/src/cmake/get_test_data.cmake
@@ -5,7 +5,7 @@
 CPMAddPackage(
   NAME fvdb_test_data
   GITHUB_REPOSITORY voxel-foundation/fvdb-test-data
-  GIT_TAG 33e501b283f743e66e11ae0dfecc00999c5856a8
+  GIT_TAG 59e48d3daa8b8fb55a30fd3d7553fc7fa773ab07
   DOWNLOAD_ONLY YES
 )
 

--- a/src/cmake/get_test_data.cmake
+++ b/src/cmake/get_test_data.cmake
@@ -5,7 +5,7 @@
 CPMAddPackage(
   NAME fvdb_test_data
   GITHUB_REPOSITORY voxel-foundation/fvdb-test-data
-  GIT_TAG 79bf6d94f9726eea45a38c10f58544ab17ce46ed
+  GIT_TAG c4f2a9ac1ead5f1318f494bd98340affc8bbaaed
   DOWNLOAD_ONLY YES
 )
 

--- a/src/cmake/get_test_data.cmake
+++ b/src/cmake/get_test_data.cmake
@@ -5,7 +5,7 @@
 CPMAddPackage(
   NAME fvdb_test_data
   GITHUB_REPOSITORY voxel-foundation/fvdb-test-data
-  GIT_TAG c4f2a9ac1ead5f1318f494bd98340affc8bbaaed
+  GIT_TAG 33e501b283f743e66e11ae0dfecc00999c5856a8
   DOWNLOAD_ONLY YES
 )
 

--- a/src/cmake/get_torch.cmake
+++ b/src/cmake/get_torch.cmake
@@ -36,6 +36,11 @@ endif()
 
 find_package(Torch REQUIRED PATHS "${TORCH_PACKAGE_DIR}/share/cmake/Torch")
 
+# Conda provides public PyTorch headers in the global environment include directory
+if(DEFINED ENV{CONDA_PREFIX})
+  list(APPEND TORCH_INCLUDE_DIRS "$ENV{CONDA_PREFIX}/include")
+endif()
+
 # Without this we can't find TH/THC headers
 set(TORCH_SOURCE_INCLUDE_DIRS ${TORCH_PACKAGE_DIR}/include)
 

--- a/src/fvdb/detail/ops/gsplat/EvaluateSphericalHarmonicsBackward.cu
+++ b/src/fvdb/detail/ops/gsplat/EvaluateSphericalHarmonicsBackward.cu
@@ -287,7 +287,7 @@ computeShBackward(
     const int64_t shDegreeToUse,
     const torch::PackedTensorAccessor64<T, 3, torch::RestrictPtrTraits> viewDirs,     // [C, N, 3]
     const torch::PackedTensorAccessor64<T, 3, torch::RestrictPtrTraits> shNCoeffs,    // [K-1, N, D]
-    const int *__restrict__ radii,                                                    // [C, N]
+    const int *__restrict__ radii,                                                    // [C, N, 2]
     const torch::PackedTensorAccessor64<T, 3, torch::RestrictPtrTraits>
         dLossDRenderQuantities,                                                       // [C, N, D]
     torch::PackedTensorAccessor64<T, 3, torch::RestrictPtrTraits> outDLossDSh0Coeffs, // [N, 1, D]
@@ -304,7 +304,8 @@ computeShBackward(
     const auto cid = eid / count;          // camera index
     const auto gid = eid % count + offset; // gaussian index
     const auto c   = idx % D;              // render channel
-    if (radii != nullptr && radii[cid * N + gid] <= 0) {
+    if (radii != nullptr &&
+        (radii[(cid * N + gid) * 2 + 0] <= 0 || radii[(cid * N + gid) * 2 + 1] <= 0)) {
         return;
     }
 
@@ -345,7 +346,7 @@ computeShDiffuseOnlyBackward(
     const int64_t D,
     const torch::PackedTensorAccessor64<T, 3, torch::RestrictPtrTraits>
         dLossDRenderQuantities,                                                      // [C, N, D]
-    const int *__restrict__ radii,                                                   // [C, N]
+    const int *__restrict__ radii,                                                   // [C, N, 2]
     torch::PackedTensorAccessor64<T, 3, torch::RestrictPtrTraits> outDLossDSh0Coeffs // [N, 1, D]
 ) {
     // parallelize over C * N * D
@@ -358,7 +359,8 @@ computeShDiffuseOnlyBackward(
     const auto cid = eid / count;          // camera index
     const auto gid = eid % count + offset; // gaussian index
     const auto c   = idx % D;              // render channel
-    if (radii != nullptr && radii[cid * N + gid] <= 0) {
+    if (radii != nullptr &&
+        (radii[(cid * N + gid) * 2 + 0] <= 0 || radii[(cid * N + gid) * 2 + 1] <= 0)) {
         return;
     }
 
@@ -376,7 +378,7 @@ dispatchEvaluateSphericalHarmonicsBwd(const int64_t shDegreeToUse,
                                       const torch::Tensor &viewDirs,  // [C, N, 3] or empty
                                       const torch::Tensor &shNCoeffs, // [N, K-1, D]
                                       const torch::Tensor &dLossDColors,
-                                      const torch::Tensor &radii,     // [C, N]
+                                      const torch::Tensor &radii,     // [C, N, 2]
                                       const bool computeDLossDViewDirs);
 
 template <>
@@ -388,7 +390,7 @@ dispatchEvaluateSphericalHarmonicsBwd<torch::kCUDA>(
     const torch::Tensor &viewDirs,               // [C, N, 3]
     const torch::Tensor &shNCoeffs,              // [N, K-1, D]
     const torch::Tensor &dLossDRenderQuantities, // [C, N, D]
-    const torch::Tensor &radii,                  // [C, N]
+    const torch::Tensor &radii,                  // [C, N, 2]
     const bool computeDLossDViewDirs) {
     FVDB_FUNC_RANGE();
     const at::cuda::OptionalCUDAGuard device_guard(at::device_of(dLossDRenderQuantities));
@@ -407,12 +409,14 @@ dispatchEvaluateSphericalHarmonicsBwd<torch::kCUDA>(
         TORCH_CHECK_VALUE(shDegreeToUse == 0, "shDegreeToUse must be 0 if no shNCoeffs");
     }
     if (hasRadii) {
-        TORCH_CHECK_VALUE(radii.dim() == 2, "radii must have two dimensions with shape [C, N]");
+        TORCH_CHECK_VALUE(radii.dim() == 3 && radii.size(2) == 2,
+                          "radii must have shape [C, N, 2] but got shape = ",
+                          radii.sizes());
         TORCH_CHECK_VALUE(numGaussians == radii.size(1),
-                          "radii must have shape [C, N] but got shape = ",
+                          "radii must have shape [C, N, 2] but got shape = ",
                           radii.sizes());
         TORCH_CHECK_VALUE(radii.size(0) == numCameras,
-                          "radii must have shape [C, N] and C must match numCameras");
+                          "radii must have shape [C, N, 2] and C must match numCameras");
         TORCH_CHECK_VALUE(radii.is_cuda(), "radii must be a CUDA tensor");
         TORCH_CHECK_VALUE(radii.is_contiguous(), "radii must be a contiguous");
     }
@@ -503,7 +507,7 @@ dispatchEvaluateSphericalHarmonicsBwd<torch::kPrivateUse1>(
     const torch::Tensor &viewDirs,               // [C, N, 3]
     const torch::Tensor &shNCoeffs,              // [N, K-1, D]
     const torch::Tensor &dLossDRenderQuantities, // [C, N, D]
-    const torch::Tensor &radii,                  // [C, N]
+    const torch::Tensor &radii,                  // [C, N, 2]
     const bool computeDLossDViewDirs) {
     FVDB_FUNC_RANGE();
 
@@ -521,12 +525,14 @@ dispatchEvaluateSphericalHarmonicsBwd<torch::kPrivateUse1>(
         TORCH_CHECK_VALUE(shDegreeToUse == 0, "shDegreeToUse must be 0 if no shNCoeffs");
     }
     if (hasRadii) {
-        TORCH_CHECK_VALUE(radii.dim() == 2, "radii must have two dimensions with shape [C, N]");
+        TORCH_CHECK_VALUE(radii.dim() == 3 && radii.size(2) == 2,
+                          "radii must have shape [C, N, 2] but got shape = ",
+                          radii.sizes());
         TORCH_CHECK_VALUE(numGaussians == radii.size(1),
-                          "radii must have shape [C, N] but got shape = ",
+                          "radii must have shape [C, N, 2] but got shape = ",
                           radii.sizes());
         TORCH_CHECK_VALUE(radii.size(0) == numCameras,
-                          "radii must have shape [C, N] and C must match numCameras");
+                          "radii must have shape [C, N, 2] and C must match numCameras");
         TORCH_CHECK_VALUE(radii.is_privateuseone(), "radii must be a PrivateUse1 tensor");
         TORCH_CHECK_VALUE(radii.is_contiguous(), "radii must be a contiguous");
     }
@@ -815,7 +821,7 @@ dispatchEvaluateSphericalHarmonicsBwd<torch::kCPU>(
     const torch::Tensor &viewDirs,               // [C, N, 3] or empty
     const torch::Tensor &shNCoeffs,              // [N, K-1, D]
     const torch::Tensor &dLossDRenderQuantities, // [C, N, D]
-    const torch::Tensor &radii,                  // [C, N]
+    const torch::Tensor &radii,                  // [C, N, 2]
     const bool computeDLossDViewDirs) {
     TORCH_CHECK(false, "CPU implementation not available");
 }
@@ -827,7 +833,7 @@ evaluateSphericalHarmonicsBwd(const int64_t shDegreeToUse,
                               const torch::Tensor &viewDirs,  // [C, N, 3] or empty
                               const torch::Tensor &shNCoeffs, // [N, K-1, D]
                               const torch::Tensor &dLossDColors,
-                              const torch::Tensor &radii,     // [C, N]
+                              const torch::Tensor &radii,     // [C, N, 2]
                               const bool computeDLossDViewDirs) {
     return FVDB_DISPATCH_KERNEL(dLossDColors.device(), [&]() {
         return dispatchEvaluateSphericalHarmonicsBwd<DeviceTag>(shDegreeToUse,

--- a/src/fvdb/detail/ops/gsplat/EvaluateSphericalHarmonicsBackward.h
+++ b/src/fvdb/detail/ops/gsplat/EvaluateSphericalHarmonicsBackward.h
@@ -26,8 +26,8 @@ namespace ops {
 /// (unpacked) where K depends on sh_degree_to_use
 /// @param[in] dLossDColors Gradients of the loss function with respect to output colors [N, 3]
 /// - ∂L/∂colors
-/// @param[in] radii radii [N] (packed) or [C, N] (unpacked) used in the forward pass for
-/// level-of-detail
+/// @param[in] radii Per-axis projected radii [C, N, 2] used in the forward pass; a gaussian
+/// is masked unless both axes are positive.
 /// @param[in] computeDLossDViewDirs Whether to compute gradients with respect to direction
 /// vectors
 ///
@@ -42,7 +42,7 @@ evaluateSphericalHarmonicsBwd(const int64_t shDegreeToUse,
                               const torch::Tensor &viewDirs,  // [C, N, 3] or empty
                               const torch::Tensor &shNCoeffs, // [N, K-1, D]
                               const torch::Tensor &dLossDColors,
-                              const torch::Tensor &radii,     // [C, N]
+                              const torch::Tensor &radii,     // [C, N, 2]
                               const bool computeDLossDViewDirs);
 
 } // namespace ops

--- a/src/fvdb/detail/ops/gsplat/EvaluateSphericalHarmonicsForward.cu
+++ b/src/fvdb/detail/ops/gsplat/EvaluateSphericalHarmonicsForward.cu
@@ -156,7 +156,7 @@ computeSh(
     const auto gid = eid % count + offset; // gaussian index
     const auto c   = idx % D;              // render channel
 
-    T result = T(0);
+    T result           = T(0);
     const bool visible = radii == nullptr ||
                          (radii[(cid * N + gid) * 2 + 0] > 0 && radii[(cid * N + gid) * 2 + 1] > 0);
     if (visible) {

--- a/src/fvdb/detail/ops/gsplat/EvaluateSphericalHarmonicsForward.cu
+++ b/src/fvdb/detail/ops/gsplat/EvaluateSphericalHarmonicsForward.cu
@@ -142,7 +142,7 @@ computeSh(
     const torch::PackedTensorAccessor64<T, 3, torch::RestrictPtrTraits> viewDirs,  // [C, N, 3]
     const torch::PackedTensorAccessor64<T, 3, torch::RestrictPtrTraits> sh0Coeffs, // [1, N, D]
     const torch::PackedTensorAccessor64<T, 3, torch::RestrictPtrTraits> shNCoeffs, // [K-1, N, D]
-    const int *__restrict__ radii,                                                 // [C, N]
+    const int *__restrict__ radii,                                                 // [C, N, 2]
     T *__restrict__ outRenderQuantities                                            // [C, N, D]
 ) {
     // parallelize over C * N * D
@@ -157,7 +157,9 @@ computeSh(
     const auto c   = idx % D;              // render channel
 
     T result = T(0);
-    if (!(radii != nullptr && radii[cid * N + gid] <= 0)) {
+    const bool visible = radii == nullptr ||
+                         (radii[(cid * N + gid) * 2 + 0] > 0 && radii[(cid * N + gid) * 2 + 1] > 0);
+    if (visible) {
         static_assert(std::is_same<T, float>::value,
                       "SH kernels assume float precision (float3 casts)");
         using vec3t            = float3;
@@ -177,7 +179,7 @@ computeShDiffuseOnly(const int64_t offset,
                      const int64_t N,
                      const int64_t D,
                      const torch::PackedTensorAccessor64<T, 3, torch::RestrictPtrTraits> sh0Coeffs,
-                     const int *__restrict__ radii, // [C, N]
+                     const int *__restrict__ radii, // [C, N, 2]
                      T *__restrict__ outRenderQuantities) {
     // parallelize over C * N * D
     auto idx = blockIdx.x * blockDim.x + threadIdx.x; // cidx * N * D + gidx * D + kidx
@@ -189,7 +191,8 @@ computeShDiffuseOnly(const int64_t offset,
     const auto cid = eid / count;          // camera index
     const auto gid = eid % count + offset; // gaussian index
     const auto c   = idx % D;              // render channel
-    if (radii != nullptr && radii[cid * N + gid] <= 0) {
+    if (radii != nullptr &&
+        (radii[(cid * N + gid) * 2 + 0] <= 0 || radii[(cid * N + gid) * 2 + 1] <= 0)) {
         outRenderQuantities[(cid * N + gid) * D + c] = T(0);
     } else {
         outRenderQuantities[(cid * N + gid) * D + c] =
@@ -205,7 +208,7 @@ torch::Tensor dispatchEvaluateSphericalHarmonicsFwd(const int64_t shDegreeToUse,
                                                     const torch::Tensor &viewDirs,  // [C, N, 3]
                                                     const torch::Tensor &sh0Coeffs, // [1, N, D]
                                                     const torch::Tensor &shNCoeffs, // [N, K-1, D]
-                                                    const torch::Tensor &radii      // [C, N]
+                                                    const torch::Tensor &radii      // [C, N, 2]
 );
 
 template <>
@@ -215,7 +218,7 @@ dispatchEvaluateSphericalHarmonicsFwd<torch::kCUDA>(const int64_t shDegreeToUse,
                                                     const torch::Tensor &viewDirs,  // [C, N, 3]
                                                     const torch::Tensor &sh0Coeffs, // [N, 1, D]
                                                     const torch::Tensor &shNCoeffs, // [N, K-1, D]
-                                                    const torch::Tensor &radii      // [C, N]
+                                                    const torch::Tensor &radii      // [C, N, 2]
 ) {
     FVDB_FUNC_RANGE();
     // Valid modes:
@@ -245,10 +248,11 @@ dispatchEvaluateSphericalHarmonicsFwd<torch::kCUDA>(const int64_t shDegreeToUse,
     }
 
     if (hasRadii) {
-        TORCH_CHECK_VALUE(radii.dim() == 2, "radii must have two dimensions with shape [C, N]");
-        TORCH_CHECK_VALUE(numGaussians == radii.size(1), "radii must have shape [C, N]");
+        TORCH_CHECK_VALUE(radii.dim() == 3 && radii.size(2) == 2,
+                          "radii must have shape [C, N, 2]");
+        TORCH_CHECK_VALUE(numGaussians == radii.size(1), "radii must have shape [C, N, 2]");
         TORCH_CHECK_VALUE(radii.size(0) == numCameras,
-                          "radii must have shape [C, N] and C must match numCameras");
+                          "radii must have shape [C, N, 2] and C must match numCameras");
         TORCH_CHECK_VALUE(radii.is_cuda(), "radii must be a CUDA tensor");
         TORCH_CHECK_VALUE(radii.is_contiguous(), "radii must be a contiguous");
     }
@@ -317,7 +321,7 @@ dispatchEvaluateSphericalHarmonicsFwd<torch::kPrivateUse1>(
     const torch::Tensor &viewDirs,  // [C, N, 3]
     const torch::Tensor &sh0Coeffs, // [N, 1, D]
     const torch::Tensor &shNCoeffs, // [N, K-1, D]
-    const torch::Tensor &radii      // [C, N]
+    const torch::Tensor &radii      // [C, N, 2]
 ) {
     FVDB_FUNC_RANGE();
     // Valid modes:
@@ -345,10 +349,11 @@ dispatchEvaluateSphericalHarmonicsFwd<torch::kPrivateUse1>(
     }
 
     if (hasRadii) {
-        TORCH_CHECK_VALUE(radii.dim() == 2, "radii must have two dimensions with shape [C, N]");
-        TORCH_CHECK_VALUE(numGaussians == radii.size(1), "radii must have shape [C, N]");
+        TORCH_CHECK_VALUE(radii.dim() == 3 && radii.size(2) == 2,
+                          "radii must have shape [C, N, 2]");
+        TORCH_CHECK_VALUE(numGaussians == radii.size(1), "radii must have shape [C, N, 2]");
         TORCH_CHECK_VALUE(radii.size(0) == numCameras,
-                          "radii must have shape [C, N] and C must match numCameras");
+                          "radii must have shape [C, N, 2] and C must match numCameras");
         TORCH_CHECK_VALUE(radii.is_privateuseone(), "radii must be a PrivateUse1 tensor");
         TORCH_CHECK_VALUE(radii.is_contiguous(), "radii must be a contiguous");
     }
@@ -426,7 +431,7 @@ dispatchEvaluateSphericalHarmonicsFwd<torch::kCPU>(const int64_t shDegreeToUse,
                                                    const torch::Tensor &dirs,      // [N, 3]
                                                    const torch::Tensor &sh0Coeffs, // [1, N, D]
                                                    const torch::Tensor &shNCoeffs, // [K-1, N, D]
-                                                   const torch::Tensor &radii      // [N]
+                                                   const torch::Tensor &radii      // [C, N, 2]
 ) {
     TORCH_CHECK(false, "CPU implementation not available");
 }
@@ -437,7 +442,7 @@ evaluateSphericalHarmonicsFwd(const int64_t shDegreeToUse,
                               const torch::Tensor &viewDirs,  // [C, N, 3]
                               const torch::Tensor &sh0Coeffs, // [1, N, D]
                               const torch::Tensor &shNCoeffs, // [N, K-1, D]
-                              const torch::Tensor &radii      // [C, N]
+                              const torch::Tensor &radii      // [C, N, 2]
 ) {
     return FVDB_DISPATCH_KERNEL(sh0Coeffs.device(), [&]() {
         return dispatchEvaluateSphericalHarmonicsFwd<DeviceTag>(

--- a/src/fvdb/detail/ops/gsplat/EvaluateSphericalHarmonicsForward.h
+++ b/src/fvdb/detail/ops/gsplat/EvaluateSphericalHarmonicsForward.h
@@ -26,8 +26,8 @@ namespace ops {
 /// [1, N, D] (unpacked), where D is the number of feature channels
 /// @param[in] shNCoeffs Higher order spherical harmonic coefficients [N, K-1, D] (packed) or
 /// [K-1, N, D] (unpacked), where K depends on sh_degree_to_use (K=(sh_degree_to_use+1)²)
-/// @param[in] radii radii [N] (packed) or [C, N] (unpacked) for view-dependent level-of-detail
-/// control
+/// @param[in] radii Per-axis projected radii [C, N, 2]. A gaussian is masked unless both axes
+/// are positive.
 ///
 /// @return Features/colors [N, D] computed from the spherical harmonics evaluation
 torch::Tensor evaluateSphericalHarmonicsFwd(const int64_t shDegreeToUse,
@@ -35,7 +35,7 @@ torch::Tensor evaluateSphericalHarmonicsFwd(const int64_t shDegreeToUse,
                                             const torch::Tensor &viewDirs,  // [C, N, 3]
                                             const torch::Tensor &sh0Coeffs, // [1, N, D]
                                             const torch::Tensor &shNCoeffs, // [N, K-1, D]
-                                            const torch::Tensor &radii      // [C, N]
+                                            const torch::Tensor &radii      // [C, N, 2]
 );
 
 } // namespace ops

--- a/src/fvdb/detail/ops/gsplat/IntersectGaussianTiles.cu
+++ b/src/fvdb/detail/ops/gsplat/IntersectGaussianTiles.cu
@@ -38,11 +38,11 @@ namespace {
 
 // Compute the number of 2d image tiles intersected by a set of 2D projected Gaussians.
 //
-// The input is a set of 2D circles with depths approximating the projection of 3D gaussians onto
-// the image plane. Each input circle is encoded as a tuple:
-// (mean_u, mean_v, radius, depth)
-// where (mean_u, mean_v) are the image-space center of the circle, radius is its radius (in pixels)
-// and depth is the (world-space) depth of the Gaussian this circle is approximating.
+// The input is a set of 2D ellipses (axis-aligned bounding boxes) with depths approximating the
+// projection of 3D gaussians onto the image plane. Each input is encoded as a tuple:
+// (mean_u, mean_v, radius_u, radius_v, depth)
+// where (mean_u, mean_v) are the image-space center, (radius_u, radius_v) are the per-axis
+// pixel radii of the AABB, and depth is the (world-space) depth of the Gaussian.
 //
 // The output is a set of counts of the number of tiles each Gaussian intersects.
 //
@@ -55,7 +55,7 @@ countTilesPerGaussian(const uint32_t gaussianOffset,
                       const uint32_t numTilesW,
                       const uint32_t numTilesH,
                       const T *__restrict__ means2d,                 // [C, N, 2] or [M, 2]
-                      const int32_t *__restrict__ radii,             // [C, N]    or [M]
+                      const int32_t *__restrict__ radii,             // [C, N, 2] or [M, 2]
                       const bool *__restrict__ tileMask,             // [C, H, W] or nullptr
                       const int32_t *__restrict__ cameraJIdx,        // NULL or [M]
                       CountT *__restrict__ outNumTilesPerGaussian) { // [ C * N ] or [ M ]
@@ -65,24 +65,26 @@ countTilesPerGaussian(const uint32_t gaussianOffset,
         // For now we'll upcast float16 and bfloat16 to float32
         using OpT = at::opmath_type<T>;
 
-        auto gidx        = idx + gaussianOffset;
-        const OpT radius = radii[gidx];
-        if (radius <= 0) {
+        auto gidx         = idx + gaussianOffset;
+        const OpT radiusU = radii[gidx * 2 + 0];
+        const OpT radiusV = radii[gidx * 2 + 1];
+        if (radiusU <= 0 || radiusV <= 0) {
             outNumTilesPerGaussian[gidx] = static_cast<CountT>(0);
         } else {
             using vec2f = float2;
 
-            const vec2f mean2d   = *reinterpret_cast<const vec2f *>(means2d + gidx * 2);
-            const OpT tileRadius = radius / static_cast<OpT>(tileSize);
-            const OpT tileMeanU  = mean2d.x / static_cast<OpT>(tileSize);
-            const OpT tileMeanV  = mean2d.y / static_cast<OpT>(tileSize);
+            const vec2f mean2d    = *reinterpret_cast<const vec2f *>(means2d + gidx * 2);
+            const OpT tileRadiusU = radiusU / static_cast<OpT>(tileSize);
+            const OpT tileRadiusV = radiusV / static_cast<OpT>(tileSize);
+            const OpT tileMeanU   = mean2d.x / static_cast<OpT>(tileSize);
+            const OpT tileMeanV   = mean2d.y / static_cast<OpT>(tileSize);
 
             // tile_min is inclusive, tile_max is exclusive
             uint2 tileMin, tileMax;
-            tileMin.x = min(max(0, (uint32_t)floor(tileMeanU - tileRadius)), numTilesW);
-            tileMin.y = min(max(0, (uint32_t)floor(tileMeanV - tileRadius)), numTilesH);
-            tileMax.x = min(max(0, (uint32_t)ceil(tileMeanU + tileRadius)), numTilesW);
-            tileMax.y = min(max(0, (uint32_t)ceil(tileMeanV + tileRadius)), numTilesH);
+            tileMin.x = min(max(0, (uint32_t)floor(tileMeanU - tileRadiusU)), numTilesW);
+            tileMin.y = min(max(0, (uint32_t)floor(tileMeanV - tileRadiusV)), numTilesH);
+            tileMax.x = min(max(0, (uint32_t)ceil(tileMeanU + tileRadiusU)), numTilesW);
+            tileMax.y = min(max(0, (uint32_t)ceil(tileMeanV + tileRadiusV)), numTilesH);
 
             outNumTilesPerGaussian[gidx] = [&]() {
                 if (tileMask) {
@@ -145,11 +147,11 @@ decodeCamTileKey(int64_t packedCamTileDepthKey, int32_t tileIdBits) {
 // Compute a set of intersections between the 2D projected Gaussians and each tile to be
 // rendered on screen.
 //
-// The input is a set of 2D circles with depths approximating the projection of 3D gaussians
-// onto the image plane. Each input circle is encoded as a tuple: (mean_u, mean_v, radius,
-// depth) where (mean_u, mean_v) are the image-space center of the circle, radius is its radius
-// (in pixels) and depth is the (world-space) depth of the Gaussian this circle is
-// approximating.
+// The input is a set of 2D AABBs with depths approximating the projection of 3D gaussians
+// onto the image plane. Each input is encoded as a tuple:
+// (mean_u, mean_v, radius_u, radius_v, depth) where (mean_u, mean_v) are the image-space center,
+// (radius_u, radius_v) are the per-axis pixel radii of the AABB, and depth is the (world-space)
+// depth of the Gaussian.
 //
 // The output is a set of gaussian/tile intersections where each intersection is parameterized
 // as: a tuple key (camera_id, tile_id, depth) gaussian_id value indexing into
@@ -172,7 +174,7 @@ computeGaussianTileIntersections(
     const uint32_t numTilesH,
     const uint32_t tileIdBits,
     const T *__restrict__ means2d,                   // [C, N, 2] or [M, 2]
-    const int32_t *__restrict__ radii,               // [C, N]    or [M]
+    const int32_t *__restrict__ radii,               // [C, N, 2] or [M, 2]
     const T *__restrict__ depths,                    // [C, N]    or [M]
     const int32_t *__restrict__ cumTilesPerGaussian, // [ C * N ] or [ M ]
     const bool *__restrict__ tileMask,               // [C, H, W] or nullptr
@@ -191,21 +193,23 @@ computeGaussianTileIntersections(
         const int32_t cidx =
             cameraJIdx == nullptr ? gidx / numGaussiansPerCamera : cameraJIdx[gidx];
 
-        const OpT radius = radii[gidx];
-        if (radius > 0) {
+        const OpT radiusU = radii[gidx * 2 + 0];
+        const OpT radiusV = radii[gidx * 2 + 1];
+        if (radiusU > 0 && radiusV > 0) {
             using vec2f = float2;
 
-            const vec2f mean2d   = *reinterpret_cast<const vec2f *>(means2d + 2 * gidx);
-            const OpT tileRadius = radius / static_cast<OpT>(tileSize);
-            const OpT tileMeanU  = mean2d.x / static_cast<OpT>(tileSize);
-            const OpT tileMeanV  = mean2d.y / static_cast<OpT>(tileSize);
+            const vec2f mean2d    = *reinterpret_cast<const vec2f *>(means2d + 2 * gidx);
+            const OpT tileRadiusU = radiusU / static_cast<OpT>(tileSize);
+            const OpT tileRadiusV = radiusV / static_cast<OpT>(tileSize);
+            const OpT tileMeanU   = mean2d.x / static_cast<OpT>(tileSize);
+            const OpT tileMeanV   = mean2d.y / static_cast<OpT>(tileSize);
 
             // tile_min is inclusive, tile_max is exclusive
             uint2 tileMin, tileMax;
-            tileMin.x = min(max(0, (uint32_t)floor(tileMeanU - tileRadius)), numTilesW);
-            tileMin.y = min(max(0, (uint32_t)floor(tileMeanV - tileRadius)), numTilesH);
-            tileMax.x = min(max(0, (uint32_t)ceil(tileMeanU + tileRadius)), numTilesW);
-            tileMax.y = min(max(0, (uint32_t)ceil(tileMeanV + tileRadius)), numTilesH);
+            tileMin.x = min(max(0, (uint32_t)floor(tileMeanU - tileRadiusU)), numTilesW);
+            tileMin.y = min(max(0, (uint32_t)floor(tileMeanV - tileRadiusV)), numTilesH);
+            tileMax.x = min(max(0, (uint32_t)ceil(tileMeanU + tileRadiusU)), numTilesW);
+            tileMax.y = min(max(0, (uint32_t)ceil(tileMeanV + tileRadiusV)), numTilesH);
 
             // If you use float64, we're casting you to float32 so we can
             // pack the depth into the key. In principle this loses precision,
@@ -355,7 +359,7 @@ computeTileOffsets(const uint32_t offset,
 std::tuple<torch::Tensor, torch::Tensor>
 intersectGaussianTilesCudaImpl(
     const torch::Tensor &means2d,                   // [C, N, 2] or [M, 2]
-    const torch::Tensor &radii,                     // [C, N] or [M]
+    const torch::Tensor &radii,                     // [C, N, 2] or [M, 2]
     const torch::Tensor &depths,                    // [C, N] or [M]
     const at::optional<torch::Tensor> &cameraJIdx,  // NULL or [M]
     const at::optional<torch::Tensor> &tileMask,    // NULL or [C, H, W]
@@ -374,7 +378,8 @@ intersectGaussianTilesCudaImpl(
     if (isPacked) {
         TORCH_CHECK(cameraJIdx.value().is_cuda(), "cameraJIdx must be a CUDA tensor");
         TORCH_CHECK_VALUE(means2d.dim() == 2, "means2d must have 2 dimensions (M, 2)");
-        TORCH_CHECK_VALUE(radii.dim() == 1, "radii must have 1 dimension (M)");
+        TORCH_CHECK_VALUE(radii.dim() == 2, "radii must have 2 dimensions (M, 2)");
+        TORCH_CHECK_VALUE(radii.size(1) == 2, "radii must have 2 components in the last dimension");
         TORCH_CHECK_VALUE(depths.dim() == 1, "depths must have 1 dimension (M)");
         TORCH_CHECK_VALUE(cameraJIdx.value().dim() == 1, "cameraJIdx must have 1 dimension (M)");
         TORCH_CHECK_VALUE(radii.size(0) == means2d.size(0),
@@ -388,11 +393,12 @@ intersectGaussianTilesCudaImpl(
         TORCH_CHECK_VALUE(means2d.size(0) == numCameras,
                           "means2d must have num_cameras in the first dimension");
         TORCH_CHECK_VALUE(means2d.size(2) == 2, "means2d must have 2 points in the last dimension");
-        TORCH_CHECK_VALUE(radii.dim() == 2, "radii must have 2 dimensions (C, N)");
+        TORCH_CHECK_VALUE(radii.dim() == 3, "radii must have 3 dimensions (C, N, 2)");
         TORCH_CHECK_VALUE(radii.size(0) == numCameras,
                           "radii must have numCameras in the first dimension");
         TORCH_CHECK_VALUE(radii.size(1) == means2d.size(1),
                           "radii must have the same number of points as means2d");
+        TORCH_CHECK_VALUE(radii.size(2) == 2, "radii must have 2 components in the last dimension");
         TORCH_CHECK_VALUE(depths.dim() == 2, "depths must have 2 dimensions (C, N)");
         TORCH_CHECK_VALUE(depths.size(0) == numCameras,
                           "depths must have numCameras in the first dimension");
@@ -587,7 +593,7 @@ sleepKernel() {
 std::tuple<torch::Tensor, torch::Tensor>
 intersectGaussianTilesPrivateUse1Impl(
     const torch::Tensor &means2d,                   // [C, N, 2] or [M, 2]
-    const torch::Tensor &radii,                     // [C, N] or [M]
+    const torch::Tensor &radii,                     // [C, N, 2] or [M, 2]
     const torch::Tensor &depths,                    // [C, N] or [M]
     const at::optional<torch::Tensor> &cameraJIdx,  // NULL or [M]
     const at::optional<torch::Tensor> &tileMask,    // NULL or [C, H, W]
@@ -607,7 +613,8 @@ intersectGaussianTilesPrivateUse1Impl(
         TORCH_CHECK(cameraJIdx.value().is_privateuseone(),
                     "camera_jidx must be a PrivateUse1 tensor");
         TORCH_CHECK_VALUE(means2d.dim() == 2, "means2d must have 2 dimensions (M, 2)");
-        TORCH_CHECK_VALUE(radii.dim() == 1, "radii must have 1 dimension (M)");
+        TORCH_CHECK_VALUE(radii.dim() == 2, "radii must have 2 dimensions (M, 2)");
+        TORCH_CHECK_VALUE(radii.size(1) == 2, "radii must have 2 components in the last dimension");
         TORCH_CHECK_VALUE(depths.dim() == 1, "depths must have 1 dimension (M)");
         TORCH_CHECK_VALUE(cameraJIdx.value().dim() == 1, "cameraJIdx must have 1 dimension (M)");
         TORCH_CHECK_VALUE(radii.size(0) == means2d.size(0),
@@ -621,11 +628,12 @@ intersectGaussianTilesPrivateUse1Impl(
         TORCH_CHECK_VALUE(means2d.size(0) == numCameras,
                           "means2d must have num_cameras in the first dimension");
         TORCH_CHECK_VALUE(means2d.size(2) == 2, "means2d must have 2 points in the last dimension");
-        TORCH_CHECK_VALUE(radii.dim() == 2, "radii must have 2 dimensions (C, N)");
+        TORCH_CHECK_VALUE(radii.dim() == 3, "radii must have 3 dimensions (C, N, 2)");
         TORCH_CHECK_VALUE(radii.size(0) == numCameras,
                           "radii must have num_cameras in the first dimension");
         TORCH_CHECK_VALUE(radii.size(1) == means2d.size(1),
                           "radii must have the same number of points as means2d");
+        TORCH_CHECK_VALUE(radii.size(2) == 2, "radii must have 2 components in the last dimension");
         TORCH_CHECK_VALUE(depths.dim() == 2, "depths must have 2 dimensions (C, N)");
         TORCH_CHECK_VALUE(depths.size(0) == numCameras,
                           "depths must have num_cameras in the first dimension");
@@ -917,7 +925,7 @@ intersectGaussianTilesPrivateUse1Impl(
 template <torch::DeviceType>
 std::tuple<torch::Tensor, torch::Tensor>
 dispatchIntersectGaussianTiles(const torch::Tensor &means2d,                 // [C, N, 2] or [M, 2]
-                               const torch::Tensor &radii,                   // [C, N] or [M]
+                               const torch::Tensor &radii,                   // [C, N, 2] or [M, 2]
                                const torch::Tensor &depths,                  // [C, N] or [M]
                                const at::optional<torch::Tensor> &cameraIds, // NULL or [M]
                                const uint32_t numCameras,
@@ -928,7 +936,7 @@ dispatchIntersectGaussianTiles(const torch::Tensor &means2d,                 // 
 template <torch::DeviceType>
 std::tuple<torch::Tensor, torch::Tensor>
 dispatchIntersectGaussianTilesSparse(const torch::Tensor &means2d,     // [C, N, 2] or [M, 2]
-                                     const torch::Tensor &radii,       // [C, N] or [M]
+                                     const torch::Tensor &radii,       // [C, N, 2] or [M, 2]
                                      const torch::Tensor &depths,      // [C, N] or [M]
                                      const torch::Tensor &tileMask,    // [C, H, W]
                                      const torch::Tensor &activeTiles, // [num_active_tiles]
@@ -942,7 +950,7 @@ template <>
 std::tuple<torch::Tensor, torch::Tensor>
 dispatchIntersectGaussianTiles<torch::kCUDA>(
     const torch::Tensor &means2d,                  // [C, N, 2] or [M, 2]
-    const torch::Tensor &radii,                    // [C, N] or [M]
+    const torch::Tensor &radii,                    // [C, N, 2] or [M, 2]
     const torch::Tensor &depths,                   // [C, N] or [M]
     const at::optional<torch::Tensor> &cameraJIdx, // NULL or [M]
     const uint32_t numCameras,
@@ -966,7 +974,7 @@ template <>
 std::tuple<torch::Tensor, torch::Tensor>
 dispatchIntersectGaussianTiles<torch::kPrivateUse1>(
     const torch::Tensor &means2d,                  // [C, N, 2] or [M, 2]
-    const torch::Tensor &radii,                    // [C, N] or [M]
+    const torch::Tensor &radii,                    // [C, N, 2] or [M, 2]
     const torch::Tensor &depths,                   // [C, N] or [M]
     const at::optional<torch::Tensor> &cameraJIdx, // NULL or [M]
     const uint32_t numCameras,
@@ -990,7 +998,7 @@ template <>
 std::tuple<torch::Tensor, torch::Tensor>
 dispatchIntersectGaussianTiles<torch::kCPU>(
     const torch::Tensor &means2d,                 // [C, N, 2] or [nnz, 2]
-    const torch::Tensor &radii,                   // [C, N] or [nnz]
+    const torch::Tensor &radii,                   // [C, N, 2] or [nnz, 2]
     const torch::Tensor &depths,                  // [C, N] or [nnz]
     const at::optional<torch::Tensor> &cameraIds, // NULL or [M]
     const uint32_t numCameras,
@@ -1004,7 +1012,7 @@ template <>
 std::tuple<torch::Tensor, torch::Tensor>
 dispatchIntersectGaussianTilesSparse<torch::kCUDA>(
     const torch::Tensor &means2d,                  // [C, N, 2] or [M, 2]
-    const torch::Tensor &radii,                    // [C, N] or [M]
+    const torch::Tensor &radii,                    // [C, N, 2] or [M, 2]
     const torch::Tensor &depths,                   // [C, N] or [M]
     const torch::Tensor &tileMask,                 // [C, H, W]
     const torch::Tensor &activeTiles,              // [num_active_tiles]
@@ -1030,7 +1038,7 @@ template <>
 std::tuple<torch::Tensor, torch::Tensor>
 dispatchIntersectGaussianTilesSparse<torch::kPrivateUse1>(
     const torch::Tensor &means2d,                  // [C, N, 2] or [M, 2]
-    const torch::Tensor &radii,                    // [C, N] or [M]
+    const torch::Tensor &radii,                    // [C, N, 2] or [M, 2]
     const torch::Tensor &depths,                   // [C, N] or [M]
     const torch::Tensor &tileMask,                 // [C, H, W]
     const torch::Tensor &activeTiles,              // [num_active_tiles]
@@ -1058,7 +1066,7 @@ template <>
 std::tuple<torch::Tensor, torch::Tensor>
 dispatchIntersectGaussianTilesSparse<torch::kCPU>(
     const torch::Tensor &means2d,                  // [C, N, 2] or [M, 2]
-    const torch::Tensor &radii,                    // [C, N] or [M]
+    const torch::Tensor &radii,                    // [C, N, 2] or [M, 2]
     const torch::Tensor &depths,                   // [C, N] or [M]
     const torch::Tensor &tileMask,                 // [C, H, W]
     const torch::Tensor &activeTiles,              // [num_active_tiles]
@@ -1073,7 +1081,7 @@ dispatchIntersectGaussianTilesSparse<torch::kCPU>(
 
 std::tuple<torch::Tensor, torch::Tensor>
 intersectGaussianTiles(const torch::Tensor &means2d,                 // [C, N, 2] or [M, 2]
-                       const torch::Tensor &radii,                   // [C, N] or [M]
+                       const torch::Tensor &radii,                   // [C, N, 2] or [M, 2]
                        const torch::Tensor &depths,                  // [C, N] or [M]
                        const at::optional<torch::Tensor> &cameraIds, // NULL or [M]
                        const uint32_t numCameras,
@@ -1088,7 +1096,7 @@ intersectGaussianTiles(const torch::Tensor &means2d,                 // [C, N, 2
 
 std::tuple<torch::Tensor, torch::Tensor>
 intersectGaussianTilesSparse(const torch::Tensor &means2d,                 // [C, N, 2] or [M, 2]
-                             const torch::Tensor &radii,                   // [C, N] or [M]
+                             const torch::Tensor &radii,                   // [C, N, 2] or [M, 2]
                              const torch::Tensor &depths,                  // [C, N] or [M]
                              const torch::Tensor &tileMask,                // [C, H, W]
                              const torch::Tensor &activeTiles,             // [num_active_tiles]

--- a/src/fvdb/detail/ops/gsplat/IntersectGaussianTiles.cu
+++ b/src/fvdb/detail/ops/gsplat/IntersectGaussianTiles.cu
@@ -378,6 +378,7 @@ intersectGaussianTilesCudaImpl(
     if (isPacked) {
         TORCH_CHECK(cameraJIdx.value().is_cuda(), "cameraJIdx must be a CUDA tensor");
         TORCH_CHECK_VALUE(means2d.dim() == 2, "means2d must have 2 dimensions (M, 2)");
+        TORCH_CHECK_VALUE(means2d.size(1) == 2, "means2d must have 2 points in the last dimension");
         TORCH_CHECK_VALUE(radii.dim() == 2, "radii must have 2 dimensions (M, 2)");
         TORCH_CHECK_VALUE(radii.size(1) == 2, "radii must have 2 components in the last dimension");
         TORCH_CHECK_VALUE(depths.dim() == 1, "depths must have 1 dimension (M)");
@@ -613,6 +614,7 @@ intersectGaussianTilesPrivateUse1Impl(
         TORCH_CHECK(cameraJIdx.value().is_privateuseone(),
                     "camera_jidx must be a PrivateUse1 tensor");
         TORCH_CHECK_VALUE(means2d.dim() == 2, "means2d must have 2 dimensions (M, 2)");
+        TORCH_CHECK_VALUE(means2d.size(1) == 2, "means2d must have 2 points in the last dimension");
         TORCH_CHECK_VALUE(radii.dim() == 2, "radii must have 2 dimensions (M, 2)");
         TORCH_CHECK_VALUE(radii.size(1) == 2, "radii must have 2 components in the last dimension");
         TORCH_CHECK_VALUE(depths.dim() == 1, "depths must have 1 dimension (M)");

--- a/src/fvdb/detail/ops/gsplat/IntersectGaussianTiles.h
+++ b/src/fvdb/detail/ops/gsplat/IntersectGaussianTiles.h
@@ -15,7 +15,7 @@ namespace ops {
 /// @brief Compute the intersection of 2D Gaussians with image tiles for efficient rasterization
 std::tuple<torch::Tensor, torch::Tensor>
 intersectGaussianTiles(const torch::Tensor &means2d,                 // [C, N, 2] or [M, 2]
-                       const torch::Tensor &radii,                   // [C, N] or [M]
+                       const torch::Tensor &radii,                   // [C, N, 2] or [M, 2]
                        const torch::Tensor &depths,                  // [C, N] or [M]
                        const at::optional<torch::Tensor> &cameraIds, // NULL or [M]
                        const uint32_t numCameras,
@@ -26,7 +26,7 @@ intersectGaussianTiles(const torch::Tensor &means2d,                 // [C, N, 2
 /// @brief Compute the intersection of 2D Gaussians with image tiles for sparse rendering
 std::tuple<torch::Tensor, torch::Tensor>
 intersectGaussianTilesSparse(const torch::Tensor &means2d,                 // [C, N, 2] or [M, 2]
-                             const torch::Tensor &radii,                   // [C, N] or [M]
+                             const torch::Tensor &radii,                   // [C, N, 2] or [M, 2]
                              const torch::Tensor &depths,                  // [C, N] or [M]
                              const torch::Tensor &tileMask,                // [C, H, W]
                              const torch::Tensor &activeTiles,             // [num_active_tiles]

--- a/src/fvdb/detail/ops/gsplat/ProjectGaussiansAnalyticBackward.cu
+++ b/src/fvdb/detail/ops/gsplat/ProjectGaussiansAnalyticBackward.cu
@@ -42,7 +42,7 @@ projectionBackwardKernel(const int32_t offset,
                          Camera camera,
                          const T eps2d,
                          // fwd outputs
-                         const int32_t *__restrict__ radii,   // [C, N]
+                         const int32_t *__restrict__ radii,   // [C, N, 2]
                          const T *__restrict__ conics,        // [C, N, 3]
                          const T *__restrict__ compensations, // [C, N] optional
                          // grad outputs
@@ -75,7 +75,11 @@ projectionBackwardKernel(const int32_t offset,
     }
     gId += offset;
     auto idx = cId * N + gId;
-    if (radii[idx] <= 0) {
+    // Per-axis visibility — culled gaussians have (0, 0); we also short-circuit
+    // when either axis is zero, matching the forward's cull logic.
+    const int32_t radiusX = radii[idx * 2 + 0];
+    const int32_t radiusY = radii[idx * 2 + 1];
+    if (radiusX <= 0 || radiusY <= 0) {
         return;
     }
 
@@ -186,7 +190,8 @@ projectionBackwardKernel(const int32_t offset,
         gpuAtomicAdd(outDLossDMeans2dNormAccum + gId, norm);
         gpuAtomicAdd(outGradientStepCounts + gId, 1);
         if (outMaxRadiiAccum != nullptr) {
-            atomicMax(outMaxRadiiAccum + gId, radii[idx]);
+            const int32_t maxRadius = (radiusX > radiusY) ? radiusX : radiusY;
+            atomicMax(outMaxRadiiAccum + gId, maxRadius);
         }
     }
 }
@@ -205,7 +210,7 @@ dispatchProjectGaussiansAnalyticBwd(
     const uint32_t imageWidth,
     const uint32_t imageHeight,
     const float eps2d,
-    const torch::Tensor &radii,                             // [C, N]
+    const torch::Tensor &radii,                             // [C, N, 2]
     const torch::Tensor &conics,                            // [C, N, 3]
     const torch::Tensor &dLossDMeans2d,                     // [C, N, 2]
     const torch::Tensor &dLossDDepths,                      // [C, N]
@@ -231,7 +236,7 @@ dispatchProjectGaussiansAnalyticBwd<torch::kCUDA>(
     const uint32_t imageHeight,
     const float eps2d,
     // fwd outputs
-    const torch::Tensor &radii,  // [C, N]
+    const torch::Tensor &radii,  // [C, N, 2]
     const torch::Tensor &conics, // [C, N, 3]
     // grad outputs
     const torch::Tensor &dLossDMeans2d,                              // [C, N, 2]
@@ -412,7 +417,7 @@ dispatchProjectGaussiansAnalyticBwd<torch::kPrivateUse1>(
     const uint32_t imageHeight,
     const float eps2d,
     // fwd outputs
-    const torch::Tensor &radii,  // [C, N]
+    const torch::Tensor &radii,  // [C, N, 2]
     const torch::Tensor &conics, // [C, N, 3]
     // grad outputs
     const torch::Tensor &dLossDMeans2d,                     // [C, N, 2]
@@ -670,7 +675,7 @@ dispatchProjectGaussiansAnalyticBwd<torch::kCPU>(
     const uint32_t imageHeight,
     const float eps2d,
     // fwd outputs
-    const torch::Tensor &radii,  // [C, N]
+    const torch::Tensor &radii,  // [C, N, 2]
     const torch::Tensor &conics, // [C, N, 3]
     // grad outputs
     const torch::Tensor &dLossDMeans2d,                     // [C, N, 2]
@@ -696,7 +701,7 @@ projectGaussiansAnalyticBwd(
     const uint32_t imageWidth,
     const uint32_t imageHeight,
     const float eps2d,
-    const torch::Tensor &radii,                             // [C, N]
+    const torch::Tensor &radii,                             // [C, N, 2]
     const torch::Tensor &conics,                            // [C, N, 3]
     const torch::Tensor &dLossDMeans2d,                     // [C, N, 2]
     const torch::Tensor &dLossDDepths,                      // [C, N]

--- a/src/fvdb/detail/ops/gsplat/ProjectGaussiansAnalyticForward.cu
+++ b/src/fvdb/detail/ops/gsplat/ProjectGaussiansAnalyticForward.cu
@@ -45,7 +45,7 @@ template <typename T, typename Camera> struct ProjectionForward {
     fvdb::TorchRAcc64<T, 2> mLogScalesAcc; // [N, 3]
 
     // Outputs
-    fvdb::TorchRAcc64<int32_t, 2> mOutRadiiAcc; // [C, N]
+    fvdb::TorchRAcc64<int32_t, 3> mOutRadiiAcc; // [C, N, 2]
     fvdb::TorchRAcc64<T, 3> mOutMeans2dAcc;     // [C, N, 2]
     fvdb::TorchRAcc64<T, 2> mOutDepthsAcc;      // [C, N]
     fvdb::TorchRAcc64<T, 3> mOutConicsAcc;      // [C, N, 3]
@@ -63,7 +63,7 @@ template <typename T, typename Camera> struct ProjectionForward {
                       const torch::Tensor &means,     // [N, 3]
                       const torch::Tensor &quats,     // [N, 4]
                       const torch::Tensor &logScales, // [N, 3]
-                      torch::Tensor outRadii,         // [C, N]
+                      torch::Tensor outRadii,         // [C, N, 2]
                       torch::Tensor outMeans2d,       // [C, N, 2]
                       torch::Tensor outDepths,        // [C, N]
                       torch::Tensor outConics,        // [C, N, 3]
@@ -72,7 +72,7 @@ template <typename T, typename Camera> struct ProjectionForward {
           mMeansAcc(means.packed_accessor64<T, 2, torch::RestrictPtrTraits>()),
           mQuatsAcc(quats.packed_accessor64<T, 2, torch::RestrictPtrTraits>()),
           mLogScalesAcc(logScales.packed_accessor64<T, 2, torch::RestrictPtrTraits>()),
-          mOutRadiiAcc(outRadii.packed_accessor64<int32_t, 2, torch::RestrictPtrTraits>()),
+          mOutRadiiAcc(outRadii.packed_accessor64<int32_t, 3, torch::RestrictPtrTraits>()),
           mOutMeans2dAcc(outMeans2d.packed_accessor64<T, 3, torch::RestrictPtrTraits>()),
           mOutDepthsAcc(outDepths.packed_accessor64<T, 2, torch::RestrictPtrTraits>()),
           mOutConicsAcc(outConics.packed_accessor64<T, 3, torch::RestrictPtrTraits>()),
@@ -109,35 +109,40 @@ template <typename T, typename Camera> struct ProjectionForward {
         auto [covar2d, mean2d, depthCam] =
             mCamera.projectWorldGaussianTo2D(cid, meanWorldSpace, covar);
         if (!mCamera.isDepthVisible(depthCam)) {
-            mOutRadiiAcc[cid][gid] = 0;
+            mOutRadiiAcc[cid][gid][0] = 0;
+            mOutRadiiAcc[cid][gid][1] = 0;
             return;
         }
 
         T compensation;
         const T det = addBlur(mEps2d, covar2d, compensation);
         if (det <= 0.f) {
-            mOutRadiiAcc[cid][gid] = 0;
+            mOutRadiiAcc[cid][gid][0] = 0;
+            mOutRadiiAcc[cid][gid][1] = 0;
             return;
         }
 
         const Mat2 covar2dInverse = covar2d.inverse();
 
-        // take 3 sigma as the radius (non-differentiable)
-        const T radius = radiusFromCovariance2dDet(covar2d, det, T(3));
-
-        if (radius <= mRadiusClip) {
-            mOutRadiiAcc[cid][gid] = 0;
+        // Per-axis radii from the 2D covariance diagonal at FVDB_EXTEND sigma.
+        // Both the radius-clip and the off-screen culls use these, so a gaussian
+        // survives the clip iff *either* axis exceeds it.
+        const T radiusX = ::cuda::std::ceil(T(FVDB_EXTEND) * ::cuda::std::sqrt(covar2d[0][0]));
+        const T radiusY = ::cuda::std::ceil(T(FVDB_EXTEND) * ::cuda::std::sqrt(covar2d[1][1]));
+        if (radiusX <= mRadiusClip && radiusY <= mRadiusClip) {
+            mOutRadiiAcc[cid][gid][0] = 0;
+            mOutRadiiAcc[cid][gid][1] = 0;
+            return;
+        }
+        if (mCamera.isProjectedFootprintOutsideImage(mean2d, radiusX, radiusY)) {
+            mOutRadiiAcc[cid][gid][0] = 0;
+            mOutRadiiAcc[cid][gid][1] = 0;
             return;
         }
 
-        // Mask out gaussians outside the image region
-        if (mCamera.isProjectedFootprintOutsideImage(mean2d, radius, radius)) {
-            mOutRadiiAcc[cid][gid] = 0;
-            return;
-        }
-
-        // Write outputs
-        mOutRadiiAcc[cid][gid]                   = int32_t(radius);
+        // Write outputs (per-axis radii match gsplat's intersect_tile convention).
+        mOutRadiiAcc[cid][gid][0]                = int32_t(radiusX);
+        mOutRadiiAcc[cid][gid][1]                = int32_t(radiusY);
         mOutMeans2dAcc[cid][gid][0]              = mean2d[0];
         mOutMeans2dAcc[cid][gid][1]              = mean2d[1];
         mOutDepthsAcc[cid][gid]                  = depthCam;
@@ -222,7 +227,7 @@ dispatchProjectGaussiansAnalyticFwd<torch::kCUDA>(
     const auto C                = worldToCamMatrices.size(0); // number of cameras
     at::cuda::CUDAStream stream = at::cuda::getCurrentCUDAStream(means.device().index());
 
-    torch::Tensor outRadii   = torch::empty({C, N}, means.options().dtype(torch::kInt32));
+    torch::Tensor outRadii   = torch::empty({C, N, 2}, means.options().dtype(torch::kInt32));
     torch::Tensor outMeans2d = torch::empty({C, N, 2}, means.options());
     torch::Tensor outDepths  = torch::empty({C, N}, means.options());
     torch::Tensor outConics  = torch::empty({C, N, 3}, means.options());
@@ -320,7 +325,7 @@ dispatchProjectGaussiansAnalyticFwd<torch::kPrivateUse1>(
     const auto N = means.size(0);              // number of gaussians
     const auto C = worldToCamMatrices.size(0); // number of cameras
 
-    torch::Tensor outRadii   = torch::empty({C, N}, means.options().dtype(torch::kInt32));
+    torch::Tensor outRadii   = torch::empty({C, N, 2}, means.options().dtype(torch::kInt32));
     torch::Tensor outMeans2d = torch::empty({C, N, 2}, means.options());
     torch::Tensor outDepths  = torch::empty({C, N}, means.options());
     torch::Tensor outConics  = torch::empty({C, N, 3}, means.options());

--- a/src/fvdb/detail/ops/gsplat/ProjectGaussiansAnalyticJaggedBackward.cu
+++ b/src/fvdb/detail/ops/gsplat/ProjectGaussiansAnalyticJaggedBackward.cu
@@ -41,7 +41,7 @@ jaggedProjectionBackwardKernel(
     Camera camera,
     const T eps2d,
     // fwd outputs
-    const int32_t *__restrict__ radii,   // [N]
+    const int32_t *__restrict__ radii,   // [N, 2]
     const T *__restrict__ conics,        // [N, 3]
     const T *__restrict__ compensations, // [N] optional
     // grad outputs
@@ -57,7 +57,11 @@ jaggedProjectionBackwardKernel(
     T *__restrict__ outDLossDWorldToCamMatrices) { // [C, 4, 4] optional
     // parallelize over N.
     const uint32_t idx = cg::this_grid().thread_rank();
-    if (idx >= N || radii[idx] <= 0) {
+    if (idx >= N) {
+        return;
+    }
+    // Per-axis visibility: culled gaussians have (0, 0).
+    if (radii[idx * 2 + 0] <= 0 || radii[idx * 2 + 1] <= 0) {
         return;
     }
 
@@ -194,7 +198,7 @@ dispatchProjectGaussiansAnalyticJaggedBwd(const torch::Tensor &gSizes, // [B] ga
                                           const uint32_t imageWidth,
                                           const uint32_t imageHeight,
                                           const float eps2d,
-                                          const torch::Tensor &radii,         // [N]
+                                          const torch::Tensor &radii,         // [N, 2]
                                           const torch::Tensor &conics,        // [N, 3]
                                           const torch::Tensor &dLossDMeans2d, // [N, 2]
                                           const torch::Tensor &dLossDDepths,  // [N]
@@ -216,7 +220,7 @@ dispatchProjectGaussiansAnalyticJaggedBwd<torch::kCUDA>(
     const uint32_t imageHeight,
     const float eps2d,
     // fwd outputs
-    const torch::Tensor &radii,  // [N]
+    const torch::Tensor &radii,  // [N, 2]
     const torch::Tensor &conics, // [N, 3]
     // grad outputs
     const torch::Tensor &dLossDMeans2d, // [N, 2]
@@ -389,7 +393,7 @@ dispatchProjectGaussiansAnalyticJaggedBwd<torch::kCPU>(
     const uint32_t imageWidth,
     const uint32_t imageHeight,
     const float eps2d,
-    const torch::Tensor &radii,         // [N]
+    const torch::Tensor &radii,         // [N, 2]
     const torch::Tensor &conics,        // [N, 3]
     const torch::Tensor &dLossDMeans2d, // [N, 2]
     const torch::Tensor &dLossDDepths,  // [N]
@@ -410,7 +414,7 @@ projectGaussiansAnalyticJaggedBwd(const torch::Tensor &gSizes,             // [B
                                   const uint32_t imageWidth,
                                   const uint32_t imageHeight,
                                   const float eps2d,
-                                  const torch::Tensor &radii,         // [N]
+                                  const torch::Tensor &radii,         // [N, 2]
                                   const torch::Tensor &conics,        // [N, 3]
                                   const torch::Tensor &dLossDMeans2d, // [N, 2]
                                   const torch::Tensor &dLossDDepths,  // [N]

--- a/src/fvdb/detail/ops/gsplat/ProjectGaussiansAnalyticJaggedForward.cu
+++ b/src/fvdb/detail/ops/gsplat/ProjectGaussiansAnalyticJaggedForward.cu
@@ -36,7 +36,7 @@ jaggedProjectionForwardKernel(const uint32_t B,
                               const T eps2d,
                               const T radiusClip,
                               // outputs
-                              int32_t *__restrict__ radii,  // [N]
+                              int32_t *__restrict__ radii,  // [N, 2]
                               T *__restrict__ means2d,      // [N, 2]
                               T *__restrict__ depths,       // [N]
                               T *__restrict__ conics,       // [N, 3]
@@ -74,38 +74,41 @@ jaggedProjectionForwardKernel(const uint32_t B,
     }
     auto [covar2d, mean2d, depthCam] = camera.projectWorldGaussianTo2D(cId, meanWorldSpace, covar);
     if (!camera.isDepthVisible(depthCam)) {
-        radii[idx] = 0;
+        radii[idx * 2 + 0] = 0;
+        radii[idx * 2 + 1] = 0;
         return;
     }
 
     T compensation;
     const T det = addBlur(eps2d, covar2d, compensation);
     if (det <= 0.f) {
-        radii[idx] = 0;
+        radii[idx * 2 + 0] = 0;
+        radii[idx * 2 + 1] = 0;
         return;
     }
 
     // compute the inverse of the 2d covariance
     const nanovdb::math::Mat2<T> covar2dInverse = covar2d.inverse();
 
-    // take 3 sigma as the radius (non-differentiable)
-    const T radius = radiusFromCovariance2dDet(covar2d, det, T(3));
-    // T v2 = b - sqrt(max(0.1f, b * b - det));
-    // T radius = ceil(3.f * sqrt(max(v1, v2)));
-
-    if (radius <= radiusClip) {
-        radii[idx] = 0;
+    // Per-axis radii from the 2D covariance diagonal at FVDB_EXTEND sigma.
+    // Both the radius-clip and the off-screen culls use these, so a gaussian
+    // survives the clip iff *either* axis exceeds it.
+    const T radiusX = ::cuda::std::ceil(T(FVDB_EXTEND) * ::cuda::std::sqrt(covar2d[0][0]));
+    const T radiusY = ::cuda::std::ceil(T(FVDB_EXTEND) * ::cuda::std::sqrt(covar2d[1][1]));
+    if (radiusX <= radiusClip && radiusY <= radiusClip) {
+        radii[idx * 2 + 0] = 0;
+        radii[idx * 2 + 1] = 0;
+        return;
+    }
+    if (camera.isProjectedFootprintOutsideImage(mean2d, radiusX, radiusY)) {
+        radii[idx * 2 + 0] = 0;
+        radii[idx * 2 + 1] = 0;
         return;
     }
 
-    // mask out gaussians outside the image region
-    if (camera.isProjectedFootprintOutsideImage(mean2d, radius, radius)) {
-        radii[idx] = 0;
-        return;
-    }
-
-    // write to outputs
-    radii[idx]                               = (int32_t)radius;
+    // Per-axis radii (matches gsplat's intersect_tile convention).
+    radii[idx * 2 + 0]                       = (int32_t)radiusX;
+    radii[idx * 2 + 1]                       = (int32_t)radiusY;
     means2d[idx * 2]                         = mean2d[0];
     means2d[idx * 2 + 1]                     = mean2d[1];
     depths[idx]                              = depthCam;
@@ -189,7 +192,7 @@ dispatchProjectGaussiansAnalyticJaggedFwd<torch::kCUDA>(
 
     at::cuda::CUDAStream stream = at::cuda::getCurrentCUDAStream(means.device().index());
 
-    torch::Tensor radii   = torch::empty({N}, means.options().dtype(torch::kInt32));
+    torch::Tensor radii   = torch::empty({N, 2}, means.options().dtype(torch::kInt32));
     torch::Tensor means2d = torch::empty({N, 2}, means.options());
     torch::Tensor depths  = torch::empty({N}, means.options());
     torch::Tensor conics  = torch::empty({N, 3}, means.options());

--- a/src/fvdb/detail/ops/gsplat/ProjectGaussiansUnscentedForward.cu
+++ b/src/fvdb/detail/ops/gsplat/ProjectGaussiansUnscentedForward.cu
@@ -192,8 +192,6 @@ template <typename ScalarType, typename Camera> struct ProjectionForwardUT {
     // Scalar Inputs
     const int64_t C;
     const int64_t N;
-    const int32_t mImageWidth;
-    const int32_t mImageHeight;
     const ScalarType mEps2d;
     const ScalarType mNearPlane;
     const ScalarType mFarPlane;
@@ -211,7 +209,7 @@ template <typename ScalarType, typename Camera> struct ProjectionForwardUT {
     const fvdb::TorchRAcc64<ScalarType, 2> mDistortionCoeffsAcc;        // [C, K]
 
     // Outputs
-    fvdb::TorchRAcc64<int32_t, 2> mOutRadiiAcc;      // [C, N]
+    fvdb::TorchRAcc64<int32_t, 3> mOutRadiiAcc;      // [C, N, 2]
     fvdb::TorchRAcc64<ScalarType, 3> mOutMeans2dAcc; // [C, N, 2]
     fvdb::TorchRAcc64<ScalarType, 2> mOutDepthsAcc;  // [C, N]
     fvdb::TorchRAcc64<ScalarType, 3> mOutConicsAcc;  // [C, N, 3]
@@ -224,8 +222,6 @@ template <typename ScalarType, typename Camera> struct ProjectionForwardUT {
 
     /// @brief Construct the functor with configuration and tensor references.
     ///
-    /// @param[in] imageWidth Image width in pixels.
-    /// @param[in] imageHeight Image height in pixels.
     /// @param[in] eps2d Blur epsilon added to covariance for numerical stability.
     /// @param[in] nearPlane Near-plane threshold for depth culling.
     /// @param[in] farPlane Far-plane threshold for depth culling.
@@ -241,14 +237,12 @@ template <typename ScalarType, typename Camera> struct ProjectionForwardUT {
     /// @param[in] worldToCamMatricesEnd [C,4,4] tensor.
     /// @param[in] projectionMatrices [C,3,3] tensor.
     /// @param[in] distortionCoeffs [C,K] tensor (K=0 for PINHOLE/ORTHOGRAPHIC; K=12 for OPENCV).
-    /// @param[out] outRadii [C,N] tensor.
+    /// @param[out] outRadii [C,N,2] tensor (per-axis pixel radius).
     /// @param[out] outMeans2d [C,N,2] tensor.
     /// @param[out] outDepths [C,N] tensor.
     /// @param[out] outConics [C,N,3] tensor.
     /// @param[out] outCompensations [C,N] tensor (optional, may be undefined).
-    ProjectionForwardUT(const int64_t imageWidth,
-                        const int64_t imageHeight,
-                        const ScalarType eps2d,
+    ProjectionForwardUT(const ScalarType eps2d,
                         const ScalarType nearPlane,
                         const ScalarType farPlane,
                         const ScalarType minRadius2d,
@@ -262,15 +256,13 @@ template <typename ScalarType, typename Camera> struct ProjectionForwardUT {
                         const torch::Tensor &worldToCamMatricesEnd,   // [C, 4, 4]
                         const torch::Tensor &projectionMatrices,      // [C, 3, 3]
                         const torch::Tensor &distortionCoeffs,        // [C, K]
-                        torch::Tensor &outRadii,                      // [C, N]
+                        torch::Tensor &outRadii,                      // [C, N, 2]
                         torch::Tensor &outMeans2d,                    // [C, N, 2]
                         torch::Tensor &outDepths,                     // [C, N]
                         torch::Tensor &outConics,                     // [C, N, 3]
                         torch::Tensor &outCompensations               // [C, N] optional
                         )
-        : C(projectionMatrices.size(0)), N(means.size(0)),
-          mImageWidth(static_cast<int32_t>(imageWidth)),
-          mImageHeight(static_cast<int32_t>(imageHeight)), mEps2d(eps2d), mNearPlane(nearPlane),
+        : C(projectionMatrices.size(0)), N(means.size(0)), mEps2d(eps2d), mNearPlane(nearPlane),
           mFarPlane(farPlane), mRadiusClip(minRadius2d), mUTParams(utParams), mCamera(camera),
           mMeansAcc(means.packed_accessor64<ScalarType, 2, torch::RestrictPtrTraits>()),
           mQuatsAcc(quats.packed_accessor64<ScalarType, 2, torch::RestrictPtrTraits>()),
@@ -283,7 +275,7 @@ template <typename ScalarType, typename Camera> struct ProjectionForwardUT {
               projectionMatrices.packed_accessor64<ScalarType, 3, torch::RestrictPtrTraits>()),
           mDistortionCoeffsAcc(
               distortionCoeffs.packed_accessor64<ScalarType, 2, torch::RestrictPtrTraits>()),
-          mOutRadiiAcc(outRadii.packed_accessor64<int32_t, 2, torch::RestrictPtrTraits>()),
+          mOutRadiiAcc(outRadii.packed_accessor64<int32_t, 3, torch::RestrictPtrTraits>()),
           mOutMeans2dAcc(outMeans2d.packed_accessor64<ScalarType, 3, torch::RestrictPtrTraits>()),
           mOutDepthsAcc(outDepths.packed_accessor64<ScalarType, 2, torch::RestrictPtrTraits>()),
           mOutConicsAcc(outConics.packed_accessor64<ScalarType, 3, torch::RestrictPtrTraits>()),
@@ -322,7 +314,8 @@ template <typename ScalarType, typename Camera> struct ProjectionForwardUT {
             const ScalarType tDepth = ScalarType(0.5);
             const ScalarType depth  = mCamera.cameraDepthAtTime(camId, meanWorldSpace, tDepth);
             if (depth < mNearPlane || depth > mFarPlane) {
-                mOutRadiiAcc[camId][gaussianId] = 0;
+                mOutRadiiAcc[camId][gaussianId][0] = 0;
+                mOutRadiiAcc[camId][gaussianId][1] = 0;
                 return;
             }
         }
@@ -351,20 +344,23 @@ template <typename ScalarType, typename Camera> struct ProjectionForwardUT {
             // Hard reject if any sigma point is behind the camera since the projection will be
             // discontinuous.
             if (status == ProjectionVisibility::BehindCamera) {
-                mOutRadiiAcc[camId][gaussianId] = 0;
+                mOutRadiiAcc[camId][gaussianId][0] = 0;
+                mOutRadiiAcc[camId][gaussianId][1] = 0;
                 return;
             }
             const bool valid_i  = (status == ProjectionVisibility::InImage);
             projected_points[i] = pix;
             valid_any |= valid_i;
             if (mUTParams.requireAllSigmaPointsInImage && !valid_i) {
-                mOutRadiiAcc[camId][gaussianId] = 0;
+                mOutRadiiAcc[camId][gaussianId][0] = 0;
+                mOutRadiiAcc[camId][gaussianId][1] = 0;
                 return;
             }
         }
 
         if (!mUTParams.requireAllSigmaPointsInImage && !valid_any) {
-            mOutRadiiAcc[camId][gaussianId] = 0;
+            mOutRadiiAcc[camId][gaussianId][0] = 0;
+            mOutRadiiAcc[camId][gaussianId][1] = 0;
             return;
         }
 
@@ -382,7 +378,8 @@ template <typename ScalarType, typename Camera> struct ProjectionForwardUT {
         ScalarType compensation;
         const ScalarType det_blur = addBlur(mEps2d, covar2d, compensation);
         if (det_blur <= ScalarType(0)) {
-            mOutRadiiAcc[camId][gaussianId] = 0;
+            mOutRadiiAcc[camId][gaussianId][0] = 0;
+            mOutRadiiAcc[camId][gaussianId][1] = 0;
             return;
         }
 
@@ -392,7 +389,8 @@ template <typename ScalarType, typename Camera> struct ProjectionForwardUT {
 
         const ScalarType det_psd = covar2d[0][0] * covar2d[1][1] - covar2d[0][1] * covar2d[1][0];
         if (!(det_psd > ScalarType(0))) {
-            mOutRadiiAcc[camId][gaussianId] = 0;
+            mOutRadiiAcc[camId][gaussianId][0] = 0;
+            mOutRadiiAcc[camId][gaussianId][1] = 0;
             return;
         }
 
@@ -402,25 +400,26 @@ template <typename ScalarType, typename Camera> struct ProjectionForwardUT {
         const ScalarType b      = 0.5f * (covar2d[0][0] + covar2d[1][1]);
         const ScalarType tmp    = sqrtf(max(0.01f, b * b - det_psd));
         const ScalarType v1     = b + tmp; // larger eigenvalue
-        const ScalarType extend = 3.0f;    // 3 sigma
+        const ScalarType extend = FVDB_EXTEND;
         ScalarType r1           = extend * sqrtf(v1);
         ScalarType radius_x     = ceilf(min(extend * sqrtf(covar2d[0][0]), r1));
         ScalarType radius_y     = ceilf(min(extend * sqrtf(covar2d[1][1]), r1));
 
         if (radius_x <= mRadiusClip && radius_y <= mRadiusClip) {
-            mOutRadiiAcc[camId][gaussianId] = 0;
+            mOutRadiiAcc[camId][gaussianId][0] = 0;
+            mOutRadiiAcc[camId][gaussianId][1] = 0;
             return;
         }
 
-        // Mask out gaussians outside the image region
-        if (mean2d[0] + radius_x <= 0 || mean2d[0] - radius_x >= mImageWidth ||
-            mean2d[1] + radius_y <= 0 || mean2d[1] - radius_y >= mImageHeight) {
-            mOutRadiiAcc[camId][gaussianId] = 0;
+        if (mCamera.isProjectedFootprintOutsideImage(mean2d, radius_x, radius_y)) {
+            mOutRadiiAcc[camId][gaussianId][0] = 0;
+            mOutRadiiAcc[camId][gaussianId][1] = 0;
             return;
         }
 
-        // Write outputs (using radius_x for compatibility, but could use both)
-        mOutRadiiAcc[camId][gaussianId]      = int32_t(max(radius_x, radius_y));
+        // Write outputs (per-axis pixel radii, matching gsplat's intersect_tile convention).
+        mOutRadiiAcc[camId][gaussianId][0]   = int32_t(radius_x);
+        mOutRadiiAcc[camId][gaussianId][1]   = int32_t(radius_y);
         mOutMeans2dAcc[camId][gaussianId][0] = mean2d[0];
         mOutMeans2dAcc[camId][gaussianId][1] = mean2d[1];
         mOutDepthsAcc[camId][gaussianId] =
@@ -552,7 +551,7 @@ dispatchProjectGaussiansUnscentedFwd<torch::kCUDA>(
     TORCH_CHECK_VALUE(distortionCoeffs.size(0) == C,
                       "distortionCoeffs must have shape [C,K] matching projectionMatrices.size(0)");
 
-    torch::Tensor outRadii   = torch::empty({C, N}, means.options().dtype(torch::kInt32));
+    torch::Tensor outRadii   = torch::empty({C, N, 2}, means.options().dtype(torch::kInt32));
     torch::Tensor outMeans2d = torch::empty({C, N, 2}, means.options());
     torch::Tensor outDepths  = torch::empty({C, N}, means.options());
     torch::Tensor outConics  = torch::empty({C, N, 3}, means.options());
@@ -580,8 +579,6 @@ dispatchProjectGaussiansUnscentedFwd<torch::kCUDA>(
                                                           rollingShutterType);
         const size_t SHARED_MEM_SIZE = camera.numSharedMemBytes();
         ProjectionForwardUT<scalar_t, OrthographicWithDistortionCamera<scalar_t>> projectionForward(
-            imageWidth,
-            imageHeight,
             eps2d,
             nearPlane,
             farPlane,
@@ -619,8 +616,6 @@ dispatchProjectGaussiansUnscentedFwd<torch::kCUDA>(
                                                          cameraModel);
         const size_t SHARED_MEM_SIZE = camera.numSharedMemBytes();
         ProjectionForwardUT<scalar_t, PerspectiveWithDistortionCamera<scalar_t>> projectionForward(
-            imageWidth,
-            imageHeight,
             eps2d,
             nearPlane,
             farPlane,

--- a/src/fvdb/detail/utils/gsplat/GaussianCameras.cuh
+++ b/src/fvdb/detail/utils/gsplat/GaussianCameras.cuh
@@ -47,6 +47,12 @@ constexpr float kBackwardProjectionNearPlane = -1e10f;
 /// @brief Far-plane used when backward projection runs without user near/far clipping.
 constexpr float kBackwardProjectionFarPlane = 1e10f;
 
+/// @brief Sigma extent used when computing the 2D screen-space footprint of a
+/// gaussian from its covariance. A radius of `FVDB_EXTEND * sigma` covers
+/// ~99.91% of the gaussian's mass — anything outside this radius is treated as
+/// negligible by the projection / tile-intersection / radius-clip paths.
+constexpr float FVDB_EXTEND = 3.33f;
+
 /// @brief Unscented Transform hyperparameters.
 struct UTParams {
     float alpha                       = 0.1f;
@@ -91,17 +97,16 @@ isOutsideImageWithRadius(const nanovdb::math::Vec2<T> &mean2d,
 }
 
 /// @brief Estimate projected radius from a 2x2 covariance using the largest eigenvalue heuristic.
+/// Takes `FVDB_EXTEND` standard deviations of the largest eigenvalue, recovered from the
+/// trace/determinant of the 2x2 covariance.
 template <typename T>
 inline __device__ T
 radiusFromCovariance2dDet(const nanovdb::math::Mat2<T> &covar2d,
                           const T det,
-                          const T sigma,
                           const T detClamp = T(0.01)) {
-    // Matches the classic FVDB/gsplat heuristic: use the largest eigenvalue of the 2x2 covariance
-    // (via trace/determinant) and take `sigma` standard deviations.
     const T b  = T(0.5) * (covar2d[0][0] + covar2d[1][1]);
     const T v1 = b + ::cuda::std::sqrt(nanovdb::math::Max(detClamp, b * b - det));
-    return ::cuda::std::ceil(sigma * ::cuda::std::sqrt(v1));
+    return ::cuda::std::ceil(T(FVDB_EXTEND) * ::cuda::std::sqrt(v1));
 }
 
 /// @brief Pack symmetric inverse covariance [[a,b],[b,c]] into row-major-3 [a,b,c].
@@ -782,6 +787,14 @@ template <typename T> struct PerspectiveWithDistortionCamera {
         }
     }
 
+    /// @brief Returns true when the footprint AABB has no overlap with the image.
+    inline __device__ bool
+    isProjectedFootprintOutsideImage(const nanovdb::math::Vec2<T> &mean2d,
+                                     const T radiusX,
+                                     const T radiusY) const {
+        return isOutsideImageWithRadius(mean2d, radiusX, radiusY, imageWidth, imageHeight);
+    }
+
     /// @brief Returns camera-space depth at a given rolling-shutter time.
     inline __device__ T
     cameraDepthAtTime(const int64_t cid,
@@ -1166,6 +1179,14 @@ template <typename T> struct OrthographicWithDistortionCamera {
         copyMat3Accessor<T>(numCameras, worldToCamEndRotShared, worldToCamEndAcc);
         copyWorldToCamTranslation<T>(numCameras, worldToCamEndTransShared, worldToCamEndAcc);
         copyMat3Accessor<T>(numCameras, projectionMatsShared, projectionMatricesAcc);
+    }
+
+    /// @brief Returns true when the footprint AABB has no overlap with the image.
+    inline __device__ bool
+    isProjectedFootprintOutsideImage(const nanovdb::math::Vec2<T> &mean2d,
+                                     const T radiusX,
+                                     const T radiusY) const {
+        return isOutsideImageWithRadius(mean2d, radiusX, radiusY, imageWidth, imageHeight);
     }
 
     /// @brief Returns camera-space depth at a given rolling-shutter time.

--- a/src/fvdb/detail/utils/gsplat/GaussianRasterize.cuh
+++ b/src/fvdb/detail/utils/gsplat/GaussianRasterize.cuh
@@ -83,7 +83,7 @@ initJaggedAccessor(const fvdb::JaggedTensor &tensor, const std::string &name) {
 /// @tparam IS_PACKED Whether the Gaussian is packed (i.e. linearized across the outer dimensions)
 template <typename ScalarType, size_t NUM_CHANNELS, bool IS_PACKED> struct RasterizeCommonArgs {
     constexpr static size_t NUM_OUTER_DIMS         = IS_PACKED ? 1 : 2;
-    constexpr static ScalarType ALPHA_THRESHOLD    = ScalarType{0.999};
+    constexpr static ScalarType ALPHA_THRESHOLD    = ScalarType{0.99};
     using vec2t                                    = nanovdb::math::Vec2<ScalarType>;
     using vec3t                                    = nanovdb::math::Vec3<ScalarType>;
     template <typename T, int N> using TorchRAcc64 = fvdb::TorchRAcc64<T, N>;

--- a/src/fvdb/detail/utils/gsplat/GaussianRasterizeFromWorld.cuh
+++ b/src/fvdb/detail/utils/gsplat/GaussianRasterizeFromWorld.cuh
@@ -21,7 +21,7 @@
 namespace fvdb::detail::ops {
 
 /// Opacity threshold used by 3DGS alpha compositing.
-constexpr __device__ float kAlphaThreshold = 0.999f;
+constexpr __device__ float kAlphaThreshold = 0.99f;
 
 /// Common dense-tile rasterization arguments shared by from-world forward/backward kernels.
 struct RasterizeFromWorldCommonArgs {

--- a/src/tests/GaussianProjectionBackwardTest.cpp
+++ b/src/tests/GaussianProjectionBackwardTest.cpp
@@ -49,7 +49,13 @@ struct GaussianProjectionBackwardTestFixture : public ::testing::Test {
         if (inputNames.size() > 5) {
             compensations = inputs[5].cuda();
             radii         = inputs[6].cuda();
-            conics        = inputs[7].cuda();
+            // The golden snapshots store radii as scalar [C, N]; the kernel
+            // now expects per-axis [C, N, 2]. Duplicate the scalar onto both
+            // axes to preserve the snapshot's cull mask (max(r, r) == r).
+            if (radii.dim() == 2) {
+                radii = radii.unsqueeze(-1).expand({-1, -1, 2}).contiguous();
+            }
+            conics = inputs[7].cuda();
         }
 
         imageWidth   = 647;

--- a/src/tests/GaussianProjectionBackwardTest.cpp
+++ b/src/tests/GaussianProjectionBackwardTest.cpp
@@ -49,13 +49,7 @@ struct GaussianProjectionBackwardTestFixture : public ::testing::Test {
         if (inputNames.size() > 5) {
             compensations = inputs[5].cuda();
             radii         = inputs[6].cuda();
-            // The golden snapshots store radii as scalar [C, N]; the kernel
-            // now expects per-axis [C, N, 2]. Duplicate the scalar onto both
-            // axes to preserve the snapshot's cull mask (max(r, r) == r).
-            if (radii.dim() == 2) {
-                radii = radii.unsqueeze(-1).expand({-1, -1, 2}).contiguous();
-            }
-            conics = inputs[7].cuda();
+            conics        = inputs[7].cuda();
         }
 
         imageWidth   = 647;

--- a/src/tests/GaussianProjectionForwardTest.cpp
+++ b/src/tests/GaussianProjectionForwardTest.cpp
@@ -182,23 +182,18 @@ TEST_F(GaussianProjectionForwardTestFixture, TestPerspectiveProjection) {
                                                        false,
                                                        false);
 
-    // The golden snapshot's radii was saved as the old scalar [C, N] layout;
-    // radii is now per-axis [C, N, 2] with a per-axis formula, so we compare
-    // visibility sets instead of element-wise radii values.
-    const auto visible         = std::get<0>(torch::min(radii > 0, /*dim=*/-1));
-    const auto expectedVisible = expectedRadii > 0;
-    EXPECT_TRUE(visible.equal(expectedVisible));
-
     // Use relaxed tolerances to account for minor numerical differences between debug and release
     // builds. The default rtol=1e-5, atol=1e-8 are too strict for operations involving exp, sqrt,
     // and inverse
 #ifdef NDEBUG
     // Release build: stricter tolerances
     EXPECT_TRUE(torch::allclose(means2d, expectedMeans2d));
+    EXPECT_TRUE(torch::allclose(radii, expectedRadii));
     EXPECT_TRUE(torch::allclose(depths, expectedDepths));
 #else
     // Debug build: relaxed tolerances due to different FP optimizations
     EXPECT_TRUE(torch::allclose(means2d, expectedMeans2d, 1e-4, 1e-4));
+    EXPECT_TRUE(torch::allclose(radii.to(torch::kFloat), expectedRadii.to(torch::kFloat), 0, 1));
     EXPECT_TRUE(torch::allclose(depths, expectedDepths, 1e-5, 1e-5));
 #endif
     // rtol=1e-4 and atol=1e-4 accounts for the fact that the test data used log(scales) instead of
@@ -224,10 +219,8 @@ TEST_F(GaussianProjectionForwardTestFixture, TestOrthographicProjection) {
                                                        false,
                                                        true);
 
-    // Radii is now per-axis [C, N, 2]; a gaussian is visible iff both axes
-    // are positive. The golden snapshot stored the old scalar [C, N] mask.
+    // other outputs are undefined where radii is zero
     auto radiiNonZeroMask = std::get<0>(torch::min(radii > 0, /*dim=*/-1)); // [C, N]
-    EXPECT_TRUE(radiiNonZeroMask.equal(expectedRadii > 0));
 
     // Use relaxed tolerances to account for minor numerical differences between debug and release
     // builds
@@ -235,12 +228,14 @@ TEST_F(GaussianProjectionForwardTestFixture, TestOrthographicProjection) {
     // Release build: stricter tolerances
     EXPECT_TRUE(torch::allclose(means2d.index({radiiNonZeroMask}),
                                 expectedMeans2d.index({radiiNonZeroMask})));
+    EXPECT_TRUE(torch::allclose(radii, expectedRadii));
     EXPECT_TRUE(torch::allclose(depths.index({radiiNonZeroMask}),
                                 expectedDepths.index({radiiNonZeroMask})));
 #else
     // Debug build: relaxed tolerances due to different FP optimizations
     EXPECT_TRUE(torch::allclose(
         means2d.index({radiiNonZeroMask}), expectedMeans2d.index({radiiNonZeroMask}), 1e-4, 1e-4));
+    EXPECT_TRUE(torch::allclose(radii.to(torch::kFloat), expectedRadii.to(torch::kFloat), 0, 1));
     EXPECT_TRUE(torch::allclose(
         depths.index({radiiNonZeroMask}), expectedDepths.index({radiiNonZeroMask}), 1e-5, 1e-5));
 #endif

--- a/src/tests/GaussianProjectionForwardTest.cpp
+++ b/src/tests/GaussianProjectionForwardTest.cpp
@@ -182,18 +182,23 @@ TEST_F(GaussianProjectionForwardTestFixture, TestPerspectiveProjection) {
                                                        false,
                                                        false);
 
+    // The golden snapshot's radii was saved as the old scalar [C, N] layout;
+    // radii is now per-axis [C, N, 2] with a per-axis formula, so we compare
+    // visibility sets instead of element-wise radii values.
+    const auto visible         = std::get<0>(torch::min(radii > 0, /*dim=*/-1));
+    const auto expectedVisible = expectedRadii > 0;
+    EXPECT_TRUE(visible.equal(expectedVisible));
+
     // Use relaxed tolerances to account for minor numerical differences between debug and release
     // builds. The default rtol=1e-5, atol=1e-8 are too strict for operations involving exp, sqrt,
     // and inverse
 #ifdef NDEBUG
     // Release build: stricter tolerances
     EXPECT_TRUE(torch::allclose(means2d, expectedMeans2d));
-    EXPECT_TRUE(torch::allclose(radii, expectedRadii));
     EXPECT_TRUE(torch::allclose(depths, expectedDepths));
 #else
     // Debug build: relaxed tolerances due to different FP optimizations
     EXPECT_TRUE(torch::allclose(means2d, expectedMeans2d, 1e-4, 1e-4));
-    EXPECT_TRUE(torch::allclose(radii.to(torch::kFloat), expectedRadii.to(torch::kFloat), 0, 1));
     EXPECT_TRUE(torch::allclose(depths, expectedDepths, 1e-5, 1e-5));
 #endif
     // rtol=1e-4 and atol=1e-4 accounts for the fact that the test data used log(scales) instead of
@@ -219,8 +224,10 @@ TEST_F(GaussianProjectionForwardTestFixture, TestOrthographicProjection) {
                                                        false,
                                                        true);
 
-    // other outputs are undefined where radii is zero
-    auto radiiNonZeroMask = radii > 0; // [C, N]
+    // Radii is now per-axis [C, N, 2]; a gaussian is visible iff both axes
+    // are positive. The golden snapshot stored the old scalar [C, N] mask.
+    auto radiiNonZeroMask = std::get<0>(torch::min(radii > 0, /*dim=*/-1)); // [C, N]
+    EXPECT_TRUE(radiiNonZeroMask.equal(expectedRadii > 0));
 
     // Use relaxed tolerances to account for minor numerical differences between debug and release
     // builds
@@ -228,14 +235,12 @@ TEST_F(GaussianProjectionForwardTestFixture, TestOrthographicProjection) {
     // Release build: stricter tolerances
     EXPECT_TRUE(torch::allclose(means2d.index({radiiNonZeroMask}),
                                 expectedMeans2d.index({radiiNonZeroMask})));
-    EXPECT_TRUE(torch::allclose(radii, expectedRadii));
     EXPECT_TRUE(torch::allclose(depths.index({radiiNonZeroMask}),
                                 expectedDepths.index({radiiNonZeroMask})));
 #else
     // Debug build: relaxed tolerances due to different FP optimizations
     EXPECT_TRUE(torch::allclose(
         means2d.index({radiiNonZeroMask}), expectedMeans2d.index({radiiNonZeroMask}), 1e-4, 1e-4));
-    EXPECT_TRUE(torch::allclose(radii.to(torch::kFloat), expectedRadii.to(torch::kFloat), 0, 1));
     EXPECT_TRUE(torch::allclose(
         depths.index({radiiNonZeroMask}), expectedDepths.index({radiiNonZeroMask}), 1e-5, 1e-5));
 #endif

--- a/src/tests/GaussianProjectionUTTest.cpp
+++ b/src/tests/GaussianProjectionUTTest.cpp
@@ -196,7 +196,7 @@ TEST_F(GaussianProjectionUTTestFixture, CenteredGaussian_NoDistortion_AnalyticMe
     auto conics_cpu  = conics.cpu();
     auto radii_cpu   = radii.cpu();
 
-    EXPECT_GT(radii_cpu[0][0].item<int32_t>(), 0);
+    EXPECT_GT(radii_cpu[0][0].min().item<int32_t>(), 0);
     EXPECT_NEAR(depths_cpu[0][0].item<float>(), z, 1e-4f);
     EXPECT_NEAR(means2d_cpu[0][0][0].item<float>(), cx, 1e-3f);
     EXPECT_NEAR(means2d_cpu[0][0][1].item<float>(), cy, 1e-3f);
@@ -299,7 +299,7 @@ TEST_F(GaussianProjectionUTTestFixture, NonlinearUTCovariance_ProducesFinitePosi
     auto conics_cpu  = conics.cpu();
     auto means2d_cpu = means2d.cpu();
 
-    ASSERT_GT(radii_cpu[0][0].item<int32_t>(), 0);
+    ASSERT_GT(radii_cpu[0][0].min().item<int32_t>(), 0);
 
     const float a     = conics_cpu[0][0][0].item<float>();
     const float b     = conics_cpu[0][0][1].item<float>();
@@ -503,7 +503,7 @@ TEST_F(GaussianProjectionUTTestFixture, DepthNearCameraPlane_BelowZEps_HardRejec
                                      false);
 
     auto radii_cpu = radii.cpu();
-    EXPECT_EQ(radii_cpu[0][0].item<int32_t>(), 0);
+    EXPECT_EQ(radii_cpu[0][0].min().item<int32_t>(), 0);
 }
 
 TEST_F(GaussianProjectionUTTestFixture, DepthNearCameraPlane_AboveZEps_Projects) {
@@ -570,7 +570,7 @@ TEST_F(GaussianProjectionUTTestFixture, DepthNearCameraPlane_AboveZEps_Projects)
 
     auto radii_cpu   = radii.cpu();
     auto means2d_cpu = means2d.cpu();
-    EXPECT_GT(radii_cpu[0][0].item<int32_t>(), 0);
+    EXPECT_GT(radii_cpu[0][0].min().item<int32_t>(), 0);
     EXPECT_NEAR(means2d_cpu[0][0][0].item<float>(), cx, 5e-3f);
     EXPECT_NEAR(means2d_cpu[0][0][1].item<float>(), cy, 5e-3f);
 }
@@ -641,7 +641,7 @@ TEST_F(GaussianProjectionUTTestFixture, Orthographic_NoDistortion_AnalyticMeanAn
     auto depths_cpu  = depths.cpu();
     auto radii_cpu   = radii.cpu();
 
-    EXPECT_GT(radii_cpu[0][0].item<int32_t>(), 0);
+    EXPECT_GT(radii_cpu[0][0].min().item<int32_t>(), 0);
     EXPECT_NEAR(depths_cpu[0][0].item<float>(), z, 1e-4f);
     EXPECT_NEAR(means2d_cpu[0][0][0].item<float>(), fx * x + cx, 1e-3f);
     EXPECT_NEAR(means2d_cpu[0][0][1].item<float>(), fy * y + cy, 1e-3f);
@@ -810,8 +810,8 @@ TEST_F(GaussianProjectionUTTestFixture, MultiCamera_RadTanDistortion_PerCameraPa
 
     auto radii_cpu   = radii.cpu();
     auto means2d_cpu = means2d.cpu();
-    EXPECT_GT(radii_cpu[0][0].item<int32_t>(), 0);
-    EXPECT_GT(radii_cpu[1][0].item<int32_t>(), 0);
+    EXPECT_GT(radii_cpu[0][0].min().item<int32_t>(), 0);
+    EXPECT_GT(radii_cpu[1][0].min().item<int32_t>(), 0);
 
     const auto [u0, v0] = projectPointWithOpenCVDistortion(
         x, y, z, fx0, fy0, cx0, cy0, {k1_0, k2_0, k3_0}, {p1_0, p2_0}, {});
@@ -899,8 +899,8 @@ TEST_F(GaussianProjectionUTTestFixture, MultiCamera_Pinhole_ZeroCoeffTensor_PerC
 
     auto radii_cpu   = radii.cpu();
     auto means2d_cpu = means2d.cpu();
-    EXPECT_GT(radii_cpu[0][0].item<int32_t>(), 0);
-    EXPECT_GT(radii_cpu[1][0].item<int32_t>(), 0);
+    EXPECT_GT(radii_cpu[0][0].min().item<int32_t>(), 0);
+    EXPECT_GT(radii_cpu[1][0].min().item<int32_t>(), 0);
 
     // UT projects sigma points through a nonlinear model; tiny mean shifts can occur due to
     // floating point and second-order effects. Keep a slightly relaxed tolerance.
@@ -991,7 +991,7 @@ TEST_F(GaussianProjectionUTTestFixture,
 
     auto radii_cpu   = radii.cpu();
     auto means2d_cpu = means2d.cpu();
-    EXPECT_GT(radii_cpu[0][0].item<int32_t>(), 0);
+    EXPECT_GT(radii_cpu[0][0].min().item<int32_t>(), 0);
 
     const auto [expected_u, expected_v] =
         projectPointWithOpenCVDistortion(x, y, z, fx, fy, cx, cy, {k1, k2, k3}, {p1, p2}, {});
@@ -1084,7 +1084,7 @@ TEST_F(GaussianProjectionUTTestFixture,
 
     auto radii_cpu   = radii.cpu();
     auto means2d_cpu = means2d.cpu();
-    EXPECT_GT(radii_cpu[0][0].item<int32_t>(), 0);
+    EXPECT_GT(radii_cpu[0][0].min().item<int32_t>(), 0);
 
     const auto [expected_u, expected_v] = projectPointWithOpenCVDistortion(
         x, y, z, fx, fy, cx, cy, {k1, k2, k3, k4, k5, k6}, {p1, p2}, {});
@@ -1185,7 +1185,7 @@ TEST_F(GaussianProjectionUTTestFixture,
 
     auto radii_cpu   = radii.cpu();
     auto means2d_cpu = means2d.cpu();
-    EXPECT_GT(radii_cpu[0][0].item<int32_t>(), 0);
+    EXPECT_GT(radii_cpu[0][0].min().item<int32_t>(), 0);
 
     const auto [expected_u, expected_v] = projectPointWithOpenCVDistortion(
         x, y, z, fx, fy, cx, cy, {k1, k2, k3, k4, k5, k6}, {p1, p2}, {s1, s2, s3, s4});
@@ -1281,7 +1281,7 @@ TEST_F(GaussianProjectionUTTestFixture,
 
     auto radii_cpu   = radii.cpu();
     auto means2d_cpu = means2d.cpu();
-    EXPECT_GT(radii_cpu[0][0].item<int32_t>(), 0);
+    EXPECT_GT(radii_cpu[0][0].min().item<int32_t>(), 0);
 
     const auto [expected_u, expected_v] = projectPointWithOpenCVDistortion(
         x, y, z, fx, fy, cx, cy, {k1, k2, k3}, {p1, p2}, {s1, s2, s3, s4});
@@ -1349,7 +1349,7 @@ TEST_F(GaussianProjectionUTTestFixture, RadTanThinPrism_IgnoresK456EvenIfNonZero
 
     auto radii_cpu   = radii.cpu();
     auto means2d_cpu = means2d.cpu();
-    EXPECT_GT(radii_cpu[0][0].item<int32_t>(), 0);
+    EXPECT_GT(radii_cpu[0][0].min().item<int32_t>(), 0);
 
     // Verify we effectively use polynomial radial + thin-prism (ignore k4..k6).
     const float fx = 500.0f, fy = 500.0f, cx = 320.0f, cy = 240.0f;
@@ -1434,7 +1434,7 @@ TEST_F(GaussianProjectionUTTestFixture,
     // When the UT kernel discards a Gaussian, only radii are defined to be 0; other outputs are
     // undefined (may contain garbage). Only assert radii here.
     auto radii_cpu = radii.cpu();
-    EXPECT_EQ(radii_cpu[0][0].item<int32_t>(), 0);
+    EXPECT_EQ(radii_cpu[0][0].min().item<int32_t>(), 0);
 }
 
 TEST_F(GaussianProjectionUTTestFixture,
@@ -1506,7 +1506,7 @@ TEST_F(GaussianProjectionUTTestFixture,
                                      false);
 
     auto radii_cpu = radii.cpu();
-    EXPECT_GT(radii_cpu[0][0].item<int32_t>(), 0);
+    EXPECT_GT(radii_cpu[0][0].min().item<int32_t>(), 0);
 }
 
 TEST_F(GaussianProjectionUTTestFixture, RollingShutterNone_DepthUsesStartPoseNotCenter) {

--- a/src/tests/GaussianRasterizeForwardTest.cpp
+++ b/src/tests/GaussianRasterizeForwardTest.cpp
@@ -330,14 +330,14 @@ TEST(GaussianRasterizeForwardMaskedEdgeTile, Child) {
     auto fopts = torch::TensorOptions().device(torch::kCUDA).dtype(torch::kFloat32);
 
     // Single Gaussian that intersects the bottom-right edge tile.
-    const auto means2d   = torch::tensor({{{16.5f, 16.5f}}}, fopts);                  // [C,N,2]
-    const auto conics    = torch::tensor({{{1.0f, 0.0f, 1.0f}}}, fopts);              // [C,N,3]
-    const auto features  = torch::tensor({{{0.4f, 0.5f, -0.6f}}}, fopts);             // [C,N,D]
-    const auto opacities = torch::tensor({{0.9f}}, fopts);                            // [C,N]
+    const auto means2d   = torch::tensor({{{16.5f, 16.5f}}}, fopts);      // [C,N,2]
+    const auto conics    = torch::tensor({{{1.0f, 0.0f, 1.0f}}}, fopts);  // [C,N,3]
+    const auto features  = torch::tensor({{{0.4f, 0.5f, -0.6f}}}, fopts); // [C,N,D]
+    const auto opacities = torch::tensor({{0.9f}}, fopts);                // [C,N]
     const auto radii     = torch::tensor(
         {{{1, 1}}}, torch::TensorOptions().device(torch::kCUDA).dtype(torch::kInt32)); // [C,N,2]
-    const auto depths      = torch::tensor({{1.0f}}, fopts);                          // [C,N]
-    const auto backgrounds = torch::tensor({{0.1f, -0.2f, 0.3f}}, fopts);             // [C,D]
+    const auto depths      = torch::tensor({{1.0f}}, fopts);                               // [C,N]
+    const auto backgrounds = torch::tensor({{0.1f, -0.2f, 0.3f}}, fopts);                  // [C,D]
 
     auto masks     = torch::ones({C, (int64_t)tileExtentH, (int64_t)tileExtentW},
                              torch::TensorOptions().device(torch::kCUDA).dtype(torch::kBool));

--- a/src/tests/GaussianRasterizeForwardTest.cpp
+++ b/src/tests/GaussianRasterizeForwardTest.cpp
@@ -335,7 +335,7 @@ TEST(GaussianRasterizeForwardMaskedEdgeTile, Child) {
     const auto features  = torch::tensor({{{0.4f, 0.5f, -0.6f}}}, fopts);             // [C,N,D]
     const auto opacities = torch::tensor({{0.9f}}, fopts);                            // [C,N]
     const auto radii     = torch::tensor(
-        {{1}}, torch::TensorOptions().device(torch::kCUDA).dtype(torch::kInt32)); // [C,N]
+        {{{1, 1}}}, torch::TensorOptions().device(torch::kCUDA).dtype(torch::kInt32)); // [C,N,2]
     const auto depths      = torch::tensor({{1.0f}}, fopts);                          // [C,N]
     const auto backgrounds = torch::tensor({{0.1f, -0.2f, 0.3f}}, fopts);             // [C,D]
 

--- a/src/tests/GaussianSphericalHarmonicsBackwardTest.cpp
+++ b/src/tests/GaussianSphericalHarmonicsBackwardTest.cpp
@@ -56,7 +56,7 @@ struct SphericalHarmonincsBackwardTestFixture : public ::testing::TestWithParam<
         K         = (shDegreeToUse + 1) * (shDegreeToUse + 1);
         shNCoeffs = torch::full({numGaussians, K - 1, numChannels}, 1.0f, floatOptsCUDA);
 
-        radii = torch::full({numCameras, numGaussians}, 1, intOptsCUDA);
+        radii = torch::full({numCameras, numGaussians, 2}, 1, intOptsCUDA);
 
         dLossDRenderQuantities =
             torch::full({numCameras, numGaussians, numChannels}, 1.0f, floatOptsCUDA);
@@ -72,10 +72,11 @@ struct SphericalHarmonincsBackwardTestFixture : public ::testing::TestWithParam<
     void
     setHalfOfRadiiToZero() {
         radii         = radii.cpu();
-        auto radiiAcc = radii.accessor<int, 2>();
+        auto radiiAcc = radii.accessor<int, 3>();
         for (int64_t i = 0; i < radii.size(0); ++i) {
             for (int64_t j = 0; j < radii.size(1); ++j) {
-                radiiAcc[i][j] = j % 2;
+                radiiAcc[i][j][0] = j % 2;
+                radiiAcc[i][j][1] = j % 2;
             }
         }
         const auto intOptsCUDA = fvdb::test::tensorOpts<int>(torch::kCUDA);

--- a/src/tests/GaussianSphericalHarmonicsForwardTest.cpp
+++ b/src/tests/GaussianSphericalHarmonicsForwardTest.cpp
@@ -56,7 +56,7 @@ struct SphericalHarmonicsForwardTestFixture : public ::testing::TestWithParam<Te
         const int64_t K = (shDegreeToUse + 1) * (shDegreeToUse + 1);
         shNCoeffs       = torch::full({numGaussians, K - 1, numChannels}, 1.0f, floatOptsCUDA);
 
-        radii = torch::full({numCameras, numGaussians}, 1, intOptsCUDA);
+        radii = torch::full({numCameras, numGaussians, 2}, 1, intOptsCUDA);
 
         const float expectedShValue = shDegreeToUse == 0 ? (0.2820947917738781 + 0.5) : 0.861482;
         expectedResult =
@@ -78,10 +78,11 @@ struct SphericalHarmonicsForwardTestFixture : public ::testing::TestWithParam<Te
     void
     setHalfOfRadiiToZero() {
         radii         = radii.cpu();
-        auto radiiAcc = radii.accessor<int, 2>();
+        auto radiiAcc = radii.accessor<int, 3>();
         for (int64_t i = 0; i < radii.size(0); ++i) {
             for (int64_t j = 0; j < radii.size(1); ++j) {
-                radiiAcc[i][j] = j % 2;
+                radiiAcc[i][j][0] = j % 2;
+                radiiAcc[i][j][1] = j % 2;
             }
         }
         const auto intOptsCUDA = fvdb::test::tensorOpts<int>(torch::kCUDA);

--- a/src/tests/GaussianTileIntersectionTest.cpp
+++ b/src/tests/GaussianTileIntersectionTest.cpp
@@ -39,12 +39,12 @@ class GaussianTileIntersectionTest : public ::testing::Test {
             },
             torch::kFloat32);
 
-        // Create radii tensor [C, N]
+        // Create radii tensor [C, N, 2] (per-axis pixel radius)
         auto const radii = torch::tensor(
-            {
-                {8, 8, 8}, // Camera 0
-                {8, 8, 8}  // Camera 1
-            },
+            {// Camera 0
+             {{8, 8}, {8, 8}, {8, 8}},
+             // Camera 1
+             {{8, 8}, {8, 8}, {8, 8}}},
             torch::kInt32);
 
         // Create depths tensor [C, N]
@@ -57,7 +57,7 @@ class GaussianTileIntersectionTest : public ::testing::Test {
 
         // Verify shapes match expected dimensions
         EXPECT_EQ(means2d.sizes(), std::vector<int64_t>({num_cameras, num_gaussians, 2}));
-        EXPECT_EQ(radii.sizes(), std::vector<int64_t>({num_cameras, num_gaussians}));
+        EXPECT_EQ(radii.sizes(), std::vector<int64_t>({num_cameras, num_gaussians, 2}));
         EXPECT_EQ(depths.sizes(), std::vector<int64_t>({num_cameras, num_gaussians}));
 
         return {means2d, radii, depths};
@@ -150,9 +150,10 @@ class GaussianTileIntersectionTest : public ::testing::Test {
 
             // Check each gaussian in this camera for intersection
             for (int64_t g = 0; g < num_gaussians; g++) {
-                float x   = means2d[cam_idx][g][0].item<float>();
-                float y   = means2d[cam_idx][g][1].item<float>();
-                int32_t r = radii[cam_idx][g].item<int32_t>();
+                float x    = means2d[cam_idx][g][0].item<float>();
+                float y    = means2d[cam_idx][g][1].item<float>();
+                int32_t rx = radii[cam_idx][g][0].item<int32_t>();
+                int32_t ry = radii[cam_idx][g][1].item<int32_t>();
 
                 // Compute tile bounds
                 float tile_left   = tile_w * tile_size;
@@ -160,9 +161,9 @@ class GaussianTileIntersectionTest : public ::testing::Test {
                 float tile_bottom = tile_h * tile_size;
                 float tile_top    = (tile_h + 1) * tile_size;
 
-                // Check if gaussian intersects tile bounds
-                bool intersects = x + r > tile_left && x - r < tile_right && y + r > tile_bottom &&
-                                  y - r < tile_top;
+                // Check if gaussian intersects tile bounds (per-axis AABB)
+                bool intersects = x + rx > tile_left && x - rx < tile_right &&
+                                  y + ry > tile_bottom && y - ry < tile_top;
 
                 if (intersects) {
                     tile_intersections.push_back(cam_idx * num_gaussians + g);
@@ -232,7 +233,7 @@ TEST_F(GaussianTileIntersectionTest, ZeroLengthGaussianTest) {
 
     // Create empty tensors with correct shapes
     auto means2d = torch::empty({numCameras, 0, 2}, torch::kFloat32); // [C, N=0, 2]
-    auto radii   = torch::empty({numCameras, 0}, torch::kInt32);      // [C. N=0]
+    auto radii   = torch::empty({numCameras, 0, 2}, torch::kInt32);   // [C, N=0, 2]
     auto depths  = torch::empty({numCameras, 0}, torch::kFloat32);    // [C, N=0]
 
     auto [tile_offsets, intersection_values] =
@@ -260,37 +261,43 @@ TEST_F(GaussianTileIntersectionTest, BadInputsFailTest) {
     const auto ng = 3;
 
     const std::vector<std::vector<std::vector<int64_t>>> configs = {
-        // Unpacked:
+        // Unpacked: shapes are {means2d, radii, depths} ([C, N, 2], [C, N, 2], [C, N]).
 
         // Wrong number of cameras
-        {{nc + 1, ng, 2}, {nc, ng}, {nc, ng}},
-        {{nc, ng, 2}, {nc - 1, ng}, {nc, ng}},
-        {{nc, ng, 2}, {nc, ng}, {nc + 8, ng}},
+        {{nc + 1, ng, 2}, {nc, ng, 2}, {nc, ng}},
+        {{nc, ng, 2}, {nc - 1, ng, 2}, {nc, ng}},
+        {{nc, ng, 2}, {nc, ng, 2}, {nc + 8, ng}},
         // Wrong number of gaussians
-        {{nc, ng + 1, 2}, {nc, ng}, {nc, ng}},
-        {{nc, ng, 2}, {nc, ng - 1}, {nc, ng}},
-        {{nc, ng, 2}, {nc, ng}, {nc, ng + 8}},
+        {{nc, ng + 1, 2}, {nc, ng, 2}, {nc, ng}},
+        {{nc, ng, 2}, {nc, ng - 1, 2}, {nc, ng}},
+        {{nc, ng, 2}, {nc, ng, 2}, {nc, ng + 8}},
         // Wrong mean dim
-        {{nc, ng, 4}, {nc, ng}, {nc, ng}},
+        {{nc, ng, 4}, {nc, ng, 2}, {nc, ng}},
+        // Wrong radii last-dim (must be 2)
+        {{nc, ng, 2}, {nc, ng, 3}, {nc, ng}},
+        {{nc, ng, 2}, {nc, ng, 1}, {nc, ng}},
         // Wrong number of dimensions
-        {{nc, 2}, {nc, 3}, {nc, 3}},
-        {{nc, 3, 2}, {nc}, {nc, 3}},
-        {{nc, 3, 2}, {nc, 3}, {nc}},
+        {{nc, 2}, {nc, 3, 2}, {nc, 3}},
+        {{nc, 3, 2}, {nc, 3}, {nc, 3}},
+        {{nc, 3, 2}, {nc, 3, 2}, {nc}},
 
-        // Packed:
+        // Packed: shapes are {means2d, radii, depths, camera_jidx} ([M, 2], [M, 2], [M], [M]).
 
         // Wrong number of gaussians
-        {{ng + 1, 2}, {ng}, {ng}, {ng}},
-        {{ng, 2}, {ng - 1}, {ng}, {ng}},
-        {{ng, 2}, {ng}, {ng + 8}, {ng}},
-        {{ng, 2}, {ng}, {ng}, {ng + 5}},
+        {{ng + 1, 2}, {ng, 2}, {ng}, {ng}},
+        {{ng, 2}, {ng - 1, 2}, {ng}, {ng}},
+        {{ng, 2}, {ng, 2}, {ng + 8}, {ng}},
+        {{ng, 2}, {ng, 2}, {ng}, {ng + 5}},
         // Wrong mean dim
-        {{ng, 4}, {nc, ng}, {nc, ng}, {ng}},
+        {{ng, 4}, {ng, 2}, {ng}, {ng}},
+        // Wrong radii last-dim
+        {{ng, 2}, {ng, 3}, {ng}, {ng}},
+        {{ng, 2}, {ng, 1}, {ng}, {ng}},
         // Wrong number of dimensions
-        {{ng, 4, 2}, {ng}, {ng}, {ng}},
-        {{ng, 2}, {ng, 7}, {ng}, {ng}},
-        {{ng, 2}, {ng}, {ng, 2, 1}, {ng}},
-        {{ng, 2}, {ng}, {ng, 2, 1}, {ng, 1}},
+        {{ng, 4, 2}, {ng, 2}, {ng}, {ng}},
+        {{ng, 2}, {ng}, {ng}, {ng}},
+        {{ng, 2}, {ng, 2, 1}, {ng}, {ng}},
+        {{ng, 2}, {ng, 2}, {ng, 2, 1}, {ng}},
     };
 
     for (auto config: configs) {
@@ -372,9 +379,9 @@ TEST_F(GaussianTileIntersectionTest, BasicIntersectionTest) {
 TEST_F(GaussianTileIntersectionTest, PackedFormatTest) {
     auto [means2d, radii, depths] = createTestData();
 
-    // Reshape tensors to packed format [M, 2] and [M]
+    // Reshape tensors to packed format: means2d [M, 2], radii [M, 2], depths [M]
     auto means2d_packed = means2d.reshape({-1, 2});
-    auto radii_packed   = radii.reshape({-1});
+    auto radii_packed   = radii.reshape({-1, 2});
     auto depths_packed  = depths.reshape({-1});
 
     // Create camera indices tensor
@@ -518,7 +525,7 @@ TEST_F(GaussianTileIntersectionTest, SparseZeroLengthGaussianTest) {
 
     // Create empty tensors with correct shapes
     auto means2d = torch::empty({numCameras, 0, 2}, torch::kFloat32); // [C, N=0, 2]
-    auto radii   = torch::empty({numCameras, 0}, torch::kInt32);      // [C. N=0]
+    auto radii   = torch::empty({numCameras, 0, 2}, torch::kInt32);   // [C, N=0, 2]
     auto depths  = torch::empty({numCameras, 0}, torch::kFloat32);    // [C, N=0]
 
     auto tile_mask           = torch::ones({numCameras, num_tiles_h, num_tiles_w}, torch::kBool);
@@ -550,9 +557,9 @@ TEST_F(GaussianTileIntersectionTest, SparseZeroLengthGaussianTest) {
 TEST_F(GaussianTileIntersectionTest, SparsePackedFormatTest) {
     auto [means2d, radii, depths] = createTestData();
 
-    // Reshape tensors to packed format [M, 2] and [M]
+    // Reshape tensors to packed format: means2d [M, 2], radii [M, 2], depths [M]
     auto means2d_packed = means2d.reshape({-1, 2});
-    auto radii_packed   = radii.reshape({-1});
+    auto radii_packed   = radii.reshape({-1, 2});
     auto depths_packed  = depths.reshape({-1});
 
     // Create camera indices tensor

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -4,4 +4,4 @@
 
 from fvdb.utils.tests import set_testing_git_tag
 
-set_testing_git_tag("6e6a5c33f42da6a6e09b5d31e1bc725238e5f51f")
+set_testing_git_tag("c34194f69c739ac5412687b6339d496152de2276")

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -4,4 +4,4 @@
 
 from fvdb.utils.tests import set_testing_git_tag
 
-set_testing_git_tag("c34194f69c739ac5412687b6339d496152de2276")
+set_testing_git_tag("59e48d3daa8b8fb55a30fd3d7553fc7fa773ab07")

--- a/tests/unit/test_gaussian_splat_3d.py
+++ b/tests/unit/test_gaussian_splat_3d.py
@@ -1400,23 +1400,17 @@ class TestGaussianRender(BaseGaussianTestCase):
             torch.save(depths, "regression_depths.pt")
             torch.save(conics, "regression_conics.pt")
 
-        # Regression test. The snapshot was stored when radii was a scalar
-        # [C, N] tensor (from ``radiusFromCovariance2dDet`` cast to int32);
-        # radii is now per-axis [C, N, 2]. The per-axis form keeps a handful
-        # (~0.4%) of gaussians whose old scalar truncated to 0 — both axes
-        # are still ≥ 1 after addBlur — so we compare other outputs on the
-        # joint-visible set rather than asserting set equality.
+        # Regression test
         test_radii = torch.load(self.data_path / "regression_radii.pt", weights_only=True)
         test_means2d = torch.load(self.data_path / "regression_means2d.pt", weights_only=True)
         test_depths = torch.load(self.data_path / "regression_depths.pt", weights_only=True)
         test_conics = torch.load(self.data_path / "regression_conics.pt", weights_only=True)
 
         visible = (radii > 0).all(dim=-1)
-        old_visible = test_radii > 0
-        joint = visible & old_visible
-        torch.testing.assert_close(means2d[joint], test_means2d[joint], atol=1e-4, rtol=1e-3)
-        torch.testing.assert_close(depths[joint], test_depths[joint], atol=1e-5, rtol=1e-4)
-        torch.testing.assert_close(conics[joint], test_conics[joint], atol=1e-5, rtol=1e-4)
+        torch.testing.assert_close(radii, test_radii)
+        torch.testing.assert_close(means2d[visible], test_means2d[visible])
+        torch.testing.assert_close(depths[visible], test_depths[visible])
+        torch.testing.assert_close(conics[visible], test_conics[visible], atol=1e-5, rtol=1e-4)
 
     def test_projection_camera_metadata(self):
         projected = self.gs3d.project_gaussians_for_images(

--- a/tests/unit/test_gaussian_splat_3d.py
+++ b/tests/unit/test_gaussian_splat_3d.py
@@ -1400,16 +1400,23 @@ class TestGaussianRender(BaseGaussianTestCase):
             torch.save(depths, "regression_depths.pt")
             torch.save(conics, "regression_conics.pt")
 
-        # Regression test
+        # Regression test. The snapshot was stored when radii was a scalar
+        # [C, N] tensor (from ``radiusFromCovariance2dDet`` cast to int32);
+        # radii is now per-axis [C, N, 2]. The per-axis form keeps a handful
+        # (~0.4%) of gaussians whose old scalar truncated to 0 — both axes
+        # are still ≥ 1 after addBlur — so we compare other outputs on the
+        # joint-visible set rather than asserting set equality.
         test_radii = torch.load(self.data_path / "regression_radii.pt", weights_only=True)
         test_means2d = torch.load(self.data_path / "regression_means2d.pt", weights_only=True)
         test_depths = torch.load(self.data_path / "regression_depths.pt", weights_only=True)
         test_conics = torch.load(self.data_path / "regression_conics.pt", weights_only=True)
 
-        torch.testing.assert_close(radii, test_radii)
-        torch.testing.assert_close(means2d[radii > 0], test_means2d[radii > 0])
-        torch.testing.assert_close(depths[radii > 0], test_depths[radii > 0])
-        torch.testing.assert_close(conics[radii > 0], test_conics[radii > 0], atol=1e-5, rtol=1e-4)
+        visible = (radii > 0).all(dim=-1)
+        old_visible = test_radii > 0
+        joint = visible & old_visible
+        torch.testing.assert_close(means2d[joint], test_means2d[joint], atol=1e-4, rtol=1e-3)
+        torch.testing.assert_close(depths[joint], test_depths[joint], atol=1e-5, rtol=1e-4)
+        torch.testing.assert_close(conics[joint], test_conics[joint], atol=1e-5, rtol=1e-4)
 
     def test_projection_camera_metadata(self):
         projected = self.gs3d.project_gaussians_for_images(
@@ -3187,7 +3194,7 @@ class TestEvaluateSphericalHarmonics(unittest.TestCase):
         C = 2  # number of cameras
 
         sh0 = torch.randn(N, 1, D, device=self.device)
-        radii = torch.ones(C, N, dtype=torch.int32, device=self.device)
+        radii = torch.ones(C, N, 2, dtype=torch.int32, device=self.device)
 
         result = evaluate_spherical_harmonics(
             sh_degree=0,
@@ -3209,7 +3216,7 @@ class TestEvaluateSphericalHarmonics(unittest.TestCase):
 
         # Known sh0 values
         sh0 = torch.ones(N, 1, D, device=self.device)
-        radii = torch.ones(C, N, dtype=torch.int32, device=self.device)
+        radii = torch.ones(C, N, 2, dtype=torch.int32, device=self.device)
 
         result = evaluate_spherical_harmonics(
             sh_degree=0,
@@ -3232,7 +3239,7 @@ class TestEvaluateSphericalHarmonics(unittest.TestCase):
 
         sh0 = torch.randn(N, 1, D, device=self.device)
         shN = torch.randn(N, 3, D, device=self.device)  # 3 coefficients for degree 1
-        radii = torch.ones(C, N, dtype=torch.int32, device=self.device)
+        radii = torch.ones(C, N, 2, dtype=torch.int32, device=self.device)
 
         # Should raise ValueError when view_directions is not provided for degree > 0
         with self.assertRaises(ValueError):
@@ -3267,7 +3274,7 @@ class TestEvaluateSphericalHarmonics(unittest.TestCase):
         # Degree 3 has (3+1)^2 = 16 bases, so K-1 = 15 higher order coefficients
         shN = torch.randn(N, 15, D, device=self.device)
         view_dirs = torch.randn(C, N, 3, device=self.device)
-        radii = torch.ones(C, N, dtype=torch.int32, device=self.device)
+        radii = torch.ones(C, N, 2, dtype=torch.int32, device=self.device)
 
         result = evaluate_spherical_harmonics(
             sh_degree=3,
@@ -3290,10 +3297,11 @@ class TestEvaluateSphericalHarmonics(unittest.TestCase):
 
         sh0 = torch.randn(N, 1, D, device=self.device)
 
-        # Create radii where some are <= 0 (should output zeros)
-        radii = torch.ones(C, N, dtype=torch.int32, device=self.device)
-        radii[0, :5] = 0  # First 5 gaussians for camera 0 should be masked
-        radii[1, 10:15] = -1  # Gaussians 10-14 for camera 1 should be masked
+        # Create radii where some are <= 0 (should output zeros). Per-axis
+        # radii: a gaussian is masked iff EITHER axis is non-positive.
+        radii = torch.ones(C, N, 2, dtype=torch.int32, device=self.device)
+        radii[0, :5, :] = 0  # First 5 gaussians for camera 0 should be masked
+        radii[1, 10:15, :] = -1  # Gaussians 10-14 for camera 1 should be masked
 
         result = evaluate_spherical_harmonics(
             sh_degree=0,
@@ -3318,7 +3326,7 @@ class TestEvaluateSphericalHarmonics(unittest.TestCase):
         sh0 = torch.randn(N, 1, D, device=self.device, requires_grad=True)
         # Note: radii must be provided for backward pass to work correctly
         # (matches GaussianSplat3d usage pattern)
-        radii = torch.ones(C, N, dtype=torch.int32, device=self.device)
+        radii = torch.ones(C, N, 2, dtype=torch.int32, device=self.device)
 
         result = evaluate_spherical_harmonics(
             sh_degree=0,
@@ -3343,7 +3351,7 @@ class TestEvaluateSphericalHarmonics(unittest.TestCase):
         shN = torch.randn(N, 15, D, device=self.device, requires_grad=True)
         view_dirs = torch.randn(C, N, 3, device=self.device)
         # Note: radii must be provided for backward pass to work correctly
-        radii = torch.ones(C, N, dtype=torch.int32, device=self.device)
+        radii = torch.ones(C, N, 2, dtype=torch.int32, device=self.device)
 
         result = evaluate_spherical_harmonics(
             sh_degree=3,
@@ -3371,7 +3379,7 @@ class TestEvaluateSphericalHarmonics(unittest.TestCase):
         sh0 = torch.randn(N, 1, D, device=self.device)
         shN = torch.randn(N, 15, D, device=self.device)
         view_dirs = torch.randn(C, N, 3, device=self.device, requires_grad=True)
-        radii = torch.ones(C, N, dtype=torch.int32, device=self.device)
+        radii = torch.ones(C, N, 2, dtype=torch.int32, device=self.device)
 
         result = evaluate_spherical_harmonics(
             sh_degree=3,
@@ -3397,7 +3405,7 @@ class TestEvaluateSphericalHarmonics(unittest.TestCase):
         sh0 = torch.randn(N, 1, D, device=self.device)
         shN = torch.randn(N, 15, D, device=self.device)
         view_dirs = torch.randn(C, N, 3, device=self.device)
-        radii = torch.ones(C, N, dtype=torch.int32, device=self.device)
+        radii = torch.ones(C, N, 2, dtype=torch.int32, device=self.device)
 
         result = evaluate_spherical_harmonics(
             sh_degree=3,
@@ -3419,7 +3427,7 @@ class TestEvaluateSphericalHarmonics(unittest.TestCase):
         sh0 = torch.randn(N, 1, D, device=self.device)
         shN = torch.randn(N, 15, D, device=self.device)
         view_dirs = torch.randn(C, N, 3, device=self.device)
-        radii = torch.ones(C, N, dtype=torch.int32, device=self.device)
+        radii = torch.ones(C, N, 2, dtype=torch.int32, device=self.device)
 
         result = evaluate_spherical_harmonics(
             sh_degree=3,
@@ -3443,7 +3451,7 @@ class TestEvaluateSphericalHarmonics(unittest.TestCase):
         K = (sh_degree + 1) ** 2
         shN = torch.randn(N, K - 1, D, device=self.device)
         view_dirs = torch.randn(C, N, 3, device=self.device)
-        radii = torch.ones(C, N, dtype=torch.int32, device=self.device)
+        radii = torch.ones(C, N, 2, dtype=torch.int32, device=self.device)
 
         result = evaluate_spherical_harmonics(
             sh_degree=sh_degree,
@@ -3464,7 +3472,7 @@ class TestEvaluateSphericalHarmonics(unittest.TestCase):
 
         sh0 = torch.randn(N, 1, D, device=self.device)
         shN = torch.randn(N, 15, D, device=self.device)
-        radii = torch.ones(C, N, dtype=torch.int32, device=self.device)
+        radii = torch.ones(C, N, 2, dtype=torch.int32, device=self.device)
 
         # Unnormalized view directions (varying magnitudes)
         view_dirs = torch.randn(C, N, 3, device=self.device) * 10.0


### PR DESCRIPTION
This set of changes improves operator parity with respect to gsplat and promotes interoperability between the frameworks.

1. Alpha threshold decreases slightly from 0.999 to 0.99
2. sigma for Gaussian influence clamping is increased slightly from 0.3 to 0.33
3. The per-axis 2d radii are both used for tile intersection as opposed to just the maximum. This reduces the number of Gaussian-tile intersections with zero contribution for anisotropic Gaussians leading to improved speed and memory savings.