### PR TITLE
CMake: Link exported Torch target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,12 +168,10 @@ set_target_properties(_fvdb_cpp PROPERTIES
 
 target_include_directories(_fvdb_cpp PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/src
-    ${TORCH_INCLUDE_DIRS}
     ${nanovdb_SOURCE_DIR}/nanovdb
     ${NANOVDB_EDITOR_INCLUDE_DIR})
 target_link_libraries(_fvdb_cpp PRIVATE
     ${TORCH_PYTHON_LIBRARY}
-    ${TORCH_LIBRARIES}
     fvdb)
 
 target_compile_options(_fvdb_cpp PRIVATE

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -59,9 +59,9 @@ set(FVDB_CPP_FILES
 )
 
 set(FVDB_CU_FILES
-    fvdb/detail/io/SaveNanoVDB.cu
     fvdb/GridBatchData.cu
     fvdb/detail/GridBatchDataFactory.cu
+    fvdb/detail/io/SaveNanoVDB.cu
     fvdb/detail/ops/ActiveGridCoords.cu
     fvdb/detail/ops/ActiveVoxelsInBoundsMask.cu
     fvdb/detail/ops/BuildCoarseGridFromFine.cu
@@ -166,20 +166,13 @@ set_target_properties(
     POSITION_INDEPENDENT_CODE ON
     INTERFACE_POSITION_INDEPENDENT_CODE ON)
 
-message(STATUS "fvdb: TORCH_INCLUDE_DIRS: ${TORCH_INCLUDE_DIRS}")
-
 target_include_directories(fvdb PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
     $<BUILD_INTERFACE:${nanovdb_SOURCE_DIR}/nanovdb>
     $<BUILD_INTERFACE:${nvtx3_SOURCE_DIR}/include>
     $<BUILD_INTERFACE:${NANOVDB_EDITOR_INCLUDE_DIR}>
     $<INSTALL_INTERFACE:include>)
-foreach(_torch_inc_dir IN LISTS TORCH_INCLUDE_DIRS)
-    target_include_directories(fvdb SYSTEM PUBLIC
-        $<BUILD_INTERFACE:${_torch_inc_dir}>)
-endforeach()
 target_include_directories(fvdb PRIVATE
-    ${TORCH_SOURCE_INCLUDE_DIRS}
     ${tinyply_SOURCE_DIR}/source)
 
 # Needed by Torch for CUDA extensions
@@ -220,8 +213,9 @@ target_compile_options(fvdb PRIVATE
     >
     $<$<AND:$<BOOL:${FVDB_LINEINFO}>,$<COMPILE_LANGUAGE:CUDA>>:-lineinfo>)
 
-target_link_libraries(fvdb PRIVATE
-    ${TORCH_LIBRARIES} tinyply cutlass blosc::blosc ZLIB::ZLIB dispatch)
+target_link_libraries(fvdb
+    PUBLIC ${TORCH_LIBRARIES}
+    PRIVATE tinyply cutlass blosc::blosc ZLIB::ZLIB dispatch)
 
 # ----------------------------------------------------------------------------
 # Precompiled headers (host C++ only)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -214,7 +214,7 @@ target_compile_options(fvdb PRIVATE
     $<$<AND:$<BOOL:${FVDB_LINEINFO}>,$<COMPILE_LANGUAGE:CUDA>>:-lineinfo>)
 
 target_link_libraries(fvdb
-    PUBLIC ${TORCH_LIBRARIES}
+    PUBLIC torch
     PRIVATE tinyply cutlass blosc::blosc ZLIB::ZLIB dispatch)
 
 # ----------------------------------------------------------------------------

--- a/src/benchmarks/CMakeLists.txt
+++ b/src/benchmarks/CMakeLists.txt
@@ -40,7 +40,6 @@ function(ConfigureDispatchBench CMAKE_BENCH_NAME)
     target_link_libraries(${CMAKE_BENCH_NAME}
         dispatch
         fvdb
-        ${TORCH_LIBRARIES}
         benchmark::benchmark_main
         $<TARGET_NAME_IF_EXISTS:conda_env>
     )
@@ -98,7 +97,6 @@ function(ConfigureBench CMAKE_BENCH_NAME)
     )
     target_link_libraries(${CMAKE_BENCH_NAME}
         fvdb
-        ${TORCH_LIBRARIES}
         benchmark::benchmark_main
         $<TARGET_NAME_IF_EXISTS:conda_env>
     )

--- a/src/cmake/fvdbConfig.cmake.in
+++ b/src/cmake/fvdbConfig.cmake.in
@@ -12,8 +12,4 @@ find_dependency(Torch)
 
 include("${CMAKE_CURRENT_LIST_DIR}/fvdbTargets.cmake")
 
-# fvdb PUBLIC-links the imported torch targets (c10, c10_cuda, torch_cuda, ...),
-# so consumers inherit torch's INTERFACE_INCLUDE_DIRECTORIES transitively via the
-# link chain. No explicit TORCH_INCLUDE_DIRS propagation needed here.
-
 check_required_components(fvdb)

--- a/src/cmake/fvdbConfig.cmake.in
+++ b/src/cmake/fvdbConfig.cmake.in
@@ -12,11 +12,8 @@ find_dependency(Torch)
 
 include("${CMAKE_CURRENT_LIST_DIR}/fvdbTargets.cmake")
 
-# Propagate Torch include directories to consumers, since fvdb's public headers
-# reference torch/ATen/c10 types.
-if(TARGET fvdb::fvdb AND TORCH_INCLUDE_DIRS)
-    set_property(TARGET fvdb::fvdb APPEND PROPERTY
-        INTERFACE_INCLUDE_DIRECTORIES "${TORCH_INCLUDE_DIRS}")
-endif()
+# fvdb PUBLIC-links the imported torch targets (c10, c10_cuda, torch_cuda, ...),
+# so consumers inherit torch's INTERFACE_INCLUDE_DIRECTORIES transitively via the
+# link chain. No explicit TORCH_INCLUDE_DIRS propagation needed here.
 
 check_required_components(fvdb)

--- a/src/cmake/get_pybind11.cmake
+++ b/src/cmake/get_pybind11.cmake
@@ -4,10 +4,21 @@
 # First make sure Python is found
 find_package(Python3 COMPONENTS Interpreter Development REQUIRED)
 
-# Get PyTorch's pybind11 version
+# Get PyTorch's pybind11 version. Sets TORCH_PYBIND11_INCLUDE_DIR and
+# PYBIND11_VERSION in the parent scope when pytorch bundles its own pybind11
+# (pip wheels do; conda-forge dropped this several versions ago). Leaves them
+# unset otherwise, so the caller falls back to find_package(pybind11).
 function(detect_torch_pybind11_version)
-    # Try to find pybind11/detail/common.h in TORCH_INCLUDE_DIRS
-    foreach(dir ${TORCH_INCLUDE_DIRS})
+    set(_candidates)
+    # pip pytorch bundles pybind11 under TORCH_PACKAGE_DIR/include (set by
+    # get_torch.cmake). TORCH_INCLUDE_DIRS may or may not cover the same dir
+    # depending on which branch of TorchConfig fires, so check it too.
+    if(TORCH_PACKAGE_DIR)
+        list(APPEND _candidates "${TORCH_PACKAGE_DIR}/include")
+    endif()
+    list(APPEND _candidates ${TORCH_INCLUDE_DIRS})
+
+    foreach(dir ${_candidates})
         if(EXISTS "${dir}/pybind11/detail/common.h")
             set(PYBIND11_HEADER "${dir}/pybind11/detail/common.h")
             set(TORCH_PYBIND11_INCLUDE_DIR "${dir}" PARENT_SCOPE)
@@ -15,40 +26,32 @@ function(detect_torch_pybind11_version)
         endif()
     endforeach()
 
-    # If not found, try python site-packages
     if(NOT PYBIND11_HEADER)
-        if(EXISTS "${PYTHON_SITE_PACKAGES}/torch/include/pybind11/detail/common.h")
-            set(PYBIND11_HEADER "${PYTHON_SITE_PACKAGES}/torch/include/pybind11/detail/common.h")
-            set(TORCH_PYBIND11_INCLUDE_DIR "${PYTHON_SITE_PACKAGES}/torch/include" PARENT_SCOPE)
-        endif()
+        message(STATUS
+            "PyTorch does not bundle pybind11 in its include tree; "
+            "falling back to find_package(pybind11) for a compatible version.")
+        return()
     endif()
 
-    if(NOT PYBIND11_HEADER)
-        message(WARNING "Could not find pybind11 headers in PyTorch")
-    endif()
-
-    # Extract the version from the header by reading the file content
     file(READ "${PYBIND11_HEADER}" header_content)
 
-    # First try standard version defines
     string(REGEX MATCH "#define PYBIND11_VERSION_MAJOR[ \t]+([0-9]+)" _ "${header_content}")
     set(MAJOR "${CMAKE_MATCH_1}")
-
     string(REGEX MATCH "#define PYBIND11_VERSION_MINOR[ \t]+([0-9]+)" _ "${header_content}")
     set(MINOR "${CMAKE_MATCH_1}")
-
     string(REGEX MATCH "#define PYBIND11_VERSION_PATCH[ \t]+([0-9]+)" _ "${header_content}")
     set(PATCH "${CMAKE_MATCH_1}")
 
-    # Check if the regex patterns matched (not if values are non-zero)
-    if(DEFINED MAJOR AND DEFINED MINOR AND DEFINED PATCH)
+    # string(REGEX MATCH) sets CMAKE_MATCH_1 to "" on no match, which DEFINED
+    # would still consider set — so check for non-empty instead.
+    if(MAJOR AND MINOR AND PATCH)
         set(PYBIND11_VERSION_MAJOR "${MAJOR}" PARENT_SCOPE)
         set(PYBIND11_VERSION_MINOR "${MINOR}" PARENT_SCOPE)
         set(PYBIND11_VERSION_PATCH "${PATCH}" PARENT_SCOPE)
         set(PYBIND11_VERSION "${MAJOR}.${MINOR}.${PATCH}" PARENT_SCOPE)
         message(STATUS "Detected PyTorch's pybind11 version: ${MAJOR}.${MINOR}.${PATCH}")
     else()
-        message(FATAL_ERROR "Could not detect PyTorch's pybind11 version")
+        message(FATAL_ERROR "Could not detect PyTorch's pybind11 version from ${PYBIND11_HEADER}")
     endif()
 endfunction()
 

--- a/src/cmake/get_pybind11.cmake
+++ b/src/cmake/get_pybind11.cmake
@@ -44,16 +44,24 @@ function(detect_torch_pybind11_version)
     string(REGEX MATCH "#define PYBIND11_VERSION_PATCH[ \t]+([0-9]+)" _ "${header_content}")
     set(PATCH "${CMAKE_MATCH_1}")
 
-    # string(REGEX MATCH) sets CMAKE_MATCH_1 to "" on no match, which DEFINED
-    # would still consider set — so check for non-empty instead.
-    if(MAJOR AND MINOR AND PATCH)
+    # string(REGEX MATCH) sets CMAKE_MATCH_1 to "" on no match, so test each
+    # component for non-empty explicitly. Avoid CMake's boolean coercion via
+    # `if(VAR)`, which treats a legitimate "0" component (e.g. PYBIND11_VERSION_PATCH
+    # 0 in a freshly-bumped major release) as false.
+    if(NOT "${MAJOR}" STREQUAL "" AND NOT "${MINOR}" STREQUAL "" AND NOT "${PATCH}" STREQUAL "")
         set(PYBIND11_VERSION_MAJOR "${MAJOR}" PARENT_SCOPE)
         set(PYBIND11_VERSION_MINOR "${MINOR}" PARENT_SCOPE)
         set(PYBIND11_VERSION_PATCH "${PATCH}" PARENT_SCOPE)
         set(PYBIND11_VERSION "${MAJOR}.${MINOR}.${PATCH}" PARENT_SCOPE)
         message(STATUS "Detected PyTorch's pybind11 version: ${MAJOR}.${MINOR}.${PATCH}")
     else()
-        message(FATAL_ERROR "Could not detect PyTorch's pybind11 version from ${PYBIND11_HEADER}")
+        # Couldn't parse a version, but TORCH_PYBIND11_INCLUDE_DIR is already set
+        # from the walk above, which is what the caller actually uses for the
+        # bundled-headers path. Only the CPM fallback below needs PYBIND11_VERSION,
+        # and that path guards against unset version explicitly.
+        message(STATUS
+            "Found PyTorch's bundled pybind11 at ${PYBIND11_HEADER} but could not "
+            "parse its version macros; bundled headers will still be used.")
     endif()
 endfunction()
 
@@ -88,6 +96,19 @@ else()
     if (pybind11_FOUND)
         message(STATUS "pybind11 found: ${pybind11_INCLUDE_DIRS}")
     else()
+        # Last-resort CPM fetch needs a concrete version to pin pybind11 to
+        # whatever pytorch was built against. If detect_torch_pybind11_version()
+        # couldn't extract one (no bundled headers + parse failure), we have no
+        # way to choose a compatible release here; bail with a clear message
+        # instead of silently fetching `v` (empty tag).
+        if(NOT PYBIND11_VERSION)
+            message(FATAL_ERROR
+                "pybind11 not found via PyTorch bundle or find_package, and "
+                "PYBIND11_VERSION is unset — cannot pin a CPM fetch. Install "
+                "pybind11 (e.g. `pip install pybind11` or `conda install pybind11`) "
+                "or ensure pytorch's bundled headers are discoverable.")
+        endif()
+
         # Set variables needed by pybind11
         set(PYBIND11_NEWPYTHON ON)
         set(PYTHON_INCLUDE_DIRS ${Python3_INCLUDE_DIRS})

--- a/src/cmake/get_pybind11.cmake
+++ b/src/cmake/get_pybind11.cmake
@@ -33,8 +33,10 @@ function(detect_torch_pybind11_version)
         return()
     endif()
 
+    # Extract the version from the header by reading the file content
     file(READ "${PYBIND11_HEADER}" header_content)
 
+    # First try standard version defines
     string(REGEX MATCH "#define PYBIND11_VERSION_MAJOR[ \t]+([0-9]+)" _ "${header_content}")
     set(MAJOR "${CMAKE_MATCH_1}")
     string(REGEX MATCH "#define PYBIND11_VERSION_MINOR[ \t]+([0-9]+)" _ "${header_content}")

--- a/src/cmake/get_torch.cmake
+++ b/src/cmake/get_torch.cmake
@@ -36,14 +36,6 @@ endif()
 
 find_package(Torch REQUIRED PATHS "${TORCH_PACKAGE_DIR}/share/cmake/Torch")
 
-# Conda provides public PyTorch headers in the global environment include directory
-if(DEFINED ENV{CONDA_PREFIX})
-  list(APPEND TORCH_INCLUDE_DIRS "$ENV{CONDA_PREFIX}/include")
-endif()
-
-# Without this we can't find TH/THC headers
-set(TORCH_SOURCE_INCLUDE_DIRS ${TORCH_PACKAGE_DIR}/include)
-
 if(NOT TORCH_PYTHON_LIBRARY)
   message(STATUS "Looking for torch_python library...")
 

--- a/src/dispatch/CMakeLists.txt
+++ b/src/dispatch/CMakeLists.txt
@@ -63,7 +63,7 @@ if(FVDB_BUILD_TESTS OR FVDB_BUILD_BENCHMARKS)
 
     target_link_libraries(dispatch_examples PUBLIC
         dispatch
-        ${TORCH_LIBRARIES}
+        torch
     )
 
     target_compile_options(dispatch_examples PRIVATE

--- a/src/dispatch/CMakeLists.txt
+++ b/src/dispatch/CMakeLists.txt
@@ -118,13 +118,18 @@ if(FVDB_BUILD_TESTS)
 
         target_include_directories(${CMAKE_TEST_NAME}_obj PRIVATE
             ${CMAKE_CURRENT_SOURCE_DIR}/tests
-            $<TARGET_PROPERTY:dispatch,INTERFACE_INCLUDE_DIRECTORIES>
-            $<TARGET_PROPERTY:dispatch_examples,INTERFACE_INCLUDE_DIRECTORIES>
-            $<TARGET_PROPERTY:GTest::gtest,INTERFACE_INCLUDE_DIRECTORIES>
-            $<TARGET_PROPERTY:GTest::gtest_main,INTERFACE_INCLUDE_DIRECTORIES>
-            ${TORCH_INCLUDE_DIRS}
             ${CUDAToolkit_INCLUDE_DIRS}
             ${CUDAToolkit_INCLUDE_DIRS}/cccl
+        )
+
+        # Propagate usage requirements (include dirs, defines, SYSTEM marker)
+        # from linked targets into the OBJECT library's compilation. Linking an
+        # OBJECT lib does not actually link — only interface properties flow.
+        target_link_libraries(${CMAKE_TEST_NAME}_obj PRIVATE
+            dispatch
+            dispatch_examples
+            GTest::gtest
+            GTest::gtest_main
         )
 
         target_compile_options(${CMAKE_TEST_NAME}_obj PRIVATE
@@ -159,7 +164,6 @@ if(FVDB_BUILD_TESTS)
         target_link_libraries(${CMAKE_TEST_NAME}
             dispatch
             dispatch_examples
-            ${TORCH_LIBRARIES}
             GTest::gtest
             GTest::gtest_main
             $<TARGET_NAME_IF_EXISTS:conda_env>

--- a/src/fvdb/detail/ops/Refine.cu
+++ b/src/fvdb/detail/ops/Refine.cu
@@ -8,7 +8,7 @@
 #include <fvdb/detail/utils/cuda/ForEachCUDA.cuh>
 #include <fvdb/detail/utils/cuda/ForEachPrivateUse1.cuh>
 
-#include <THC/THCAtomics.cuh>
+#include <ATen/cuda/Atomic.cuh>
 #include <c10/cuda/CUDAException.h>
 
 namespace fvdb {

--- a/src/fvdb/detail/ops/SampleBezierWithGradBackward.cu
+++ b/src/fvdb/detail/ops/SampleBezierWithGradBackward.cu
@@ -9,7 +9,7 @@
 #include <fvdb/detail/utils/cuda/ForEachCUDA.cuh>
 
 #include <ATen/OpMathType.h>
-#include <THC/THCAtomics.cuh>
+#include <ATen/cuda/Atomic.cuh>
 #include <c10/cuda/CUDAException.h>
 
 namespace fvdb {

--- a/src/fvdb/detail/ops/SampleTrilinearWithGradBackward.cu
+++ b/src/fvdb/detail/ops/SampleTrilinearWithGradBackward.cu
@@ -10,7 +10,7 @@
 #include <fvdb/detail/utils/cuda/ForEachPrivateUse1.cuh>
 
 #include <ATen/OpMathType.h>
-#include <THC/THCAtomics.cuh>
+#include <ATen/cuda/Atomic.cuh>
 #include <c10/cuda/CUDAException.h>
 
 #include <cstdint>

--- a/src/fvdb/detail/ops/SplatBezier.cu
+++ b/src/fvdb/detail/ops/SplatBezier.cu
@@ -8,7 +8,7 @@
 #include <fvdb/detail/utils/Utils.h>
 #include <fvdb/detail/utils/cuda/ForEachCUDA.cuh>
 
-#include <THC/THCAtomics.cuh>
+#include <ATen/cuda/Atomic.cuh>
 #include <c10/cuda/CUDAException.h>
 
 namespace fvdb {

--- a/src/fvdb/detail/ops/SplatTrilinear.cu
+++ b/src/fvdb/detail/ops/SplatTrilinear.cu
@@ -9,7 +9,7 @@
 #include <fvdb/detail/utils/cuda/ForEachCUDA.cuh>
 #include <fvdb/detail/utils/cuda/ForEachPrivateUse1.cuh>
 
-#include <THC/THCAtomics.cuh>
+#include <ATen/cuda/Atomic.cuh>
 #include <c10/cuda/CUDAException.h>
 
 #include <cstdint>

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -25,22 +25,20 @@ set_target_properties(fvdb_test_utils
   CXX_STANDARD_REQUIRED ON
 )
 
-# Include PRIVATE for compiling the library, PUBLIC for consumers (test executables)
-# Add src dir PRIVATE to find <tests/utils/ImageUtils.h> from ImageUtils.cpp
-target_include_directories(fvdb_test_utils
-  PRIVATE
-    ${CMAKE_SOURCE_DIR}/src # To find <tests/utils/ImageUtils.h>
-    ${PNG_INCLUDE_DIRS}     # Include directory for png.h
-    ${NANOVDB_EDITOR_INCLUDE_DIR}
-  # PUBLIC includes could be added if ImageUtils.h included e.g., Torch headers
-  # PUBLIC
-    # ${TORCH_INCLUDE_DIRS}
+# Test util headers (utils/Tensor.h, utils/ImageUtils.h) include torch headers,
+# so torch must be a PUBLIC dependency. Test executables that include these
+# headers inherit torch's usage requirements transitively.
+target_include_directories(fvdb_test_utils PUBLIC
+  ${CMAKE_SOURCE_DIR}/src # To find <tests/utils/ImageUtils.h>
+)
+target_include_directories(fvdb_test_utils PRIVATE
+  ${PNG_INCLUDE_DIRS}
+  ${NANOVDB_EDITOR_INCLUDE_DIR}
 )
 
-# Link dependencies PRIVATE as they are implementation details
-target_link_libraries(fvdb_test_utils PRIVATE
-  PNG::PNG
-  ${TORCH_LIBRARIES} # Link utils against Torch
+target_link_libraries(fvdb_test_utils
+  PUBLIC ${TORCH_LIBRARIES}
+  PRIVATE PNG::PNG
 )
 # --- End Test Utilities Library Definition ---
 
@@ -67,12 +65,18 @@ function(ConfigureTest CMAKE_TEST_NAME)
   # Test sources need to find <tests/utils/ImageUtils.h> etc.
   target_include_directories(${CMAKE_TEST_NAME}_obj PRIVATE
     ${CMAKE_SOURCE_DIR}/src # Include src for finding <tests/utils/...>
-    $<TARGET_PROPERTY:fvdb,INTERFACE_INCLUDE_DIRECTORIES> # Get includes exposed by fvdb
-    $<TARGET_PROPERTY:GTest::gtest,INTERFACE_INCLUDE_DIRECTORIES> # Get includes exposed by GTest::gtest
-    $<TARGET_PROPERTY:GTest::gtest_main,INTERFACE_INCLUDE_DIRECTORIES> # Get includes exposed by GTest::gtest_main
     ${CUDAToolkit_INCLUDE_DIRS}
     ${CUDAToolkit_INCLUDE_DIRS}/cccl
     ${NANOVDB_EDITOR_INCLUDE_DIR}
+  )
+
+  # Propagate usage requirements (include dirs, defines, SYSTEM marker) from
+  # fvdb and gtest into the OBJECT library's compilation. linking an OBJECT lib
+  # does not actually link — it only carries interface properties forward.
+  target_link_libraries(${CMAKE_TEST_NAME}_obj PRIVATE
+    fvdb
+    GTest::gtest
+    GTest::gtest_main
   )
 
   target_compile_options(${CMAKE_TEST_NAME}_obj PRIVATE

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -37,7 +37,7 @@ target_include_directories(fvdb_test_utils PRIVATE
 )
 
 target_link_libraries(fvdb_test_utils
-  PUBLIC ${TORCH_LIBRARIES}
+  PUBLIC torch
   PRIVATE PNG::PNG
 )
 # --- End Test Utilities Library Definition ---


### PR DESCRIPTION
## Summary

Refactor fvdb's CMake to consume libtorch through the canonical aggregate imported target `torch` instead of the legacy `${TORCH_INCLUDE_DIRS}` / `${TORCH_LIBRARIES}` variables, and retire `<THC/THCAtomics.cuh>` in favor of `<ATen/cuda/Atomic.cuh>` which was the only other reason we needed to have the include path for `TORCH_INCLUDE_DIRS` (regardless, THC is deprecated and is just a shim for ATen). Together these make the build robust against upstream pytorch / conda-forge packaging changes that were previously masked by MKL's `mklvars.sh` injecting `CPATH=$CONDA_PREFIX/include`.

## Why

The gtest build broke under conda-forge pytorch 2.10.0 build 304 with:

```
fatal error: torch/custom_class.h: No such file or directory
```

Tracing it down: `TorchConfig.cmake`'s top-level branch only sets `TORCH_INCLUDE_DIRS = $PREFIX/include/torch/csrc/api/include`, omitting `$PREFIX/include` itself — where the umbrella headers (`torch/custom_class.h`, `torch/extension.h`, etc.) actually live. Older builds picked up that path by accident via MKL's `mklvars.sh` activation script exporting `CPATH`. conda-forge `mkl 2026.0.0` (shipped alongside pytorch build 304) dropped that script, exposing the latent gap.

The fix that landed as #661 backfilled `TORCH_INCLUDE_DIRS` with `$CONDA_PREFIX/include` when `CONDA_PREFIX` is defined. That works, but it papers over the underlying issue: the project was reading the TorchConfig variables directly and missing the include paths that only the imported torch targets carry. Switching to the canonical imported target:

- gets the full torch interface (includes, defines, SYSTEM marker, link deps) propagated transitively to all consumers
- removes the need for per-environment backfill — pip and conda flows both go through the same target-based mechanism
- lets downstream C++ users of `fvdb::fvdb` inherit torch's usage requirements via the link chain in `fvdbTargets.cmake` instead of via the legacy variable
- avoids exporting raw `.so` paths (verified in env: `${TORCH_LIBRARIES}` expands to a mix of imported targets and raw paths — `torch;torch_library;<libc10.so>;CUDA::nvrtc;<libc10_cuda.so>` — which would hardcode build-time library paths into downstream exports). Linking just `torch` transitively pulls in `torch_cpu_library`/`torch_cuda_library` (which force-link the `.so` files via `-Wl,--no-as-needed,$<TARGET_FILE:...>`) and the full IID chain, with no raw paths exported.

## Changes

**libtorch consumption**

- `src/CMakeLists.txt`: `fvdb` now `PUBLIC`-links `torch` (was `PRIVATE ${TORCH_LIBRARIES}`). The manual `foreach(_torch_inc_dir IN LISTS TORCH_INCLUDE_DIRS)` loop replicating torch include dirs onto fvdb's interface is removed — `INTERFACE_INCLUDE_DIRECTORIES` now flows transitively from the imported targets. Public linking is the more appropriate choice since our headers expose Torch functionality/classes.
- `src/tests/CMakeLists.txt`: test `OBJECT` libraries now `target_link_libraries(... PRIVATE fvdb GTest::gtest GTest::gtest_main)` instead of scraping `$<TARGET_PROPERTY:fvdb,INTERFACE_INCLUDE_DIRECTORIES>` via genex (which only returns the target's own includes, not the transitive ones). `fvdb_test_utils` switched to `PUBLIC torch` link since `utils/Tensor.h` and `utils/ImageUtils.h` expose torch types.
- `src/dispatch/CMakeLists.txt`: same `OBJECT`-library refactor for dispatch tests; `dispatch_examples` now `PUBLIC`-links `torch` instead of `${TORCH_LIBRARIES}`; redundant explicit `${TORCH_LIBRARIES}` on the test executables removed.
- `src/benchmarks/CMakeLists.txt`: dropped redundant `${TORCH_LIBRARIES}` on benchmark executables (inherited via `fvdb`'s `PUBLIC` link).
- Top-level `CMakeLists.txt`: dropped redundant `${TORCH_INCLUDE_DIRS}` / `${TORCH_LIBRARIES}` on `_fvdb_cpp` (inherited via `fvdb`).

**THC → ATen migration**

- 5 `.cu` files (`Refine.cu`, `SplatBezier.cu`, `SplatTrilinear.cu`, `SampleBezierWithGradBackward.cu`, `SampleTrilinearWithGradBackward.cu`): `<THC/THCAtomics.cuh>` → `<ATen/cuda/Atomic.cuh>`. `THCAtomics.cuh` is a deprecated one-line shim around the ATen header.

**CMake plumbing cleanup**

- `src/cmake/get_torch.cmake`: removed dead `TORCH_SOURCE_INCLUDE_DIRS` (only needed for the retired THC headers); removed the `CONDA_PREFIX` backfill of `TORCH_INCLUDE_DIRS` from #661 (no longer needed — nothing in-tree reads `TORCH_INCLUDE_DIRS` for compilation, and downstream consumers go through `fvdbConfig.cmake`).
- `src/cmake/fvdbConfig.cmake.in`: removed the explicit `set_property(... INTERFACE_INCLUDE_DIRECTORIES ${TORCH_INCLUDE_DIRS})` on `fvdb::fvdb` — downstream now inherits torch via the imported targets exported in `fvdbTargets.cmake`.
- `src/cmake/get_pybind11.cmake`: hardened `detect_torch_pybind11_version` — walks `${TORCH_PACKAGE_DIR}/include` first (where pip pytorch bundles pybind11), then `TORCH_INCLUDE_DIRS`; early-returns when pybind11 isn't found in pytorch's tree (lets the existing `find_package(pybind11)` fallback handle it) instead of `file(READ)`ing an empty path and silently producing `Detected PyTorch's pybind11 version: ..`; drops the dead `PYTHON_SITE_PACKAGES` fallback (variable was never set anywhere in the build); replaces the misleading `if(DEFINED MAJOR ...)` check with a truthiness check (CMake's `string(REGEX MATCH)` sets capture variables to `""` on no match, which `DEFINED` doesn't distinguish from a real match).

## Test plan

- [x] `ninja all` under `pytorch 2.10.0 build 304 + mkl 2026.0.0` — previously failing — now builds all targets cleanly, including the originally-failing `PackedJaggedAccessorTest`.
- [x] `ninja all` under `pytorch 2.10.0 build 303 + mkl 2025.3.1` (control) — still builds cleanly; behavior is symmetric across both envs.
- [x] `_fvdb_cpp.so` Python module links and loads.