### PR TITLE
Add narrow-band SDF reinitialize/retopologize ops

### DIFF
--- a/fvdb/__init__.py
+++ b/fvdb/__init__.py
@@ -271,7 +271,7 @@ def gaussian_render_jagged(
 
 from .convolution_plan import ConvolutionPlan
 from .gaussian_splatting import GaussianSplat3d, ProjectedGaussianSplats
-from .enums import CameraModel, ProjectionMethod, RollingShutterType, ShOrderingMode
+from .enums import CameraModel, ProjectionMethod, RollingShutterType, ShOrderingMode, SmoothingMode
 from ._gaussian_autograd import _EvaluateGaussianSHFn
 
 
@@ -383,6 +383,7 @@ __all__ = [
     "ProjectionMethod",
     "RollingShutterType",
     "ShOrderingMode",
+    "SmoothingMode",
     "ConvolutionPlan",
     "NanoVDBGridMetadata",
     # Concatenation of jagged tensors or grid/grid batches

--- a/fvdb/_fvdb_cpp.pyi
+++ b/fvdb/_fvdb_cpp.pyi
@@ -870,6 +870,21 @@ def integrate_tsdf_with_features(
     weight_images: torch.Tensor | None,
 ) -> tuple[GridBatchData, JaggedTensor, JaggedTensor, JaggedTensor]: ...
 
+# SDF ops
+class SmoothingMode(Enum):
+    MEAN_CURVATURE = ...
+    TAUBIN = ...
+
+def reinitialize_sdf(
+    grid: GridBatchData,
+    field: JaggedTensor,
+    band: int,
+    redistance_iters: int,
+    order: int,
+    smooth: int,
+    smoothing: SmoothingMode,
+) -> JaggedTensor: ...
+
 # Topology / misc
 def grid_edge_network(
     grid: GridBatchData,

--- a/fvdb/enums.py
+++ b/fvdb/enums.py
@@ -33,6 +33,30 @@ class ShOrderingMode(str, Enum):
     """
 
 
+class SmoothingMode(IntEnum):
+    """
+    Laplacian smoothing mode used to de-staircase a signed distance field in
+    :meth:`fvdb.Grid.reinitialize_sdf` / :meth:`fvdb.Grid.retopologize_sdf` (and their
+    :class:`fvdb.GridBatch` counterparts).
+
+    The number of smoothing passes is controlled separately by the ``smooth`` argument; this enum
+    selects *which* umbrella-Laplacian flow each pass applies. Values mirror the C++
+    ``fvdb::detail::ops::SmoothingMode`` enum.
+    """
+
+    MEAN_CURVATURE = 0
+    """
+    Mean-curvature flow: each pass moves every voxel toward the average of its 6 face neighbours.
+    Effective at removing staircase artifacts but shrinks the surface (volume loss) if over-applied.
+    """
+
+    TAUBIN = 1
+    """
+    Volume-preserving Taubin smoothing: alternates a positive (shrinking) and a slightly larger
+    negative (inflating) Laplacian step per pass, de-staircasing with much less volume loss.
+    """
+
+
 class RollingShutterType(IntEnum):
     """
     Rolling shutter policy for camera projection / ray generation.

--- a/fvdb/functional/__init__.py
+++ b/fvdb/functional/__init__.py
@@ -93,6 +93,14 @@ from ._meshing import (
     marching_cubes_single,
 )
 
+# Signed distance fields
+from ._sdf import (
+    reinitialize_sdf_batch,
+    reinitialize_sdf_single,
+    retopologize_sdf_batch,
+    retopologize_sdf_single,
+)
+
 # Pooling / refinement
 from ._pooling import (
     avg_pool_batch,
@@ -260,6 +268,11 @@ __all__ = [
     "integrate_tsdf_single",
     "integrate_tsdf_with_features_batch",
     "integrate_tsdf_with_features_single",
+    # Signed distance fields
+    "reinitialize_sdf_batch",
+    "reinitialize_sdf_single",
+    "retopologize_sdf_batch",
+    "retopologize_sdf_single",
     # Topology
     "clip_batch",
     "clip_single",

--- a/fvdb/functional/_sdf.py
+++ b/fvdb/functional/_sdf.py
@@ -150,20 +150,18 @@ def retopologize_sdf_batch(
 
     .. seealso:: :func:`retopologize_sdf_single`, :func:`reinitialize_sdf_batch`
     """
+    # per-grid narrow-band half-width; voxel size may vary across the batch
+    band_width = band * grid.voxel_sizes[:, 0]
     if pad:
-        # Seed fresh voxels as exterior. A single positive seed >= every grid's band width is fine:
+        # Seed fresh voxels as exterior. A positive seed >= every grid's band width is fine:
         # reinitialize_sdf re-clamps it to that grid's +band*vx, so only its (positive) sign matters.
-        seed = band * float(grid.voxel_sizes[:, 0].max())
         dilated = grid.dilated_grid(band)
-        field = inject_batch(dilated, grid, field, default_value=seed)
+        field = inject_batch(dilated, grid, field, default_value=float(band_width.max()))
         grid = dilated
     phi = reinitialize_sdf_batch(grid, field, band, smooth, order, smoothing, redistance_iters)
     if not prune:
         return grid, phi
-    # per-voxel band half-width (voxel size may vary per grid in the batch)
-    voxel_sizes = grid.voxel_sizes[:, 0].to(phi.jdata.device)
-    band_width = band * voxel_sizes[phi.jidx.long()] * 0.999
-    mask = phi.jdata.abs() < band_width
+    mask = phi.jdata.abs() < band_width.to(phi.jdata.device)[phi.jidx.long()] * 0.999
     return grid.pruned_grid(phi.jagged_like(mask)), phi.rmask(mask)
 
 
@@ -211,8 +209,11 @@ def retopologize_sdf_single(
 
     .. seealso:: :func:`retopologize_sdf_batch`, :func:`reinitialize_sdf_single`
     """
+    # narrow-band half-width
     band_width = band * float(grid.voxel_size[0])
     if pad:
+        # Seed fresh voxels as exterior. A positive seed >= the grid's band width is fine:
+        # reinitialize_sdf re-clamps it to +band*vx, so only its (positive) sign matters.
         dilated = grid.dilated_grid(band)
         field = inject_single(dilated, grid, field, default_value=band_width)
         grid = dilated

--- a/fvdb/functional/_sdf.py
+++ b/fvdb/functional/_sdf.py
@@ -18,9 +18,9 @@ if TYPE_CHECKING:
     from ..grid_batch import GridBatch
 
 
-def _to_cpp_smoothing(smoothing: SmoothingMode | int) -> "_fvdb_cpp.SmoothingMode":
+def _to_cpp_smoothing(smoothing: SmoothingMode) -> "_fvdb_cpp.SmoothingMode":
     """Convert a public :class:`fvdb.SmoothingMode` to the bound C++ enum (matched by member name)."""
-    return getattr(_fvdb_cpp.SmoothingMode, SmoothingMode(smoothing).name)
+    return getattr(_fvdb_cpp.SmoothingMode, smoothing.name)
 
 
 # ---------------------------------------------------------------------------
@@ -34,7 +34,7 @@ def reinitialize_sdf_batch(
     band: int = 3,
     smooth: int = 0,
     order: int = 3,
-    smoothing: SmoothingMode | int = SmoothingMode.MEAN_CURVATURE,
+    smoothing: SmoothingMode = SmoothingMode.MEAN_CURVATURE,
     redistance_iters: int = -1,
 ) -> JaggedTensor:
     """Re-initialize a signed per-voxel field into an SDF on the same grid batch.
@@ -72,7 +72,7 @@ def reinitialize_sdf_single(
     band: int = 3,
     smooth: int = 0,
     order: int = 3,
-    smoothing: SmoothingMode | int = SmoothingMode.MEAN_CURVATURE,
+    smoothing: SmoothingMode = SmoothingMode.MEAN_CURVATURE,
     redistance_iters: int = -1,
 ) -> torch.Tensor:
     """Re-initialize a signed per-voxel field into an SDF on a single grid.
@@ -111,7 +111,7 @@ def retopologize_sdf_batch(
     band: int = 3,
     smooth: int = 0,
     order: int = 3,
-    smoothing: SmoothingMode | int = SmoothingMode.MEAN_CURVATURE,
+    smoothing: SmoothingMode = SmoothingMode.MEAN_CURVATURE,
     redistance_iters: int = -1,
     pad: bool = True,
     prune: bool = True,
@@ -173,7 +173,7 @@ def retopologize_sdf_single(
     band: int = 3,
     smooth: int = 0,
     order: int = 3,
-    smoothing: SmoothingMode | int = SmoothingMode.MEAN_CURVATURE,
+    smoothing: SmoothingMode = SmoothingMode.MEAN_CURVATURE,
     redistance_iters: int = -1,
     pad: bool = True,
     prune: bool = True,

--- a/fvdb/functional/_sdf.py
+++ b/fvdb/functional/_sdf.py
@@ -1,0 +1,223 @@
+# Copyright Contributors to the OpenVDB Project
+# SPDX-License-Identifier: Apache-2.0
+#
+"""Functional API for signed-distance-field (SDF) re-initialization and narrow-band retopologization."""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+
+from .. import _fvdb_cpp
+from ..enums import SmoothingMode
+from ..jagged_tensor import JaggedTensor
+from ._dense import inject_batch, inject_single
+
+if TYPE_CHECKING:
+    from ..grid import Grid
+    from ..grid_batch import GridBatch
+
+
+def _to_cpp_smoothing(smoothing: SmoothingMode | int) -> "_fvdb_cpp.SmoothingMode":
+    """Convert a public :class:`fvdb.SmoothingMode` to the bound C++ enum (matched by member name)."""
+    return getattr(_fvdb_cpp.SmoothingMode, SmoothingMode(smoothing).name)
+
+
+# ---------------------------------------------------------------------------
+#  reinitialize_sdf  (fixed-topology redistance + de-staircase)
+# ---------------------------------------------------------------------------
+
+
+def reinitialize_sdf_batch(
+    grid: GridBatch,
+    field: JaggedTensor,
+    band: int = 3,
+    smooth: int = 0,
+    order: int = 3,
+    smoothing: SmoothingMode | int = SmoothingMode.MEAN_CURVATURE,
+    redistance_iters: int = -1,
+) -> JaggedTensor:
+    """Re-initialize a signed per-voxel field into an SDF on the same grid batch.
+
+    Redistances ``field`` to satisfy ``|grad phi| = 1`` (TVD-RK Godunov upwind eikonal solve with a
+    frozen Peng sign), then optionally de-staircases it with curvature-based smoothing. The grid
+    topology is unchanged: the returned field has the same per-voxel ordering as ``field``.
+
+    Args:
+        grid (GridBatch): The grid batch defining the sparse topology.
+        field (JaggedTensor): Per-voxel signed field values.
+        band (int): Narrow-band half-width in voxels. The field is clamped to ``[-band*vx, band*vx]``.
+        smooth (int): Number of smoothing passes (``0`` disables smoothing).
+        order (int): TVD-RK order, one of ``1`` (Euler), ``2`` (Heun), or ``3`` (Shu-Osher).
+        smoothing (SmoothingMode): Which Laplacian flow each smoothing pass applies --
+            :attr:`~fvdb.SmoothingMode.MEAN_CURVATURE` (default) or
+            :attr:`~fvdb.SmoothingMode.TAUBIN` (volume-preserving). Only used when ``smooth > 0``.
+        redistance_iters (int): Number of redistancing sweeps. ``<= 0`` uses the default
+            ``max(6, round(2.5*band) + 2)``.
+
+    Returns:
+        sdf (JaggedTensor): The re-initialized SDF, same per-voxel ordering as ``field``.
+
+    .. seealso:: :func:`reinitialize_sdf_single`, :func:`retopologize_sdf_batch`
+    """
+    result = _fvdb_cpp.reinitialize_sdf(
+        grid.data, field._impl, band, redistance_iters, order, smooth, _to_cpp_smoothing(smoothing)
+    )
+    return JaggedTensor(impl=result)
+
+
+def reinitialize_sdf_single(
+    grid: Grid,
+    field: torch.Tensor,
+    band: int = 3,
+    smooth: int = 0,
+    order: int = 3,
+    smoothing: SmoothingMode | int = SmoothingMode.MEAN_CURVATURE,
+    redistance_iters: int = -1,
+) -> torch.Tensor:
+    """Re-initialize a signed per-voxel field into an SDF on a single grid.
+
+    Args:
+        grid (Grid): The single grid defining the sparse topology.
+        field (torch.Tensor): Per-voxel signed field values, shape ``(num_voxels,)``.
+        band (int): Narrow-band half-width in voxels.
+        smooth (int): Number of smoothing passes (``0`` disables smoothing).
+        order (int): TVD-RK order, one of ``1``, ``2``, or ``3``.
+        smoothing (SmoothingMode): Which Laplacian flow each smoothing pass applies --
+            :attr:`~fvdb.SmoothingMode.MEAN_CURVATURE` (default) or
+            :attr:`~fvdb.SmoothingMode.TAUBIN` (volume-preserving). Only used when ``smooth > 0``.
+        redistance_iters (int): Number of redistancing sweeps. ``<= 0`` uses the default.
+
+    Returns:
+        sdf (torch.Tensor): The re-initialized SDF, shape ``(num_voxels,)``.
+
+    .. seealso:: :func:`reinitialize_sdf_batch`, :func:`retopologize_sdf_single`
+    """
+    field_jt = JaggedTensor(field)
+    result = _fvdb_cpp.reinitialize_sdf(
+        grid.data, field_jt._impl, band, redistance_iters, order, smooth, _to_cpp_smoothing(smoothing)
+    )
+    return JaggedTensor(impl=result).jdata
+
+
+# ---------------------------------------------------------------------------
+#  retopologize_sdf  (reinitialize + narrow-band prune)
+# ---------------------------------------------------------------------------
+
+
+def retopologize_sdf_batch(
+    grid: GridBatch,
+    field: JaggedTensor,
+    band: int = 3,
+    smooth: int = 0,
+    order: int = 3,
+    smoothing: SmoothingMode | int = SmoothingMode.MEAN_CURVATURE,
+    redistance_iters: int = -1,
+    pad: bool = True,
+    prune: bool = True,
+) -> tuple[GridBatch, JaggedTensor]:
+    """Retopologize a signed field into a clean narrow-band SDF on a (possibly pruned) grid batch.
+
+    If ``pad`` is ``True`` the grid is first dilated by ``band`` voxels (so the eikonal solve has room
+    to propagate a full-width band), then :func:`reinitialize_sdf_batch` is run, and finally, if
+    ``prune`` is ``True``, the grid is pruned to the voxels strictly inside the band
+    (``|phi| < band*vx*0.999``). The prune reuses :meth:`GridBatch.pruned_grid`; the resulting field
+    is selected in the grid's canonical voxel order so it stays aligned with the pruned grid.
+
+    Args:
+        grid (GridBatch): The grid batch defining the sparse topology.
+        field (JaggedTensor): Per-voxel signed field values.
+        band (int): Narrow-band half-width in voxels.
+        smooth (int): Number of smoothing passes (``0`` disables smoothing).
+        order (int): TVD-RK order, one of ``1``, ``2``, or ``3``.
+        smoothing (SmoothingMode): Which Laplacian flow each smoothing pass applies --
+            :attr:`~fvdb.SmoothingMode.MEAN_CURVATURE` (default) or
+            :attr:`~fvdb.SmoothingMode.TAUBIN` (volume-preserving). Only used when ``smooth > 0``.
+        redistance_iters (int): Number of redistancing sweeps. ``<= 0`` uses the default.
+        pad (bool): If ``True`` (default) dilate the grid by ``band`` voxels before redistancing so
+            the output narrow band is a full ``band`` voxels wide even if the input grid had a
+            thinner active region. Newly added voxels are seeded as *exterior* (``+band*vx``), which
+            is correct when the dilation extends outward -- i.e. when the grid's interior (the
+            ``phi < 0`` region) is already represented (the usual case for occupancy/TSDF/mesh-derived
+            fields). For a thin shell that does not fill its interior, pass ``pad=False`` and supply a
+            grid that already has an adequate band.
+        prune (bool): If ``True`` prune to the narrow band; if ``False`` return the (possibly
+            padded) grid and the re-initialized field unchanged.
+
+    Returns:
+        out_grid (GridBatch): The pruned (or, with ``prune=False``, the padded/original) grid batch.
+        sdf (JaggedTensor): The narrow-band SDF, aligned with ``out_grid``.
+
+    .. seealso:: :func:`retopologize_sdf_single`, :func:`reinitialize_sdf_batch`
+    """
+    if pad:
+        # Seed fresh voxels as exterior. A single positive seed >= every grid's band width is fine:
+        # reinitialize_sdf re-clamps it to that grid's +band*vx, so only its (positive) sign matters.
+        seed = band * float(grid.voxel_sizes[:, 0].max())
+        dilated = grid.dilated_grid(band)
+        field = inject_batch(dilated, grid, field, default_value=seed)
+        grid = dilated
+    phi = reinitialize_sdf_batch(grid, field, band, smooth, order, smoothing, redistance_iters)
+    if not prune:
+        return grid, phi
+    # per-voxel band half-width (voxel size may vary per grid in the batch)
+    voxel_sizes = grid.voxel_sizes[:, 0].to(phi.jdata.device)
+    band_width = band * voxel_sizes[phi.jidx.long()] * 0.999
+    mask = phi.jdata.abs() < band_width
+    return grid.pruned_grid(phi.jagged_like(mask)), phi.rmask(mask)
+
+
+def retopologize_sdf_single(
+    grid: Grid,
+    field: torch.Tensor,
+    band: int = 3,
+    smooth: int = 0,
+    order: int = 3,
+    smoothing: SmoothingMode | int = SmoothingMode.MEAN_CURVATURE,
+    redistance_iters: int = -1,
+    pad: bool = True,
+    prune: bool = True,
+) -> tuple[Grid, torch.Tensor]:
+    """Retopologize a signed field into a clean narrow-band SDF on a (possibly pruned) single grid.
+
+    If ``pad`` is ``True`` the grid is first dilated by ``band`` voxels (so the eikonal solve has room
+    to propagate a full-width band), then :func:`reinitialize_sdf_single` is run, and finally, if
+    ``prune`` is ``True``, the grid is pruned to the voxels strictly inside the band
+    (``|phi| < band*vx*0.999``).
+
+    Args:
+        grid (Grid): The single grid defining the sparse topology.
+        field (torch.Tensor): Per-voxel signed field values, shape ``(num_voxels,)``.
+        band (int): Narrow-band half-width in voxels.
+        smooth (int): Number of smoothing passes (``0`` disables smoothing).
+        order (int): TVD-RK order, one of ``1``, ``2``, or ``3``.
+        smoothing (SmoothingMode): Which Laplacian flow each smoothing pass applies --
+            :attr:`~fvdb.SmoothingMode.MEAN_CURVATURE` (default) or
+            :attr:`~fvdb.SmoothingMode.TAUBIN` (volume-preserving). Only used when ``smooth > 0``.
+        redistance_iters (int): Number of redistancing sweeps. ``<= 0`` uses the default.
+        pad (bool): If ``True`` (default) dilate the grid by ``band`` voxels before redistancing so
+            the output narrow band is a full ``band`` voxels wide even if the input grid had a
+            thinner active region. Newly added voxels are seeded as *exterior* (``+band*vx``), which
+            is correct when the dilation extends outward -- i.e. when the grid's interior (the
+            ``phi < 0`` region) is already represented (the usual case for occupancy/TSDF/mesh-derived
+            fields). For a thin shell that does not fill its interior, pass ``pad=False`` and supply a
+            grid that already has an adequate band.
+        prune (bool): If ``True`` prune to the narrow band; if ``False`` return the (possibly padded)
+            grid and the re-initialized field unchanged.
+
+    Returns:
+        out_grid (Grid): The pruned (or, with ``prune=False``, the padded/original) grid.
+        sdf (torch.Tensor): The narrow-band SDF, aligned with ``out_grid``.
+
+    .. seealso:: :func:`retopologize_sdf_batch`, :func:`reinitialize_sdf_single`
+    """
+    band_width = band * float(grid.voxel_size[0])
+    if pad:
+        dilated = grid.dilated_grid(band)
+        field = inject_single(dilated, grid, field, default_value=band_width)
+        grid = dilated
+    phi = reinitialize_sdf_single(grid, field, band, smooth, order, smoothing, redistance_iters)
+    if not prune:
+        return grid, phi
+    mask = phi.abs() < band_width * 0.999
+    return grid.pruned_grid(mask), phi[mask]

--- a/fvdb/grid.py
+++ b/fvdb/grid.py
@@ -1489,7 +1489,7 @@ class Grid:
         band: int = 3,
         smooth: int = 0,
         order: int = 3,
-        smoothing: SmoothingMode | str = SmoothingMode.MEAN_CURVATURE,
+        smoothing: SmoothingMode = SmoothingMode.MEAN_CURVATURE,
         redistance_iters: int = -1,
     ) -> torch.Tensor:
         """Re-initialize a signed per-voxel field into an SDF on this grid (topology unchanged).
@@ -1520,7 +1520,7 @@ class Grid:
         band: int = 3,
         smooth: int = 0,
         order: int = 3,
-        smoothing: SmoothingMode | str = SmoothingMode.MEAN_CURVATURE,
+        smoothing: SmoothingMode = SmoothingMode.MEAN_CURVATURE,
         redistance_iters: int = -1,
         pad: bool = True,
         prune: bool = True,

--- a/fvdb/grid.py
+++ b/fvdb/grid.py
@@ -1512,9 +1512,7 @@ class Grid:
         """
         from . import functional
 
-        return functional.reinitialize_sdf_single(
-            self, field, band, smooth, order, smoothing, redistance_iters
-        )
+        return functional.reinitialize_sdf_single(self, field, band, smooth, order, smoothing, redistance_iters)
 
     def retopologize_sdf(
         self,

--- a/fvdb/grid.py
+++ b/fvdb/grid.py
@@ -31,6 +31,7 @@ from typing import TYPE_CHECKING, Any, overload
 import torch
 
 from ._fvdb_cpp import GridBatchData
+from .enums import SmoothingMode
 from .jagged_tensor import JaggedTensor
 from .types import DeviceIdentifier, NumericMaxRank1
 
@@ -1481,6 +1482,82 @@ class Grid:
         from . import functional
 
         return functional.marching_cubes_single(self, field, level)
+
+    def reinitialize_sdf(
+        self,
+        field: torch.Tensor,
+        band: int = 3,
+        smooth: int = 0,
+        order: int = 3,
+        smoothing: SmoothingMode | str = SmoothingMode.MEAN_CURVATURE,
+        redistance_iters: int = -1,
+    ) -> torch.Tensor:
+        """Re-initialize a signed per-voxel field into an SDF on this grid (topology unchanged).
+
+        Redistances ``field`` to ``|grad phi| = 1`` (TVD-RK Godunov eikonal solve with a frozen
+        Peng sign), then optionally de-staircases it with curvature-based smoothing.
+
+        Args:
+            field (torch.Tensor): Per-voxel signed field, shape ``(num_voxels,)``.
+            band (int): Narrow-band half-width in voxels (clamps the field to ``[-band*vx, band*vx]``).
+            smooth (int): Number of smoothing passes (``0`` disables smoothing).
+            order (int): TVD-RK order, one of ``1``, ``2``, or ``3``.
+            smoothing (SmoothingMode): Which Laplacian flow each smoothing pass applies --
+                :attr:`~fvdb.SmoothingMode.MEAN_CURVATURE` (default) or
+                :attr:`~fvdb.SmoothingMode.TAUBIN` (volume-preserving). Only used when ``smooth > 0``.
+            redistance_iters (int): Number of redistancing sweeps; ``<= 0`` uses the default.
+
+        Returns:
+            sdf (torch.Tensor): The re-initialized SDF, shape ``(num_voxels,)``.
+        """
+        from . import functional
+
+        return functional.reinitialize_sdf_single(
+            self, field, band, smooth, order, smoothing, redistance_iters
+        )
+
+    def retopologize_sdf(
+        self,
+        field: torch.Tensor,
+        band: int = 3,
+        smooth: int = 0,
+        order: int = 3,
+        smoothing: SmoothingMode | str = SmoothingMode.MEAN_CURVATURE,
+        redistance_iters: int = -1,
+        pad: bool = True,
+        prune: bool = True,
+    ) -> tuple[Grid, torch.Tensor]:
+        """Retopologize a signed field into a clean narrow-band SDF on a (possibly pruned) grid.
+
+        If ``pad`` is ``True`` this grid is first dilated by ``band`` voxels so the redistance has
+        room to build a full-width band, then :meth:`reinitialize_sdf` is run, and finally, if
+        ``prune`` is ``True``, the grid is pruned to the voxels strictly inside the band
+        (``|phi| < band*vx*0.999``).
+
+        Args:
+            field (torch.Tensor): Per-voxel signed field, shape ``(num_voxels,)``.
+            band (int): Narrow-band half-width in voxels.
+            smooth (int): Number of smoothing passes (``0`` disables smoothing).
+            order (int): TVD-RK order, one of ``1``, ``2``, or ``3``.
+            smoothing (SmoothingMode): Which Laplacian flow each smoothing pass applies --
+                :attr:`~fvdb.SmoothingMode.MEAN_CURVATURE` (default) or
+                :attr:`~fvdb.SmoothingMode.TAUBIN` (volume-preserving). Only used when ``smooth > 0``.
+            redistance_iters (int): Number of redistancing sweeps; ``<= 0`` uses the default.
+            pad (bool): If ``True`` (default) dilate by ``band`` first so the output band is a full
+                ``band`` voxels wide even if the input grid was thinner. New voxels are seeded as
+                exterior (``+band*vx``), which is correct when the interior (``phi < 0``) is already
+                represented; for a hollow thin shell, pass ``pad=False`` with a pre-banded grid.
+            prune (bool): If ``True`` prune to the narrow band, else return the (padded) grid.
+
+        Returns:
+            out_grid (Grid): The pruned (or padded/original) grid.
+            sdf (torch.Tensor): The narrow-band SDF, aligned with ``out_grid``.
+        """
+        from . import functional
+
+        return functional.retopologize_sdf_single(
+            self, field, band, smooth, order, smoothing, redistance_iters, pad, prune
+        )
 
     def integrate_tsdf(
         self,

--- a/fvdb/grid_batch.py
+++ b/fvdb/grid_batch.py
@@ -34,6 +34,7 @@ import numpy as np
 import torch
 
 from . import _fvdb_cpp, _parse_device_string
+from .enums import SmoothingMode
 from .jagged_tensor import JaggedTensor
 from .types import DeviceIdentifier, GridBatchIndex, NumericMaxRank1, NumericMaxRank2
 
@@ -1027,6 +1028,84 @@ class GridBatch:
         from . import functional
 
         return functional.marching_cubes_batch(self, field, level)
+
+    def reinitialize_sdf(
+        self,
+        field: JaggedTensor,
+        band: int = 3,
+        smooth: int = 0,
+        order: int = 3,
+        smoothing: SmoothingMode | str = SmoothingMode.MEAN_CURVATURE,
+        redistance_iters: int = -1,
+    ) -> JaggedTensor:
+        """Re-initialize a signed per-voxel field into an SDF on this grid batch (topology unchanged).
+
+        Redistances ``field`` to ``|grad phi| = 1`` (TVD-RK Godunov eikonal solve with a frozen
+        Peng sign), then optionally de-staircases it with curvature-based smoothing.
+
+        Args:
+            field (JaggedTensor): Per-voxel signed field values.
+            band (int): Narrow-band half-width in voxels (clamps the field to ``[-band*vx, band*vx]``).
+            smooth (int): Number of smoothing passes (``0`` disables smoothing).
+            order (int): TVD-RK order, one of ``1``, ``2``, or ``3``.
+            smoothing (SmoothingMode): Which Laplacian flow each smoothing pass applies --
+                :attr:`~fvdb.SmoothingMode.MEAN_CURVATURE` (default) or
+                :attr:`~fvdb.SmoothingMode.TAUBIN` (volume-preserving). Only used when ``smooth > 0``.
+            redistance_iters (int): Number of redistancing sweeps; ``<= 0`` uses the default.
+
+        Returns:
+            sdf (JaggedTensor): The re-initialized SDF, same per-voxel ordering as ``field``.
+
+        .. seealso:: :meth:`Grid.reinitialize_sdf`
+        """
+        from . import functional
+
+        return functional.reinitialize_sdf_batch(self, field, band, smooth, order, smoothing, redistance_iters)
+
+    def retopologize_sdf(
+        self,
+        field: JaggedTensor,
+        band: int = 3,
+        smooth: int = 0,
+        order: int = 3,
+        smoothing: SmoothingMode | str = SmoothingMode.MEAN_CURVATURE,
+        redistance_iters: int = -1,
+        pad: bool = True,
+        prune: bool = True,
+    ) -> tuple["GridBatch", JaggedTensor]:
+        """Retopologize a signed field into a clean narrow-band SDF on a (possibly pruned) grid batch.
+
+        If ``pad`` is ``True`` the grid is first dilated by ``band`` voxels so the redistance has
+        room to build a full-width band, then :meth:`reinitialize_sdf` is run, and finally, if
+        ``prune`` is ``True``, the grid is pruned to the voxels strictly inside the band
+        (``|phi| < band*vx*0.999``).
+
+        Args:
+            field (JaggedTensor): Per-voxel signed field values.
+            band (int): Narrow-band half-width in voxels.
+            smooth (int): Number of smoothing passes (``0`` disables smoothing).
+            order (int): TVD-RK order, one of ``1``, ``2``, or ``3``.
+            smoothing (SmoothingMode): Which Laplacian flow each smoothing pass applies --
+                :attr:`~fvdb.SmoothingMode.MEAN_CURVATURE` (default) or
+                :attr:`~fvdb.SmoothingMode.TAUBIN` (volume-preserving). Only used when ``smooth > 0``.
+            redistance_iters (int): Number of redistancing sweeps; ``<= 0`` uses the default.
+            pad (bool): If ``True`` (default) dilate by ``band`` first so the output band is a full
+                ``band`` voxels wide even if the input grid was thinner. New voxels are seeded as
+                exterior (``+band*vx``), which is correct when the interior (``phi < 0``) is already
+                represented; for a hollow thin shell, pass ``pad=False`` with a pre-banded grid.
+            prune (bool): If ``True`` prune to the narrow band, else return the (padded) grid batch.
+
+        Returns:
+            out_grid (GridBatch): The pruned (or padded/original) grid batch.
+            sdf (JaggedTensor): The narrow-band SDF, aligned with ``out_grid``.
+
+        .. seealso:: :meth:`Grid.retopologize_sdf`
+        """
+        from . import functional
+
+        return functional.retopologize_sdf_batch(
+            self, field, band, smooth, order, smoothing, redistance_iters, pad, prune
+        )
 
     def max_pool(
         self,

--- a/fvdb/grid_batch.py
+++ b/fvdb/grid_batch.py
@@ -1035,7 +1035,7 @@ class GridBatch:
         band: int = 3,
         smooth: int = 0,
         order: int = 3,
-        smoothing: SmoothingMode | str = SmoothingMode.MEAN_CURVATURE,
+        smoothing: SmoothingMode = SmoothingMode.MEAN_CURVATURE,
         redistance_iters: int = -1,
     ) -> JaggedTensor:
         """Re-initialize a signed per-voxel field into an SDF on this grid batch (topology unchanged).
@@ -1068,7 +1068,7 @@ class GridBatch:
         band: int = 3,
         smooth: int = 0,
         order: int = 3,
-        smoothing: SmoothingMode | str = SmoothingMode.MEAN_CURVATURE,
+        smoothing: SmoothingMode = SmoothingMode.MEAN_CURVATURE,
         redistance_iters: int = -1,
         pad: bool = True,
         prune: bool = True,

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -144,6 +144,7 @@ set(FVDB_CU_FILES
     fvdb/detail/ops/SplatTrilinear.cu
     fvdb/detail/ops/VoxelToWorld.cu
     fvdb/detail/ops/Refine.cu
+    fvdb/detail/ops/ReinitializeSdf.cu
     fvdb/detail/ops/VolumeRender.cu
     fvdb/detail/ops/NeighborIndexes.cu
     fvdb/detail/ops/VoxelsAlongRays.cu

--- a/src/cmake/get_nanovdb.cmake
+++ b/src/cmake/get_nanovdb.cmake
@@ -4,7 +4,7 @@
 CPMAddPackage(
     NAME nanovdb
     GITHUB_REPOSITORY AcademySoftwareFoundation/openvdb
-    GIT_TAG fec59777b768eae283659c5b87e377ac31653e41
+    GIT_TAG f9754140ba6031813b37d8e1b239ed0253ebd96d
     SOURCE_SUBDIR nanovdb/nanovdb
     DOWNLOAD_ONLY YES
 )

--- a/src/fvdb/detail/ops/ReinitializeSdf.cu
+++ b/src/fvdb/detail/ops/ReinitializeSdf.cu
@@ -1,0 +1,473 @@
+// Copyright Contributors to the OpenVDB Project
+// SPDX-License-Identifier: Apache-2.0
+//
+#include <fvdb/detail/ops/ReinitializeSdf.h>
+#include <fvdb/detail/utils/cuda/GridDim.h>
+
+#include <nanovdb/NanoVDB.h>
+#include <nanovdb/cuda/DeviceBuffer.h>
+#include <nanovdb/math/Math.h>
+#include <nanovdb/tools/VoxelBlockManager.h>
+#include <nanovdb/tools/cuda/VoxelBlockManager.cuh>
+
+#include <ATen/Dispatch.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAException.h>
+
+#include <algorithm>
+#include <cmath>
+
+namespace fvdb {
+namespace detail {
+namespace ops {
+
+namespace {
+
+using OnIndexGridT = nanovdb::NanoGrid<nanovdb::ValueOnIndex>;
+using VbmBuffer    = nanovdb::cuda::DeviceBuffer;
+
+// log2 of the VoxelBlockManager block width: each VBM block spans 2^9 = 512 active voxels.
+static constexpr int kLog2BlockWidth = 9;
+
+// ------------------------- VBM fused 6-face stencil preamble -------------------------
+// The VBM decode gives the centre coord / value-index for free; we then read just the 6 FACE
+// neighbours through a cached ReadAccessor. Yields `centerIndex` (the centre voxel's value index)
+// and `faceIndex[6]` (the 6 face-neighbour value indices, -x,+x,-y,+y,-z,+z; 0 =
+// inactive/background). Kernels using it take the grid/firstLeafID/jumpMap/firstOffset parameters
+// by these exact names.
+#define VBM_FACES_BEGIN()                                                                        \
+    constexpr int blockWidth = 1 << kLog2BlockWidth, jumpMapWordCount = blockWidth / 64;         \
+    using VoxelBlockManagerT = nanovdb::tools::cuda::VoxelBlockManager<kLog2BlockWidth>;         \
+    __shared__ uint32_t sharedLeafIndex[blockWidth];                                             \
+    __shared__ uint16_t sharedVoxelOffset[blockWidth];                                           \
+    VoxelBlockManagerT::template decodeInverseMaps<nanovdb::ValueOnIndex>(                       \
+        grid,                                                                                    \
+        firstLeafID[blockIdx.x],                                                                 \
+        &jumpMap[uint64_t(blockIdx.x) * jumpMapWordCount],                                       \
+        firstOffset + uint64_t(blockIdx.x) * blockWidth,                                         \
+        sharedLeafIndex,                                                                         \
+        sharedVoxelOffset);                                                                      \
+    if (sharedLeafIndex[threadIdx.x] == VoxelBlockManagerT::UnusedLeafIndex)                     \
+        return;                                                                                  \
+    const auto &leaf = grid->tree().template getFirstNode<0>()[sharedLeafIndex[threadIdx.x]];    \
+    const nanovdb::Coord centerCoord = leaf.offsetToGlobalCoord(sharedVoxelOffset[threadIdx.x]); \
+    const uint64_t centerIndex       = leaf.getValue(sharedVoxelOffset[threadIdx.x]);            \
+    auto accessor                    = grid->getAccessor();                                      \
+    const uint64_t faceIndex[6]      = {accessor.getValue(centerCoord.offsetBy(-1, 0, 0)),       \
+                                        accessor.getValue(centerCoord.offsetBy(1, 0, 0)),        \
+                                        accessor.getValue(centerCoord.offsetBy(0, -1, 0)),       \
+                                        accessor.getValue(centerCoord.offsetBy(0, 1, 0)),        \
+                                        accessor.getValue(centerCoord.offsetBy(0, 0, -1)),       \
+                                        accessor.getValue(centerCoord.offsetBy(0, 0, 1))};
+
+// =====================  fused stencil kernels ====================================================
+// frozen Peng smoothed sign from a field's value + central-difference gradient.
+template <typename ScalarT>
+__global__ void
+signFusedKernel(const OnIndexGridT *grid,
+                const uint32_t *firstLeafID,
+                const uint64_t *jumpMap,
+                uint64_t firstOffset,
+                const ScalarT *field,
+                ScalarT voxelSize,
+                ScalarT *sign) {
+    VBM_FACES_BEGIN();
+    ScalarT xm = field[faceIndex[0]], xp = field[faceIndex[1]], ym = field[faceIndex[2]],
+            yp = field[faceIndex[3]], zm = field[faceIndex[4]], zp = field[faceIndex[5]];
+    ScalarT gradX = (xp - xm) / (2 * voxelSize), gradY = (yp - ym) / (2 * voxelSize),
+            gradZ = (zp - zm) / (2 * voxelSize), phiCenter = field[centerIndex];
+    sign[centerIndex] =
+        phiCenter / nanovdb::math::Sqrt(phiCenter * phiCenter +
+                                        (gradX * gradX + gradY * gradY + gradZ * gradZ) *
+                                            voxelSize * voxelSize +
+                                        ScalarT(1e-12));
+}
+
+// One-sided upwind selection of the squared one-dimensional derivative for the Godunov scheme.
+template <typename ScalarT>
+__device__ inline ScalarT
+upwind(ScalarT backwardDiff, ScalarT forwardDiff, ScalarT sgn) {
+    if (sgn > 0) {
+        ScalarT backTerm = nanovdb::math::Max(backwardDiff, ScalarT(0));
+        ScalarT fwdTerm  = nanovdb::math::Min(forwardDiff, ScalarT(0));
+        return nanovdb::math::Max(backTerm * backTerm, fwdTerm * fwdTerm);
+    } else {
+        ScalarT backTerm = nanovdb::math::Min(backwardDiff, ScalarT(0));
+        ScalarT fwdTerm  = nanovdb::math::Max(forwardDiff, ScalarT(0));
+        return nanovdb::math::Max(backTerm * backTerm, fwdTerm * fwdTerm);
+    }
+}
+
+// Godunov RHS: d phi/dt = sign * (1 - |grad phi|), one-sided upwind on the 6 faces.
+template <typename ScalarT>
+__global__ void
+godunovFusedKernel(const OnIndexGridT *grid,
+                   const uint32_t *firstLeafID,
+                   const uint64_t *jumpMap,
+                   uint64_t firstOffset,
+                   const ScalarT *field,
+                   const ScalarT *sign,
+                   ScalarT voxelSize,
+                   ScalarT *rhs) {
+    VBM_FACES_BEGIN();
+    ScalarT center = field[centerIndex], sgn = sign[centerIndex];
+    ScalarT xm = field[faceIndex[0]], xp = field[faceIndex[1]], ym = field[faceIndex[2]],
+            yp = field[faceIndex[3]], zm = field[faceIndex[4]], zp = field[faceIndex[5]];
+    ScalarT gradMag = nanovdb::math::Sqrt(
+        upwind<ScalarT>((center - xm) / voxelSize, (xp - center) / voxelSize, sgn) +
+        upwind<ScalarT>((center - ym) / voxelSize, (yp - center) / voxelSize, sgn) +
+        upwind<ScalarT>((center - zm) / voxelSize, (zp - center) / voxelSize, sgn));
+    rhs[centerIndex] = sgn * (ScalarT(1) - gradMag);
+}
+
+// one umbrella-Laplacian smoothing pass: out[centerIndex] = in + weight*(faceMean - in).
+// Double-buffered (in != out) so neighbour reads see the pre-pass field.
+template <typename ScalarT>
+__global__ void
+smoothFusedKernel(const OnIndexGridT *grid,
+                  const uint32_t *firstLeafID,
+                  const uint64_t *jumpMap,
+                  uint64_t firstOffset,
+                  const ScalarT *in,
+                  ScalarT weight,
+                  ScalarT *out) {
+    VBM_FACES_BEGIN();
+    ScalarT center   = in[centerIndex];
+    ScalarT faceMean = (in[faceIndex[0]] + in[faceIndex[1]] + in[faceIndex[2]] + in[faceIndex[3]] +
+                        in[faceIndex[4]] + in[faceIndex[5]]) *
+                       (ScalarT(1) / ScalarT(6));
+    out[centerIndex] = center + weight * (faceMean - center);
+}
+
+// =====================  value-indexed kernels (no stencil) =======================================
+template <typename ScalarT>
+__global__ void
+fillKernel(ScalarT *data, int64_t count, ScalarT value) {
+    int64_t i = int64_t(blockIdx.x) * blockDim.x + threadIdx.x;
+    if (i < count)
+        data[i] = value;
+}
+
+// out = clip(phiBaseCoeff*phiBase + stageCoeff*stage + rhsCoeff*timeStep*rhs, -bandWidth,
+// bandWidth) (the TVD-RK combiners). Never writes slot 0.
+template <typename ScalarT>
+__global__ void
+combineKernel(ScalarT *out,
+              const ScalarT *phiBase,
+              const ScalarT *stage,
+              const ScalarT *rhs,
+              ScalarT phiBaseCoeff,
+              ScalarT stageCoeff,
+              ScalarT rhsCoeff,
+              ScalarT timeStep,
+              ScalarT bandWidth,
+              int64_t valueCount) {
+    int64_t i = int64_t(blockIdx.x) * blockDim.x + threadIdx.x;
+    if (i < 1 || i >= valueCount)
+        return;
+    ScalarT value = phiBaseCoeff * phiBase[i] +
+                    (stageCoeff != ScalarT(0) ? stageCoeff * stage[i] : ScalarT(0)) +
+                    rhsCoeff * timeStep * rhs[i];
+    out[i] = nanovdb::math::Min(nanovdb::math::Max(value, -bandWidth), bandWidth);
+}
+
+// Heun final: out = clip(phiBase + 0.5 timeStep (rhs0+rhs1), -bandWidth, bandWidth). Never writes
+// slot 0.
+template <typename ScalarT>
+__global__ void
+heunKernel(ScalarT *out,
+           const ScalarT *phiBase,
+           const ScalarT *rhs0,
+           const ScalarT *rhs1,
+           ScalarT timeStep,
+           ScalarT bandWidth,
+           int64_t valueCount) {
+    int64_t i = int64_t(blockIdx.x) * blockDim.x + threadIdx.x;
+    if (i < 1 || i >= valueCount)
+        return;
+    ScalarT value = phiBase[i] + ScalarT(0.5) * timeStep * (rhs0[i] + rhs1[i]);
+    out[i]        = nanovdb::math::Min(nanovdb::math::Max(value, -bandWidth), bandWidth);
+}
+
+// small VBM helper: build once, expose the block count + the firstLeafID/jumpMap device pointers.
+struct VBMHelper {
+    nanovdb::tools::VoxelBlockManagerHandle<VbmBuffer> handle;
+    uint32_t blockCount{0};
+    uint64_t firstOffset{0}, valueCount{1};
+    VBMHelper(OnIndexGridT *grid, cudaStream_t stream) {
+        handle = nanovdb::tools::cuda::buildVoxelBlockManager<kLog2BlockWidth, VbmBuffer>(
+            grid, 0, 0, 0, stream);
+        blockCount  = (uint32_t)handle.blockCount();
+        firstOffset = handle.firstOffset();
+        valueCount  = handle.lastOffset() + 1;
+    }
+    const uint32_t *
+    firstLeafID() const {
+        return handle.deviceFirstLeafID();
+    }
+    const uint64_t *
+    jumpMap() const {
+        return handle.deviceJumpMap();
+    }
+};
+
+// Redistance (|grad phi| = 1) + optional de-staircase one grid's value-indexed buffer, in place.
+// `phi`/scratch are length `valueCount` with slot 0 holding the +bandWidth background; the
+// stencil/combiner kernels never write slot 0 (so inactive-neighbour reads always see the boundary
+// value).
+template <typename ScalarT>
+void
+runReinit(OnIndexGridT *grid,
+          const VBMHelper &vbm,
+          ScalarT *phi,
+          ScalarT *sign,
+          ScalarT *phiBase,
+          ScalarT *stage,
+          ScalarT *rhs0,
+          ScalarT *rhs1,
+          int64_t valueCount,
+          ScalarT voxelSize,
+          ScalarT bandWidth,
+          int band,
+          int smooth,
+          int order,
+          bool taubin,
+          int redistanceIters,
+          cudaStream_t stream) {
+    const uint32_t blockCount   = vbm.blockCount;
+    constexpr int blockWidth    = 1 << kLog2BlockWidth;
+    const uint32_t *firstLeafID = vbm.firstLeafID();
+    const uint64_t *jumpMap     = vbm.jumpMap();
+    const uint64_t firstOffset  = vbm.firstOffset;
+    const ScalarT timeStep      = ScalarT(0.4) * voxelSize;
+
+    auto godunov = [&](const ScalarT *field, ScalarT *out) {
+        if (blockCount) {
+            godunovFusedKernel<ScalarT><<<blockCount, blockWidth, 0, stream>>>(
+                grid, firstLeafID, jumpMap, firstOffset, field, sign, voxelSize, out);
+            C10_CUDA_KERNEL_LAUNCH_CHECK();
+        }
+    };
+    auto redistance = [&](int iters) {
+        if (blockCount) {
+            signFusedKernel<ScalarT><<<blockCount, blockWidth, 0, stream>>>(
+                grid, firstLeafID, jumpMap, firstOffset, phi, voxelSize, sign);
+            C10_CUDA_KERNEL_LAUNCH_CHECK();
+        }
+        for (int it = 0; it < iters; ++it) {
+            C10_CUDA_CHECK(cudaMemcpyAsync(
+                phiBase, phi, valueCount * sizeof(ScalarT), cudaMemcpyDeviceToDevice, stream));
+            godunov(phi, rhs0); // rhs0 = rhs(phi)
+
+            // Every scheme begins with the same forward-Euler step. For RK1 this is the final
+            // update (written to phi); for RK2/RK3 it is the first stage (written to `stage`).
+            ScalarT *firstStage = (order <= 1) ? phi : stage;
+            combineKernel<ScalarT>
+                <<<GET_BLOCKS(valueCount, DEFAULT_BLOCK_DIM), DEFAULT_BLOCK_DIM, 0, stream>>>(
+                    firstStage,
+                    phiBase,
+                    nullptr,
+                    rhs0,
+                    ScalarT(1),
+                    ScalarT(0),
+                    ScalarT(1),
+                    timeStep,
+                    bandWidth,
+                    valueCount);
+
+            if (order == 2) { // Heun (TVD-RK2)
+                godunov(stage, rhs1);
+                heunKernel<ScalarT>
+                    <<<GET_BLOCKS(valueCount, DEFAULT_BLOCK_DIM), DEFAULT_BLOCK_DIM, 0, stream>>>(
+                        phi, phiBase, rhs0, rhs1, timeStep, bandWidth, valueCount);
+            } else if (order == 3) { // Shu-Osher TVD-RK3
+                godunov(stage, rhs0);
+                combineKernel<ScalarT>
+                    <<<GET_BLOCKS(valueCount, DEFAULT_BLOCK_DIM), DEFAULT_BLOCK_DIM, 0, stream>>>(
+                        stage,
+                        phiBase,
+                        stage,
+                        rhs0,
+                        ScalarT(0.75),
+                        ScalarT(0.25),
+                        ScalarT(0.25),
+                        timeStep,
+                        bandWidth,
+                        valueCount);
+                godunov(stage, rhs0);
+                combineKernel<ScalarT>
+                    <<<GET_BLOCKS(valueCount, DEFAULT_BLOCK_DIM), DEFAULT_BLOCK_DIM, 0, stream>>>(
+                        phi,
+                        phiBase,
+                        stage,
+                        rhs0,
+                        ScalarT(1.0 / 3.0),
+                        ScalarT(2.0 / 3.0),
+                        ScalarT(2.0 / 3.0),
+                        timeStep,
+                        bandWidth,
+                        valueCount);
+            }
+            C10_CUDA_KERNEL_LAUNCH_CHECK();
+        }
+    };
+
+    const int defaultIters = std::max(6, (int)std::lround(2.5 * band) + 2);
+    redistance(redistanceIters > 0 ? redistanceIters : defaultIters);
+
+    if (smooth) {
+        ScalarT *cur = phi, *other = stage; // ping-pong (stage[0] already = bandWidth)
+        auto pass = [&](ScalarT weight) {
+            if (blockCount) {
+                smoothFusedKernel<ScalarT><<<blockCount, blockWidth, 0, stream>>>(
+                    grid, firstLeafID, jumpMap, firstOffset, cur, weight, other);
+                C10_CUDA_KERNEL_LAUNCH_CHECK();
+            }
+            std::swap(cur, other);
+        };
+        if (taubin) {
+            for (int i = 0; i < smooth; ++i) {
+                pass(ScalarT(0.5));
+                pass(ScalarT(-0.53));
+            } // volume-preserving
+        } else {
+            for (int i = 0; i < smooth; ++i)
+                pass(ScalarT(1.0)); // mean-curvature
+        }
+        if (cur != phi)
+            C10_CUDA_CHECK(cudaMemcpyAsync(
+                phi, cur, valueCount * sizeof(ScalarT), cudaMemcpyDeviceToDevice, stream));
+        redistance(std::max(4, smooth));
+    }
+}
+
+template <typename ScalarT>
+void
+reinitializeSdfCuda(const GridBatchData &batchHdl,
+                    const torch::Tensor &field,
+                    torch::Tensor &out,
+                    int band,
+                    int redistanceIters,
+                    int order,
+                    int smooth,
+                    bool taubin) {
+    cudaStream_t stream = at::cuda::getCurrentCUDAStream(batchHdl.device().index()).stream();
+    auto opts           = torch::TensorOptions().dtype(field.dtype()).device(field.device());
+
+    const ScalarT *fieldPtr = field.data_ptr<ScalarT>();
+    ScalarT *outPtr         = out.data_ptr<ScalarT>();
+
+    for (int64_t batchIdx = 0; batchIdx < batchHdl.batchSize(); ++batchIdx) {
+        const int64_t numVoxels = batchHdl.numVoxelsAt(batchIdx);
+        if (numVoxels == 0)
+            continue;
+        OnIndexGridT *grid =
+            batchHdl.mGridHdl->deviceGrid<nanovdb::ValueOnIndex>((uint32_t)batchIdx);
+        const int64_t voxelOffset = batchHdl.cumVoxelsAt(batchIdx);
+        const ScalarT voxelSize   = (ScalarT)batchHdl.voxelSizeAt(batchIdx)[0];
+        const ScalarT bandWidth = (ScalarT)band * voxelSize; // narrow-band half-width, world units
+
+        VBMHelper vbm(grid, stream);
+        const int64_t valueCount = (int64_t)vbm.valueCount;  // numVoxels + 1 (slot 0 = background)
+
+        torch::Tensor phiBuf     = torch::empty({valueCount}, opts);
+        torch::Tensor signBuf    = torch::empty({valueCount}, opts);
+        torch::Tensor phiBaseBuf = torch::empty({valueCount}, opts);
+        torch::Tensor stageBuf   = torch::empty({valueCount}, opts);
+        torch::Tensor rhs0Buf    = torch::empty({valueCount}, opts);
+        torch::Tensor rhs1Buf = (order == 2) ? torch::empty({valueCount}, opts) : torch::Tensor();
+        ScalarT *phi          = phiBuf.data_ptr<ScalarT>();
+        ScalarT *sign         = signBuf.data_ptr<ScalarT>();
+        ScalarT *phiBase      = phiBaseBuf.data_ptr<ScalarT>();
+        ScalarT *stage        = stageBuf.data_ptr<ScalarT>();
+        ScalarT *rhs0         = rhs0Buf.data_ptr<ScalarT>();
+        ScalarT *rhs1         = (order == 2) ? rhs1Buf.data_ptr<ScalarT>() : nullptr;
+
+        // gather: phi[0] = bandWidth (outside BC), phi[1..] = field; stage[0] = bandWidth (RK slot
+        // 0)
+        fillKernel<ScalarT>
+            <<<GET_BLOCKS(valueCount, DEFAULT_BLOCK_DIM), DEFAULT_BLOCK_DIM, 0, stream>>>(
+                phi, valueCount, bandWidth);
+        C10_CUDA_KERNEL_LAUNCH_CHECK();
+        fillKernel<ScalarT>
+            <<<GET_BLOCKS(valueCount, DEFAULT_BLOCK_DIM), DEFAULT_BLOCK_DIM, 0, stream>>>(
+                stage, valueCount, bandWidth);
+        C10_CUDA_KERNEL_LAUNCH_CHECK();
+        C10_CUDA_CHECK(cudaMemcpyAsync(phi + 1,
+                                       fieldPtr + voxelOffset,
+                                       numVoxels * sizeof(ScalarT),
+                                       cudaMemcpyDeviceToDevice,
+                                       stream));
+
+        runReinit<ScalarT>(grid,
+                           vbm,
+                           phi,
+                           sign,
+                           phiBase,
+                           stage,
+                           rhs0,
+                           rhs1,
+                           valueCount,
+                           voxelSize,
+                           bandWidth,
+                           band,
+                           smooth,
+                           order,
+                           taubin,
+                           redistanceIters,
+                           stream);
+
+        // scatter: out[voxelOffset..] = phi[1..]
+        C10_CUDA_CHECK(cudaMemcpyAsync(outPtr + voxelOffset,
+                                       phi + 1,
+                                       numVoxels * sizeof(ScalarT),
+                                       cudaMemcpyDeviceToDevice,
+                                       stream));
+        C10_CUDA_CHECK(cudaStreamSynchronize(stream));
+    }
+}
+
+} // namespace
+
+JaggedTensor
+reinitializeSdf(const GridBatchData &batchHdl,
+                const JaggedTensor &field,
+                int band,
+                int redistanceIters,
+                int order,
+                int smooth,
+                SmoothingMode smoothing) {
+    const bool taubin = (smoothing == SmoothingMode::TAUBIN);
+    TORCH_CHECK_VALUE(
+        field.ldim() == 1,
+        "Expected field to have 1 list dimension (a single list of per-voxel values)");
+    TORCH_CHECK_TYPE(field.is_floating_point(), "field must have a floating point type");
+    TORCH_CHECK_VALUE(field.numel() == batchHdl.totalVoxels(),
+                      "field value count does not match the number of voxels in the grid");
+    TORCH_CHECK_VALUE(field.num_outer_lists() == batchHdl.batchSize(),
+                      "field batch size does not match the grid batch size");
+    TORCH_CHECK_VALUE(band >= 1, "band must be >= 1");
+    TORCH_CHECK_VALUE(order >= 1 && order <= 3, "order must be 1, 2, or 3");
+    TORCH_CHECK_VALUE(smooth >= 0, "smooth must be >= 0");
+    batchHdl.checkDevice(field);
+    TORCH_CHECK(field.device().is_cuda(),
+                "reinitialize_sdf currently requires a CUDA device (VoxelBlockManager solver)");
+    TORCH_CHECK_TYPE(field.scalar_type() == torch::kFloat32 ||
+                         field.scalar_type() == torch::kFloat64,
+                     "reinitialize_sdf supports float32 or float64 fields");
+
+    torch::Tensor fieldJdata = field.jdata().contiguous();
+    if (fieldJdata.dim() != 1)
+        fieldJdata = fieldJdata.view({-1});
+
+    torch::Tensor out = torch::empty_like(fieldJdata);
+    AT_DISPATCH_FLOATING_TYPES(fieldJdata.scalar_type(), "reinitializeSdf", [&] {
+        reinitializeSdfCuda<scalar_t>(
+            batchHdl, fieldJdata, out, band, redistanceIters, order, smooth, taubin);
+    });
+    return field.jagged_like(out);
+}
+
+} // namespace ops
+} // namespace detail
+} // namespace fvdb

--- a/src/fvdb/detail/ops/ReinitializeSdf.h
+++ b/src/fvdb/detail/ops/ReinitializeSdf.h
@@ -1,0 +1,56 @@
+// Copyright Contributors to the OpenVDB Project
+// SPDX-License-Identifier: Apache-2.0
+//
+#ifndef FVDB_DETAIL_OPS_REINITIALIZESDF_H
+#define FVDB_DETAIL_OPS_REINITIALIZESDF_H
+
+#include <fvdb/GridBatchData.h>
+#include <fvdb/JaggedTensor.h>
+
+#include <torch/types.h>
+
+#include <cstdint>
+
+namespace fvdb {
+namespace detail {
+namespace ops {
+
+/// @brief Laplacian smoothing mode for the SDF reinitialization de-staircase passes.
+///        Mirrored by the Python ``fvdb.SmoothingMode`` enum (matching member names).
+enum class SmoothingMode : int32_t {
+    MEAN_CURVATURE = 0, ///< Mean-curvature flow (umbrella Laplacian, weight 1.0 per pass).
+    TAUBIN         = 1, ///< Volume-preserving Taubin smoothing (alternating 0.5 / -0.53 passes).
+};
+
+/// @brief Re-initialize a signed per-voxel field into a signed distance field on the *same* grid.
+///
+/// Redistances the input field to satisfy |grad phi| = 1 (TVD-RK Godunov upwind eikonal solve with
+/// a frozen Peng sign), then optionally de-staircases it with mean-curvature or volume-preserving
+/// Taubin Laplacian smoothing. The grid topology is unchanged: the returned JaggedTensor has the
+/// same per-voxel ordering as the input.
+///
+/// @param batchHdl    Grid batch defining the sparse topology.
+/// @param field       Per-voxel signed field (a single list of scalar values, numel ==
+/// totalVoxels).
+/// @param band        Narrow-band half-width in voxels. The field is clamped to [-band*vx, band*vx]
+///                    each sweep and the "outside" Dirichlet value for inactive neighbours is
+///                    +band*vx.
+/// @param redistanceIters  Number of TVD-RK redistancing sweeps. Pass <= 0 to use the default
+///                         max(6, round(2.5*band) + 2).
+/// @param order       TVD-RK order: 1 (forward Euler), 2 (Heun), or 3 (Shu-Osher).
+/// @param smooth      Number of smoothing passes (0 disables smoothing).
+/// @param smoothing   Which Laplacian flow each smoothing pass applies (mean-curvature or Taubin).
+/// @return A new per-voxel SDF JaggedTensor on the same grid/ordering as @p field.
+JaggedTensor reinitializeSdf(const GridBatchData &batchHdl,
+                             const JaggedTensor &field,
+                             int band,
+                             int redistanceIters,
+                             int order,
+                             int smooth,
+                             SmoothingMode smoothing);
+
+} // namespace ops
+} // namespace detail
+} // namespace fvdb
+
+#endif // FVDB_DETAIL_OPS_REINITIALIZESDF_H

--- a/src/python/GridBatchOps.cpp
+++ b/src/python/GridBatchOps.cpp
@@ -52,6 +52,7 @@
 // Meshing / TSDF
 #include <fvdb/detail/ops/IntegrateTSDF.h>
 #include <fvdb/detail/ops/MarchingCubes.h>
+#include <fvdb/detail/ops/ReinitializeSdf.h>
 
 // Topology / misc
 #include <fvdb/detail/ops/GridEdgeNetwork.h>
@@ -120,6 +121,14 @@ bind_grid_batch_ops(py::module &m) {
     using GBI     = fvdb::GridBatchData;
     using JT      = fvdb::JaggedTensor;
     namespace ops = fvdb::detail::ops;
+
+    // -----------------------------------------------------------------------
+    // Enum types
+    // -----------------------------------------------------------------------
+    py::enum_<ops::SmoothingMode>(m, "SmoothingMode")
+        .value("MEAN_CURVATURE", ops::SmoothingMode::MEAN_CURVATURE)
+        .value("TAUBIN", ops::SmoothingMode::TAUBIN)
+        .export_values();
 
     // -----------------------------------------------------------------------
     // Interpolation: forward
@@ -449,6 +458,16 @@ bind_grid_batch_ops(py::module &m) {
 
     m.def(
         "marching_cubes", &ops::marchingCubes, py::arg("grid"), py::arg("field"), py::arg("level"));
+
+    m.def("reinitialize_sdf",
+          &ops::reinitializeSdf,
+          py::arg("grid"),
+          py::arg("field"),
+          py::arg("band"),
+          py::arg("redistance_iters"),
+          py::arg("order"),
+          py::arg("smooth"),
+          py::arg("smoothing"));
 
     m.def("integrate_tsdf",
           &ops::integrateTSDF,

--- a/tests/unit/test_sdf.py
+++ b/tests/unit/test_sdf.py
@@ -1,0 +1,155 @@
+# Copyright Contributors to the OpenVDB Project
+# SPDX-License-Identifier: Apache-2.0
+#
+import unittest
+
+import torch
+
+import fvdb
+
+
+def _dense_cube_grid(vx: float, half: int, device: torch.device) -> "fvdb.Grid":
+    """A dense (2*half+1)^3 cube grid built by placing one point at each voxel centre."""
+    rng = torch.arange(-half, half + 1, device=device, dtype=torch.float32)
+    ii, jj, kk = torch.meshgrid(rng, rng, rng, indexing="ij")
+    ijk = torch.stack([ii, jj, kk], dim=-1).reshape(-1, 3)
+    pts = ijk * vx
+    return fvdb.Grid.from_points(pts, voxel_size=vx)
+
+
+class ReinitializeSdfTests(unittest.TestCase):
+    def setUp(self):
+        if not torch.cuda.is_available():
+            self.skipTest("reinitialize_sdf requires a CUDA device")
+        torch.manual_seed(0)
+        self.device = torch.device("cuda:0")
+        self.vx = 0.05
+        self.R = 0.3
+        self.band = 3
+        self.bw = self.band * self.vx
+        self.grid = _dense_cube_grid(self.vx, half=12, device=self.device)
+        centers = self.grid.ijk.float() * self.vx  # voxel centres (origin 0)
+        self.analytic = centers.norm(dim=1) - self.R  # exact sphere SDF at each voxel centre
+
+    def _band_mask(self, width_voxels: float) -> torch.Tensor:
+        return self.analytic.abs() < width_voxels * self.vx
+
+    # ------------------------------------------------------------------ reinit
+    def test_reinitialize_preserves_good_sdf(self):
+        """Redistancing an already-correct SDF (|grad phi| = 1) should preserve it in the band."""
+        field = self.analytic.clamp(-self.bw, self.bw)
+        phi = self.grid.reinitialize_sdf(field, band=self.band, smooth=0, order=3)
+        self.assertEqual(phi.shape[0], self.grid.num_voxels)
+        m = self._band_mask(self.band - 1)
+        err = (phi[m] - self.analytic[m]).abs()
+        self.assertLess(err.mean().item(), 0.25 * self.vx)
+        self.assertLess(err.max().item(), 1.0 * self.vx)
+
+    def test_reinitialize_recovers_from_step(self):
+        """Redistancing a crude +/-band sign step should recover the sphere SDF near the surface."""
+        field = torch.where(
+            self.analytic < 0,
+            torch.full_like(self.analytic, -self.bw),
+            torch.full_like(self.analytic, self.bw),
+        )
+        phi = self.grid.reinitialize_sdf(field, band=self.band, smooth=0, order=3)
+        m = self._band_mask(self.band - 1)
+        err = (phi[m] - self.analytic[m]).abs()
+        self.assertLess(err.mean().item(), 0.6 * self.vx)
+
+    def test_band_clamp(self):
+        field = self.analytic.clamp(-self.bw, self.bw)
+        phi = self.grid.reinitialize_sdf(field, band=self.band)
+        self.assertLessEqual(phi.abs().max().item(), self.bw + 1e-4)
+
+    def test_order_and_smoothing_run(self):
+        field = self.analytic.clamp(-self.bw, self.bw)
+        for order in (1, 2, 3):
+            phi = self.grid.reinitialize_sdf(field, band=self.band, order=order)
+            self.assertEqual(phi.shape[0], self.grid.num_voxels)
+        # smoothing mode accepts the SmoothingMode enum or its integer value
+        for mode in (fvdb.SmoothingMode.MEAN_CURVATURE, fvdb.SmoothingMode.TAUBIN, 1):
+            phi = self.grid.reinitialize_sdf(field, band=self.band, smooth=4, smoothing=mode)
+            self.assertEqual(phi.shape[0], self.grid.num_voxels)
+
+    def test_float64(self):
+        field = self.analytic.clamp(-self.bw, self.bw).double()
+        phi = self.grid.reinitialize_sdf(field, band=self.band, order=3)
+        self.assertEqual(phi.dtype, torch.float64)
+        m = self._band_mask(self.band - 1)
+        err = (phi[m] - self.analytic[m].double()).abs()
+        self.assertLess(err.mean().item(), 0.25 * self.vx)
+
+    # ------------------------------------------------------------------ retopo
+    def test_retopologize_prune(self):
+        field = self.analytic.clamp(-self.bw, self.bw)
+        pruned, phi = self.grid.retopologize_sdf(field, band=self.band, prune=True)
+        self.assertEqual(phi.shape[0], pruned.num_voxels)
+        self.assertLessEqual(pruned.num_voxels, self.grid.num_voxels)
+        self.assertLess(phi.abs().max().item(), self.bw)  # strictly inside the band
+        v, f, n = pruned.marching_cubes(phi, level=0.0)
+        self.assertGreater(v.shape[0], 0)
+
+    def test_prune_ordering_guard(self):
+        """The rmask-based prune must align with the pruned grid's canonical voxel order."""
+        field = self.analytic.clamp(-self.bw, self.bw)
+        phi_full = self.grid.reinitialize_sdf(field, band=self.band)
+        mask = phi_full.abs() < self.bw * 0.999
+        pruned, phi = self.grid.retopologize_sdf(field, band=self.band, prune=True)
+        self.assertTrue(torch.equal(self.grid.ijk[mask], pruned.ijk))
+        self.assertTrue(torch.allclose(phi, phi_full[mask]))
+
+    def test_no_prune_no_pad_returns_same_grid(self):
+        field = self.analytic.clamp(-self.bw, self.bw)
+        grid_out, phi = self.grid.retopologize_sdf(field, band=self.band, pad=False, prune=False)
+        self.assertEqual(grid_out.num_voxels, self.grid.num_voxels)
+        self.assertEqual(phi.shape[0], self.grid.num_voxels)
+
+    def test_pad_widens_thin_band(self):
+        """A filled ball with only a ~1-voxel exterior shell should gain a full band with pad=True."""
+        rng = torch.arange(-12, 13, device=self.device, dtype=torch.float32)
+        ii, jj, kk = torch.meshgrid(rng, rng, rng, indexing="ij")
+        ijk = torch.stack([ii, jj, kk], dim=-1).reshape(-1, 3)
+        r = (ijk * self.vx).norm(dim=1)
+        # solid interior + ~1 exterior layer (filled interior, thin exterior band)
+        pts = (ijk * self.vx)[r < self.R + 0.5 * self.vx]
+        g = fvdb.Grid.from_points(pts, voxel_size=self.vx)
+        analytic = (g.ijk.float() * self.vx).norm(dim=1) - self.R
+        field = analytic.clamp(-self.bw, self.bw)
+
+        g0, phi0 = g.retopologize_sdf(field, band=self.band, pad=False, prune=True)
+        g1, phi1 = g.retopologize_sdf(field, band=self.band, pad=True, prune=True)
+
+        # padding produces a genuine multi-voxel exterior band; without it the band is truncated
+        self.assertGreater((phi1 > 0.5 * self.vx).sum().item(), (phi0 > 0.5 * self.vx).sum().item())
+        self.assertGreater(g1.num_voxels, g0.num_voxels)
+        self.assertGreater(phi1.max().item(), 2.0 * self.vx)  # ~full band*vx exterior reach
+        self.assertLess(phi0.max().item(), 1.5 * self.vx)  # truncated to the input topology
+        v, f, n = g1.marching_cubes(phi1, level=0.0)
+        self.assertGreater(v.shape[0], 0)
+
+    # ------------------------------------------------------------------ batch
+    def test_batch_matches_single(self):
+        vx = self.vx
+        gb = fvdb.GridBatch.from_points(
+            fvdb.JaggedTensor([self._cube_points(vx, 12), self._cube_points(vx, 10)]),
+            voxel_sizes=vx,
+        )
+        analytic = (gb.ijk.jdata.float() * vx).norm(dim=1) - self.R
+        field = gb.jagged_like(analytic.clamp(-self.bw, self.bw))
+        phi = gb.reinitialize_sdf(field, band=self.band, order=3)
+        self.assertEqual(phi.jdata.shape[0], gb.total_voxels)
+        for i in range(gb.grid_count):
+            single = fvdb.Grid.from_points(self._cube_points(vx, [12, 10][i]), voxel_size=vx)
+            a = ((single.ijk.float() * vx).norm(dim=1) - self.R).clamp(-self.bw, self.bw)
+            phi_single = single.reinitialize_sdf(a, band=self.band, order=3)
+            self.assertTrue(torch.allclose(phi[i].jdata, phi_single, atol=1e-5))
+
+    def _cube_points(self, vx: float, half: int) -> torch.Tensor:
+        rng = torch.arange(-half, half + 1, device=self.device, dtype=torch.float32)
+        ii, jj, kk = torch.meshgrid(rng, rng, rng, indexing="ij")
+        return torch.stack([ii, jj, kk], dim=-1).reshape(-1, 3) * vx
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_sdf.py
+++ b/tests/unit/test_sdf.py
@@ -67,8 +67,8 @@ class ReinitializeSdfTests(unittest.TestCase):
         for order in (1, 2, 3):
             phi = self.grid.reinitialize_sdf(field, band=self.band, order=order)
             self.assertEqual(phi.shape[0], self.grid.num_voxels)
-        # smoothing mode accepts the SmoothingMode enum or its integer value
-        for mode in (fvdb.SmoothingMode.MEAN_CURVATURE, fvdb.SmoothingMode.TAUBIN, 1):
+        # smoothing mode is selected with the SmoothingMode enum
+        for mode in (fvdb.SmoothingMode.MEAN_CURVATURE, fvdb.SmoothingMode.TAUBIN):
             phi = self.grid.reinitialize_sdf(field, band=self.band, smooth=4, smoothing=mode)
             self.assertEqual(phi.shape[0], self.grid.num_voxels)
 


### PR DESCRIPTION
Adds an SDF reinitialization operator and a narrow-band retopologization helper. The core is a VoxelBlockManager (VBM) eikonal solver ported from standalone code used in a NanoVDB meshing prototype.

## Motivation

This is the first needed component of a port of the OpenVDB `VolumeToMesh` dual-contouring meshing tool to NanoVDB + VoxelBlockManager that I've been developing as a standalone example and I imagined is likely useful for other applications which use `fvdb-core`.

## Changes

### Core CUDA op — `src/fvdb/detail/ops/ReinitializeSdf.{h,cu}` (new)

`reinitialize_sdf` redistances a per-voxel signed field to `|grad phi| = 1` on the **same grid** (topology unchanged):

* TVD-RK Godunov upwind eikonal solve, order 1 (forward Euler), 2 (Heun), or 3 (Shu-Osher), with a frozen Peng smoothed sign.
* Optional de-staircasing by mean-curvature or volume-preserving Taubin Laplacian smoothing (`smooth` passes), selected via `SmoothingMode`.
* The field is clamped to `[-band*vx, band*vx]` each sweep; inactive face-neighbours read the `+band*vx` "outside" value.
* Per-grid loop over the batch; per-grid value-indexed scratch buffers (slot 0 holds the background) are gathered from / scattered to the `JaggedTensor`.
* `float32` / `float64`; **CUDA only** (the VBM is a CUDA structure — CPU raises a clear `TORCH_CHECK`).

### Python composition — `fvdb/functional/_sdf.py` (new)

`retopologize_sdf` composes `reinitialize_sdf` with existing ops, no new C++ plumbing:

1. (optional, default `pad=True`) dilate by `band` via `dilated_grid` and carry the field onto the new voxels via `inject`, seeding them as exterior, so the output band is a full `band` voxels wide even when the input grid's active band was thinner;
2. `reinitialize_sdf`;  (optional, default `prune=True`) keep `|phi| < band*vx*0.999` via the existing `pruned_grid` and select the field with `JaggedTensor.rmask`. The mask-based prune preserves canonical voxel order, so the field stays aligned with the pruned grid **without a re-inject**.

### Public API

* `fvdb.functional.{reinitialize,retopologize}_sdf_{single,batch}` (+ exports).
* `Grid.reinitialize_sdf` / `Grid.retopologize_sdf` and the `GridBatch` equivalents
* New `SmoothingMode` enum following fvdb's cross-boundary-enum convention

### Dependency — `src/cmake/get_nanovdb.cmake`

* Bumped the NanoVDB pin `fec59777 → f9754140` for the VoxelBlockManager build/decode API (`buildVoxelBlockManager`, `decodeInverseMaps`, `VoxelBlockManagerHandle`).

## Test plan

Built and tested in the `fvdb` conda env (PyTorch 2.11, CUDA 13, sm_120):

- [x] `tests/unit/test_sdf.py`: 10 passed — sphere-SDF preserved under redistancing (mean err ~0.09·vx), recovered from a crude sign step (~0.25·vx), band clamp, narrow-band prune, **prune voxel-order alignment guard** (`grid.ijk[mask] == pruned.ijk`), padding widens a thin band, batch-vs-single parity, and `float64`.
- [x] NanoVDB bump regression (run before adding the op): full rebuild on the new pin with no API drift; `tests/unit/test_inject.py` + `test_io.py` (234 passed) and `test_dual.py` + `test_basic_ops_single.py` (94 passed).
- [x] `ReinitializeSdf.cu` compiles clean under `-Werror=all-warnings` / `-Xcompiler=-Wall,-Werror`.

## Notes / risks

* **`retopologize_sdf(pad=True)` seeding.** New voxels created with padding are seeded as *exterior* (`+band*vx`), which is correct when the dilation extends outward — i.e. the grid's interior (`phi < 0`) is already represented (occupancy/TSDF/mesh-derived fields, the common case). For a hollow thin shell that doesn't fill its interior, pass `pad=False` with a pre-banded grid. Documented in the docstring.
* **Dtype.** `float32` / `float64` only — `float16` is intentionally rejected (the eikonal solve needs the precision).
