### PR TITLE
CI: Removed the pytorch upper-bound version in `pyproject.toml`

### DIFF
--- a/.github/workflows/cu128-nightly.yml
+++ b/.github/workflows/cu128-nightly.yml
@@ -138,7 +138,8 @@ jobs:
       - name: Install pip dependencies
         run: |
           uv venv
-          uv pip install --no-cache-dir -r fvdb/env/build_requirements.txt --extra-index-url https://download.pytorch.org/whl/cu128
+          echo "torch==${{ needs.versions.outputs.torch-full-version }}" > "${RUNNER_TEMP}/torch-constraints.txt"
+          uv pip install --no-cache-dir -c "${RUNNER_TEMP}/torch-constraints.txt" -r fvdb/env/build_requirements.txt --extra-index-url https://download.pytorch.org/whl/cu128
 
       - name: Build fvdb
         run: |
@@ -275,7 +276,8 @@ jobs:
       - name: Install pip dependencies
         run: |
           uv venv
-          uv pip install --no-cache-dir -r fvdb/env/test_requirements.txt --extra-index-url https://download.pytorch.org/whl/cu128
+          echo "torch==${{ needs.versions.outputs.torch-full-version }}" > "${RUNNER_TEMP}/torch-constraints.txt"
+          uv pip install --no-cache-dir -c "${RUNNER_TEMP}/torch-constraints.txt" -r fvdb/env/test_requirements.txt --extra-index-url https://download.pytorch.org/whl/cu128
 
       - name: Download package
         uses: actions/download-artifact@v8

--- a/.github/workflows/cu128.yml
+++ b/.github/workflows/cu128.yml
@@ -152,7 +152,8 @@ jobs:
       - name: Install pip dependencies
         run: |
           uv venv
-          uv pip install --no-cache-dir -r env/build_requirements.txt --extra-index-url https://download.pytorch.org/whl/cu128
+          echo "torch==${{ needs.versions.outputs.torch-full-version }}" > "${RUNNER_TEMP}/torch-constraints.txt"
+          uv pip install --no-cache-dir -c "${RUNNER_TEMP}/torch-constraints.txt" -r env/build_requirements.txt --extra-index-url https://download.pytorch.org/whl/cu128
 
       - name: Build fvdb
         run: |
@@ -316,7 +317,8 @@ jobs:
       - name: Install pip dependencies
         run: |
           uv venv
-          uv pip install --no-cache-dir -r env/build_requirements.txt --extra-index-url https://download.pytorch.org/whl/cu128
+          echo "torch==${{ needs.versions.outputs.torch-full-version }}" > "${RUNNER_TEMP}/torch-constraints.txt"
+          uv pip install --no-cache-dir -c "${RUNNER_TEMP}/torch-constraints.txt" -r env/build_requirements.txt --extra-index-url https://download.pytorch.org/whl/cu128
 
       - name: Download gtests
         uses: actions/download-artifact@v8
@@ -409,7 +411,8 @@ jobs:
       - name: Install pip dependencies
         run: |
           uv venv
-          uv pip install --no-cache-dir -r env/test_requirements.txt --extra-index-url https://download.pytorch.org/whl/cu128
+          echo "torch==${{ needs.versions.outputs.torch-full-version }}" > "${RUNNER_TEMP}/torch-constraints.txt"
+          uv pip install --no-cache-dir -c "${RUNNER_TEMP}/torch-constraints.txt" -r env/test_requirements.txt --extra-index-url https://download.pytorch.org/whl/cu128
           uv pip install --no-cache-dir setuptools
 
       - name: Download package
@@ -504,7 +507,8 @@ jobs:
       - name: Install pip dependencies
         run: |
           uv venv
-          uv pip install --no-cache-dir -r env/test_requirements.txt --extra-index-url https://download.pytorch.org/whl/cu128
+          echo "torch==${{ needs.versions.outputs.torch-full-version }}" > "${RUNNER_TEMP}/torch-constraints.txt"
+          uv pip install --no-cache-dir -c "${RUNNER_TEMP}/torch-constraints.txt" -r env/test_requirements.txt --extra-index-url https://download.pytorch.org/whl/cu128
 
       - name: Download package
         uses: actions/download-artifact@v8

--- a/.github/workflows/cu130-nightly.yml
+++ b/.github/workflows/cu130-nightly.yml
@@ -136,7 +136,8 @@ jobs:
       - name: Install pip dependencies
         run: |
           uv venv
-          uv pip install --no-cache-dir -r fvdb/env/build_requirements.txt --extra-index-url https://download.pytorch.org/whl/cu130
+          echo "torch==${{ needs.versions.outputs.torch-full-version }}" > "${RUNNER_TEMP}/torch-constraints.txt"
+          uv pip install --no-cache-dir -c "${RUNNER_TEMP}/torch-constraints.txt" -r fvdb/env/build_requirements.txt --extra-index-url https://download.pytorch.org/whl/cu130
 
       - name: Build fvdb
         run: |
