### PR TITLE
Fix Conda build failure

### DIFF
--- a/src/cmake/get_torch.cmake
+++ b/src/cmake/get_torch.cmake
@@ -36,6 +36,11 @@ endif()
 
 find_package(Torch REQUIRED PATHS "${TORCH_PACKAGE_DIR}/share/cmake/Torch")
 
+# Conda provides public PyTorch headers in the global environment include directory
+if(DEFINED ENV{CONDA_PREFIX})
+  list(APPEND TORCH_INCLUDE_DIRS "$ENV{CONDA_PREFIX}/include")
+endif()
+
 # Without this we can't find TH/THC headers
 set(TORCH_SOURCE_INCLUDE_DIRS ${TORCH_PACKAGE_DIR}/include)
 


### PR DESCRIPTION
The Conda build is currently failing with: `/__w/fvdb-core/fvdb-core/src/fvdb/JaggedTensor.h:7:10: fatal error: torch/custom_class.h: No such file or directory` because the Conda PyTorch packages install Torch headers to the global environment include directory and that directory isn't covered by the Torch CMake configuration file.