### PR TITLE
Improve prefetch granularity for rasterization kernels

### DIFF
--- a/src/fvdb/detail/ops/gsplat/RasterizeScreenSpaceGaussiansBackward.cu
+++ b/src/fvdb/detail/ops/gsplat/RasterizeScreenSpaceGaussiansBackward.cu
@@ -1213,15 +1213,13 @@ callRasterizeBackwardPrivateUse1(
             renderedAlphas, lastGaussianIds, dLossDRenderedFeatures, dLossDRenderedAlphas);
     }();
 
+    const uint32_t tileExtentH    = renderWindow.tileExtentH(tileSize);
+    const uint32_t tileExtentW    = renderWindow.tileExtentW(tileSize);
+    const uint32_t tilesPerCamera = tileExtentH * tileExtentW;
     // Compute tile count: for sparse mode use activeTiles, for dense mode compute from image dims
-    uint32_t tileCount;
-    if (activeTiles.has_value()) {
-        tileCount = activeTiles.value().size(0);
-    } else {
-        const uint32_t tileExtentH = renderWindow.tileExtentH(tileSize);
-        const uint32_t tileExtentW = renderWindow.tileExtentW(tileSize);
-        tileCount                  = C * tileExtentH * tileExtentW;
-    }
+    uint32_t tileCount = activeTiles.has_value() ? activeTiles.value().size(0) : C * tilesPerCamera;
+    std::vector<torch::Tensor> tileTensors = {dLossDRenderedFeatures.jdata(),
+                                              dLossDRenderedAlphas.jdata()};
 
     std::vector<cudaEvent_t> events(c10::cuda::device_count());
     for (const auto deviceId: c10::irange(c10::cuda::device_count())) {
@@ -1238,23 +1236,29 @@ callRasterizeBackwardPrivateUse1(
 
         uint32_t deviceTileOffset, deviceTileCount;
         std::tie(deviceTileOffset, deviceTileCount) = deviceChunk(tileCount, deviceId);
-        uint32_t cameraOffset                       = deviceTileOffset / (tileCount / C);
-        uint32_t cameraCount =
-            cuda::ceil_div(deviceTileOffset + deviceTileCount, tileCount / C) - cameraOffset;
         if (deviceTileCount) {
-            // Prefetch the outputs of the operator. The inputs are already resident on the GPU from
-            // the forward pass and while prefetching them is idempotent, it does incur an
-            // additional overhead.
-            std::vector<torch::Tensor> tensors = {dLossDRenderedFeatures.jdata(),
-                                                  dLossDRenderedAlphas.jdata(),
-                                                  outDLossDMeans2d,
-                                                  outDLossDConics,
-                                                  outDLossDFeatures,
-                                                  outDLossDOpacities};
+            std::vector<void *> prefetchPointers;
+            std::vector<size_t> prefetchSizes;
+            const TilePrefetchRange tileRange{deviceTileOffset,
+                                              deviceTileCount,
+                                              tileExtentH,
+                                              tileExtentW,
+                                              renderWindow.height,
+                                              renderWindow.width,
+                                              tileSize};
+            appendPerTilePrefetchRanges(prefetchPointers, prefetchSizes, tileTensors, tileRange);
+
+            const uint32_t cameraOffset = deviceTileOffset / tilesPerCamera;
+            const uint32_t cameraCount =
+                cuda::ceil_div(deviceTileOffset + deviceTileCount, tilesPerCamera) - cameraOffset;
+            std::vector<torch::Tensor> tensors = {
+                outDLossDMeans2d, outDLossDConics, outDLossDFeatures, outDLossDOpacities};
             if (absGrad) {
                 tensors.emplace_back(outDLossDMeans2dAbs);
             }
-            perCameraPrefetchBatchAsync(tensors, cameraOffset, cameraCount, deviceId, stream);
+            appendPerCameraPrefetchRanges(
+                prefetchPointers, prefetchSizes, tensors, cameraOffset, cameraCount);
+            memPrefetchBatchAsync(prefetchPointers, prefetchSizes, deviceId, stream);
 
             // Zero the outputs of the operator that need to be accumulated.
             tensors = {outDLossDMeans2d, outDLossDConics, outDLossDFeatures, outDLossDOpacities};

--- a/src/fvdb/detail/ops/gsplat/RasterizeScreenSpaceGaussiansForward.cu
+++ b/src/fvdb/detail/ops/gsplat/RasterizeScreenSpaceGaussiansForward.cu
@@ -684,8 +684,9 @@ launchRasterizeForwardKernels(
     auto outAlphas   = fvdb::JaggedTensor(alphasToRenderVec);
     auto outLastIds  = fvdb::JaggedTensor(lastIdsToRenderVec);
 
-    auto isSparse      = activeTiles.has_value();
-    uint32_t tileCount = isSparse ? activeTiles.value().size(0) : C * tileExtentH * tileExtentW;
+    auto isSparse                 = activeTiles.has_value();
+    const uint32_t tilesPerCamera = tileExtentH * tileExtentW;
+    uint32_t tileCount            = isSparse ? activeTiles.value().size(0) : C * tilesPerCamera;
 
     std::vector<cudaEvent_t> events(c10::cuda::device_count());
     for (const auto deviceId: c10::irange(c10::cuda::device_count())) {
@@ -700,14 +701,8 @@ launchRasterizeForwardKernels(
     auto reshapedFeatures =
         outFeatures.jdata().view({C, renderWindow.height, renderWindow.width, channels});
 
-    std::vector<torch::Tensor> tensors = {means2d,
-                                          conics,
-                                          features,
-                                          opacities,
-                                          tileOffsets,
-                                          reshapedAlphas,
-                                          reshapedLastIds,
-                                          reshapedFeatures};
+    std::vector<torch::Tensor> tileTensors = {
+        tileOffsets, reshapedAlphas, reshapedLastIds, reshapedFeatures};
 
     for (const auto deviceId: c10::irange(c10::cuda::device_count())) {
         C10_CUDA_CHECK(cudaSetDevice(deviceId));
@@ -716,12 +711,27 @@ launchRasterizeForwardKernels(
 
         uint32_t deviceTileOffset, deviceTileCount;
         std::tie(deviceTileOffset, deviceTileCount) = deviceChunk(tileCount, deviceId);
-        uint32_t cameraOffset = deviceTileOffset / (tileExtentH * tileExtentW);
-        uint32_t cameraCount =
-            cuda::ceil_div(deviceTileOffset + deviceTileCount, (tileExtentH * tileExtentW)) -
-            cameraOffset;
         if (deviceTileCount) {
-            perCameraPrefetchBatchAsync(tensors, cameraOffset, cameraCount, deviceId, stream);
+            std::vector<void *> prefetchPointers;
+            std::vector<size_t> prefetchSizes;
+            const TilePrefetchRange tileRange{deviceTileOffset,
+                                              deviceTileCount,
+                                              tileExtentH,
+                                              tileExtentW,
+                                              renderWindow.height,
+                                              renderWindow.width,
+                                              tileSize};
+            appendPerTilePrefetchRanges(prefetchPointers, prefetchSizes, tileTensors, tileRange);
+            if constexpr (!IS_PACKED) {
+                const uint32_t cameraOffset = deviceTileOffset / tilesPerCamera;
+                const uint32_t cameraCount =
+                    cuda::ceil_div(deviceTileOffset + deviceTileCount, tilesPerCamera) -
+                    cameraOffset;
+                std::vector<torch::Tensor> cameraTensors = {means2d, conics, features, opacities};
+                appendPerCameraPrefetchRanges(
+                    prefetchPointers, prefetchSizes, cameraTensors, cameraOffset, cameraCount);
+            }
+            memPrefetchBatchAsync(prefetchPointers, prefetchSizes, deviceId, stream);
         }
         C10_CUDA_CHECK(cudaEventRecord(events[deviceId], stream));
     }

--- a/src/fvdb/detail/utils/cuda/Prefetch.cpp
+++ b/src/fvdb/detail/utils/cuda/Prefetch.cpp
@@ -9,8 +9,115 @@
 #include <c10/core/ScalarType.h>
 #include <c10/cuda/CUDAException.h>
 
+#include <algorithm>
+#include <cstdint>
+#include <vector>
+
 namespace fvdb {
 namespace detail {
+
+namespace {
+
+void
+appendPerTileTensorRanges(std::vector<void *> &prefetchPointers,
+                          std::vector<size_t> &prefetchSizes,
+                          const torch::Tensor &tensor,
+                          const TilePrefetchRange &range) {
+    const size_t scalarSize    = c10::elementSize(tensor.scalar_type());
+    const size_t tileSizeBytes = tensor.stride(2) * scalarSize;
+    const size_t prefetchSize  = range.count * tileSizeBytes;
+    auto *const prefetchPointer =
+        static_cast<uint8_t *>(tensor.data_ptr()) + range.offset * tileSizeBytes;
+    if (prefetchSize > 0) {
+        prefetchPointers.emplace_back(prefetchPointer);
+        prefetchSizes.emplace_back(prefetchSize);
+    }
+}
+
+void
+appendPerTileImageRanges(std::vector<void *> &prefetchPointers,
+                         std::vector<size_t> &prefetchSizes,
+                         const torch::Tensor &tensor,
+                         const TilePrefetchRange &range,
+                         uint64_t tilesPerCamera) {
+    const size_t scalarSize        = c10::elementSize(tensor.scalar_type());
+    const size_t pixelStrideBytes  = tensor.stride(2) * scalarSize;
+    const size_t rowStrideBytes    = tensor.stride(1) * scalarSize;
+    const size_t cameraStrideBytes = tensor.stride(0) * scalarSize;
+    const uint64_t tileRangeEnd    = static_cast<uint64_t>(range.offset) + range.count;
+    uint64_t currentTile           = range.offset;
+
+    while (currentTile < tileRangeEnd) {
+        const uint64_t cameraId        = currentTile / tilesPerCamera;
+        const uint64_t cameraTileBegin = cameraId * tilesPerCamera;
+        const uint64_t nextCameraTile =
+            std::min<uint64_t>(tileRangeEnd, cameraTileBegin + tilesPerCamera);
+        const uint32_t firstTileInCamera = static_cast<uint32_t>(currentTile - cameraTileBegin);
+        const uint32_t lastTileInCamera =
+            static_cast<uint32_t>(nextCameraTile - cameraTileBegin - 1);
+
+        const uint32_t firstTileRow = firstTileInCamera / range.numTilesW;
+        const uint32_t firstTileCol = firstTileInCamera % range.numTilesW;
+        const uint32_t lastTileRow  = lastTileInCamera / range.numTilesW;
+        const uint32_t lastTileCol  = lastTileInCamera % range.numTilesW;
+
+        const uint32_t rowStart = firstTileRow * range.tileSize;
+        const uint32_t rowEnd =
+            std::min<uint32_t>(range.imageHeight, (lastTileRow + 1) * range.tileSize);
+        const uint32_t colStart = firstTileCol * range.tileSize;
+        const uint32_t colEnd =
+            std::min<uint32_t>(range.imageWidth, (lastTileCol + 1) * range.tileSize);
+
+        if (rowStart < rowEnd) {
+            auto *cameraPtr =
+                static_cast<uint8_t *>(tensor.data_ptr()) + cameraId * cameraStrideBytes;
+            auto *prefetchPointer =
+                cameraPtr + rowStart * rowStrideBytes + colStart * pixelStrideBytes;
+            auto *prefetchEnd =
+                cameraPtr + (rowEnd - 1) * rowStrideBytes + colEnd * pixelStrideBytes;
+            if (prefetchPointer < prefetchEnd) {
+                const size_t prefetchSize = static_cast<size_t>(prefetchEnd - prefetchPointer);
+                prefetchPointers.emplace_back(prefetchPointer);
+                prefetchSizes.emplace_back(prefetchSize);
+            }
+        }
+
+        currentTile = nextCameraTile;
+    }
+}
+
+} // namespace
+
+void
+memPrefetchBatchAsync(std::vector<void *> &prefetchPointers,
+                      std::vector<size_t> &prefetchSizes,
+                      int deviceId,
+                      cudaStream_t stream) {
+    TORCH_CHECK(stream, "cudaMemPrefetchBatchAsync does not support the default stream");
+    if (prefetchPointers.empty()) {
+        return;
+    }
+
+#if (CUDART_VERSION < 13000)
+    for (size_t i = 0; i < prefetchPointers.size(); ++i) {
+        C10_CUDA_CHECK(nanovdb::util::cuda::memPrefetchAsync(
+            prefetchPointers[i], prefetchSizes[i], deviceId, stream));
+    }
+#else
+    const cudaMemLocation location                 = {cudaMemLocationTypeDevice, deviceId};
+    std::vector<cudaMemLocation> prefetchLocations = {location};
+    std::vector<size_t> prefetchLocationIndices    = {0};
+
+    C10_CUDA_CHECK(cudaMemPrefetchBatchAsync(prefetchPointers.data(),
+                                             prefetchSizes.data(),
+                                             prefetchPointers.size(),
+                                             prefetchLocations.data(),
+                                             prefetchLocationIndices.data(),
+                                             prefetchLocations.size(),
+                                             0,
+                                             stream));
+#endif
+}
 
 void
 perCameraPrefetchAsync(const torch::Tensor &tensor,
@@ -35,47 +142,69 @@ perCameraPrefetchBatchAsync(const torch::TensorList &tensors,
                             uint32_t cameraCount,
                             int deviceId,
                             cudaStream_t stream) {
-    TORCH_CHECK(stream, "cudaMemPrefetchBatchAsync does not support the default stream");
-#if (CUDART_VERSION < 13000)
+    std::vector<void *> prefetchPointers;
+    std::vector<size_t> prefetchSizes;
+    appendPerCameraPrefetchRanges(
+        prefetchPointers, prefetchSizes, tensors, cameraOffset, cameraCount);
+    memPrefetchBatchAsync(prefetchPointers, prefetchSizes, deviceId, stream);
+}
+
+void
+appendPerCameraPrefetchRanges(std::vector<void *> &prefetchPointers,
+                              std::vector<size_t> &prefetchSizes,
+                              const torch::TensorList &tensors,
+                              uint32_t cameraOffset,
+                              uint32_t cameraCount) {
     for (size_t i = 0; i < tensors.size(); ++i) {
         const auto &tensor = tensors[i];
         TORCH_CHECK(tensor.is_contiguous(), "Tensor to prefetch is not contiguous");
         TORCH_CHECK(cameraOffset + cameraCount <= tensor.size(0),
                     "Tensor does not have a batched first dimension");
-        size_t scalarSize = c10::elementSize(tensor.scalar_type());
-        C10_CUDA_CHECK(
-            nanovdb::util::cuda::memPrefetchAsync(static_cast<uint8_t *>(tensor.data_ptr()) +
-                                                      cameraOffset * tensor.stride(0) * scalarSize,
-                                                  cameraCount * tensor.stride(0) * scalarSize,
-                                                  deviceId,
-                                                  stream));
+        const size_t scalarSize   = c10::elementSize(tensor.scalar_type());
+        const size_t prefetchSize = cameraCount * tensor.stride(0) * scalarSize;
+        if (prefetchSize > 0) {
+            prefetchPointers.emplace_back(static_cast<uint8_t *>(tensor.data_ptr()) +
+                                          cameraOffset * tensor.stride(0) * scalarSize);
+            prefetchSizes.emplace_back(prefetchSize);
+        }
     }
-#else
-    std::vector<void *> prefetchPointers;
-    std::vector<size_t> prefetchSizes;
-    const cudaMemLocation location                 = {cudaMemLocationTypeDevice, deviceId};
-    std::vector<cudaMemLocation> prefetchLocations = {location};
-    std::vector<size_t> prefetchLocationIndices    = {0};
+}
+
+void
+appendPerTilePrefetchRanges(std::vector<void *> &prefetchPointers,
+                            std::vector<size_t> &prefetchSizes,
+                            const torch::TensorList &tensors,
+                            const TilePrefetchRange &range) {
+    if (range.count == 0) {
+        return;
+    }
+    TORCH_CHECK(range.numTilesH > 0 && range.numTilesW > 0,
+                "Tile dimensions must be greater than 0");
+    TORCH_CHECK(range.tileSize > 0, "Tile size must be greater than 0");
+    const uint64_t tilesPerCamera =
+        static_cast<uint64_t>(range.numTilesH) * static_cast<uint64_t>(range.numTilesW);
 
     for (size_t i = 0; i < tensors.size(); ++i) {
         const auto &tensor = tensors[i];
         TORCH_CHECK(tensor.is_contiguous(), "Tensor to prefetch is not contiguous");
-        TORCH_CHECK(cameraOffset + cameraCount <= tensor.size(0),
-                    "Tensor does not have a batched first dimension");
-        size_t scalarSize = c10::elementSize(tensor.scalar_type());
-        prefetchPointers.emplace_back(static_cast<uint8_t *>(tensor.data_ptr()) +
-                                      cameraOffset * tensor.stride(0) * scalarSize);
-        prefetchSizes.emplace_back(cameraCount * tensor.stride(0) * scalarSize);
+        TORCH_CHECK(tensor.dim() >= 3, "Tensor to prefetch must have at least 3 dimensions");
+        TORCH_CHECK(static_cast<uint64_t>(range.offset) + static_cast<uint64_t>(range.count) <=
+                        static_cast<uint64_t>(tensor.size(0)) * tilesPerCamera,
+                    "Tile range exceeds tensor tile dimensions");
+
+        if (tensor.size(1) == static_cast<int64_t>(range.numTilesH) &&
+            tensor.size(2) == static_cast<int64_t>(range.numTilesW)) {
+            appendPerTileTensorRanges(prefetchPointers, prefetchSizes, tensor, range);
+        } else if (tensor.size(1) == static_cast<int64_t>(range.imageHeight) &&
+                   tensor.size(2) == static_cast<int64_t>(range.imageWidth)) {
+            appendPerTileImageRanges(
+                prefetchPointers, prefetchSizes, tensor, range, tilesPerCamera);
+        } else {
+            TORCH_CHECK(false,
+                        "Tensor to prefetch must have dimensions [C, numTilesH, numTilesW, ...] "
+                        "or [C, imageHeight, imageWidth, ...]");
+        }
     }
-    C10_CUDA_CHECK(cudaMemPrefetchBatchAsync(prefetchPointers.data(),
-                                             prefetchSizes.data(),
-                                             prefetchPointers.size(),
-                                             prefetchLocations.data(),
-                                             prefetchLocationIndices.data(),
-                                             prefetchLocations.size(),
-                                             0,
-                                             stream));
-#endif
 }
 
 void

--- a/src/fvdb/detail/utils/cuda/Prefetch.h
+++ b/src/fvdb/detail/utils/cuda/Prefetch.h
@@ -8,8 +8,20 @@
 
 #include <cuda_runtime_api.h>
 
+#include <vector>
+
 namespace fvdb {
 namespace detail {
+
+struct TilePrefetchRange {
+    uint32_t offset;
+    uint32_t count;
+    uint32_t numTilesH;
+    uint32_t numTilesW;
+    uint32_t imageHeight;
+    uint32_t imageWidth;
+    uint32_t tileSize;
+};
 
 /// Given a contiguous tensor with dimensions [C, ...] where C is the number of cameras, we prefetch
 /// the slices [cameraOffset : cameraCount, ...] to the specified device ordered on the input
@@ -28,6 +40,25 @@ void perCameraPrefetchBatchAsync(const torch::TensorList &tensors,
                                  uint32_t cameraCount,
                                  int deviceId,
                                  cudaStream_t stream);
+
+void appendPerCameraPrefetchRanges(std::vector<void *> &prefetchPointers,
+                                   std::vector<size_t> &prefetchSizes,
+                                   const torch::TensorList &tensors,
+                                   uint32_t cameraOffset,
+                                   uint32_t cameraCount);
+
+/// Given a list of contiguous tensors laid out as either [C, numTilesH, numTilesW, ...] or
+/// [C, imageHeight, imageWidth, ...], append the memory touched by the tile range
+/// [tileOffset, tileOffset + tileCount) to the prefetch batch.
+void appendPerTilePrefetchRanges(std::vector<void *> &prefetchPointers,
+                                 std::vector<size_t> &prefetchSizes,
+                                 const torch::TensorList &tensors,
+                                 const TilePrefetchRange &range);
+
+void memPrefetchBatchAsync(std::vector<void *> &prefetchPointers,
+                           std::vector<size_t> &prefetchSizes,
+                           int deviceId,
+                           cudaStream_t stream);
 
 /// Given a list of contiguous tensors each with dimensions [C, ...] where C is the number of
 /// cameras, we memset the slices [cameraOffset : cameraCount, ...] to the specified value

--- a/src/fvdb/detail/utils/cuda/Utils.cuh
+++ b/src/fvdb/detail/utils/cuda/Utils.cuh
@@ -18,15 +18,21 @@ namespace detail {
 static constexpr size_t kPageSize = 1u << 21;
 
 inline std::tuple<size_t, size_t>
-deviceAlignedChunk(size_t alignment, size_t size, c10::DeviceIndex device) {
-    size_t chunkSize = alignment * ((size + alignment * c10::cuda::device_count() - 1) /
-                                    (c10::cuda::device_count() * alignment));
+deviceAlignedChunk(size_t alignment, size_t size, c10::DeviceIndex device, size_t deviceCount) {
+    TORCH_CHECK(deviceCount > 0, "Device count must be greater than 0");
+    size_t chunkSize =
+        alignment * ((size + alignment * deviceCount - 1) / (deviceCount * alignment));
     auto chunkOffset = chunkSize * device;
     if (chunkOffset + chunkSize > size) {
         chunkOffset = std::min(chunkOffset, size);
         chunkSize   = std::min(chunkSize, size - chunkOffset);
     }
     return std::make_tuple(chunkOffset, chunkSize);
+}
+
+inline std::tuple<size_t, size_t>
+deviceAlignedChunk(size_t alignment, size_t size, c10::DeviceIndex device) {
+    return deviceAlignedChunk(alignment, size, device, c10::cuda::device_count());
 }
 
 inline std::tuple<size_t, size_t>

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -144,6 +144,7 @@ ConfigureTest(ExampleTest "ExampleTest.cpp")
 
 # Configure unit tests
 ConfigureTest(HDDAIteratorsTest "HDDAIteratorsTest.cpp")
+ConfigureTest(PrefetchTest "PrefetchTest.cpp")
 ConfigureTest(JaggedTensorTest "JaggedTensorTest.cpp")
 ConfigureTest(PackedJaggedAccessorTest "PackedJaggedAccessorTest.cu")
 ConfigureTest(GaussianComputeSparseInfoTest "GaussianComputeSparseInfoTest.cpp")

--- a/src/tests/PrefetchTest.cpp
+++ b/src/tests/PrefetchTest.cpp
@@ -1,0 +1,145 @@
+// Copyright Contributors to the OpenVDB Project
+// SPDX-License-Identifier: Apache-2.0
+
+#include <fvdb/detail/utils/cuda/Prefetch.h>
+#include <fvdb/detail/utils/cuda/Utils.cuh>
+
+#include <c10/core/ScalarType.h>
+#include <torch/types.h>
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <vector>
+
+namespace {
+
+constexpr uint32_t kNumTilesH      = 2;
+constexpr uint32_t kNumTilesW      = 3;
+constexpr uint32_t kImageH         = 7;
+constexpr uint32_t kImageW         = 10;
+constexpr uint32_t kTileSize       = 4;
+constexpr uint32_t kChannels       = 3;
+constexpr uint32_t kTilesPerCamera = kNumTilesH * kNumTilesW;
+
+class PrefetchTest : public ::testing::Test {
+  protected:
+    void
+    checkPerTileRanges(uint32_t batchSize, uint32_t deviceCount) {
+        const auto options = torch::TensorOptions().dtype(torch::kFloat32);
+        const auto batch   = static_cast<int64_t>(batchSize);
+
+        auto tileTensor                    = torch::empty({batch,
+                                                           static_cast<int64_t>(kNumTilesH),
+                                                           static_cast<int64_t>(kNumTilesW),
+                                                           static_cast<int64_t>(kChannels)},
+                                       options);
+        auto imageTensor                   = torch::empty({batch,
+                                                           static_cast<int64_t>(kImageH),
+                                                           static_cast<int64_t>(kImageW),
+                                                           static_cast<int64_t>(kChannels)},
+                                        options);
+        std::vector<torch::Tensor> tensors = {tileTensor, imageTensor};
+        const uint64_t totalTiles          = static_cast<uint64_t>(batchSize) * kTilesPerCamera;
+
+        for (uint32_t deviceId = 0; deviceId < deviceCount; ++deviceId) {
+            const auto [chunkOffset, chunkCount] = fvdb::detail::deviceAlignedChunk(
+                1, batchSize * kTilesPerCamera, deviceId, deviceCount);
+            const auto tileOffset = static_cast<uint32_t>(chunkOffset);
+            const auto tileCount  = static_cast<uint32_t>(chunkCount);
+            ASSERT_GT(tileCount, 0u);
+            const uint64_t tileRangeEnd = static_cast<uint64_t>(tileOffset) + tileCount;
+
+            // Chunks must stay inside the batched tile domain.
+            EXPECT_LT(tileOffset, tileRangeEnd);
+            EXPECT_LE(tileRangeEnd, totalTiles);
+            if (deviceId + 1 == deviceCount) {
+                EXPECT_EQ(tileRangeEnd, totalTiles);
+            }
+
+            std::vector<void *> prefetchPointers;
+            std::vector<size_t> prefetchSizes;
+            const fvdb::detail::TilePrefetchRange range{
+                tileOffset, tileCount, kNumTilesH, kNumTilesW, kImageH, kImageW, kTileSize};
+            fvdb::detail::appendPerTilePrefetchRanges(
+                prefetchPointers, prefetchSizes, tensors, range);
+
+            auto *const tileBase           = static_cast<uint8_t *>(tileTensor.data_ptr());
+            auto *const imageBase          = static_cast<uint8_t *>(imageTensor.data_ptr());
+            const size_t scalarSize        = c10::elementSize(tileTensor.scalar_type());
+            const size_t tileSizeBytes     = tileTensor.stride(2) * scalarSize;
+            const size_t cameraStrideBytes = imageTensor.stride(0) * scalarSize;
+
+            const uint32_t cameraOffset = tileOffset / kTilesPerCamera;
+            const uint32_t cameraCount =
+                static_cast<uint32_t>((tileRangeEnd + kTilesPerCamera - 1) / kTilesPerCamera) -
+                cameraOffset;
+            const size_t expectedRangeCount = static_cast<size_t>(cameraCount) + 1;
+
+            // One tile range, plus one image range per touched camera.
+            ASSERT_EQ(prefetchPointers.size(), expectedRangeCount);
+            ASSERT_EQ(prefetchSizes.size(), expectedRangeCount);
+
+            const auto tileBaseAddress  = reinterpret_cast<std::uintptr_t>(tileBase);
+            const auto imageBaseAddress = reinterpret_cast<std::uintptr_t>(imageBase);
+            const auto tileTensorEnd =
+                tileBaseAddress + static_cast<size_t>(tileTensor.numel()) * scalarSize;
+            const auto tileRangeBegin = reinterpret_cast<std::uintptr_t>(prefetchPointers[0]);
+            const auto tilePointerEnd = tileRangeBegin + prefetchSizes[0];
+
+            // The first range should exactly match the requested tile-layout span.
+            EXPECT_EQ(prefetchPointers[0],
+                      static_cast<void *>(tileBase + tileOffset * tileSizeBytes));
+            EXPECT_EQ(prefetchSizes[0], tileCount * tileSizeBytes);
+            EXPECT_GT(prefetchSizes[0], 0ul);
+
+            // The tile span must be non-empty and within tensor storage.
+            EXPECT_LT(tileRangeBegin, tilePointerEnd);
+            EXPECT_GE(tileRangeBegin, tileBaseAddress);
+            EXPECT_LE(tilePointerEnd, tileTensorEnd);
+
+            for (uint32_t cameraIndex = 0; cameraIndex < cameraCount; ++cameraIndex) {
+                const size_t rangeIndex = static_cast<size_t>(cameraIndex) + 1;
+                const uint32_t cameraId = cameraOffset + cameraIndex;
+                const auto cameraBegin  = imageBaseAddress + cameraId * cameraStrideBytes;
+                const auto cameraEnd    = cameraBegin + cameraStrideBytes;
+                const auto rangeBegin =
+                    reinterpret_cast<std::uintptr_t>(prefetchPointers[rangeIndex]);
+                const auto rangeEnd        = rangeBegin + prefetchSizes[rangeIndex];
+                const auto cameraTileBegin = static_cast<uint64_t>(cameraId) * kTilesPerCamera;
+                const auto cameraTileEnd   = cameraTileBegin + kTilesPerCamera;
+
+                // Image ranges must be non-empty and contained in one camera.
+                EXPECT_GT(prefetchSizes[rangeIndex], 0ul);
+                EXPECT_LT(rangeBegin, rangeEnd);
+                EXPECT_GE(rangeBegin, cameraBegin);
+                EXPECT_LE(rangeEnd, cameraEnd);
+
+                // A fully covered camera should prefetch its whole image slice.
+                if (static_cast<uint64_t>(tileOffset) <= cameraTileBegin &&
+                    cameraTileEnd <= tileRangeEnd) {
+                    EXPECT_EQ(rangeBegin, cameraBegin);
+                    EXPECT_EQ(prefetchSizes[rangeIndex], cameraStrideBytes);
+                }
+            }
+        }
+    }
+};
+
+TEST_F(PrefetchTest, PerTileRangesBatch1Device1) {
+    checkPerTileRanges(1, 1);
+}
+
+TEST_F(PrefetchTest, PerTileRangesBatch1Device2) {
+    checkPerTileRanges(1, 2);
+}
+
+TEST_F(PrefetchTest, PerTileRangesBatch2Device1) {
+    checkPerTileRanges(2, 1);
+}
+
+TEST_F(PrefetchTest, PerTileRangesBatch2Device2) {
+    checkPerTileRanges(2, 2);
+}
+
+} // namespace


### PR DESCRIPTION
Prior to this PR, we prefetched image-space tensors with camera granularity. That is, if an image in a camera was rendered across multiple GPUs, each GPU would prefetch the entire image. This is overly conservative and increases the amount of bandwidth required.

This PR refines that prefetching to have better granularity by prefetching on the tiles rendered by each GPU. This reduces the amount of cross-device traffic and leads to an approximately 5% speedup on 2x RTX 3090s for training.