@@ -273,7 +274,8 @@ jobs:
       - name: Install pip dependencies
         run: |
           uv venv
-          uv pip install --no-cache-dir -r fvdb/env/test_requirements.txt --extra-index-url https://download.pytorch.org/whl/cu130
+          echo "torch==${{ needs.versions.outputs.torch-full-version }}" > "${RUNNER_TEMP}/torch-constraints.txt"
+          uv pip install --no-cache-dir -c "${RUNNER_TEMP}/torch-constraints.txt" -r fvdb/env/test_requirements.txt --extra-index-url https://download.pytorch.org/whl/cu130
 
       - name: Download package
         uses: actions/download-artifact@v8

--- a/.github/workflows/cu130.yml
+++ b/.github/workflows/cu130.yml
@@ -152,7 +152,8 @@ jobs:
       - name: Install pip dependencies
         run: |
           uv venv
-          uv pip install --no-cache-dir -r env/build_requirements.txt --extra-index-url https://download.pytorch.org/whl/cu130
+          echo "torch==${{ needs.versions.outputs.torch-full-version }}" > "${RUNNER_TEMP}/torch-constraints.txt"
+          uv pip install --no-cache-dir -c "${RUNNER_TEMP}/torch-constraints.txt" -r env/build_requirements.txt --extra-index-url https://download.pytorch.org/whl/cu130
 
       - name: Build fvdb
         run: |
@@ -316,7 +317,8 @@ jobs:
       - name: Install pip dependencies
         run: |
           uv venv
-          uv pip install --no-cache-dir -r env/build_requirements.txt --extra-index-url https://download.pytorch.org/whl/cu130
+          echo "torch==${{ needs.versions.outputs.torch-full-version }}" > "${RUNNER_TEMP}/torch-constraints.txt"
+          uv pip install --no-cache-dir -c "${RUNNER_TEMP}/torch-constraints.txt" -r env/build_requirements.txt --extra-index-url https://download.pytorch.org/whl/cu130
 
       - name: Download gtests
         uses: actions/download-artifact@v8
@@ -409,7 +411,8 @@ jobs:
       - name: Install pip dependencies
         run: |
           uv venv
-          uv pip install --no-cache-dir -r env/test_requirements.txt --extra-index-url https://download.pytorch.org/whl/cu130 --index-strategy unsafe-best-match
+          echo "torch==${{ needs.versions.outputs.torch-full-version }}" > "${RUNNER_TEMP}/torch-constraints.txt"
+          uv pip install --no-cache-dir -c "${RUNNER_TEMP}/torch-constraints.txt" -r env/test_requirements.txt --extra-index-url https://download.pytorch.org/whl/cu130 --index-strategy unsafe-best-match
           uv pip install --no-cache-dir setuptools
 
       - name: Download package
@@ -504,7 +507,8 @@ jobs:
       - name: Install pip dependencies
         run: |
           uv venv
-          uv pip install --no-cache-dir -r env/test_requirements.txt --extra-index-url https://download.pytorch.org/whl/cu130 --index-strategy unsafe-best-match
+          echo "torch==${{ needs.versions.outputs.torch-full-version }}" > "${RUNNER_TEMP}/torch-constraints.txt"
+          uv pip install --no-cache-dir -c "${RUNNER_TEMP}/torch-constraints.txt" -r env/test_requirements.txt --extra-index-url https://download.pytorch.org/whl/cu130 --index-strategy unsafe-best-match
 
       - name: Download package
         uses: actions/download-artifact@v8

--- a/.github/workflows/nightly-publish.yml
+++ b/.github/workflows/nightly-publish.yml
@@ -151,7 +151,10 @@ jobs:
           TORCH_VERSION="${{ matrix.torch-version }}"
           echo "Installing PyTorch ${TORCH_VERSION} for ${CUDA_TAG}"
           uv venv
-          uv pip install --no-cache torch==${TORCH_VERSION}.0 -r env/build_requirements.txt --extra-index-url https://download.pytorch.org/whl/${CUDA_TAG}
+          # Pin the tested PyTorch via a constraints file so the unbounded torch in
+          # build_requirements.txt resolves to the matrix version.
+          echo "torch==${TORCH_VERSION}.0" > "${RUNNER_TEMP}/torch-constraints.txt"
+          uv pip install --no-cache -c "${RUNNER_TEMP}/torch-constraints.txt" -r env/build_requirements.txt --extra-index-url https://download.pytorch.org/whl/${CUDA_TAG}
 
       - name: Set nightly version
         run: |

--- a/.github/workflows/nightly-publish.yml
+++ b/.github/workflows/nightly-publish.yml
@@ -152,8 +152,8 @@ jobs:
           echo "Installing PyTorch ${TORCH_VERSION} for ${CUDA_TAG}"
           uv venv
           # Pin the tested PyTorch via a constraints file so the unbounded torch in
-          # build_requirements.txt resolves to the matrix version.
-          echo "torch==${TORCH_VERSION}.0" > "${RUNNER_TEMP}/torch-constraints.txt"
+          # build_requirements.txt resolves to the version recorded in versions.json.
+          echo "torch==${{ needs.versions.outputs.torch-full-version }}" > "${RUNNER_TEMP}/torch-constraints.txt"
           uv pip install --no-cache -c "${RUNNER_TEMP}/torch-constraints.txt" -r env/build_requirements.txt --extra-index-url https://download.pytorch.org/whl/${CUDA_TAG}
 
       - name: Set nightly version

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -223,8 +223,8 @@ jobs:
           TORCH_VERSION="${{ matrix.torch-version }}"
           echo "Installing PyTorch ${TORCH_VERSION} for ${CUDA_TAG}"
           # Pin the tested PyTorch via a constraints file so the unbounded torch in
-          # build_requirements.txt resolves to the matrix version.
-          echo "torch==${TORCH_VERSION}.0" > "${RUNNER_TEMP}/torch-constraints.txt"
+          # build_requirements.txt resolves to the version recorded in versions.json.
+          echo "torch==${{ needs.versions.outputs.torch-full-version }}" > "${RUNNER_TEMP}/torch-constraints.txt"
           uv pip install --no-cache -c "${RUNNER_TEMP}/torch-constraints.txt" -r env/build_requirements.txt --extra-index-url https://download.pytorch.org/whl/${CUDA_TAG}
 
       - name: Add a post-release to version (used for testing on TestPyPI)
@@ -653,7 +653,7 @@ jobs:
       - name: Install wheel
         run: |
           CUDA_TAG="cu$(echo "${{ matrix.cuda-version }}" | tr -d '.')"
-          echo "torch==${{ matrix.torch-version }}.0" > "${RUNNER_TEMP}/torch-constraints.txt"
+          echo "torch==${{ needs.versions.outputs.torch-full-version }}" > "${RUNNER_TEMP}/torch-constraints.txt"
           uv pip install --no-cache -c "${RUNNER_TEMP}/torch-constraints.txt" torch --extra-index-url https://download.pytorch.org/whl/${CUDA_TAG}
           uv pip install dist/fvdb_core-*.whl
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -222,8 +222,10 @@ jobs:
           CUDA_TAG="cu$(echo "${{ matrix.cuda-version }}" | tr -d '.')"
           TORCH_VERSION="${{ matrix.torch-version }}"
           echo "Installing PyTorch ${TORCH_VERSION} for ${CUDA_TAG}"
-          # Install build requirements with explicit PyTorch version (explicit version takes precedence)
-          uv pip install --no-cache torch==${TORCH_VERSION}.0 -r env/build_requirements.txt --extra-index-url https://download.pytorch.org/whl/${CUDA_TAG}
+          # Pin the tested PyTorch via a constraints file so the unbounded torch in
+          # build_requirements.txt resolves to the matrix version.
+          echo "torch==${TORCH_VERSION}.0" > "${RUNNER_TEMP}/torch-constraints.txt"
+          uv pip install --no-cache -c "${RUNNER_TEMP}/torch-constraints.txt" -r env/build_requirements.txt --extra-index-url https://download.pytorch.org/whl/${CUDA_TAG}
 
       - name: Add a post-release to version (used for testing on TestPyPI)
         if: ${{ needs.pr-flags.outputs.s3 == 'false' }}
@@ -651,7 +653,8 @@ jobs:
       - name: Install wheel
         run: |
           CUDA_TAG="cu$(echo "${{ matrix.cuda-version }}" | tr -d '.')"
-          uv pip install --no-cache torch==${{ matrix.torch-version }}.0 --extra-index-url https://download.pytorch.org/whl/${CUDA_TAG}
+          echo "torch==${{ matrix.torch-version }}.0" > "${RUNNER_TEMP}/torch-constraints.txt"
+          uv pip install --no-cache -c "${RUNNER_TEMP}/torch-constraints.txt" torch --extra-index-url https://download.pytorch.org/whl/${CUDA_TAG}
           uv pip install dist/fvdb_core-*.whl
 
       - name: Run smoke test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,8 +11,8 @@ license = { text = "Apache-2.0" }
 requires-python = ">=3.10"
 readme = "README.md"
 dependencies = [
-    # Require torch; users will choose the correct CUDA build from PyTorch's index
-    "torch>=2.8,<2.13",
+    # Require torch; users will choose the correct CUDA build from PyTorch's index.
+    "torch>=2.8",
     "numpy",
 ]
 optional-dependencies = {viewer = ["nanovdb-editor>=0.0.23,<0.2.0"]}


### PR DESCRIPTION
Removed the `<2.13` from the torch requirements in the `pyproject.toml`
Change all the CI workflows that build their environments with uv/pip to use a `-c torch-constraints.txt` that gets JIT-built from our `versions.json` file to constrain the correct torch version

This was inspired by a conversation with @jameslamb in our conda-forge feedstock:  https://github.com/conda-forge/fvdb-core-feedstock/pull/34#issuecomment-4783236270