### PR TITLE
CI Token Best Practices Sweep

### DIFF
--- a/.github/scripts/check_runner_token_policy.py
+++ b/.github/scripts/check_runner_token_policy.py
@@ -49,14 +49,13 @@ ALLOWED_LINE = re.compile(r"^\s*github-token:\s*\$\{\{\s*secrets\." + re.escape(
 
 # Paths (relative to repo root) that are allowed to mention the token name at
 # all. The workflows are where it is legitimately used; CI tooling under
-# .github/scripts/ (this script and its tests) and the security doc reference it
-# by name out of necessity. None of these can expose the token *value*: rules
-# 2-3 guarantee the secret is only ever interpolated into the machulav action,
-# so a file merely containing the name string is harmless.
+# .github/scripts/ (this script and its tests) references it by name out of
+# necessity. None of these can expose the token *value*: rules 2-3 guarantee the
+# secret is only ever interpolated into the machulav action, so a file merely
+# containing the name string is harmless.
 ALLOWED_PATH_PREFIXES = (
     ".github/workflows/",
     ".github/scripts/",
-    ".github/workflow-security.md",
 )
 
 

--- a/.github/scripts/check_runner_token_policy.py
+++ b/.github/scripts/check_runner_token_policy.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Repo-specific CI policy for the EC2 runner admin token.
+
+This script enforces, by inspecting the workflow files themselves:
+
+  1. The token name may appear ONLY inside ``.github/workflows/*.{yml,yaml}``
+     (and in this enforcement script). It must not leak into source, docs, etc.
+
+  2. Every textual occurrence in a workflow must be EXACTLY the action input:
+         github-token: ${{ secrets.EC2_RUNNER_TOKEN }}
+     (whitespace inside ``${{ }}`` is tolerated). This single rule already
+     forbids putting the token in ``env:``, ``GH_TOKEN``/``GITHUB_TOKEN``,
+     ``with.token``, a ``run:`` script, or a reusable-workflow ``secrets:``
+     block, because none of those match this pattern.
+
+  3. The step that consumes the token must ``uses: machulav/ec2-github-runner``.
+
+  4. A job that references the token must not pull untrusted code into its
+     workspace alongside the privileged context: no local actions
+     (``uses: ./...``) and no ``actions/checkout``. (Sibling ``run:`` steps are
+     fine -- rule 2 guarantees they can never reference the token, since it
+     only ever appears as the ``github-token`` input.)
+
+Usage:
+    check_runner_token_policy.py [WORKFLOW_DIR] [--repo-root DIR]
+
+Exit code 0 = compliant, 1 = one or more violations.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+TOKEN_NAME = "EC2_RUNNER_TOKEN"
+TOKEN_REF = f"secrets.{TOKEN_NAME}"
+ALLOWED_ACTION = "machulav/ec2-github-runner"
+
+# The one and only allowed textual form, e.g.
+#   github-token: ${{ secrets.EC2_RUNNER_TOKEN }}
+ALLOWED_LINE = re.compile(r"^\s*github-token:\s*\$\{\{\s*secrets\." + re.escape(TOKEN_NAME) + r"\s*\}\}\s*$")
+
+# Paths (relative to repo root) that are allowed to mention the token name at
+# all. The workflows are where it is legitimately used; this script names it by
+# necessity.
+ALLOWED_PATH_PREFIXES = (
+    ".github/workflows/",
+    ".github/scripts/check_runner_token_policy.py",
+)
+
+
+def fail(violations: list[str], path: Path, job: str | None, message: str) -> None:
+    loc = f"{path}" + (f" [job: {job}]" if job else "")
+    violations.append(f"{loc}: {message}")
+
+
+def iter_steps(job: dict):
+    for step in job.get("steps") or []:
+        if isinstance(step, dict):
+            yield step
+
+
+def check_workflow_file(path: Path, violations: list[str]) -> None:
+    text = path.read_text()
+    if TOKEN_REF not in text and TOKEN_NAME not in text:
+        return
+
+    # --- Rule 2: every line mentioning the token must be the exact input. -----
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        if TOKEN_NAME not in line:
+            continue
+        if not ALLOWED_LINE.match(line):
+            fail(
+                violations,
+                path,
+                None,
+                f"line {lineno}: '{TOKEN_NAME}' may only appear as "
+                f"'github-token: ${{{{ secrets.{TOKEN_NAME} }}}}', got: {line.strip()!r}",
+            )
+
+    # --- Structural rules 3 & 4 via parsed YAML. ------------------------------
+    try:
+        data = yaml.safe_load(text) or {}
+    except yaml.YAMLError as exc:
+        fail(violations, path, None, f"could not parse YAML: {exc}")
+        return
+
+    jobs = data.get("jobs") or {}
+    for job_name, job in jobs.items():
+        if not isinstance(job, dict):
+            continue
+        job_text = yaml.safe_dump(job)
+        if TOKEN_NAME not in job_text:
+            continue
+
+        token_steps = []
+        for step in iter_steps(job):
+            step_text = yaml.safe_dump(step)
+            if TOKEN_NAME not in step_text:
+                continue
+            token_steps.append(step)
+
+            # Rule 3: the consuming step must be the EC2 runner action.
+            uses = (step.get("uses") or "").split("@")[0]
+            if uses != ALLOWED_ACTION:
+                fail(
+                    violations,
+                    path,
+                    job_name,
+                    f"step '{step.get('name', uses or '<unnamed>')}' uses the token "
+                    f"but is not '{ALLOWED_ACTION}' (uses: {uses or '<none>'})",
+                )
+
+            # Rule 2 (structural backstop): only via the github-token input.
+            with_block = step.get("with") or {}
+            offending = {
+                k: v for k, v in with_block.items() if k != "github-token" and TOKEN_NAME in yaml.safe_dump({k: v})
+            }
+            if offending:
+                fail(
+                    violations,
+                    path,
+                    job_name,
+                    f"token passed via disallowed input(s): {sorted(offending)}",
+                )
+
+        if not token_steps:
+            # Token appears in the job but in no step (e.g. job-level env: or a
+            # reusable-workflow `secrets:` block). That is never allowed.
+            fail(
+                violations,
+                path,
+                job_name,
+                "token referenced at job level (env/secrets/with), not as an " f"'{ALLOWED_ACTION}' step input",
+            )
+            continue
+
+        # Rule 4: a privileged job must not pull untrusted code into its
+        # workspace (no local actions, no checkout) next to the token.
+        for step in iter_steps(job):
+            uses = step.get("uses") or ""
+            bare = uses.split("@")[0]
+            if uses.startswith("./") or uses.startswith("../"):
+                fail(
+                    violations,
+                    path,
+                    job_name,
+                    f"job exposes the token and also runs a LOCAL action " f"(uses: {uses}); not allowed",
+                )
+            if bare == "actions/checkout":
+                fail(
+                    violations,
+                    path,
+                    job_name,
+                    "job exposes the token and also runs actions/checkout; "
+                    "the privileged token must not share a job with checked-out "
+                    "code",
+                )
+
+
+def check_no_leaks_outside_workflows(repo_root: Path, violations: list[str]) -> None:
+    """Rule 1: the token name must not appear anywhere except the workflows."""
+    try:
+        out = subprocess.run(
+            ["git", "-C", str(repo_root), "grep", "-l", "-I", "-F", TOKEN_NAME],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except FileNotFoundError:
+        # No git available; skip the repo-wide check (workflow rules still run).
+        return
+
+    for rel in out.stdout.splitlines():
+        rel = rel.strip()
+        if not rel:
+            continue
+        if any(rel.startswith(p) for p in ALLOWED_PATH_PREFIXES):
+            continue
+        violations.append(f"{rel}: '{TOKEN_NAME}' must not be referenced outside " f".github/workflows/")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "workflow_dir",
+        nargs="?",
+        default=".github/workflows",
+        help="directory containing workflow YAML files",
+    )
+    parser.add_argument(
+        "--repo-root",
+        default=".",
+        help="repo root for the leak check (default: current directory)",
+    )
+    args = parser.parse_args()
+
+    workflow_dir = Path(args.workflow_dir)
+    repo_root = Path(args.repo_root)
+
+    if not workflow_dir.is_dir():
+        print(f"error: workflow dir not found: {workflow_dir}", file=sys.stderr)
+        return 1
+
+    violations: list[str] = []
+
+    files = sorted(set(workflow_dir.glob("*.yml")) | set(workflow_dir.glob("*.yaml")))
+    for path in files:
+        check_workflow_file(path, violations)
+
+    check_no_leaks_outside_workflows(repo_root, violations)
+
+    if violations:
+        print(
+            f"\n❌ EC2 runner token policy violations ({len(violations)}):\n",
+            file=sys.stderr,
+        )
+        for v in violations:
+            print(f"  - {v}", file=sys.stderr)
+        print(
+            "\nThe admin-scoped runner token may ONLY be used as:\n"
+            f"    github-token: ${{{{ secrets.{TOKEN_NAME} }}}}\n"
+            f"  in a step that uses '{ALLOWED_ACTION}', inside a job that does\n"
+            "  not check out code or run local actions. See "
+            ".github/scripts/check_runner_token_policy.py.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        f"✅ EC2 runner token policy: OK ({len(files)} workflow file(s) scanned; "
+        f"token used only as '{ALLOWED_ACTION}' input)."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/check_runner_token_policy.py
+++ b/.github/scripts/check_runner_token_policy.py
@@ -169,34 +169,45 @@ def check_workflow_file(path: Path, violations: list[str]) -> None:
                 )
 
 
-def check_no_leaks_outside_workflows(repo_root: Path, violations: list[str]) -> None:
-    """Rule 1: the token name must not appear anywhere except the workflows."""
+def check_no_leaks_outside_workflows(repo_root: Path, violations: list[str], ref: str | None = None) -> None:
+    """Rule 1: the token name must not appear anywhere except the workflows.
+
+    When ``ref`` is given (e.g. a PR head SHA or ``FETCH_HEAD``), the search runs
+    against that commit's *tree* instead of the working tree. This lets the
+    Workflow Security gate enforce Rule 1 over the whole proposed PR snapshot --
+    including files outside ``.github/workflows`` -- while the policy script
+    itself still runs from the trusted base checkout. ``git grep`` only reads
+    blobs, so scanning an untrusted ref executes nothing.
+    """
+    cmd = ["git", "-C", str(repo_root), "grep", "-l", "-I", "-F", TOKEN_NAME]
+    if ref:
+        cmd.append(ref)
     try:
-        out = subprocess.run(
-            ["git", "-C", str(repo_root), "grep", "-l", "-I", "-F", TOKEN_NAME],
-            capture_output=True,
-            text=True,
-            check=False,
-        )
+        out = subprocess.run(cmd, capture_output=True, text=True, check=False)
     except FileNotFoundError:
         # No git available; skip the repo-wide check (workflow rules still run).
         return
 
     # `git grep` exits 0 when matches are found and 1 when there are none. Any
-    # other code (e.g. 128 when repo_root is not a git worktree) means the leak
-    # check could not run -- fail closed rather than silently passing.
+    # other code (e.g. 128 when repo_root is not a git worktree, or the ref is
+    # missing) means the leak check could not run -- fail closed rather than
+    # silently passing.
     if out.returncode not in (0, 1):
         violations.append(
             f"<repo-wide leak check>: 'git grep' failed (exit {out.returncode}) "
-            f"in {repo_root}; cannot verify '{TOKEN_NAME}' is confined to "
-            f".github/workflows/. stderr: {out.stderr.strip()!r}"
+            f"in {repo_root}{f' for ref {ref}' if ref else ''}; cannot verify "
+            f"'{TOKEN_NAME}' is confined to .github/workflows/. "
+            f"stderr: {out.stderr.strip()!r}"
         )
         return
 
-    for rel in out.stdout.splitlines():
-        rel = rel.strip()
-        if not rel:
+    for line in out.stdout.splitlines():
+        line = line.strip()
+        if not line:
             continue
+        # With a ref, `git grep` prefixes each match with "<ref>:"; strip it to
+        # get the repo-relative path.
+        rel = line.split(":", 1)[1] if ref else line
         if any(rel.startswith(p) for p in ALLOWED_PATH_PREFIXES):
             continue
         violations.append(f"{rel}: '{TOKEN_NAME}' must not be referenced outside " f".github/workflows/")
@@ -215,6 +226,12 @@ def main() -> int:
         default=".",
         help="repo root for the leak check (default: current directory)",
     )
+    parser.add_argument(
+        "--leak-check-ref",
+        default=None,
+        help="git ref/commit to run the Rule 1 leak check against (e.g. a PR "
+        "head SHA or FETCH_HEAD). Defaults to the working tree.",
+    )
     args = parser.parse_args()
 
     workflow_dir = Path(args.workflow_dir)
@@ -230,7 +247,7 @@ def main() -> int:
     for path in files:
         check_workflow_file(path, violations)
 
-    check_no_leaks_outside_workflows(repo_root, violations)
+    check_no_leaks_outside_workflows(repo_root, violations, ref=args.leak_check_ref)
 
     if violations:
         print(

--- a/.github/scripts/check_runner_token_policy.py
+++ b/.github/scripts/check_runner_token_policy.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# Copyright Contributors to the OpenVDB Project
 # SPDX-License-Identifier: Apache-2.0
 """Repo-specific CI policy for the EC2 runner admin token.
 
@@ -47,11 +48,15 @@ ALLOWED_ACTION = "machulav/ec2-github-runner"
 ALLOWED_LINE = re.compile(r"^\s*github-token:\s*\$\{\{\s*secrets\." + re.escape(TOKEN_NAME) + r"\s*\}\}\s*$")
 
 # Paths (relative to repo root) that are allowed to mention the token name at
-# all. The workflows are where it is legitimately used; this script names it by
-# necessity.
+# all. The workflows are where it is legitimately used; CI tooling under
+# .github/scripts/ (this script and its tests) and the security doc reference it
+# by name out of necessity. None of these can expose the token *value*: rules
+# 2-3 guarantee the secret is only ever interpolated into the machulav action,
+# so a file merely containing the name string is harmless.
 ALLOWED_PATH_PREFIXES = (
     ".github/workflows/",
-    ".github/scripts/check_runner_token_policy.py",
+    ".github/scripts/",
+    ".github/workflow-security.md",
 )
 
 
@@ -175,6 +180,17 @@ def check_no_leaks_outside_workflows(repo_root: Path, violations: list[str]) -> 
         )
     except FileNotFoundError:
         # No git available; skip the repo-wide check (workflow rules still run).
+        return
+
+    # `git grep` exits 0 when matches are found and 1 when there are none. Any
+    # other code (e.g. 128 when repo_root is not a git worktree) means the leak
+    # check could not run -- fail closed rather than silently passing.
+    if out.returncode not in (0, 1):
+        violations.append(
+            f"<repo-wide leak check>: 'git grep' failed (exit {out.returncode}) "
+            f"in {repo_root}; cannot verify '{TOKEN_NAME}' is confined to "
+            f".github/workflows/. stderr: {out.stderr.strip()!r}"
+        )
         return
 
     for rel in out.stdout.splitlines():

--- a/.github/scripts/check_runner_token_policy.py
+++ b/.github/scripts/check_runner_token_policy.py
@@ -23,6 +23,14 @@ This script enforces, by inspecting the workflow files themselves:
      fine -- rule 2 guarantees they can never reference the token, since it
      only ever appears as the ``github-token`` input.)
 
+  5. No dynamic secret access (``secrets[...]``) anywhere in a workflow. Rules
+     1-4 are textual: they key on the literal name ``EC2_RUNNER_TOKEN``. Dynamic
+     indexing such as ``secrets[format('EC2_RUNNER_%s', 'TOKEN')]`` or
+     ``secrets[matrix.name]`` could resolve the admin token *without* spelling
+     its name, evading every other rule. It is never used legitimately here, so
+     reject it outright (this check runs on every workflow, even ones that never
+     mention the token by name).
+
 Usage:
     check_runner_token_policy.py [WORKFLOW_DIR] [--repo-root DIR]
 
@@ -46,6 +54,10 @@ ALLOWED_ACTION = "machulav/ec2-github-runner"
 # The one and only allowed textual form, e.g.
 #   github-token: ${{ secrets.EC2_RUNNER_TOKEN }}
 ALLOWED_LINE = re.compile(r"^\s*github-token:\s*\$\{\{\s*secrets\." + re.escape(TOKEN_NAME) + r"\s*\}\}\s*$")
+
+# Dynamic secret access, e.g. secrets['X'], secrets[matrix.y], secrets[format(...)].
+# The \b avoids matching identifiers that merely end in "secrets" (e.g. mysecrets[0]).
+DYNAMIC_SECRET = re.compile(r"\bsecrets\s*\[")
 
 # Paths (relative to repo root) that are allowed to mention the token name at
 # all. The workflows are where it is legitimately used; CI tooling under
@@ -72,6 +84,21 @@ def iter_steps(job: dict):
 
 def check_workflow_file(path: Path, violations: list[str]) -> None:
     text = path.read_text()
+
+    # --- Rule 5: no dynamic secret access (runs on every workflow). -----------
+    # Must run before the token-name early return below: the whole point is that
+    # dynamic indexing can reach the token without naming it.
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        if DYNAMIC_SECRET.search(line):
+            fail(
+                violations,
+                path,
+                None,
+                f"line {lineno}: dynamic secret access is not allowed -- use "
+                f"'secrets.<NAME>', not 'secrets[...]' (it can resolve "
+                f"'{TOKEN_NAME}' without naming it): {line.strip()!r}",
+            )
+
     if TOKEN_REF not in text and TOKEN_NAME not in text:
         return
 

--- a/.github/scripts/check_runner_token_policy.py
+++ b/.github/scripts/check_runner_token_policy.py
@@ -5,8 +5,9 @@
 
 This script enforces, by inspecting the workflow files themselves:
 
-  1. The token name may appear ONLY inside ``.github/workflows/*.{yml,yaml}``
-     (and in this enforcement script). It must not leak into source, docs, etc.
+  1. The token name may appear ONLY inside ``.github/workflows/`` and the CI
+     tooling under ``.github/scripts/`` (this enforcement script and its tests).
+     It must not leak into product source, docs, etc.
 
   2. Every textual occurrence in a workflow must be EXACTLY the action input:
          github-token: ${{ secrets.EC2_RUNNER_TOKEN }}
@@ -69,6 +70,8 @@ ALLOWED_PATH_PREFIXES = (
     ".github/workflows/",
     ".github/scripts/",
 )
+# Human-readable form of the allowed locations, for violation/error messages.
+ALLOWED_PATHS_DESC = " or ".join(ALLOWED_PATH_PREFIXES)
 
 
 def fail(violations: list[str], path: Path, job: str | None, message: str) -> None:
@@ -215,7 +218,7 @@ def check_no_leaks_outside_workflows(repo_root: Path, violations: list[str], ref
         # run the check, so fail closed rather than silently passing.
         violations.append(
             f"<repo-wide leak check>: 'git' not found; cannot verify "
-            f"'{TOKEN_NAME}' is confined to .github/workflows/"
+            f"'{TOKEN_NAME}' is confined to {ALLOWED_PATHS_DESC}"
         )
         return
 
@@ -227,7 +230,7 @@ def check_no_leaks_outside_workflows(repo_root: Path, violations: list[str], ref
         violations.append(
             f"<repo-wide leak check>: 'git grep' failed (exit {out.returncode}) "
             f"in {repo_root}{f' for ref {ref}' if ref else ''}; cannot verify "
-            f"'{TOKEN_NAME}' is confined to .github/workflows/. "
+            f"'{TOKEN_NAME}' is confined to {ALLOWED_PATHS_DESC}. "
             f"stderr: {out.stderr.strip()!r}"
         )
         return
@@ -241,7 +244,7 @@ def check_no_leaks_outside_workflows(repo_root: Path, violations: list[str], ref
         rel = line.split(":", 1)[1] if ref else line
         if any(rel.startswith(p) for p in ALLOWED_PATH_PREFIXES):
             continue
-        violations.append(f"{rel}: '{TOKEN_NAME}' must not be referenced outside " f".github/workflows/")
+        violations.append(f"{rel}: '{TOKEN_NAME}' must not be referenced outside {ALLOWED_PATHS_DESC}")
 
 
 def main() -> int:

--- a/.github/scripts/check_runner_token_policy.py
+++ b/.github/scripts/check_runner_token_policy.py
@@ -185,7 +185,12 @@ def check_no_leaks_outside_workflows(repo_root: Path, violations: list[str], ref
     try:
         out = subprocess.run(cmd, capture_output=True, text=True, check=False)
     except FileNotFoundError:
-        # No git available; skip the repo-wide check (workflow rules still run).
+        # git is required to verify confinement; if it is unavailable we cannot
+        # run the check, so fail closed rather than silently passing.
+        violations.append(
+            f"<repo-wide leak check>: 'git' not found; cannot verify "
+            f"'{TOKEN_NAME}' is confined to .github/workflows/"
+        )
         return
 
     # `git grep` exits 0 when matches are found and 1 when there are none. Any

--- a/.github/scripts/test_check_runner_token_policy.py
+++ b/.github/scripts/test_check_runner_token_policy.py
@@ -241,6 +241,25 @@ def test_leak_check_fails_closed_outside_git_worktree(tmp_path):
     assert any("git grep' failed" in v for v in violations)
 
 
+def test_leak_check_against_ref_passes_on_clean_repo():
+    """Scanning a committed ref (the gate's PR-tree mode) flags nothing here:
+    the token name only appears in allowed CI paths at HEAD."""
+    if not _git_available():
+        pytest.skip("git not available")
+    violations: list[str] = []
+    policy.check_no_leaks_outside_workflows(REPO_ROOT, violations, ref="HEAD")
+    assert violations == [], "\n".join(violations)
+
+
+def test_leak_check_fails_closed_on_missing_ref(tmp_path):
+    """An unknown ref must fail closed rather than silently passing."""
+    if not _git_available():
+        pytest.skip("git not available")
+    violations: list[str] = []
+    policy.check_no_leaks_outside_workflows(REPO_ROOT, violations, ref="no_such_ref_xyz")
+    assert any("git grep' failed" in v for v in violations)
+
+
 def _git_available() -> bool:
     try:
         subprocess.run(["git", "--version"], capture_output=True, check=False)

--- a/.github/scripts/test_check_runner_token_policy.py
+++ b/.github/scripts/test_check_runner_token_policy.py
@@ -260,6 +260,18 @@ def test_leak_check_fails_closed_on_missing_ref(tmp_path):
     assert any("git grep' failed" in v for v in violations)
 
 
+def test_leak_check_fails_closed_when_git_missing(monkeypatch):
+    """If git is not installed, the leak check must record a violation."""
+
+    def _raise(*args, **kwargs):
+        raise FileNotFoundError("git")
+
+    monkeypatch.setattr(policy.subprocess, "run", _raise)
+    violations: list[str] = []
+    policy.check_no_leaks_outside_workflows(REPO_ROOT, violations)
+    assert any("'git' not found" in v for v in violations)
+
+
 def _git_available() -> bool:
     try:
         subprocess.run(["git", "--version"], capture_output=True, check=False)

--- a/.github/scripts/test_check_runner_token_policy.py
+++ b/.github/scripts/test_check_runner_token_policy.py
@@ -138,6 +138,76 @@ def test_token_via_non_github_token_input_is_rejected(tmp_path):
     assert violations  # line rule and/or disallowed-input rule fire
 
 
+# --- rule 5: no dynamic secret access (evades the textual name check) --------
+
+
+def test_dynamic_secret_access_via_format_is_rejected(tmp_path):
+    """secrets[format(...)] resolves the token without spelling its name."""
+    violations = _check(
+        tmp_path,
+        """
+        name: bad
+        on: [push]
+        jobs:
+          leak:
+            runs-on: ubuntu-latest
+            steps:
+              - run: echo "${{ secrets[format('EC2_RUNNER_%s', 'TOKEN')] }}"
+        """,
+    )
+    assert any("dynamic secret access" in v for v in violations)
+
+
+def test_dynamic_secret_access_via_matrix_is_rejected(tmp_path):
+    violations = _check(
+        tmp_path,
+        """
+        name: bad
+        on: [push]
+        jobs:
+          leak:
+            runs-on: ubuntu-latest
+            steps:
+              - run: echo "${{ secrets[matrix.name] }}"
+        """,
+    )
+    assert any("dynamic secret access" in v for v in violations)
+
+
+def test_dynamic_secret_access_is_rejected_even_without_token_name(tmp_path):
+    """The check runs on every workflow, even ones that never name the token."""
+    violations = _check(
+        tmp_path,
+        """
+        name: bad
+        on: [push]
+        jobs:
+          leak:
+            runs-on: ubuntu-latest
+            steps:
+              - run: echo "${{ secrets['SOME_OTHER_SECRET'] }}"
+        """,
+    )
+    assert any("dynamic secret access" in v for v in violations)
+
+
+def test_identifier_ending_in_secrets_is_not_flagged(tmp_path):
+    """`\\b` must not match e.g. mysecrets[0] (not a secrets-context access)."""
+    violations = _check(
+        tmp_path,
+        """
+        name: ok
+        on: [push]
+        jobs:
+          build:
+            runs-on: ubuntu-latest
+            steps:
+              - run: echo "${{ fromJSON(needs.x.outputs.mysecrets)[0] }}"
+        """,
+    )
+    assert violations == []
+
+
 # --- rule 3: only machulav/ec2-github-runner may consume the token -----------
 
 

--- a/.github/scripts/test_check_runner_token_policy.py
+++ b/.github/scripts/test_check_runner_token_policy.py
@@ -1,0 +1,249 @@
+# Copyright Contributors to the OpenVDB Project
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the EC2 runner-token CI policy.
+
+Exercises check_runner_token_policy.py -- the security gate that enforces that
+``secrets.EC2_RUNNER_TOKEN`` is only ever used as the ``github-token`` input to
+``machulav/ec2-github-runner``. Run by .github/workflows/workflow-security.yml
+on every PR (it needs only pyyaml + pytest, no fvdb build).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("yaml")
+
+HERE = Path(__file__).resolve().parent
+REPO_ROOT = HERE.parents[1]
+SCRIPT_PATH = HERE / "check_runner_token_policy.py"
+
+
+def _load_policy_module():
+    spec = importlib.util.spec_from_file_location("runner_token_policy", SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+policy = _load_policy_module()
+
+
+def _check(tmp_path: Path, yaml_text: str) -> list[str]:
+    """Write a workflow file and return the policy violations it produces."""
+    wf = tmp_path / "wf.yml"
+    wf.write_text(textwrap.dedent(yaml_text))
+    violations: list[str] = []
+    policy.check_workflow_file(wf, violations)
+    return violations
+
+
+# --- compliant baseline ------------------------------------------------------
+
+
+def test_compliant_workflow_has_no_violations(tmp_path):
+    violations = _check(
+        tmp_path,
+        """
+        name: ok
+        on: [push]
+        jobs:
+          start:
+            runs-on: ubuntu-latest
+            steps:
+              - uses: machulav/ec2-github-runner@343a1b2ae682e681c3cec9a235d882da17ff04ef
+                with:
+                  mode: start
+                  github-token: ${{ secrets.EC2_RUNNER_TOKEN }}
+        """,
+    )
+    assert violations == []
+
+
+def test_workflow_without_token_is_ignored(tmp_path):
+    violations = _check(
+        tmp_path,
+        """
+        name: notoken
+        on: [push]
+        jobs:
+          build:
+            runs-on: ubuntu-latest
+            steps:
+              - uses: actions/checkout@v4
+              - run: echo hello
+        """,
+    )
+    assert violations == []
+
+
+# --- rule 2: token may only appear as the github-token input -----------------
+
+
+def test_token_in_env_is_rejected(tmp_path):
+    violations = _check(
+        tmp_path,
+        """
+        name: bad
+        on: [push]
+        jobs:
+          leak:
+            runs-on: ubuntu-latest
+            env:
+              GH_TOKEN: ${{ secrets.EC2_RUNNER_TOKEN }}
+            steps:
+              - run: gh api /repos
+        """,
+    )
+    assert any("may only appear" in v for v in violations)
+
+
+def test_token_in_run_step_is_rejected(tmp_path):
+    violations = _check(
+        tmp_path,
+        """
+        name: bad
+        on: [push]
+        jobs:
+          leak:
+            runs-on: ubuntu-latest
+            steps:
+              - run: echo "${{ secrets.EC2_RUNNER_TOKEN }}"
+        """,
+    )
+    assert any("may only appear" in v for v in violations)
+
+
+def test_token_via_non_github_token_input_is_rejected(tmp_path):
+    violations = _check(
+        tmp_path,
+        """
+        name: bad
+        on: [push]
+        jobs:
+          start:
+            runs-on: ubuntu-latest
+            steps:
+              - uses: machulav/ec2-github-runner@343a1b2ae682e681c3cec9a235d882da17ff04ef
+                with:
+                  mode: start
+                  token: ${{ secrets.EC2_RUNNER_TOKEN }}
+        """,
+    )
+    assert violations  # line rule and/or disallowed-input rule fire
+
+
+# --- rule 3: only machulav/ec2-github-runner may consume the token -----------
+
+
+def test_token_to_wrong_action_is_rejected(tmp_path):
+    violations = _check(
+        tmp_path,
+        """
+        name: bad
+        on: [push]
+        jobs:
+          evil:
+            runs-on: ubuntu-latest
+            steps:
+              - uses: some/other-action@v1
+                with:
+                  github-token: ${{ secrets.EC2_RUNNER_TOKEN }}
+        """,
+    )
+    assert any("machulav/ec2-github-runner" in v for v in violations)
+
+
+# --- rule 4: token job must not pull in untrusted code -----------------------
+
+
+def test_checkout_in_token_job_is_rejected(tmp_path):
+    violations = _check(
+        tmp_path,
+        """
+        name: bad
+        on: [push]
+        jobs:
+          start:
+            runs-on: ubuntu-latest
+            steps:
+              - uses: actions/checkout@v4
+              - uses: machulav/ec2-github-runner@343a1b2ae682e681c3cec9a235d882da17ff04ef
+                with:
+                  mode: start
+                  github-token: ${{ secrets.EC2_RUNNER_TOKEN }}
+        """,
+    )
+    assert any("actions/checkout" in v for v in violations)
+
+
+def test_local_action_in_token_job_is_rejected(tmp_path):
+    violations = _check(
+        tmp_path,
+        """
+        name: bad
+        on: [push]
+        jobs:
+          start:
+            runs-on: ubuntu-latest
+            steps:
+              - uses: ./.github/actions/evil
+              - uses: machulav/ec2-github-runner@343a1b2ae682e681c3cec9a235d882da17ff04ef
+                with:
+                  mode: start
+                  github-token: ${{ secrets.EC2_RUNNER_TOKEN }}
+        """,
+    )
+    assert any("LOCAL action" in v for v in violations)
+
+
+def test_job_level_token_with_no_step_is_rejected(tmp_path):
+    violations = _check(
+        tmp_path,
+        """
+        name: bad
+        on: [push]
+        jobs:
+          call:
+            uses: ./.github/workflows/reusable.yml
+            secrets:
+              gh-token: ${{ secrets.EC2_RUNNER_TOKEN }}
+        """,
+    )
+    assert violations
+
+
+# --- the real fvdb workflows must all pass -----------------------------------
+
+
+def test_repo_workflows_are_compliant():
+    workflow_dir = REPO_ROOT / ".github" / "workflows"
+    violations: list[str] = []
+    for path in sorted(workflow_dir.glob("*.yml")):
+        policy.check_workflow_file(path, violations)
+    assert violations == [], "real workflows violate the runner-token policy:\n" + "\n".join(violations)
+
+
+# --- rule 1: leak check fails closed when git cannot run ---------------------
+
+
+def test_leak_check_fails_closed_outside_git_worktree(tmp_path):
+    """A non-git directory must produce a violation, not a silent pass."""
+    if not _git_available():
+        pytest.skip("git not available")
+    violations: list[str] = []
+    policy.check_no_leaks_outside_workflows(tmp_path, violations)
+    assert any("git grep' failed" in v for v in violations)
+
+
+def _git_available() -> bool:
+    try:
+        subprocess.run(["git", "--version"], capture_output=True, check=False)
+        return True
+    except FileNotFoundError:
+        return False

--- a/.github/workflows/check-changes.yml
+++ b/.github/workflows/check-changes.yml
@@ -24,7 +24,7 @@ jobs:
     outputs:
       should_test: ${{ github.event_name != 'pull_request_target' || steps.filter.outputs.src == 'true' }}
     steps:
-      - uses: dorny/paths-filter@v4
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         if: github.event_name == 'pull_request_target'
         with:

--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
-      - uses: psf/black@stable
+      - uses: psf/black@87928e6d6761a4a6d22250e1fee5601b3998086e # stable
         with:
           options: "--check --diff --verbose"
           src: "./"
@@ -44,7 +44,7 @@ jobs:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
         persist-credentials: false
-    - uses: swahtz/include-guards-check-action@master
+    - uses: swahtz/include-guards-check-action@41d1997205f936c50e23272c849398168b72083a # master
       with:
         path: 'src/'
 
@@ -55,7 +55,7 @@ jobs:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
         persist-credentials: false
-    - uses: enarx/spdx@master
+    - uses: enarx/spdx@d4020ee98e3101dd487c5184f27c6a6fb4f88709 # master
       with:
         licenses: |-
           Apache-2.0

--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -9,6 +9,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   test-python-black-lint:
     name: Python code style (black)

--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -14,7 +14,9 @@ jobs:
     name: Python code style (black)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - uses: psf/black@stable
         with:
           options: "--check --diff --verbose"
@@ -25,8 +27,10 @@ jobs:
     name: C++ code style (clang-format)
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
-    - uses: DoozyX/clang-format-lint-action@v0.20
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      with:
+        persist-credentials: false
+    - uses: DoozyX/clang-format-lint-action@bcb4eb2cb0d707ee4f3e5cc3b456eb075f12cf73 # v0.20
       with:
         source: 'src/'
         extensions: 'h,cpp,cc,cu,cuh'
@@ -37,7 +41,9 @@ jobs:
     name: Include guards
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      with:
+        persist-credentials: false
     - uses: swahtz/include-guards-check-action@master
       with:
         path: 'src/'
@@ -46,7 +52,9 @@ jobs:
     name: SPDX identifiers
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      with:
+        persist-credentials: false
     - uses: enarx/spdx@master
       with:
         licenses: |-
@@ -58,7 +66,9 @@ jobs:
     name: Trailing spaces
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      with:
+        persist-credentials: false
     - name: test
       run: |
           set +e
@@ -71,7 +81,9 @@ jobs:
     name: Spaces not tabs
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      with:
+        persist-credentials: false
     - name: test
       run: |
           set +e

--- a/.github/workflows/cu128-nightly.yml
+++ b/.github/workflows/cu128-nightly.yml
@@ -52,13 +52,16 @@ jobs:
           apt-get install -y software-properties-common
           add-apt-repository -y ppa:ubuntu-toolchain-r/test
           apt-get update
-          apt-get install -y gcc-${{ needs.versions.outputs.gcc-toolset }} g++-${{ needs.versions.outputs.gcc-toolset }}
-          update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${{ needs.versions.outputs.gcc-toolset }} 100
-          update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${{ needs.versions.outputs.gcc-toolset }} 100
+          apt-get install -y gcc-${NEEDS_VERSIONS_OUTPUTS_GCC_TOOLSET} g++-${NEEDS_VERSIONS_OUTPUTS_GCC_TOOLSET}
+          update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${NEEDS_VERSIONS_OUTPUTS_GCC_TOOLSET} 100
+          update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${NEEDS_VERSIONS_OUTPUTS_GCC_TOOLSET} 100
+        env:
+          NEEDS_VERSIONS_OUTPUTS_GCC_TOOLSET: ${{ needs.versions.outputs.gcc-toolset }}
       ### Get the PR branch and apply changes to the target branch
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0 # Fetch all history for all branches
+          persist-credentials: false
       - name: Determine the target branch of the PR
         run: |
           echo "Fetching pull request metadata..."
@@ -127,10 +130,12 @@ jobs:
 
       - name: Install CMake
         run: >
-          wget -nv https://github.com/Kitware/CMake/releases/download/v${{ needs.versions.outputs.cmake-version }}/cmake-${{ needs.versions.outputs.cmake-version }}-linux-x86_64.sh &&
+          wget -nv https://github.com/Kitware/CMake/releases/download/v${NEEDS_VERSIONS_OUTPUTS_CMAKE_VERSION}/cmake-${NEEDS_VERSIONS_OUTPUTS_CMAKE_VERSION}-linux-x86_64.sh &&
           mkdir /opt/cmake &&
-          sh cmake-${{ needs.versions.outputs.cmake-version }}-linux-x86_64.sh --prefix=/usr/local --skip-license &&
+          sh cmake-${NEEDS_VERSIONS_OUTPUTS_CMAKE_VERSION}-linux-x86_64.sh --prefix=/usr/local --skip-license &&
           cmake --version
+        env:
+          NEEDS_VERSIONS_OUTPUTS_CMAKE_VERSION: ${{ needs.versions.outputs.cmake-version }}
 
       - name: Install apt dependencies
         run: apt install -y zlib1g-dev libpng-dev pkg-config
@@ -138,14 +143,18 @@ jobs:
       - name: Install pip dependencies
         run: |
           uv venv
-          echo "torch==${{ needs.versions.outputs.torch-full-version }}" > "${RUNNER_TEMP}/torch-constraints.txt"
+          echo "torch==${NEEDS_VERSIONS_OUTPUTS_TORCH_FULL_VERSION}" > "${RUNNER_TEMP}/torch-constraints.txt"
           uv pip install --no-cache-dir -c "${RUNNER_TEMP}/torch-constraints.txt" -r fvdb/env/build_requirements.txt --extra-index-url https://download.pytorch.org/whl/cu128
+        env:
+          NEEDS_VERSIONS_OUTPUTS_TORCH_FULL_VERSION: ${{ needs.versions.outputs.torch-full-version }}
 
       - name: Build fvdb
         run: |
           source .venv/bin/activate
           cd fvdb;
-          TORCH_CUDA_ARCH_LIST="${{ needs.versions.outputs.cuda-arch-pr }}" ./build.sh wheel verbose gtests benchmarks
+          TORCH_CUDA_ARCH_LIST="${NEEDS_VERSIONS_OUTPUTS_CUDA_ARCH_PR}" ./build.sh wheel verbose gtests benchmarks
+        env:
+          NEEDS_VERSIONS_OUTPUTS_CUDA_ARCH_PR: ${{ needs.versions.outputs.cuda-arch-pr }}
 
       - name: Upload wheel
         uses: actions/upload-artifact@v7
@@ -204,6 +213,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0 # Fetch all history for all branches
+          persist-credentials: false
       - name: Determine the target branch of the PR
         run: |
           echo "Fetching pull request metadata..."
@@ -276,8 +286,10 @@ jobs:
       - name: Install pip dependencies
         run: |
           uv venv
-          echo "torch==${{ needs.versions.outputs.torch-full-version }}" > "${RUNNER_TEMP}/torch-constraints.txt"
+          echo "torch==${NEEDS_VERSIONS_OUTPUTS_TORCH_FULL_VERSION}" > "${RUNNER_TEMP}/torch-constraints.txt"
           uv pip install --no-cache-dir -c "${RUNNER_TEMP}/torch-constraints.txt" -r fvdb/env/test_requirements.txt --extra-index-url https://download.pytorch.org/whl/cu128
+        env:
+          NEEDS_VERSIONS_OUTPUTS_TORCH_FULL_VERSION: ${{ needs.versions.outputs.torch-full-version }}
 
       - name: Download package
         uses: actions/download-artifact@v8

--- a/.github/workflows/cu128-nightly.yml
+++ b/.github/workflows/cu128-nightly.yml
@@ -11,8 +11,6 @@ permissions:
   deployments: read
   pull-requests: read
   issues: read
-  # Need ID token write permission to use OIDC
-  id-token: write
 
 jobs:
   versions:

--- a/.github/workflows/cu128-nightly.yml
+++ b/.github/workflows/cu128-nightly.yml
@@ -58,7 +58,7 @@ jobs:
         env:
           NEEDS_VERSIONS_OUTPUTS_GCC_TOOLSET: ${{ needs.versions.outputs.gcc-toolset }}
       ### Get the PR branch and apply changes to the target branch
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0 # Fetch all history for all branches
           persist-credentials: false
@@ -122,7 +122,7 @@ jobs:
         with:
           version: "${{ needs.versions.outputs.uv-version }}"
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '${{ needs.versions.outputs.python-default }}'
         env:
@@ -157,7 +157,7 @@ jobs:
           NEEDS_VERSIONS_OUTPUTS_CUDA_ARCH_PR: ${{ needs.versions.outputs.cuda-arch-pr }}
 
       - name: Upload wheel
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
             name: fvdb-test-package
             path: fvdb/dist/*.whl
@@ -169,7 +169,7 @@ jobs:
         run: tar -cvf fvdb-gtest.tar fvdb/build/
 
       - name: Upload gtests
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
             name: fvdb-gtest
             path: fvdb-gtest.tar
@@ -210,7 +210,7 @@ jobs:
             && apt install gh -y
           which jq || apt install -y jq
       ### Get the PR branch and apply changes to the target branch
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0 # Fetch all history for all branches
           persist-credentials: false
@@ -274,7 +274,7 @@ jobs:
         with:
           version: "${{ needs.versions.outputs.uv-version }}"
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '${{ needs.versions.outputs.python-default }}'
         env:
@@ -292,7 +292,7 @@ jobs:
           NEEDS_VERSIONS_OUTPUTS_TORCH_FULL_VERSION: ${{ needs.versions.outputs.torch-full-version }}
 
       - name: Download package
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
             name: fvdb-test-package
             path: ./dist
@@ -313,7 +313,7 @@ jobs:
           pytest benchmark --benchmark-json benchmark/output.json
 
       - name: Store benchmark result
-        uses: benchmark-action/github-action-benchmark@v1
+        uses: benchmark-action/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba # v1.22.1
         with:
             name: Python Benchmark with pytest-benchmark
             tool: 'pytest'

--- a/.github/workflows/cu128.yml
+++ b/.github/workflows/cu128.yml
@@ -52,7 +52,7 @@ jobs:
         uses: machulav/ec2-github-runner@v2
         with:
           mode: start
-          github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+          github-token: ${{ secrets.EC2_RUNNER_TOKEN }}
           ec2-image-id: ${{ needs.versions.outputs.aws-cpu-ami }}
           ec2-instance-type: m6a.8xlarge
           subnet-id: ${{ needs.versions.outputs.aws-subnet }}
@@ -211,7 +211,7 @@ jobs:
         uses: machulav/ec2-github-runner@v2
         with:
           mode: stop
-          github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+          github-token: ${{ secrets.EC2_RUNNER_TOKEN }}
           label: ${{ needs.start-build-runner.outputs.label }}
           ec2-instance-id: ${{ needs.start-build-runner.outputs.ec2-instance-id }}
 
@@ -236,7 +236,7 @@ jobs:
         uses: machulav/ec2-github-runner@v2
         with:
           mode: start
-          github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+          github-token: ${{ secrets.EC2_RUNNER_TOKEN }}
           ec2-image-id: ${{ needs.versions.outputs.aws-gpu-ami }}
           ec2-instance-type: g6.2xlarge # 8 CPU-core, L4 GPU
           subnet-id: ${{ needs.versions.outputs.aws-subnet }}
@@ -558,6 +558,6 @@ jobs:
         uses: machulav/ec2-github-runner@v2
         with:
           mode: stop
-          github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+          github-token: ${{ secrets.EC2_RUNNER_TOKEN }}
           label: ${{ needs.start-tests-gpu-runner.outputs.label }}
           ec2-instance-id: ${{ needs.start-tests-gpu-runner.outputs.ec2-instance-id }}

--- a/.github/workflows/cu128.yml
+++ b/.github/workflows/cu128.yml
@@ -168,7 +168,7 @@ jobs:
           source .venv/bin/activate
           NANOVDB_EDITOR_SPEC=$(python .github/scripts/get_viewer_dependency.py)
           pip install "$NANOVDB_EDITOR_SPEC"
-          ./build.sh wheel verbose gtests benchmarks --cuda-arch-list '${NEEDS_VERSIONS_OUTPUTS_CUDA_ARCH_PR}'
+          ./build.sh wheel verbose gtests benchmarks --cuda-arch-list "${NEEDS_VERSIONS_OUTPUTS_CUDA_ARCH_PR}"
         env:
           NEEDS_VERSIONS_OUTPUTS_CUDA_ARCH_PR: ${{ needs.versions.outputs.cuda-arch-pr }}
 

--- a/.github/workflows/cu128.yml
+++ b/.github/workflows/cu128.yml
@@ -15,8 +15,6 @@ permissions:
   deployments: read
   pull-requests: read
   issues: read
-  # Need ID token write permission to use OIDC
-  id-token: write
 
 jobs:
   ##############################################################################
@@ -35,6 +33,8 @@ jobs:
     name: Start CPU-only EC2 runner for build
     needs: [check-changes, versions]
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # Required for AWS OIDC
     if: >-
       needs.check-changes.outputs.should_test == 'true'
       && (github.event.pull_request.draft == false || github.event_name != 'pull_request_target')
@@ -207,6 +207,8 @@ jobs:
       - fvdb-build # required to wait when the main job is done
       - versions
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # Required for AWS OIDC
     # required to stop the runner even if the error happened in the previous jobs
     # but only if the start-tests-gpu-runner job was not skipped
     if: ${{ always() && needs.start-build-runner.result != 'skipped' }}
@@ -231,6 +233,8 @@ jobs:
     name: Start EC2 GPU runner for gtests
     needs: [fvdb-build, versions]
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # Required for AWS OIDC
     outputs:
       label: ${{ steps.start-tests-gpu-runner.outputs.label }}
       ec2-instance-id: ${{ steps.start-tests-gpu-runner.outputs.ec2-instance-id }}
@@ -565,6 +569,8 @@ jobs:
       - fvdb-docs-test # required to wait when the main job is done
       - versions
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # Required for AWS OIDC
     # required to stop the runner even if the error happened in the previous jobs
     # but only if the start-tests-gpu-runner job was not skipped
     if: ${{ always() && needs.start-tests-gpu-runner.result != 'skipped' }}

--- a/.github/workflows/cu128.yml
+++ b/.github/workflows/cu128.yml
@@ -1,6 +1,7 @@
 name: fVDB pip CUDA 12.8 Build and Test
 
 on:
+  # zizmor: ignore[dangerous-triggers] pull_request_target is required to provision AWS runners; privileged credentials are scoped to runner lifecycle jobs.
   pull_request_target:
     branches:
       - '**'

--- a/.github/workflows/cu128.yml
+++ b/.github/workflows/cu128.yml
@@ -43,13 +43,13 @@ jobs:
       ec2-instance-id: ${{ steps.start-build-runner.outputs.ec2-instance-id }}
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b # v6.2.1
         with:
           role-to-assume: ${{ needs.versions.outputs.aws-role }}
           aws-region: ${{ needs.versions.outputs.aws-region }}
       - name: Start EC2 runner
         id: start-build-runner
-        uses: machulav/ec2-github-runner@v2
+        uses: machulav/ec2-github-runner@343a1b2ae682e681c3cec9a235d882da17ff04ef # v2.6.1
         with:
           mode: start
           github-token: ${{ secrets.EC2_RUNNER_TOKEN }}
@@ -90,7 +90,7 @@ jobs:
         env:
           NEEDS_VERSIONS_OUTPUTS_GCC_TOOLSET: ${{ needs.versions.outputs.gcc-toolset }}
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0 # Fetch all history for all branches
           # For pull requests, this automatically checks out the merge commit
@@ -136,7 +136,7 @@ jobs:
         with:
           version: "${{ needs.versions.outputs.uv-version }}"
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '${{ needs.versions.outputs.python-default }}'
         env:
@@ -172,7 +172,7 @@ jobs:
           NEEDS_VERSIONS_OUTPUTS_CUDA_ARCH_PR: ${{ needs.versions.outputs.cuda-arch-pr }}
 
       - name: Upload wheel
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
             name: fvdb-test-package
             path: dist/*.whl
@@ -184,7 +184,7 @@ jobs:
         run: tar -cvf fvdb-gtest.tar build/
 
       - name: Upload gtests
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
             name: fvdb-gtest
             path: fvdb-gtest.tar
@@ -212,12 +212,12 @@ jobs:
     if: ${{ always() && needs.start-build-runner.result != 'skipped' }}
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b # v6.2.1
         with:
           role-to-assume: ${{ needs.versions.outputs.aws-role }}
           aws-region: ${{ needs.versions.outputs.aws-region }}
       - name: Stop EC2 runner
-        uses: machulav/ec2-github-runner@v2
+        uses: machulav/ec2-github-runner@343a1b2ae682e681c3cec9a235d882da17ff04ef # v2.6.1
         with:
           mode: stop
           github-token: ${{ secrets.EC2_RUNNER_TOKEN }}
@@ -236,13 +236,13 @@ jobs:
       ec2-instance-id: ${{ steps.start-tests-gpu-runner.outputs.ec2-instance-id }}
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b # v6.2.1
         with:
           role-to-assume: ${{ needs.versions.outputs.aws-role }}
           aws-region: ${{ needs.versions.outputs.aws-region }}
       - name: Start EC2 GPU runner
         id: start-tests-gpu-runner
-        uses: machulav/ec2-github-runner@v2
+        uses: machulav/ec2-github-runner@343a1b2ae682e681c3cec9a235d882da17ff04ef # v2.6.1
         with:
           mode: start
           github-token: ${{ secrets.EC2_RUNNER_TOKEN }}
@@ -278,7 +278,7 @@ jobs:
           apt-get update
           apt-get install -y libstdc++6
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0 # Fetch all history for all branches
           # For pull requests, this automatically checks out the merge commit
@@ -308,7 +308,7 @@ jobs:
         with:
           version: "${{ needs.versions.outputs.uv-version }}"
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '${{ needs.versions.outputs.python-default }}'
         env:
@@ -335,7 +335,7 @@ jobs:
           NEEDS_VERSIONS_OUTPUTS_TORCH_FULL_VERSION: ${{ needs.versions.outputs.torch-full-version }}
 
       - name: Download gtests
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
             name: fvdb-gtest
             path: .
@@ -383,7 +383,7 @@ jobs:
           apt-get update
           apt-get install -y libstdc++6
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0 # Fetch all history for all branches
           # For pull requests, this automatically checks out the merge commit
@@ -413,7 +413,7 @@ jobs:
         with:
           version: "${{ needs.versions.outputs.uv-version }}"
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         id: setup-python
         with:
           python-version: '${{ needs.versions.outputs.python-default }}'
@@ -433,7 +433,7 @@ jobs:
           NEEDS_VERSIONS_OUTPUTS_TORCH_FULL_VERSION: ${{ needs.versions.outputs.torch-full-version }}
 
       - name: Download package
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
             name: fvdb-test-package
             path: ./dist
@@ -484,7 +484,7 @@ jobs:
           apt-get update
           apt-get install -y libstdc++6
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0 # Fetch all history for all branches
           # For pull requests, this automatically checks out the merge commit
@@ -513,7 +513,7 @@ jobs:
         with:
           version: "${{ needs.versions.outputs.uv-version }}"
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '${{ needs.versions.outputs.python-default }}'
         env:
@@ -531,7 +531,7 @@ jobs:
           NEEDS_VERSIONS_OUTPUTS_TORCH_FULL_VERSION: ${{ needs.versions.outputs.torch-full-version }}
 
       - name: Download package
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
             name: fvdb-test-package
             path: ./dist
@@ -570,12 +570,12 @@ jobs:
     if: ${{ always() && needs.start-tests-gpu-runner.result != 'skipped' }}
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b # v6.2.1
         with:
           role-to-assume: ${{ needs.versions.outputs.aws-role }}
           aws-region: ${{ needs.versions.outputs.aws-region }}
       - name: Stop EC2 runner
-        uses: machulav/ec2-github-runner@v2
+        uses: machulav/ec2-github-runner@343a1b2ae682e681c3cec9a235d882da17ff04ef # v2.6.1
         with:
           mode: stop
           github-token: ${{ secrets.EC2_RUNNER_TOKEN }}

--- a/.github/workflows/cu128.yml
+++ b/.github/workflows/cu128.yml
@@ -84,9 +84,11 @@ jobs:
           apt-get install -y software-properties-common
           add-apt-repository -y ppa:ubuntu-toolchain-r/test
           apt-get update
-          apt-get install -y gcc-${{ needs.versions.outputs.gcc-toolset }} g++-${{ needs.versions.outputs.gcc-toolset }}
-          update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${{ needs.versions.outputs.gcc-toolset }} 100
-          update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${{ needs.versions.outputs.gcc-toolset }} 100
+          apt-get install -y gcc-${NEEDS_VERSIONS_OUTPUTS_GCC_TOOLSET} g++-${NEEDS_VERSIONS_OUTPUTS_GCC_TOOLSET}
+          update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${NEEDS_VERSIONS_OUTPUTS_GCC_TOOLSET} 100
+          update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${NEEDS_VERSIONS_OUTPUTS_GCC_TOOLSET} 100
+        env:
+          NEEDS_VERSIONS_OUTPUTS_GCC_TOOLSET: ${{ needs.versions.outputs.gcc-toolset }}
 
       - uses: actions/checkout@v6
         with:
@@ -94,6 +96,7 @@ jobs:
           # For pull requests, this automatically checks out the merge commit
           # For pushes, this checks out the pushed commit
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha }}
+          persist-credentials: false
       - name: Fetch PR branch
         if: github.event_name == 'pull_request_target'
         run: |
@@ -141,10 +144,12 @@ jobs:
 
       - name: Install CMake
         run: >
-          wget -nv https://github.com/Kitware/CMake/releases/download/v${{ needs.versions.outputs.cmake-version }}/cmake-${{ needs.versions.outputs.cmake-version }}-linux-x86_64.sh &&
+          wget -nv https://github.com/Kitware/CMake/releases/download/v${NEEDS_VERSIONS_OUTPUTS_CMAKE_VERSION}/cmake-${NEEDS_VERSIONS_OUTPUTS_CMAKE_VERSION}-linux-x86_64.sh &&
           mkdir /opt/cmake &&
-          sh cmake-${{ needs.versions.outputs.cmake-version }}-linux-x86_64.sh --prefix=/usr/local --skip-license &&
+          sh cmake-${NEEDS_VERSIONS_OUTPUTS_CMAKE_VERSION}-linux-x86_64.sh --prefix=/usr/local --skip-license &&
           cmake --version
+        env:
+          NEEDS_VERSIONS_OUTPUTS_CMAKE_VERSION: ${{ needs.versions.outputs.cmake-version }}
 
       - name: Install apt dependencies
         run: apt install -y zlib1g-dev libpng-dev pkg-config
@@ -152,15 +157,19 @@ jobs:
       - name: Install pip dependencies
         run: |
           uv venv
-          echo "torch==${{ needs.versions.outputs.torch-full-version }}" > "${RUNNER_TEMP}/torch-constraints.txt"
+          echo "torch==${NEEDS_VERSIONS_OUTPUTS_TORCH_FULL_VERSION}" > "${RUNNER_TEMP}/torch-constraints.txt"
           uv pip install --no-cache-dir -c "${RUNNER_TEMP}/torch-constraints.txt" -r env/build_requirements.txt --extra-index-url https://download.pytorch.org/whl/cu128
+        env:
+          NEEDS_VERSIONS_OUTPUTS_TORCH_FULL_VERSION: ${{ needs.versions.outputs.torch-full-version }}
 
       - name: Build fvdb
         run: |
           source .venv/bin/activate
           NANOVDB_EDITOR_SPEC=$(python .github/scripts/get_viewer_dependency.py)
           pip install "$NANOVDB_EDITOR_SPEC"
-          ./build.sh wheel verbose gtests benchmarks --cuda-arch-list '${{ needs.versions.outputs.cuda-arch-pr }}'
+          ./build.sh wheel verbose gtests benchmarks --cuda-arch-list '${NEEDS_VERSIONS_OUTPUTS_CUDA_ARCH_PR}'
+        env:
+          NEEDS_VERSIONS_OUTPUTS_CUDA_ARCH_PR: ${{ needs.versions.outputs.cuda-arch-pr }}
 
       - name: Upload wheel
         uses: actions/upload-artifact@v7
@@ -275,6 +284,7 @@ jobs:
           # For pull requests, this automatically checks out the merge commit
           # For pushes, this checks out the pushed commit
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha }}
+          persist-credentials: false
       - name: Fetch PR branch
         if: github.event_name == 'pull_request_target'
         run: |
@@ -306,10 +316,12 @@ jobs:
 
       - name: Install CMake
         run: >
-          wget -nv https://github.com/Kitware/CMake/releases/download/v${{ needs.versions.outputs.cmake-version }}/cmake-${{ needs.versions.outputs.cmake-version }}-linux-x86_64.sh &&
+          wget -nv https://github.com/Kitware/CMake/releases/download/v${NEEDS_VERSIONS_OUTPUTS_CMAKE_VERSION}/cmake-${NEEDS_VERSIONS_OUTPUTS_CMAKE_VERSION}-linux-x86_64.sh &&
           mkdir /opt/cmake &&
-          sh cmake-${{ needs.versions.outputs.cmake-version }}-linux-x86_64.sh --prefix=/usr/local --skip-license &&
+          sh cmake-${NEEDS_VERSIONS_OUTPUTS_CMAKE_VERSION}-linux-x86_64.sh --prefix=/usr/local --skip-license &&
           cmake --version
+        env:
+          NEEDS_VERSIONS_OUTPUTS_CMAKE_VERSION: ${{ needs.versions.outputs.cmake-version }}
 
       - name: Install apt dependencies
         run: apt install -y zlib1g-dev libpng-dev mesa-vulkan-drivers vulkan-tools make
@@ -317,8 +329,10 @@ jobs:
       - name: Install pip dependencies
         run: |
           uv venv
-          echo "torch==${{ needs.versions.outputs.torch-full-version }}" > "${RUNNER_TEMP}/torch-constraints.txt"
+          echo "torch==${NEEDS_VERSIONS_OUTPUTS_TORCH_FULL_VERSION}" > "${RUNNER_TEMP}/torch-constraints.txt"
           uv pip install --no-cache-dir -c "${RUNNER_TEMP}/torch-constraints.txt" -r env/build_requirements.txt --extra-index-url https://download.pytorch.org/whl/cu128
+        env:
+          NEEDS_VERSIONS_OUTPUTS_TORCH_FULL_VERSION: ${{ needs.versions.outputs.torch-full-version }}
 
       - name: Download gtests
         uses: actions/download-artifact@v8
@@ -375,6 +389,7 @@ jobs:
           # For pull requests, this automatically checks out the merge commit
           # For pushes, this checks out the pushed commit
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha }}
+          persist-credentials: false
 
       - name: Fetch PR branch
         if: github.event_name == 'pull_request_target'
@@ -411,9 +426,11 @@ jobs:
       - name: Install pip dependencies
         run: |
           uv venv
-          echo "torch==${{ needs.versions.outputs.torch-full-version }}" > "${RUNNER_TEMP}/torch-constraints.txt"
+          echo "torch==${NEEDS_VERSIONS_OUTPUTS_TORCH_FULL_VERSION}" > "${RUNNER_TEMP}/torch-constraints.txt"
           uv pip install --no-cache-dir -c "${RUNNER_TEMP}/torch-constraints.txt" -r env/test_requirements.txt --extra-index-url https://download.pytorch.org/whl/cu128
           uv pip install --no-cache-dir setuptools
+        env:
+          NEEDS_VERSIONS_OUTPUTS_TORCH_FULL_VERSION: ${{ needs.versions.outputs.torch-full-version }}
 
       - name: Download package
         uses: actions/download-artifact@v8
@@ -473,6 +490,7 @@ jobs:
           # For pull requests, this automatically checks out the merge commit
           # For pushes, this checks out the pushed commit
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha }}
+          persist-credentials: false
 
       - name: Fetch PR branch
         if: github.event_name == 'pull_request_target'
@@ -507,8 +525,10 @@ jobs:
       - name: Install pip dependencies
         run: |
           uv venv
-          echo "torch==${{ needs.versions.outputs.torch-full-version }}" > "${RUNNER_TEMP}/torch-constraints.txt"
+          echo "torch==${NEEDS_VERSIONS_OUTPUTS_TORCH_FULL_VERSION}" > "${RUNNER_TEMP}/torch-constraints.txt"
           uv pip install --no-cache-dir -c "${RUNNER_TEMP}/torch-constraints.txt" -r env/test_requirements.txt --extra-index-url https://download.pytorch.org/whl/cu128
+        env:
+          NEEDS_VERSIONS_OUTPUTS_TORCH_FULL_VERSION: ${{ needs.versions.outputs.torch-full-version }}
 
       - name: Download package
         uses: actions/download-artifact@v8

--- a/.github/workflows/cu130-nightly.yml
+++ b/.github/workflows/cu130-nightly.yml
@@ -150,7 +150,7 @@ jobs:
         run: |
           source .venv/bin/activate
           cd fvdb;
-          ./build.sh wheel verbose gtests benchmarks --cuda-arch-list '${NEEDS_VERSIONS_OUTPUTS_CUDA_ARCH_PR}'
+          ./build.sh wheel verbose gtests benchmarks --cuda-arch-list "${NEEDS_VERSIONS_OUTPUTS_CUDA_ARCH_PR}"
         env:
           NEEDS_VERSIONS_OUTPUTS_CUDA_ARCH_PR: ${{ needs.versions.outputs.cuda-arch-pr }}
 

--- a/.github/workflows/cu130-nightly.yml
+++ b/.github/workflows/cu130-nightly.yml
@@ -56,7 +56,7 @@ jobs:
         env:
           NEEDS_VERSIONS_OUTPUTS_GCC_TOOLSET: ${{ needs.versions.outputs.gcc-toolset }}
       ### Get the PR branch and apply changes to the target branch
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0 # Fetch all history for all branches
           persist-credentials: false
@@ -120,7 +120,7 @@ jobs:
         with:
           version: "${{ needs.versions.outputs.uv-version }}"
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '${{ needs.versions.outputs.python-default }}'
         env:
@@ -155,7 +155,7 @@ jobs:
           NEEDS_VERSIONS_OUTPUTS_CUDA_ARCH_PR: ${{ needs.versions.outputs.cuda-arch-pr }}
 
       - name: Upload wheel
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
             name: fvdb-test-package
             path: fvdb/dist/*.whl
@@ -167,7 +167,7 @@ jobs:
         run: tar -cvf fvdb-gtest.tar fvdb/build/
 
       - name: Upload gtests
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
             name: fvdb-gtest
             path: fvdb-gtest.tar
@@ -208,7 +208,7 @@ jobs:
             && apt install gh -y
           which jq || apt install -y jq
       ### Get the PR branch and apply changes to the target branch
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0 # Fetch all history for all branches
           persist-credentials: false
@@ -272,7 +272,7 @@ jobs:
         with:
           version: "${{ needs.versions.outputs.uv-version }}"
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '${{ needs.versions.outputs.python-default }}'
         env:
@@ -290,7 +290,7 @@ jobs:
           NEEDS_VERSIONS_OUTPUTS_TORCH_FULL_VERSION: ${{ needs.versions.outputs.torch-full-version }}
 
       - name: Download package
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
             name: fvdb-test-package
             path: ./dist
@@ -311,7 +311,7 @@ jobs:
           pytest benchmark --benchmark-json benchmark/output.json
 
       - name: Store benchmark result
-        uses: benchmark-action/github-action-benchmark@v1
+        uses: benchmark-action/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba # v1.22.1
         with:
             name: Python Benchmark with pytest-benchmark
             tool: 'pytest'

--- a/.github/workflows/cu130-nightly.yml
+++ b/.github/workflows/cu130-nightly.yml
@@ -50,13 +50,16 @@ jobs:
           apt-get install -y software-properties-common
           add-apt-repository -y ppa:ubuntu-toolchain-r/test
           apt-get update
-          apt-get install -y gcc-${{ needs.versions.outputs.gcc-toolset }} g++-${{ needs.versions.outputs.gcc-toolset }}
-          update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${{ needs.versions.outputs.gcc-toolset }} 100
-          update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${{ needs.versions.outputs.gcc-toolset }} 100
+          apt-get install -y gcc-${NEEDS_VERSIONS_OUTPUTS_GCC_TOOLSET} g++-${NEEDS_VERSIONS_OUTPUTS_GCC_TOOLSET}
+          update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${NEEDS_VERSIONS_OUTPUTS_GCC_TOOLSET} 100
+          update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${NEEDS_VERSIONS_OUTPUTS_GCC_TOOLSET} 100
+        env:
+          NEEDS_VERSIONS_OUTPUTS_GCC_TOOLSET: ${{ needs.versions.outputs.gcc-toolset }}
       ### Get the PR branch and apply changes to the target branch
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0 # Fetch all history for all branches
+          persist-credentials: false
       - name: Determine the target branch of the PR
         run: |
           echo "Fetching pull request metadata..."
@@ -125,10 +128,12 @@ jobs:
 
       - name: Install CMake
         run: >
-          wget -nv https://github.com/Kitware/CMake/releases/download/v${{ needs.versions.outputs.cmake-version }}/cmake-${{ needs.versions.outputs.cmake-version }}-linux-x86_64.sh &&
+          wget -nv https://github.com/Kitware/CMake/releases/download/v${NEEDS_VERSIONS_OUTPUTS_CMAKE_VERSION}/cmake-${NEEDS_VERSIONS_OUTPUTS_CMAKE_VERSION}-linux-x86_64.sh &&
           mkdir /opt/cmake &&
-          sh cmake-${{ needs.versions.outputs.cmake-version }}-linux-x86_64.sh --prefix=/usr/local --skip-license &&
+          sh cmake-${NEEDS_VERSIONS_OUTPUTS_CMAKE_VERSION}-linux-x86_64.sh --prefix=/usr/local --skip-license &&
           cmake --version
+        env:
+          NEEDS_VERSIONS_OUTPUTS_CMAKE_VERSION: ${{ needs.versions.outputs.cmake-version }}
 
       - name: Install apt dependencies
         run: apt install -y zlib1g-dev libpng-dev pkg-config
@@ -136,14 +141,18 @@ jobs:
       - name: Install pip dependencies
         run: |
           uv venv
-          echo "torch==${{ needs.versions.outputs.torch-full-version }}" > "${RUNNER_TEMP}/torch-constraints.txt"
+          echo "torch==${NEEDS_VERSIONS_OUTPUTS_TORCH_FULL_VERSION}" > "${RUNNER_TEMP}/torch-constraints.txt"
           uv pip install --no-cache-dir -c "${RUNNER_TEMP}/torch-constraints.txt" -r fvdb/env/build_requirements.txt --extra-index-url https://download.pytorch.org/whl/cu130
+        env:
+          NEEDS_VERSIONS_OUTPUTS_TORCH_FULL_VERSION: ${{ needs.versions.outputs.torch-full-version }}
 
       - name: Build fvdb
         run: |
           source .venv/bin/activate
           cd fvdb;
-          ./build.sh wheel verbose gtests benchmarks --cuda-arch-list '${{ needs.versions.outputs.cuda-arch-pr }}'
+          ./build.sh wheel verbose gtests benchmarks --cuda-arch-list '${NEEDS_VERSIONS_OUTPUTS_CUDA_ARCH_PR}'
+        env:
+          NEEDS_VERSIONS_OUTPUTS_CUDA_ARCH_PR: ${{ needs.versions.outputs.cuda-arch-pr }}
 
       - name: Upload wheel
         uses: actions/upload-artifact@v7
@@ -202,6 +211,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0 # Fetch all history for all branches
+          persist-credentials: false
       - name: Determine the target branch of the PR
         run: |
           echo "Fetching pull request metadata..."
@@ -274,8 +284,10 @@ jobs:
       - name: Install pip dependencies
         run: |
           uv venv
-          echo "torch==${{ needs.versions.outputs.torch-full-version }}" > "${RUNNER_TEMP}/torch-constraints.txt"
+          echo "torch==${NEEDS_VERSIONS_OUTPUTS_TORCH_FULL_VERSION}" > "${RUNNER_TEMP}/torch-constraints.txt"
           uv pip install --no-cache-dir -c "${RUNNER_TEMP}/torch-constraints.txt" -r fvdb/env/test_requirements.txt --extra-index-url https://download.pytorch.org/whl/cu130
+        env:
+          NEEDS_VERSIONS_OUTPUTS_TORCH_FULL_VERSION: ${{ needs.versions.outputs.torch-full-version }}
 
       - name: Download package
         uses: actions/download-artifact@v8

--- a/.github/workflows/cu130.yml
+++ b/.github/workflows/cu130.yml
@@ -52,7 +52,7 @@ jobs:
         uses: machulav/ec2-github-runner@v2
         with:
           mode: start
-          github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+          github-token: ${{ secrets.EC2_RUNNER_TOKEN }}
           ec2-image-id: ${{ needs.versions.outputs.aws-cpu-ami }}
           ec2-instance-type: m6a.8xlarge
           subnet-id: ${{ needs.versions.outputs.aws-subnet }}
@@ -211,7 +211,7 @@ jobs:
         uses: machulav/ec2-github-runner@v2
         with:
           mode: stop
-          github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+          github-token: ${{ secrets.EC2_RUNNER_TOKEN }}
           label: ${{ needs.start-build-runner.outputs.label }}
           ec2-instance-id: ${{ needs.start-build-runner.outputs.ec2-instance-id }}
 
@@ -236,7 +236,7 @@ jobs:
         uses: machulav/ec2-github-runner@v2
         with:
           mode: start
-          github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+          github-token: ${{ secrets.EC2_RUNNER_TOKEN }}
           ec2-image-id: ${{ needs.versions.outputs.aws-gpu-ami }}
           ec2-instance-type: g6.2xlarge # 8 CPU-core, L4 GPU
           subnet-id: ${{ needs.versions.outputs.aws-subnet }}
@@ -558,6 +558,6 @@ jobs:
         uses: machulav/ec2-github-runner@v2
         with:
           mode: stop
-          github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+          github-token: ${{ secrets.EC2_RUNNER_TOKEN }}
           label: ${{ needs.start-tests-gpu-runner.outputs.label }}
           ec2-instance-id: ${{ needs.start-tests-gpu-runner.outputs.ec2-instance-id }}

--- a/.github/workflows/cu130.yml
+++ b/.github/workflows/cu130.yml
@@ -168,7 +168,7 @@ jobs:
           source .venv/bin/activate
           NANOVDB_EDITOR_SPEC=$(python .github/scripts/get_viewer_dependency.py)
           pip install "$NANOVDB_EDITOR_SPEC"
-          ./build.sh wheel verbose gtests benchmarks --cuda-arch-list '${NEEDS_VERSIONS_OUTPUTS_CUDA_ARCH_PR}'
+          ./build.sh wheel verbose gtests benchmarks --cuda-arch-list "${NEEDS_VERSIONS_OUTPUTS_CUDA_ARCH_PR}"
         env:
           NEEDS_VERSIONS_OUTPUTS_CUDA_ARCH_PR: ${{ needs.versions.outputs.cuda-arch-pr }}
 

--- a/.github/workflows/cu130.yml
+++ b/.github/workflows/cu130.yml
@@ -1,6 +1,7 @@
 name: fVDB pip CUDA 13.0 Build and Test
 
 on:
+  # zizmor: ignore[dangerous-triggers] pull_request_target is required to provision AWS runners; privileged credentials are scoped to runner lifecycle jobs.
   pull_request_target:
     branches:
       - '**'

--- a/.github/workflows/cu130.yml
+++ b/.github/workflows/cu130.yml
@@ -84,9 +84,11 @@ jobs:
           apt-get install -y software-properties-common
           add-apt-repository -y ppa:ubuntu-toolchain-r/test
           apt-get update
-          apt-get install -y gcc-${{ needs.versions.outputs.gcc-toolset }} g++-${{ needs.versions.outputs.gcc-toolset }}
-          update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${{ needs.versions.outputs.gcc-toolset }} 100
-          update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${{ needs.versions.outputs.gcc-toolset }} 100
+          apt-get install -y gcc-${NEEDS_VERSIONS_OUTPUTS_GCC_TOOLSET} g++-${NEEDS_VERSIONS_OUTPUTS_GCC_TOOLSET}
+          update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${NEEDS_VERSIONS_OUTPUTS_GCC_TOOLSET} 100
+          update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${NEEDS_VERSIONS_OUTPUTS_GCC_TOOLSET} 100
+        env:
+          NEEDS_VERSIONS_OUTPUTS_GCC_TOOLSET: ${{ needs.versions.outputs.gcc-toolset }}
 
       - uses: actions/checkout@v6
         with:
@@ -94,6 +96,7 @@ jobs:
           # For pull requests, this automatically checks out the merge commit
           # For pushes, this checks out the pushed commit
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha }}
+          persist-credentials: false
       - name: Fetch PR branch
         if: github.event_name == 'pull_request_target'
         run: |
@@ -141,10 +144,12 @@ jobs:
 
       - name: Install CMake
         run: >
-          wget -nv https://github.com/Kitware/CMake/releases/download/v${{ needs.versions.outputs.cmake-version }}/cmake-${{ needs.versions.outputs.cmake-version }}-linux-x86_64.sh &&
+          wget -nv https://github.com/Kitware/CMake/releases/download/v${NEEDS_VERSIONS_OUTPUTS_CMAKE_VERSION}/cmake-${NEEDS_VERSIONS_OUTPUTS_CMAKE_VERSION}-linux-x86_64.sh &&
           mkdir /opt/cmake &&
-          sh cmake-${{ needs.versions.outputs.cmake-version }}-linux-x86_64.sh --prefix=/usr/local --skip-license &&
+          sh cmake-${NEEDS_VERSIONS_OUTPUTS_CMAKE_VERSION}-linux-x86_64.sh --prefix=/usr/local --skip-license &&
           cmake --version
+        env:
+          NEEDS_VERSIONS_OUTPUTS_CMAKE_VERSION: ${{ needs.versions.outputs.cmake-version }}
 
       - name: Install apt dependencies
         run: apt install -y zlib1g-dev libpng-dev pkg-config
@@ -152,15 +157,19 @@ jobs:
       - name: Install pip dependencies
         run: |
           uv venv
-          echo "torch==${{ needs.versions.outputs.torch-full-version }}" > "${RUNNER_TEMP}/torch-constraints.txt"
+          echo "torch==${NEEDS_VERSIONS_OUTPUTS_TORCH_FULL_VERSION}" > "${RUNNER_TEMP}/torch-constraints.txt"
           uv pip install --no-cache-dir -c "${RUNNER_TEMP}/torch-constraints.txt" -r env/build_requirements.txt --extra-index-url https://download.pytorch.org/whl/cu130
+        env:
+          NEEDS_VERSIONS_OUTPUTS_TORCH_FULL_VERSION: ${{ needs.versions.outputs.torch-full-version }}
 
       - name: Build fvdb
         run: |
           source .venv/bin/activate
           NANOVDB_EDITOR_SPEC=$(python .github/scripts/get_viewer_dependency.py)
           pip install "$NANOVDB_EDITOR_SPEC"
-          ./build.sh wheel verbose gtests benchmarks --cuda-arch-list '${{ needs.versions.outputs.cuda-arch-pr }}'
+          ./build.sh wheel verbose gtests benchmarks --cuda-arch-list '${NEEDS_VERSIONS_OUTPUTS_CUDA_ARCH_PR}'
+        env:
+          NEEDS_VERSIONS_OUTPUTS_CUDA_ARCH_PR: ${{ needs.versions.outputs.cuda-arch-pr }}
 
       - name: Upload wheel
         uses: actions/upload-artifact@v7
@@ -275,6 +284,7 @@ jobs:
           # For pull requests, this automatically checks out the merge commit
           # For pushes, this checks out the pushed commit
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha }}
+          persist-credentials: false
       - name: Fetch PR branch
         if: github.event_name == 'pull_request_target'
         run: |
@@ -306,10 +316,12 @@ jobs:
 
       - name: Install CMake
         run: >
-          wget -nv https://github.com/Kitware/CMake/releases/download/v${{ needs.versions.outputs.cmake-version }}/cmake-${{ needs.versions.outputs.cmake-version }}-linux-x86_64.sh &&
+          wget -nv https://github.com/Kitware/CMake/releases/download/v${NEEDS_VERSIONS_OUTPUTS_CMAKE_VERSION}/cmake-${NEEDS_VERSIONS_OUTPUTS_CMAKE_VERSION}-linux-x86_64.sh &&
           mkdir /opt/cmake &&
-          sh cmake-${{ needs.versions.outputs.cmake-version }}-linux-x86_64.sh --prefix=/usr/local --skip-license &&
+          sh cmake-${NEEDS_VERSIONS_OUTPUTS_CMAKE_VERSION}-linux-x86_64.sh --prefix=/usr/local --skip-license &&
           cmake --version
+        env:
+          NEEDS_VERSIONS_OUTPUTS_CMAKE_VERSION: ${{ needs.versions.outputs.cmake-version }}
 
       - name: Install apt dependencies
         run: apt install -y zlib1g-dev libpng-dev mesa-vulkan-drivers vulkan-tools make
@@ -317,8 +329,10 @@ jobs:
       - name: Install pip dependencies
         run: |
           uv venv
-          echo "torch==${{ needs.versions.outputs.torch-full-version }}" > "${RUNNER_TEMP}/torch-constraints.txt"
+          echo "torch==${NEEDS_VERSIONS_OUTPUTS_TORCH_FULL_VERSION}" > "${RUNNER_TEMP}/torch-constraints.txt"
           uv pip install --no-cache-dir -c "${RUNNER_TEMP}/torch-constraints.txt" -r env/build_requirements.txt --extra-index-url https://download.pytorch.org/whl/cu130
+        env:
+          NEEDS_VERSIONS_OUTPUTS_TORCH_FULL_VERSION: ${{ needs.versions.outputs.torch-full-version }}
 
       - name: Download gtests
         uses: actions/download-artifact@v8
@@ -375,6 +389,7 @@ jobs:
           # For pull requests, this automatically checks out the merge commit
           # For pushes, this checks out the pushed commit
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha }}
+          persist-credentials: false
 
       - name: Fetch PR branch
         if: github.event_name == 'pull_request_target'
@@ -411,9 +426,11 @@ jobs:
       - name: Install pip dependencies
         run: |
           uv venv
-          echo "torch==${{ needs.versions.outputs.torch-full-version }}" > "${RUNNER_TEMP}/torch-constraints.txt"
+          echo "torch==${NEEDS_VERSIONS_OUTPUTS_TORCH_FULL_VERSION}" > "${RUNNER_TEMP}/torch-constraints.txt"
           uv pip install --no-cache-dir -c "${RUNNER_TEMP}/torch-constraints.txt" -r env/test_requirements.txt --extra-index-url https://download.pytorch.org/whl/cu130 --index-strategy unsafe-best-match
           uv pip install --no-cache-dir setuptools
+        env:
+          NEEDS_VERSIONS_OUTPUTS_TORCH_FULL_VERSION: ${{ needs.versions.outputs.torch-full-version }}
 
       - name: Download package
         uses: actions/download-artifact@v8
@@ -473,6 +490,7 @@ jobs:
           # For pull requests, this automatically checks out the merge commit
           # For pushes, this checks out the pushed commit
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha }}
+          persist-credentials: false
 
       - name: Fetch PR branch
         if: github.event_name == 'pull_request_target'
@@ -507,8 +525,10 @@ jobs:
       - name: Install pip dependencies
         run: |
           uv venv
-          echo "torch==${{ needs.versions.outputs.torch-full-version }}" > "${RUNNER_TEMP}/torch-constraints.txt"
+          echo "torch==${NEEDS_VERSIONS_OUTPUTS_TORCH_FULL_VERSION}" > "${RUNNER_TEMP}/torch-constraints.txt"
           uv pip install --no-cache-dir -c "${RUNNER_TEMP}/torch-constraints.txt" -r env/test_requirements.txt --extra-index-url https://download.pytorch.org/whl/cu130 --index-strategy unsafe-best-match
+        env:
+          NEEDS_VERSIONS_OUTPUTS_TORCH_FULL_VERSION: ${{ needs.versions.outputs.torch-full-version }}
 
       - name: Download package
         uses: actions/download-artifact@v8

--- a/.github/workflows/cu130.yml
+++ b/.github/workflows/cu130.yml
@@ -43,13 +43,13 @@ jobs:
       ec2-instance-id: ${{ steps.start-build-runner.outputs.ec2-instance-id }}
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b # v6.2.1
         with:
           role-to-assume: ${{ needs.versions.outputs.aws-role }}
           aws-region: ${{ needs.versions.outputs.aws-region }}
       - name: Start EC2 runner
         id: start-build-runner
-        uses: machulav/ec2-github-runner@v2
+        uses: machulav/ec2-github-runner@343a1b2ae682e681c3cec9a235d882da17ff04ef # v2.6.1
         with:
           mode: start
           github-token: ${{ secrets.EC2_RUNNER_TOKEN }}
@@ -90,7 +90,7 @@ jobs:
         env:
           NEEDS_VERSIONS_OUTPUTS_GCC_TOOLSET: ${{ needs.versions.outputs.gcc-toolset }}
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0 # Fetch all history for all branches
           # For pull requests, this automatically checks out the merge commit
@@ -136,7 +136,7 @@ jobs:
         with:
           version: "${{ needs.versions.outputs.uv-version }}"
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '${{ needs.versions.outputs.python-default }}'
         env:
@@ -172,7 +172,7 @@ jobs:
           NEEDS_VERSIONS_OUTPUTS_CUDA_ARCH_PR: ${{ needs.versions.outputs.cuda-arch-pr }}
 
       - name: Upload wheel
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
             name: fvdb-test-package
             path: dist/*.whl
@@ -184,7 +184,7 @@ jobs:
         run: tar -cvf fvdb-gtest.tar build/
 
       - name: Upload gtests
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
             name: fvdb-gtest
             path: fvdb-gtest.tar
@@ -212,12 +212,12 @@ jobs:
     if: ${{ always() && needs.start-build-runner.result != 'skipped' }}
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b # v6.2.1
         with:
           role-to-assume: ${{ needs.versions.outputs.aws-role }}
           aws-region: ${{ needs.versions.outputs.aws-region }}
       - name: Stop EC2 runner
-        uses: machulav/ec2-github-runner@v2
+        uses: machulav/ec2-github-runner@343a1b2ae682e681c3cec9a235d882da17ff04ef # v2.6.1
         with:
           mode: stop
           github-token: ${{ secrets.EC2_RUNNER_TOKEN }}
@@ -236,13 +236,13 @@ jobs:
       ec2-instance-id: ${{ steps.start-tests-gpu-runner.outputs.ec2-instance-id }}
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b # v6.2.1
         with:
           role-to-assume: ${{ needs.versions.outputs.aws-role }}
           aws-region: ${{ needs.versions.outputs.aws-region }}
       - name: Start EC2 GPU runner
         id: start-tests-gpu-runner
-        uses: machulav/ec2-github-runner@v2
+        uses: machulav/ec2-github-runner@343a1b2ae682e681c3cec9a235d882da17ff04ef # v2.6.1
         with:
           mode: start
           github-token: ${{ secrets.EC2_RUNNER_TOKEN }}
@@ -278,7 +278,7 @@ jobs:
           apt-get update
           apt-get install -y libstdc++6
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0 # Fetch all history for all branches
           # For pull requests, this automatically checks out the merge commit
@@ -308,7 +308,7 @@ jobs:
         with:
           version: "${{ needs.versions.outputs.uv-version }}"
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '${{ needs.versions.outputs.python-default }}'
         env:
@@ -335,7 +335,7 @@ jobs:
           NEEDS_VERSIONS_OUTPUTS_TORCH_FULL_VERSION: ${{ needs.versions.outputs.torch-full-version }}
 
       - name: Download gtests
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
             name: fvdb-gtest
             path: .
@@ -383,7 +383,7 @@ jobs:
           apt-get update
           apt-get install -y libstdc++6
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0 # Fetch all history for all branches
           # For pull requests, this automatically checks out the merge commit
@@ -413,7 +413,7 @@ jobs:
         with:
           version: "${{ needs.versions.outputs.uv-version }}"
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         id: setup-python
         with:
           python-version: '${{ needs.versions.outputs.python-default }}'
@@ -433,7 +433,7 @@ jobs:
           NEEDS_VERSIONS_OUTPUTS_TORCH_FULL_VERSION: ${{ needs.versions.outputs.torch-full-version }}
 
       - name: Download package
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
             name: fvdb-test-package
             path: ./dist
@@ -484,7 +484,7 @@ jobs:
           apt-get update
           apt-get install -y libstdc++6
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0 # Fetch all history for all branches
           # For pull requests, this automatically checks out the merge commit
@@ -513,7 +513,7 @@ jobs:
         with:
           version: "${{ needs.versions.outputs.uv-version }}"
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '${{ needs.versions.outputs.python-default }}'
         env:
@@ -531,7 +531,7 @@ jobs:
           NEEDS_VERSIONS_OUTPUTS_TORCH_FULL_VERSION: ${{ needs.versions.outputs.torch-full-version }}
 
       - name: Download package
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
             name: fvdb-test-package
             path: ./dist
@@ -570,12 +570,12 @@ jobs:
     if: ${{ always() && needs.start-tests-gpu-runner.result != 'skipped' }}
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b # v6.2.1
         with:
           role-to-assume: ${{ needs.versions.outputs.aws-role }}
           aws-region: ${{ needs.versions.outputs.aws-region }}
       - name: Stop EC2 runner
-        uses: machulav/ec2-github-runner@v2
+        uses: machulav/ec2-github-runner@343a1b2ae682e681c3cec9a235d882da17ff04ef # v2.6.1
         with:
           mode: stop
           github-token: ${{ secrets.EC2_RUNNER_TOKEN }}

--- a/.github/workflows/cu130.yml
+++ b/.github/workflows/cu130.yml
@@ -15,8 +15,6 @@ permissions:
   deployments: read
   pull-requests: read
   issues: read
-  # Need ID token write permission to use OIDC
-  id-token: write
 
 jobs:
   ##############################################################################
@@ -35,6 +33,8 @@ jobs:
     name: Start CPU-only EC2 runner for build
     needs: [check-changes, versions]
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # Required for AWS OIDC
     if: >-
       needs.check-changes.outputs.should_test == 'true'
       && (github.event.pull_request.draft == false || github.event_name != 'pull_request_target')
@@ -207,6 +207,8 @@ jobs:
       - fvdb-build # required to wait when the main job is done
       - versions
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # Required for AWS OIDC
     # required to stop the runner even if the error happened in the previous jobs
     # but only if the start-build-runner job was not skipped
     if: ${{ always() && needs.start-build-runner.result != 'skipped' }}
@@ -231,6 +233,8 @@ jobs:
     name: Start EC2 GPU runner for gtests
     needs: [fvdb-build, versions]
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # Required for AWS OIDC
     outputs:
       label: ${{ steps.start-tests-gpu-runner.outputs.label }}
       ec2-instance-id: ${{ steps.start-tests-gpu-runner.outputs.ec2-instance-id }}
@@ -565,6 +569,8 @@ jobs:
       - fvdb-docs-test # required to wait when the main job is done
       - versions
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # Required for AWS OIDC
     # required to stop the runner even if the error happened in the previous jobs
     # but only if the start-tests-gpu-runner job was not skipped
     if: ${{ always() && needs.start-tests-gpu-runner.result != 'skipped' }}

--- a/.github/workflows/docs-build-test.yml
+++ b/.github/workflows/docs-build-test.yml
@@ -21,6 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/docs-build-test.yml
+++ b/.github/workflows/docs-build-test.yml
@@ -20,11 +20,11 @@ jobs:
     name: Sphinx build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.12"
 

--- a/.github/workflows/docs-build-test.yml
+++ b/.github/workflows/docs-build-test.yml
@@ -15,6 +15,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   sphinx-build:
     name: Sphinx build

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -46,4 +46,4 @@ jobs:
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v3.0.2-node.24
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -40,10 +40,10 @@ jobs:
           touch _site/.nojekyll
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: _site/
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v3.0.2-node.24

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -30,12 +30,13 @@ jobs:
         id: membership
         env:
           GH_TOKEN: ${{ secrets.ISSUES_PAT }}
+          GITHUB_EVENT_ISSUE_USER_LOGIN: ${{ github.event.issue.user.login }}
         run: |
           if [ -z "${GH_TOKEN:-}" ]; then
             echo "::error::ISSUES_PAT is not configured"
             exit 1
           fi
-          AUTHOR="${{ github.event.issue.user.login }}"
+          AUTHOR="${GITHUB_EVENT_ISSUE_USER_LOGIN}"
           RESPONSE=$( (gh api "orgs/openvdb/teams/fvdb-dev/memberships/$AUTHOR" \
             -i --silent 2>&1 || true) )
           HTTP_CODE=$(printf '%s\n' "$RESPONSE" | grep -m1 '^HTTP/' | awk '{print $2}' || true)

--- a/.github/workflows/load-versions.yml
+++ b/.github/workflows/load-versions.yml
@@ -99,6 +99,7 @@ jobs:
           sparse-checkout: .github/versions.json
           sparse-checkout-cone-mode: false
           ref: ${{ inputs.ref || '' }}
+          persist-credentials: false
       - name: Parse versions.json
         id: parse
         run: |

--- a/.github/workflows/load-versions.yml
+++ b/.github/workflows/load-versions.yml
@@ -94,7 +94,7 @@ jobs:
       auditwheel-excludes: ${{ steps.parse.outputs.auditwheel-excludes }}
       auditwheel-excludes-cuda-major: ${{ steps.parse.outputs.auditwheel-excludes-cuda-major }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           sparse-checkout: .github/versions.json
           sparse-checkout-cone-mode: false

--- a/.github/workflows/nightly-publish.yml
+++ b/.github/workflows/nightly-publish.yml
@@ -31,6 +31,7 @@ jobs:
         with:
           ref: main
           fetch-depth: 0
+          persist-credentials: false
       - name: Decide whether to build
         id: decide
         run: |
@@ -67,8 +68,10 @@ jobs:
       - name: Stagger job starts to avoid API rate limits
         run: |
           DELAY=$((RANDOM % 16))
-          echo "Delaying start by ${DELAY} seconds for Python ${{ matrix.python-version }}"
+          echo "Delaying start by ${DELAY} seconds for Python ${MATRIX_PYTHON_VERSION}"
           sleep $DELAY
+        env:
+          MATRIX_PYTHON_VERSION: ${{ matrix.python-version }}
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6
         with:
@@ -118,12 +121,15 @@ jobs:
     steps:
       - name: Install prerequisites
         run: |
-          dnf install -y git wget procps-ng findutils gcc-toolset-${{ needs.versions.outputs.gcc-toolset }}
-          echo 'source /opt/rh/gcc-toolset-${{ needs.versions.outputs.gcc-toolset }}/enable' > /etc/profile.d/gcc-toolset-${{ needs.versions.outputs.gcc-toolset }}.sh
+          dnf install -y git wget procps-ng findutils gcc-toolset-${NEEDS_VERSIONS_OUTPUTS_GCC_TOOLSET}
+          echo 'source /opt/rh/gcc-toolset-${NEEDS_VERSIONS_OUTPUTS_GCC_TOOLSET}/enable' > /etc/profile.d/gcc-toolset-${NEEDS_VERSIONS_OUTPUTS_GCC_TOOLSET}.sh
+        env:
+          NEEDS_VERSIONS_OUTPUTS_GCC_TOOLSET: ${{ needs.versions.outputs.gcc-toolset }}
 
       - uses: actions/checkout@v6
         with:
           ref: main
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86
@@ -132,34 +138,42 @@ jobs:
 
       - name: Set up Python
         run: |
-          uv python install ${{ matrix.python-version }}
+          uv python install ${MATRIX_PYTHON_VERSION}
           uv venv
+        env:
+          MATRIX_PYTHON_VERSION: ${{ matrix.python-version }}
 
       - name: Install CMake
         run: >
-          wget -nv https://github.com/Kitware/CMake/releases/download/v${{ needs.versions.outputs.cmake-version }}/cmake-${{ needs.versions.outputs.cmake-version }}-linux-x86_64.sh &&
+          wget -nv https://github.com/Kitware/CMake/releases/download/v${NEEDS_VERSIONS_OUTPUTS_CMAKE_VERSION}/cmake-${NEEDS_VERSIONS_OUTPUTS_CMAKE_VERSION}-linux-x86_64.sh &&
           mkdir /opt/cmake &&
-          sh cmake-${{ needs.versions.outputs.cmake-version }}-linux-x86_64.sh --prefix=/usr/local --skip-license &&
+          sh cmake-${NEEDS_VERSIONS_OUTPUTS_CMAKE_VERSION}-linux-x86_64.sh --prefix=/usr/local --skip-license &&
           cmake --version
+        env:
+          NEEDS_VERSIONS_OUTPUTS_CMAKE_VERSION: ${{ needs.versions.outputs.cmake-version }}
 
       - name: Install system dependencies
         run: dnf install -y zlib-devel libpng-devel pkgconfig unzip procps-ng findutils
 
       - name: Install pip dependencies
         run: |
-          CUDA_TAG="cu$(echo "${{ matrix.cuda-version }}" | tr -d '.')"
-          TORCH_VERSION="${{ matrix.torch-version }}"
+          CUDA_TAG="cu$(echo "${MATRIX_CUDA_VERSION}" | tr -d '.')"
+          TORCH_VERSION="${MATRIX_TORCH_VERSION}"
           echo "Installing PyTorch ${TORCH_VERSION} for ${CUDA_TAG}"
           uv venv
           # Pin the tested PyTorch via a constraints file so the unbounded torch in
           # build_requirements.txt resolves to the version recorded in versions.json.
-          echo "torch==${{ needs.versions.outputs.torch-full-version }}" > "${RUNNER_TEMP}/torch-constraints.txt"
+          echo "torch==${NEEDS_VERSIONS_OUTPUTS_TORCH_FULL_VERSION}" > "${RUNNER_TEMP}/torch-constraints.txt"
           uv pip install --no-cache -c "${RUNNER_TEMP}/torch-constraints.txt" -r env/build_requirements.txt --extra-index-url https://download.pytorch.org/whl/${CUDA_TAG}
+        env:
+          MATRIX_CUDA_VERSION: ${{ matrix.cuda-version }}
+          MATRIX_TORCH_VERSION: ${{ matrix.torch-version }}
+          NEEDS_VERSIONS_OUTPUTS_TORCH_FULL_VERSION: ${{ needs.versions.outputs.torch-full-version }}
 
       - name: Set nightly version
         run: |
-          TORCH_TAG="$(echo "${{ matrix.torch-version }}" | tr -d '.')"
-          CUDA_TAG="$(echo "${{ matrix.cuda-version }}" | tr -d '.')"
+          TORCH_TAG="$(echo "${MATRIX_TORCH_VERSION}" | tr -d '.')"
+          CUDA_TAG="$(echo "${MATRIX_CUDA_VERSION}" | tr -d '.')"
           # Anchor the nightly at the upcoming release recorded in pyproject.toml
           # (e.g. 0.5.0.dev0 -> 0.5.0) so PEP 440 ordering puts nightlies between
           # the previous final release and the next one.
@@ -173,18 +187,23 @@ jobs:
           sed -i -E "s/^version *= *\"[^\"]+\"/version = \"${NIGHTLY_VERSION}\"/" pyproject.toml
           echo "Nightly version: $NIGHTLY_VERSION"
           grep '^version' pyproject.toml
+        env:
+          MATRIX_TORCH_VERSION: ${{ matrix.torch-version }}
+          MATRIX_CUDA_VERSION: ${{ matrix.cuda-version }}
 
       - name: Build fvdb
         run: |
           source .venv/bin/activate
-          ./build.sh wheel strip_symbols verbose --cuda-arch-list '${{ needs.versions.outputs.cuda-arch-publish }}'
+          ./build.sh wheel strip_symbols verbose --cuda-arch-list '${NEEDS_VERSIONS_OUTPUTS_CUDA_ARCH_PUBLISH}'
+        env:
+          NEEDS_VERSIONS_OUTPUTS_CUDA_ARCH_PUBLISH: ${{ needs.versions.outputs.cuda-arch-publish }}
 
       - name: Repair wheel for manylinux
         run: |
           source .venv/bin/activate
           pip install auditwheel patchelf
           ldd --version | head -n1
-          CUDA_MAJOR=$(echo "${{ matrix.cuda-version }}" | cut -d. -f1)
+          CUDA_MAJOR=$(echo "${MATRIX_CUDA_VERSION}" | cut -d. -f1)
           auditwheel repair dist/fvdb_core-*.whl -w dist/ \
             --exclude libcuda.so.1 \
             --exclude libcudart.so.${CUDA_MAJOR} \
@@ -215,6 +234,8 @@ jobs:
             rm dist/fvdb_core-*-linux_x86_64.whl
           fi
           ls -lh dist/
+        env:
+          MATRIX_CUDA_VERSION: ${{ matrix.cuda-version }}
 
       - name: Upload wheel
         uses: actions/upload-artifact@v7
@@ -269,7 +290,7 @@ jobs:
           set -euo pipefail
           CUTOFF=$(date -u -d '30 days ago' '+%Y-%m-%d')
           echo "Pruning nightly wheels uploaded before $CUTOFF"
-          LISTING=$(aws s3 ls "s3://${S3_BUCKET}/${SIMPLE_PREFIX}/${{ steps.proj.outputs.normalized }}/" 2>/dev/null || true)
+          LISTING=$(aws s3 ls "s3://${S3_BUCKET}/${SIMPLE_PREFIX}/${STEPS_PROJ_OUTPUTS_NORMALIZED}/" 2>/dev/null || true)
           if [ -z "$LISTING" ]; then
             echo "No existing wheels found (first run or empty prefix) -- nothing to prune"
             exit 0
@@ -280,16 +301,18 @@ jobs:
             FILE_PART=$(echo "$line" | awk '{print $4}')
             if [[ "$FILE_PART" == *.whl ]] && [[ "$DATE_PART" < "$CUTOFF" ]]; then
               echo "Removing: $FILE_PART (uploaded $DATE_PART)"
-              aws s3 rm "s3://${S3_BUCKET}/${SIMPLE_PREFIX}/${{ steps.proj.outputs.normalized }}/$FILE_PART" --only-show-errors
+              aws s3 rm "s3://${S3_BUCKET}/${SIMPLE_PREFIX}/${STEPS_PROJ_OUTPUTS_NORMALIZED}/$FILE_PART" --only-show-errors
               DELETED=$((DELETED + 1))
             fi
           done <<< "$LISTING"
           echo "Pruned $DELETED old nightly wheel(s)"
+        env:
+          STEPS_PROJ_OUTPUTS_NORMALIZED: ${{ steps.proj.outputs.normalized }}
 
       - name: Upload wheels to S3 project directory
         run: |
           set -euo pipefail
-          DEST="s3://${S3_BUCKET}/${SIMPLE_PREFIX}/${{ steps.proj.outputs.normalized }}/"
+          DEST="s3://${S3_BUCKET}/${SIMPLE_PREFIX}/${STEPS_PROJ_OUTPUTS_NORMALIZED}/"
           echo "Uploading wheels to $DEST"
           shopt -s nullglob
           upload_failed=0
@@ -308,21 +331,23 @@ jobs:
           fi
           echo "All wheels uploaded successfully"
           sleep 2
+        env:
+          STEPS_PROJ_OUTPUTS_NORMALIZED: ${{ steps.proj.outputs.normalized }}
 
       - name: Generate project index.html
         run: |
           set -euo pipefail
-          OUTDIR="dist/index-gen/${{ steps.proj.outputs.normalized }}"
+          OUTDIR="dist/index-gen/${STEPS_PROJ_OUTPUTS_NORMALIZED}"
           mkdir -p "$OUTDIR"
           INDEX_FILE="$OUTDIR/index.html"
-          TITLE="Links for ${{ steps.proj.outputs.project_name }}"
-          wheels=$(aws s3 ls "s3://${S3_BUCKET}/${SIMPLE_PREFIX}/${{ steps.proj.outputs.normalized }}/" | { grep -E '\.whl$' || true; } | awk '{print $4}')
+          TITLE="Links for ${STEPS_PROJ_OUTPUTS_PROJECT_NAME}"
+          wheels=$(aws s3 ls "s3://${S3_BUCKET}/${SIMPLE_PREFIX}/${STEPS_PROJ_OUTPUTS_NORMALIZED}/" | { grep -E '\.whl$' || true; } | awk '{print $4}')
 
           echo "Found wheels in S3:"
           echo "$wheels"
 
           if [ -z "$wheels" ]; then
-            echo "WARNING: No wheels found in S3 at s3://${S3_BUCKET}/${SIMPLE_PREFIX}/${{ steps.proj.outputs.normalized }}/"
+            echo "WARNING: No wheels found in S3 at s3://${S3_BUCKET}/${SIMPLE_PREFIX}/${STEPS_PROJ_OUTPUTS_NORMALIZED}/"
             echo "This may indicate an upload failure or timing issue"
           fi
 
@@ -339,7 +364,7 @@ jobs:
                 echo "  Computed SHA256 from local file: ${sha:0:16}..." >&2
               else
                 echo "  Downloading $whl to compute hash..." >&2
-                if aws s3 cp "s3://${S3_BUCKET}/${SIMPLE_PREFIX}/${{ steps.proj.outputs.normalized }}/$whl" "/tmp/$whl" --only-show-errors; then
+                if aws s3 cp "s3://${S3_BUCKET}/${SIMPLE_PREFIX}/${STEPS_PROJ_OUTPUTS_NORMALIZED}/$whl" "/tmp/$whl" --only-show-errors; then
                   sha=$(sha256sum "/tmp/$whl" | awk '{print $1}')
                   rm "/tmp/$whl"
                   echo "  Computed SHA256 from S3 file: ${sha:0:16}..." >&2
@@ -357,11 +382,14 @@ jobs:
           echo "Generated index.html:"
           cat "$INDEX_FILE"
 
-          aws s3 cp "$INDEX_FILE" "s3://${S3_BUCKET}/${SIMPLE_PREFIX}/${{ steps.proj.outputs.normalized }}/index.html" \
+          aws s3 cp "$INDEX_FILE" "s3://${S3_BUCKET}/${SIMPLE_PREFIX}/${STEPS_PROJ_OUTPUTS_NORMALIZED}/index.html" \
             --content-type text/html \
             --cache-control "public, max-age=60, must-revalidate" \
             --only-show-errors
           echo "Index uploaded successfully"
+        env:
+          STEPS_PROJ_OUTPUTS_NORMALIZED: ${{ steps.proj.outputs.normalized }}
+          STEPS_PROJ_OUTPUTS_PROJECT_NAME: ${{ steps.proj.outputs.project_name }}
 
       - name: Generate root simple index.html
         run: |
@@ -388,7 +416,7 @@ jobs:
       - name: Invalidate CloudFront cache for simple-index paths
         run: |
           set -euo pipefail
-          DOMAIN="${{ needs.versions.outputs.aws-cloudfront-distribution-domain }}"
+          DOMAIN="${NEEDS_VERSIONS_OUTPUTS_AWS_CLOUDFRONT_DISTRIBUTION_DOMAIN}"
           if [ -z "$DOMAIN" ] || [ "$DOMAIN" = "null" ]; then
             echo "No CloudFront distribution domain configured (aws.cloudfront_distribution_domain in versions.json); skipping invalidation"
             exit 0
@@ -401,7 +429,7 @@ jobs:
             echo "(IAM role may need cloudfront:ListDistributions permission)"
             exit 0
           fi
-          NORM="${{ steps.proj.outputs.normalized }}"
+          NORM="${STEPS_PROJ_OUTPUTS_NORMALIZED}"
           # Invalidate both the trailing-slash directory paths (what pip and
           # browsers actually request) and the underlying index.html object
           # paths. CloudFront caches each request URI independently, so
@@ -422,6 +450,9 @@ jobs:
             echo "(IAM role may need cloudfront:CreateInvalidation permission)"
             exit 0
           fi
+        env:
+          NEEDS_VERSIONS_OUTPUTS_AWS_CLOUDFRONT_DISTRIBUTION_DOMAIN: ${{ needs.versions.outputs.aws-cloudfront-distribution-domain }}
+          STEPS_PROJ_OUTPUTS_NORMALIZED: ${{ steps.proj.outputs.normalized }}
 
   ##############################################################################
   # STOP EC2 BUILD RUNNERS
@@ -446,7 +477,7 @@ jobs:
       - name: Find EC2 instance ID by label
         id: find-instance
         run: |
-          LABEL="nightly-${{ matrix.python-version }}-pt${{ matrix.torch-version }}-cu${{ matrix.cuda-version }}-${{ github.run_id }}"
+          LABEL="nightly-${MATRIX_PYTHON_VERSION}-pt${MATRIX_TORCH_VERSION}-cu${MATRIX_CUDA_VERSION}-${{ github.run_id }}"
           echo "Looking for instance with RunnerLabel: $LABEL"
 
           INSTANCE_ID=$(aws ec2 describe-instances \
@@ -462,6 +493,10 @@ jobs:
             echo "Found instance: $INSTANCE_ID"
             echo "instance-id=$INSTANCE_ID" >> $GITHUB_OUTPUT
           fi
+        env:
+          MATRIX_PYTHON_VERSION: ${{ matrix.python-version }}
+          MATRIX_TORCH_VERSION: ${{ matrix.torch-version }}
+          MATRIX_CUDA_VERSION: ${{ matrix.cuda-version }}
       - name: Stop EC2 runner
         if: steps.find-instance.outputs.instance-id != ''
         uses: machulav/ec2-github-runner@v2

--- a/.github/workflows/nightly-publish.yml
+++ b/.github/workflows/nightly-publish.yml
@@ -79,7 +79,7 @@ jobs:
         uses: machulav/ec2-github-runner@v2
         with:
           mode: start
-          github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+          github-token: ${{ secrets.EC2_RUNNER_TOKEN }}
           ec2-image-id: ${{ needs.versions.outputs.aws-cpu-ami }}
           ec2-instance-type: m6a.xlarge
           subnet-id: ${{ needs.versions.outputs.aws-subnet }}
@@ -467,6 +467,6 @@ jobs:
         uses: machulav/ec2-github-runner@v2
         with:
           mode: stop
-          github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+          github-token: ${{ secrets.EC2_RUNNER_TOKEN }}
           label: nightly-${{ matrix.python-version }}-pt${{ matrix.torch-version }}-cu${{ matrix.cuda-version }}-${{ github.run_id }}
           ec2-instance-id: ${{ steps.find-instance.outputs.instance-id }}

--- a/.github/workflows/nightly-publish.yml
+++ b/.github/workflows/nightly-publish.yml
@@ -123,7 +123,7 @@ jobs:
       - name: Install prerequisites
         run: |
           dnf install -y git wget procps-ng findutils gcc-toolset-${NEEDS_VERSIONS_OUTPUTS_GCC_TOOLSET}
-          echo 'source /opt/rh/gcc-toolset-${NEEDS_VERSIONS_OUTPUTS_GCC_TOOLSET}/enable' > /etc/profile.d/gcc-toolset-${NEEDS_VERSIONS_OUTPUTS_GCC_TOOLSET}.sh
+          echo "source /opt/rh/gcc-toolset-${NEEDS_VERSIONS_OUTPUTS_GCC_TOOLSET}/enable" > /etc/profile.d/gcc-toolset-${NEEDS_VERSIONS_OUTPUTS_GCC_TOOLSET}.sh
         env:
           NEEDS_VERSIONS_OUTPUTS_GCC_TOOLSET: ${{ needs.versions.outputs.gcc-toolset }}
 
@@ -195,7 +195,7 @@ jobs:
       - name: Build fvdb
         run: |
           source .venv/bin/activate
-          ./build.sh wheel strip_symbols verbose --cuda-arch-list '${NEEDS_VERSIONS_OUTPUTS_CUDA_ARCH_PUBLISH}'
+          ./build.sh wheel strip_symbols verbose --cuda-arch-list "${NEEDS_VERSIONS_OUTPUTS_CUDA_ARCH_PUBLISH}"
         env:
           NEEDS_VERSIONS_OUTPUTS_CUDA_ARCH_PUBLISH: ${{ needs.versions.outputs.cuda-arch-publish }}
 

--- a/.github/workflows/nightly-publish.yml
+++ b/.github/workflows/nightly-publish.yml
@@ -27,7 +27,7 @@ jobs:
     outputs:
       should_build: ${{ steps.decide.outputs.should_build }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: main
           fetch-depth: 0
@@ -73,13 +73,13 @@ jobs:
         env:
           MATRIX_PYTHON_VERSION: ${{ matrix.python-version }}
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b # v6.2.1
         with:
           role-to-assume: ${{ needs.versions.outputs.aws-role }}
           aws-region: ${{ needs.versions.outputs.aws-region }}
       - name: Start EC2 runner
         id: start-build-runner
-        uses: machulav/ec2-github-runner@v2
+        uses: machulav/ec2-github-runner@343a1b2ae682e681c3cec9a235d882da17ff04ef # v2.6.1
         with:
           mode: start
           github-token: ${{ secrets.EC2_RUNNER_TOKEN }}
@@ -126,7 +126,7 @@ jobs:
         env:
           NEEDS_VERSIONS_OUTPUTS_GCC_TOOLSET: ${{ needs.versions.outputs.gcc-toolset }}
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: main
           persist-credentials: false
@@ -238,7 +238,7 @@ jobs:
           MATRIX_CUDA_VERSION: ${{ matrix.cuda-version }}
 
       - name: Upload wheel
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: fvdb-nightly-${{ matrix.python-version }}-torch${{ matrix.torch-version }}-cu${{ matrix.cuda-version }}
           path: dist/fvdb_core-*.whl
@@ -257,13 +257,13 @@ jobs:
       SIMPLE_PREFIX: simple-nightly
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b # v6.2.1
         with:
           role-to-assume: ${{ needs.versions.outputs.aws-role }}
           aws-region: ${{ needs.versions.outputs.aws-region }}
 
       - name: Download all built wheels
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: fvdb-nightly-*
           path: dist
@@ -470,7 +470,7 @@ jobs:
       matrix: ${{ fromJSON(needs.versions.outputs.publish-matrix) }}
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b # v6.2.1
         with:
           role-to-assume: ${{ needs.versions.outputs.aws-role }}
           aws-region: ${{ needs.versions.outputs.aws-region }}
@@ -499,7 +499,7 @@ jobs:
           MATRIX_CUDA_VERSION: ${{ matrix.cuda-version }}
       - name: Stop EC2 runner
         if: steps.find-instance.outputs.instance-id != ''
-        uses: machulav/ec2-github-runner@v2
+        uses: machulav/ec2-github-runner@343a1b2ae682e681c3cec9a235d882da17ff04ef # v2.6.1
         with:
           mode: stop
           github-token: ${{ secrets.EC2_RUNNER_TOKEN }}

--- a/.github/workflows/nightly-publish.yml
+++ b/.github/workflows/nightly-publish.yml
@@ -14,7 +14,6 @@ concurrency:
 
 permissions:
   contents: read
-  id-token: write
 
 jobs:
   ##############################################################################
@@ -61,6 +60,8 @@ jobs:
     needs: [check-new-commits, versions]
     if: needs.check-new-commits.outputs.should_build == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # Required for AWS OIDC
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.versions.outputs.publish-matrix) }}
@@ -252,6 +253,8 @@ jobs:
     needs: [nightly-build, versions]
     if: ${{ !cancelled() && needs.nightly-build.result == 'success' }}
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # Required for AWS OIDC
     env:
       S3_BUCKET: fvdb-packages
       SIMPLE_PREFIX: simple-nightly
@@ -465,6 +468,8 @@ jobs:
       - versions
     runs-on: ubuntu-latest
     if: ${{ always() && needs.start-build-runner.result != 'skipped' }}
+    permissions:
+      id-token: write  # Required for AWS OIDC
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.versions.outputs.publish-matrix) }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -38,6 +38,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0 # Fetch all history for all branches
+          persist-credentials: false
       - name: Determine the target branch of the PR
         run: |
           echo "Fetching pull request metadata..."
@@ -107,7 +108,9 @@ jobs:
       - name: Build fvdb
         run: |
           micromamba activate fvdb_build
-          TORCH_CUDA_ARCH_LIST="${{ needs.versions.outputs.cuda-arch-publish }}" ./build.sh wheel verbose gtests benchmarks
+          TORCH_CUDA_ARCH_LIST="${NEEDS_VERSIONS_OUTPUTS_CUDA_ARCH_PUBLISH}" ./build.sh wheel verbose gtests benchmarks
+        env:
+          NEEDS_VERSIONS_OUTPUTS_CUDA_ARCH_PUBLISH: ${{ needs.versions.outputs.cuda-arch-publish }}
 
       - name: Upload wheel
         uses: actions/upload-artifact@v7
@@ -154,6 +157,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0 # Fetch all history for all branches
+          persist-credentials: false
       - name: Determine the target branch of the PR
         run: |
           echo "Fetching pull request metadata..."

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -35,7 +35,7 @@ jobs:
         shell: bash -el {0}
     steps:
       ### Get the PR branch and apply changes to the target branch
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0 # Fetch all history for all branches
           persist-credentials: false
@@ -99,7 +99,7 @@ jobs:
       #### End of git merge
 
       - name: Set up fvdb_build Conda env
-        uses: mamba-org/setup-micromamba@v3
+        uses: mamba-org/setup-micromamba@d7c9bd84e824b79d2af72a2d4196c7f4300d3476 # v3.0.0
         with:
           post-cleanup: 'all'
           environment-name: fvdb_build
@@ -113,7 +113,7 @@ jobs:
           NEEDS_VERSIONS_OUTPUTS_CUDA_ARCH_PUBLISH: ${{ needs.versions.outputs.cuda-arch-publish }}
 
       - name: Upload wheel
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
             name: fvdb-test-package
             path: dist/*.whl
@@ -125,7 +125,7 @@ jobs:
         run: tar -cvf fvdb-gtest.tar build/
 
       - name: Upload gtests
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
             name: fvdb-gtest
             path: fvdb-gtest.tar
@@ -154,7 +154,7 @@ jobs:
         shell: bash -el {0}
     steps:
       ### Get the PR branch and apply changes to the target branch
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0 # Fetch all history for all branches
           persist-credentials: false
@@ -218,7 +218,7 @@ jobs:
       #### End of git merge
 
       - name: Set up fvdb_test Conda env
-        uses: mamba-org/setup-micromamba@v3
+        uses: mamba-org/setup-micromamba@d7c9bd84e824b79d2af72a2d4196c7f4300d3476 # v3.0.0
         with:
           cache-environment: false
           post-cleanup: 'all'
@@ -226,7 +226,7 @@ jobs:
           environment-file: env/test_environment.yml
 
       - name: Download package
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
             name: fvdb-test-package
             path: ./dist
@@ -246,7 +246,7 @@ jobs:
           pytest benchmark --benchmark-json benchmark/output.json
 
       - name: Store benchmark result
-        uses: benchmark-action/github-action-benchmark@v1
+        uses: benchmark-action/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba # v1.22.1
         with:
             name: Python Benchmark with pytest-benchmark
             tool: 'pytest'

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -11,8 +11,6 @@ permissions:
   deployments: read
   pull-requests: read
   issues: read
-  # Need ID token write permission to use OIDC
-  id-token: write
 
 jobs:
   versions:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,7 +51,7 @@ jobs:
     steps:
       - name: Compute publish routing flags
         id: flags
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
             const isPR = context.eventName === 'pull_request';
@@ -84,7 +84,7 @@ jobs:
             core.setOutput('pypi', pypi ? 'true' : 'false');
             core.setOutput('release', release ? 'true' : 'false');
             core.setOutput('release_push', releasePush ? 'true' : 'false');
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           sparse-checkout: env/test_environment.yml
           sparse-checkout-cone-mode: false
@@ -132,13 +132,13 @@ jobs:
         env:
           MATRIX_PYTHON_VERSION: ${{ matrix.python-version }}
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b # v6.2.1
         with:
           role-to-assume: ${{ needs.versions.outputs.aws-role }}
           aws-region: ${{ needs.versions.outputs.aws-region }}
       - name: Start EC2 runner
         id: start-build-runner
-        uses: machulav/ec2-github-runner@v2
+        uses: machulav/ec2-github-runner@343a1b2ae682e681c3cec9a235d882da17ff04ef # v2.6.1
         with:
           mode: start
           github-token: ${{ secrets.EC2_RUNNER_TOKEN }}
@@ -180,7 +180,7 @@ jobs:
           echo 'source /opt/rh/gcc-toolset-${NEEDS_VERSIONS_OUTPUTS_GCC_TOOLSET}/enable' > /etc/profile.d/gcc-toolset-${NEEDS_VERSIONS_OUTPUTS_GCC_TOOLSET}.sh
         env:
           NEEDS_VERSIONS_OUTPUTS_GCC_TOOLSET: ${{ needs.versions.outputs.gcc-toolset }}
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0 # Fetch all history for all branches
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.ref || inputs.branch || github.ref }}
@@ -324,7 +324,7 @@ jobs:
           MATRIX_CUDA_VERSION: ${{ matrix.cuda-version }}
 
       - name: Upload wheel
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: fvdb-publish-package-${{ matrix.python-version }}-torch${{ matrix.torch-version }}-cu${{ matrix.cuda-version }}
           path: dist/fvdb_core-*.whl
@@ -347,13 +347,13 @@ jobs:
       id-token: write  # IMPORTANT: mandatory for trusted publishing
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
           ref: ${{ inputs.branch || github.ref }}
           persist-credentials: false
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '${{ needs.versions.outputs.python-default }}'
       - name: Add post-release to version (TestPyPI only)
@@ -391,13 +391,13 @@ jobs:
       SIMPLE_PREFIX: ${{ needs.pr-flags.outputs.release == 'true' && 'simple' || 'simple-staging' }}
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b # v6.2.1
         with:
           role-to-assume: ${{ needs.versions.outputs.aws-role }}
           aws-region: ${{ needs.versions.outputs.aws-region }}
 
       - name: Download all built wheels
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: fvdb-publish-package-*
           path: dist
@@ -625,13 +625,13 @@ jobs:
         env:
           MATRIX_PYTHON_VERSION: ${{ matrix.python-version }}
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b # v6.2.1
         with:
           role-to-assume: ${{ needs.versions.outputs.aws-role }}
           aws-region: ${{ needs.versions.outputs.aws-region }}
       - name: Start EC2 GPU runner
         id: start-validation-runner
-        uses: machulav/ec2-github-runner@v2
+        uses: machulav/ec2-github-runner@343a1b2ae682e681c3cec9a235d882da17ff04ef # v2.6.1
         with:
           mode: start
           github-token: ${{ secrets.EC2_RUNNER_TOKEN }}
@@ -683,7 +683,7 @@ jobs:
           MATRIX_PYTHON_VERSION: ${{ matrix.python-version }}
 
       - name: Download wheel artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: fvdb-publish-package-${{ matrix.python-version }}-torch${{ matrix.torch-version }}-cu${{ matrix.cuda-version }}
           path: dist
@@ -732,14 +732,14 @@ jobs:
       - name: Install prerequisites
         run: dnf install -y git wget procps-ng findutils
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
           ref: ${{ inputs.branch || github.ref }}
           persist-credentials: false
 
       - name: Set up fvdb_test Conda env
-        uses: mamba-org/setup-micromamba@v3
+        uses: mamba-org/setup-micromamba@d7c9bd84e824b79d2af72a2d4196c7f4300d3476 # v3.0.0
         with:
           cache-environment: false
           post-cleanup: 'all'
@@ -747,7 +747,7 @@ jobs:
           environment-file: env/test_environment.yml
 
       - name: Download wheel artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: fvdb-publish-package-${{ needs.pr-flags.outputs.test_python_version }}-torch${{ needs.pr-flags.outputs.test_torch_version }}-cu${{ needs.pr-flags.outputs.test_cuda_version }}
           path: dist
@@ -779,7 +779,7 @@ jobs:
       matrix: ${{ fromJSON(needs.versions.outputs.publish-matrix) }}
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b # v6.2.1
         with:
           role-to-assume: ${{ needs.versions.outputs.aws-role }}
           aws-region: ${{ needs.versions.outputs.aws-region }}
@@ -808,7 +808,7 @@ jobs:
           MATRIX_CUDA_VERSION: ${{ matrix.cuda-version }}
       - name: Stop EC2 runner
         if: steps.find-instance.outputs.instance-id != ''
-        uses: machulav/ec2-github-runner@v2
+        uses: machulav/ec2-github-runner@343a1b2ae682e681c3cec9a235d882da17ff04ef # v2.6.1
         with:
           mode: stop
           github-token: ${{ secrets.EC2_RUNNER_TOKEN }}
@@ -828,7 +828,7 @@ jobs:
       matrix: ${{ fromJSON(needs.versions.outputs.publish-matrix) }}
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b # v6.2.1
         with:
           role-to-assume: ${{ needs.versions.outputs.aws-role }}
           aws-region: ${{ needs.versions.outputs.aws-region }}
@@ -858,7 +858,7 @@ jobs:
           MATRIX_CUDA_VERSION: ${{ matrix.cuda-version }}
       - name: Stop EC2 runner
         if: steps.find-instance.outputs.instance-id != ''
-        uses: machulav/ec2-github-runner@v2
+        uses: machulav/ec2-github-runner@343a1b2ae682e681c3cec9a235d882da17ff04ef # v2.6.1
         with:
           mode: stop
           github-token: ${{ secrets.EC2_RUNNER_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -180,7 +180,7 @@ jobs:
       - name: Install prerequisites
         run: |
           dnf install -y git wget procps-ng findutils gcc-toolset-${NEEDS_VERSIONS_OUTPUTS_GCC_TOOLSET}
-          echo 'source /opt/rh/gcc-toolset-${NEEDS_VERSIONS_OUTPUTS_GCC_TOOLSET}/enable' > /etc/profile.d/gcc-toolset-${NEEDS_VERSIONS_OUTPUTS_GCC_TOOLSET}.sh
+          echo "source /opt/rh/gcc-toolset-${NEEDS_VERSIONS_OUTPUTS_GCC_TOOLSET}/enable" > /etc/profile.d/gcc-toolset-${NEEDS_VERSIONS_OUTPUTS_GCC_TOOLSET}.sh
         env:
           NEEDS_VERSIONS_OUTPUTS_GCC_TOOLSET: ${{ needs.versions.outputs.gcc-toolset }}
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -273,7 +273,7 @@ jobs:
       - name: Build fvdb
         run: |
           source .venv/bin/activate
-          ./build.sh wheel strip_symbols verbose --cuda-arch-list '${NEEDS_VERSIONS_OUTPUTS_CUDA_ARCH_PUBLISH}'
+          ./build.sh wheel strip_symbols verbose --cuda-arch-list "${NEEDS_VERSIONS_OUTPUTS_CUDA_ARCH_PUBLISH}"
         env:
           NEEDS_VERSIONS_OUTPUTS_CUDA_ARCH_PUBLISH: ${{ needs.versions.outputs.cuda-arch-publish }}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -138,7 +138,7 @@ jobs:
         uses: machulav/ec2-github-runner@v2
         with:
           mode: start
-          github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+          github-token: ${{ secrets.EC2_RUNNER_TOKEN }}
           ec2-image-id: ${{ needs.versions.outputs.aws-cpu-ami }}
           ec2-instance-type: m6a.8xlarge
           subnet-id: ${{ needs.versions.outputs.aws-subnet }}
@@ -599,7 +599,7 @@ jobs:
         uses: machulav/ec2-github-runner@v2
         with:
           mode: start
-          github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+          github-token: ${{ secrets.EC2_RUNNER_TOKEN }}
           ec2-image-id: ${{ needs.versions.outputs.aws-gpu-ami }}
           ec2-instance-type: g6.xlarge
           subnet-id: ${{ needs.versions.outputs.aws-subnet }}
@@ -765,7 +765,7 @@ jobs:
         uses: machulav/ec2-github-runner@v2
         with:
           mode: stop
-          github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+          github-token: ${{ secrets.EC2_RUNNER_TOKEN }}
           label: val-${{ matrix.python-version }}-pt${{ matrix.torch-version }}-cu${{ matrix.cuda-version }}-${{ github.run_id }}
           ec2-instance-id: ${{ steps.find-instance.outputs.instance-id }}
 
@@ -811,6 +811,6 @@ jobs:
         uses: machulav/ec2-github-runner@v2
         with:
           mode: stop
-          github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+          github-token: ${{ secrets.EC2_RUNNER_TOKEN }}
           label: ec2-${{ matrix.python-version }}-pt${{ matrix.torch-version }}-cu${{ matrix.cuda-version }}-${{ github.run_id }}
           ec2-instance-id: ${{ steps.find-instance.outputs.instance-id }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,8 +32,6 @@ permissions:
   deployments: read
   pull-requests: read
   issues: read
-  # Need ID token write permission to use OIDC
-  id-token: write
 
 jobs:
   pr-flags:
@@ -52,14 +50,17 @@ jobs:
       - name: Compute publish routing flags
         id: flags
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        env:
+          PUBLISH_TARGET: ${{ inputs.publish_target }}
         with:
           script: |
             const isPR = context.eventName === 'pull_request';
             const isPush = context.eventName === 'push';
             const isRelease = context.eventName === 'release';
             const isDispatch = context.eventName === 'workflow_dispatch';
-            let s3 = '${{ inputs.publish_target }}' == 's3';
-            let pypi = isDispatch && '${{ inputs.publish_target }}' == 'testpypi';
+            const publishTarget = process.env.PUBLISH_TARGET || '';
+            let s3 = publishTarget === 's3';
+            let pypi = isDispatch && publishTarget === 'testpypi';
             let releasePush = false;
             let release = false;
             if (isPR) {
@@ -75,7 +76,7 @@ jobs:
               s3 = true;
               pypi = true;
               release = true;
-            } else if (isDispatch && '${{ inputs.publish_target }}' == 'release') {
+            } else if (isDispatch && publishTarget === 'release') {
               s3 = true;
               pypi = true;
               release = true;
@@ -118,6 +119,8 @@ jobs:
   start-build-runner:
     name: Start CPU-only EC2 runner for build
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # Required for AWS OIDC
     needs: versions
     strategy:
       fail-fast: false
@@ -344,6 +347,7 @@ jobs:
       url: ${{ (needs.pr-flags.outputs.release == 'true' && 'https://pypi.org/p/fvdb-core') || 'https://test.pypi.org/p/fvdb-core' }}
 
     permissions:
+      contents: read
       id-token: write  # IMPORTANT: mandatory for trusted publishing
 
     steps:
@@ -376,7 +380,7 @@ jobs:
           echo "Built sdist:"
           ls -lh dist/
       - name: Publish distribution
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         with:
           repository-url: ${{ (needs.pr-flags.outputs.release == 'true' && 'https://upload.pypi.org/legacy/') || 'https://test.pypi.org/legacy/' }}
           verbose: true
@@ -386,6 +390,8 @@ jobs:
     needs: [pr-flags, fvdb-build, versions]
     if: ${{ !cancelled() && needs.pr-flags.outputs.s3 == 'true' && needs.fvdb-build.result == 'success' }}
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # Required for AWS OIDC
     env:
       S3_BUCKET: fvdb-packages
       SIMPLE_PREFIX: ${{ needs.pr-flags.outputs.release == 'true' && 'simple' || 'simple-staging' }}
@@ -613,6 +619,8 @@ jobs:
     needs: [pr-flags, fvdb-build, versions]
     if: ${{ !cancelled() && needs.fvdb-build.result == 'success' && (needs.pr-flags.outputs.release_push == 'true' || needs.pr-flags.outputs.release == 'true' || inputs.run_validation == true) }}
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # Required for AWS OIDC
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.versions.outputs.publish-matrix) }}
@@ -774,6 +782,8 @@ jobs:
       - versions
     runs-on: ubuntu-latest
     if: ${{ always() && needs.start-validation-runner.result != 'skipped' }}
+    permissions:
+      id-token: write  # Required for AWS OIDC
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.versions.outputs.publish-matrix) }}
@@ -823,6 +833,8 @@ jobs:
       - versions
     runs-on: ubuntu-latest
     if: ${{ always() }} # required to stop the runner even if the error happened in the previous jobs
+    permissions:
+      id-token: write  # Required for AWS OIDC
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.versions.outputs.publish-matrix) }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -89,6 +89,7 @@ jobs:
           sparse-checkout: env/test_environment.yml
           sparse-checkout-cone-mode: false
           ref: ${{ inputs.branch || github.ref }}
+          persist-credentials: false
       - name: Parse test environment versions
         id: test-env
         run: |
@@ -126,8 +127,10 @@ jobs:
         run: |
           # Random delay between 0 and 15 seconds to stagger runner registrations
           DELAY=$((RANDOM % 16))
-          echo "Delaying start by ${DELAY} seconds for Python ${{ matrix.python-version }}"
+          echo "Delaying start by ${DELAY} seconds for Python ${MATRIX_PYTHON_VERSION}"
           sleep $DELAY
+        env:
+          MATRIX_PYTHON_VERSION: ${{ matrix.python-version }}
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6
         with:
@@ -173,12 +176,15 @@ jobs:
     steps:
       - name: Install prerequisites
         run: |
-          dnf install -y git wget procps-ng findutils gcc-toolset-${{ needs.versions.outputs.gcc-toolset }}
-          echo 'source /opt/rh/gcc-toolset-${{ needs.versions.outputs.gcc-toolset }}/enable' > /etc/profile.d/gcc-toolset-${{ needs.versions.outputs.gcc-toolset }}.sh
+          dnf install -y git wget procps-ng findutils gcc-toolset-${NEEDS_VERSIONS_OUTPUTS_GCC_TOOLSET}
+          echo 'source /opt/rh/gcc-toolset-${NEEDS_VERSIONS_OUTPUTS_GCC_TOOLSET}/enable' > /etc/profile.d/gcc-toolset-${NEEDS_VERSIONS_OUTPUTS_GCC_TOOLSET}.sh
+        env:
+          NEEDS_VERSIONS_OUTPUTS_GCC_TOOLSET: ${{ needs.versions.outputs.gcc-toolset }}
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0 # Fetch all history for all branches
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.ref || inputs.branch || github.ref }}
+          persist-credentials: false
 
       - name: Fetch PR branch
         if: github.event_name == 'pull_request_target'
@@ -200,18 +206,23 @@ jobs:
         uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86
         with:
           version: "${{ needs.versions.outputs.uv-version }}"
+          enable-cache: false
 
       - name: Set up Python
         run: |
-          uv python install ${{ matrix.python-version }}
+          uv python install ${MATRIX_PYTHON_VERSION}
           uv venv
+        env:
+          MATRIX_PYTHON_VERSION: ${{ matrix.python-version }}
 
       - name: Install CMake
         run: >
-          wget -nv https://github.com/Kitware/CMake/releases/download/v${{ needs.versions.outputs.cmake-version }}/cmake-${{ needs.versions.outputs.cmake-version }}-linux-x86_64.sh &&
+          wget -nv https://github.com/Kitware/CMake/releases/download/v${NEEDS_VERSIONS_OUTPUTS_CMAKE_VERSION}/cmake-${NEEDS_VERSIONS_OUTPUTS_CMAKE_VERSION}-linux-x86_64.sh &&
           mkdir /opt/cmake &&
-          sh cmake-${{ needs.versions.outputs.cmake-version }}-linux-x86_64.sh --prefix=/usr/local --skip-license &&
+          sh cmake-${NEEDS_VERSIONS_OUTPUTS_CMAKE_VERSION}-linux-x86_64.sh --prefix=/usr/local --skip-license &&
           cmake --version
+        env:
+          NEEDS_VERSIONS_OUTPUTS_CMAKE_VERSION: ${{ needs.versions.outputs.cmake-version }}
 
       - name: Install system dependencies
         run: dnf install -y zlib-devel libpng-devel pkgconfig unzip procps-ng findutils
@@ -219,13 +230,17 @@ jobs:
       - name: Install pip dependencies
         run: |
           # Convert CUDA version from 12.8 to cu128 format for PyTorch index
-          CUDA_TAG="cu$(echo "${{ matrix.cuda-version }}" | tr -d '.')"
-          TORCH_VERSION="${{ matrix.torch-version }}"
+          CUDA_TAG="cu$(echo "${MATRIX_CUDA_VERSION}" | tr -d '.')"
+          TORCH_VERSION="${MATRIX_TORCH_VERSION}"
           echo "Installing PyTorch ${TORCH_VERSION} for ${CUDA_TAG}"
           # Pin the tested PyTorch via a constraints file so the unbounded torch in
           # build_requirements.txt resolves to the version recorded in versions.json.
-          echo "torch==${{ needs.versions.outputs.torch-full-version }}" > "${RUNNER_TEMP}/torch-constraints.txt"
+          echo "torch==${NEEDS_VERSIONS_OUTPUTS_TORCH_FULL_VERSION}" > "${RUNNER_TEMP}/torch-constraints.txt"
           uv pip install --no-cache -c "${RUNNER_TEMP}/torch-constraints.txt" -r env/build_requirements.txt --extra-index-url https://download.pytorch.org/whl/${CUDA_TAG}
+        env:
+          MATRIX_CUDA_VERSION: ${{ matrix.cuda-version }}
+          MATRIX_TORCH_VERSION: ${{ matrix.torch-version }}
+          NEEDS_VERSIONS_OUTPUTS_TORCH_FULL_VERSION: ${{ needs.versions.outputs.torch-full-version }}
 
       - name: Add a post-release to version (used for testing on TestPyPI)
         if: ${{ needs.pr-flags.outputs.s3 == 'false' }}
@@ -244,15 +259,20 @@ jobs:
       - name: Add local version for S3 publish
         if: ${{ needs.pr-flags.outputs.s3 == 'true' }}
         run: |
-          TORCH_TAG="$(echo "${{ matrix.torch-version }}" | tr -d '.')"
-          CUDA_TAG="$(echo "${{ matrix.cuda-version }}" | tr -d '.')"
+          TORCH_TAG="$(echo "${MATRIX_TORCH_VERSION}" | tr -d '.')"
+          CUDA_TAG="$(echo "${MATRIX_CUDA_VERSION}" | tr -d '.')"
           sed -i -E 's/^version\s*=\s*"([^"]+)"/version = "\1+pt'"${TORCH_TAG}"'.cu'"${CUDA_TAG}"'"/' pyproject.toml
           grep '^version' pyproject.toml
+        env:
+          MATRIX_TORCH_VERSION: ${{ matrix.torch-version }}
+          MATRIX_CUDA_VERSION: ${{ matrix.cuda-version }}
 
       - name: Build fvdb
         run: |
           source .venv/bin/activate
-          ./build.sh wheel strip_symbols verbose --cuda-arch-list '${{ needs.versions.outputs.cuda-arch-publish }}'
+          ./build.sh wheel strip_symbols verbose --cuda-arch-list '${NEEDS_VERSIONS_OUTPUTS_CUDA_ARCH_PUBLISH}'
+        env:
+          NEEDS_VERSIONS_OUTPUTS_CUDA_ARCH_PUBLISH: ${{ needs.versions.outputs.cuda-arch-publish }}
 
       - name: Repair wheel for manylinux
         if: ${{ needs.pr-flags.outputs.s3 != 'true' || needs.pr-flags.outputs.release_push == 'true' || needs.pr-flags.outputs.release == 'true' }}
@@ -261,7 +281,7 @@ jobs:
           uv pip install auditwheel patchelf
           # Check glibc version
           ldd --version | head -n1
-          CUDA_MAJOR=$(echo "${{ matrix.cuda-version }}" | cut -d. -f1)
+          CUDA_MAJOR=$(echo "${MATRIX_CUDA_VERSION}" | cut -d. -f1)
           # Exclude CUDA, PyTorch, and other system libraries to keep wheel size down
           auditwheel repair dist/fvdb_core-*.whl -w dist/ \
             --exclude libcuda.so.1 \
@@ -300,6 +320,8 @@ jobs:
           echo ""
           echo "Largest files in wheel:"
           unzip -l dist/fvdb_core-*.whl | sort -k1 -n -r | head -30
+        env:
+          MATRIX_CUDA_VERSION: ${{ matrix.cuda-version }}
 
       - name: Upload wheel
         uses: actions/upload-artifact@v7
@@ -329,6 +351,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ inputs.branch || github.ref }}
+          persist-credentials: false
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
@@ -402,7 +425,7 @@ jobs:
           set -euo pipefail
           CUTOFF=$(date -u -d '30 days ago' '+%Y-%m-%d')
           echo "Pruning staging wheels uploaded before $CUTOFF"
-          LISTING=$(aws s3 ls "s3://${S3_BUCKET}/${SIMPLE_PREFIX}/${{ steps.proj.outputs.normalized }}/" 2>/dev/null || true)
+          LISTING=$(aws s3 ls "s3://${S3_BUCKET}/${SIMPLE_PREFIX}/${STEPS_PROJ_OUTPUTS_NORMALIZED}/" 2>/dev/null || true)
           if [ -z "$LISTING" ]; then
             echo "No existing wheels found -- nothing to prune"
             exit 0
@@ -413,16 +436,18 @@ jobs:
             FILE_PART=$(echo "$line" | awk '{print $4}')
             if [[ "$FILE_PART" == *.whl ]] && [[ "$DATE_PART" < "$CUTOFF" ]]; then
               echo "Removing: $FILE_PART (uploaded $DATE_PART)"
-              aws s3 rm "s3://${S3_BUCKET}/${SIMPLE_PREFIX}/${{ steps.proj.outputs.normalized }}/$FILE_PART" --only-show-errors
+              aws s3 rm "s3://${S3_BUCKET}/${SIMPLE_PREFIX}/${STEPS_PROJ_OUTPUTS_NORMALIZED}/$FILE_PART" --only-show-errors
               DELETED=$((DELETED + 1))
             fi
           done <<< "$LISTING"
           echo "Pruned $DELETED old staging wheel(s)"
+        env:
+          STEPS_PROJ_OUTPUTS_NORMALIZED: ${{ steps.proj.outputs.normalized }}
 
       - name: Upload wheels to S3 project directory
         run: |
           set -euo pipefail
-          DEST="s3://${S3_BUCKET}/${SIMPLE_PREFIX}/${{ steps.proj.outputs.normalized }}"
+          DEST="s3://${S3_BUCKET}/${SIMPLE_PREFIX}/${STEPS_PROJ_OUTPUTS_NORMALIZED}"
           # Ensure trailing slash exactly once
           DEST="${DEST%/}/"
           echo "Uploading wheels to $DEST"
@@ -446,23 +471,25 @@ jobs:
           # Brief delay to ensure S3 consistency for subsequent listing
           echo "Waiting 2 seconds for S3 consistency..."
           sleep 2
+        env:
+          STEPS_PROJ_OUTPUTS_NORMALIZED: ${{ steps.proj.outputs.normalized }}
 
       - name: Generate project index.html
         run: |
           set -euo pipefail
-          OUTDIR="dist/index-gen/${{ steps.proj.outputs.normalized }}"
+          OUTDIR="dist/index-gen/${STEPS_PROJ_OUTPUTS_NORMALIZED}"
           mkdir -p "$OUTDIR"
           INDEX_FILE="$OUTDIR/index.html"
-          TITLE="Links for ${{ steps.proj.outputs.project_name }}"
+          TITLE="Links for ${STEPS_PROJ_OUTPUTS_PROJECT_NAME}"
           # List wheels from S3 to ensure index matches what's actually uploaded and previous versions
           # Use grep -E and || true to handle case where no wheels exist yet, then extract filename (field 4)
-          wheels=$(aws s3 ls "s3://${S3_BUCKET}/${SIMPLE_PREFIX}/${{ steps.proj.outputs.normalized }}/" | { grep -E '\.whl$' || true; } | awk '{print $4}')
+          wheels=$(aws s3 ls "s3://${S3_BUCKET}/${SIMPLE_PREFIX}/${STEPS_PROJ_OUTPUTS_NORMALIZED}/" | { grep -E '\.whl$' || true; } | awk '{print $4}')
 
           echo "Found wheels in S3:"
           echo "$wheels"
 
           if [ -z "$wheels" ]; then
-            echo "WARNING: No wheels found in S3 at s3://${S3_BUCKET}/${SIMPLE_PREFIX}/${{ steps.proj.outputs.normalized }}/"
+            echo "WARNING: No wheels found in S3 at s3://${S3_BUCKET}/${SIMPLE_PREFIX}/${STEPS_PROJ_OUTPUTS_NORMALIZED}/"
             echo "This may indicate an upload failure or timing issue"
           fi
 
@@ -481,7 +508,7 @@ jobs:
               else
                 # Download temporarily to compute hash
                 echo "  → Downloading $whl to compute hash..." >&2
-                if aws s3 cp "s3://${S3_BUCKET}/${SIMPLE_PREFIX}/${{ steps.proj.outputs.normalized }}/$whl" "/tmp/$whl" --only-show-errors; then
+                if aws s3 cp "s3://${S3_BUCKET}/${SIMPLE_PREFIX}/${STEPS_PROJ_OUTPUTS_NORMALIZED}/$whl" "/tmp/$whl" --only-show-errors; then
                   sha=$(sha256sum "/tmp/$whl" | awk '{print $1}')
                   rm "/tmp/$whl"
                   echo "  ✓ Computed SHA256 from S3 file: ${sha:0:16}..." >&2
@@ -505,11 +532,14 @@ jobs:
           cat "$INDEX_FILE"
 
           echo "Uploading index.html to S3..."
-          aws s3 cp "$INDEX_FILE" "s3://${S3_BUCKET}/${SIMPLE_PREFIX}/${{ steps.proj.outputs.normalized }}/index.html" \
+          aws s3 cp "$INDEX_FILE" "s3://${S3_BUCKET}/${SIMPLE_PREFIX}/${STEPS_PROJ_OUTPUTS_NORMALIZED}/index.html" \
             --content-type text/html \
             --cache-control "public, max-age=60, must-revalidate" \
             --only-show-errors
           echo "Index uploaded successfully"
+        env:
+          STEPS_PROJ_OUTPUTS_NORMALIZED: ${{ steps.proj.outputs.normalized }}
+          STEPS_PROJ_OUTPUTS_PROJECT_NAME: ${{ steps.proj.outputs.project_name }}
 
       - name: Generate root simple index.html
         run: |
@@ -537,7 +567,7 @@ jobs:
       - name: Invalidate CloudFront cache for simple-index paths
         run: |
           set -euo pipefail
-          DOMAIN="${{ needs.versions.outputs.aws-cloudfront-distribution-domain }}"
+          DOMAIN="${NEEDS_VERSIONS_OUTPUTS_AWS_CLOUDFRONT_DISTRIBUTION_DOMAIN}"
           if [ -z "$DOMAIN" ] || [ "$DOMAIN" = "null" ]; then
             echo "No CloudFront distribution domain configured (aws.cloudfront_distribution_domain in versions.json); skipping invalidation"
             exit 0
@@ -550,7 +580,7 @@ jobs:
             echo "(IAM role may need cloudfront:ListDistributions permission)"
             exit 0
           fi
-          NORM="${{ steps.proj.outputs.normalized }}"
+          NORM="${STEPS_PROJ_OUTPUTS_NORMALIZED}"
           # Invalidate both the trailing-slash directory paths (what pip and
           # browsers actually request) and the underlying index.html object
           # paths. CloudFront caches each request URI independently, so
@@ -571,6 +601,9 @@ jobs:
             echo "(IAM role may need cloudfront:CreateInvalidation permission)"
             exit 0
           fi
+        env:
+          NEEDS_VERSIONS_OUTPUTS_AWS_CLOUDFRONT_DISTRIBUTION_DOMAIN: ${{ needs.versions.outputs.aws-cloudfront-distribution-domain }}
+          STEPS_PROJ_OUTPUTS_NORMALIZED: ${{ steps.proj.outputs.normalized }}
 
   ##############################################################################
   # GPU VALIDATION: SMOKE TEST + UNIT TESTS
@@ -587,8 +620,10 @@ jobs:
       - name: Stagger job starts to avoid API rate limits
         run: |
           DELAY=$((RANDOM % 16))
-          echo "Delaying start by ${DELAY} seconds for Python ${{ matrix.python-version }}"
+          echo "Delaying start by ${DELAY} seconds for Python ${MATRIX_PYTHON_VERSION}"
           sleep $DELAY
+        env:
+          MATRIX_PYTHON_VERSION: ${{ matrix.python-version }}
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6
         with:
@@ -638,11 +673,14 @@ jobs:
         uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86
         with:
           version: "${{ needs.versions.outputs.uv-version }}"
+          enable-cache: false
 
       - name: Set up Python
         run: |
-          uv python install ${{ matrix.python-version }}
+          uv python install ${MATRIX_PYTHON_VERSION}
           uv venv
+        env:
+          MATRIX_PYTHON_VERSION: ${{ matrix.python-version }}
 
       - name: Download wheel artifact
         uses: actions/download-artifact@v8
@@ -652,10 +690,13 @@ jobs:
 
       - name: Install wheel
         run: |
-          CUDA_TAG="cu$(echo "${{ matrix.cuda-version }}" | tr -d '.')"
-          echo "torch==${{ needs.versions.outputs.torch-full-version }}" > "${RUNNER_TEMP}/torch-constraints.txt"
+          CUDA_TAG="cu$(echo "${MATRIX_CUDA_VERSION}" | tr -d '.')"
+          echo "torch==${NEEDS_VERSIONS_OUTPUTS_TORCH_FULL_VERSION}" > "${RUNNER_TEMP}/torch-constraints.txt"
           uv pip install --no-cache -c "${RUNNER_TEMP}/torch-constraints.txt" torch --extra-index-url https://download.pytorch.org/whl/${CUDA_TAG}
           uv pip install dist/fvdb_core-*.whl
+        env:
+          MATRIX_CUDA_VERSION: ${{ matrix.cuda-version }}
+          NEEDS_VERSIONS_OUTPUTS_TORCH_FULL_VERSION: ${{ needs.versions.outputs.torch-full-version }}
 
       - name: Run smoke test
         run: |
@@ -695,6 +736,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ inputs.branch || github.ref }}
+          persist-credentials: false
 
       - name: Set up fvdb_test Conda env
         uses: mamba-org/setup-micromamba@v3
@@ -744,7 +786,7 @@ jobs:
       - name: Find EC2 instance ID by label
         id: find-instance
         run: |
-          LABEL="val-${{ matrix.python-version }}-pt${{ matrix.torch-version }}-cu${{ matrix.cuda-version }}-${{ github.run_id }}"
+          LABEL="val-${MATRIX_PYTHON_VERSION}-pt${MATRIX_TORCH_VERSION}-cu${MATRIX_CUDA_VERSION}-${{ github.run_id }}"
           echo "Looking for instance with RunnerLabel: $LABEL"
 
           INSTANCE_ID=$(aws ec2 describe-instances \
@@ -760,6 +802,10 @@ jobs:
             echo "Found instance: $INSTANCE_ID"
             echo "instance-id=$INSTANCE_ID" >> $GITHUB_OUTPUT
           fi
+        env:
+          MATRIX_PYTHON_VERSION: ${{ matrix.python-version }}
+          MATRIX_TORCH_VERSION: ${{ matrix.torch-version }}
+          MATRIX_CUDA_VERSION: ${{ matrix.cuda-version }}
       - name: Stop EC2 runner
         if: steps.find-instance.outputs.instance-id != ''
         uses: machulav/ec2-github-runner@v2
@@ -789,7 +835,7 @@ jobs:
       - name: Find EC2 instance ID by label
         id: find-instance
         run: |
-          LABEL="ec2-${{ matrix.python-version }}-pt${{ matrix.torch-version }}-cu${{ matrix.cuda-version }}-${{ github.run_id }}"
+          LABEL="ec2-${MATRIX_PYTHON_VERSION}-pt${MATRIX_TORCH_VERSION}-cu${MATRIX_CUDA_VERSION}-${{ github.run_id }}"
           echo "Looking for instance with RunnerLabel: $LABEL"
 
           # Query by the custom RunnerLabel tag we set during instance creation
@@ -806,6 +852,10 @@ jobs:
             echo "Found instance: $INSTANCE_ID"
             echo "instance-id=$INSTANCE_ID" >> $GITHUB_OUTPUT
           fi
+        env:
+          MATRIX_PYTHON_VERSION: ${{ matrix.python-version }}
+          MATRIX_TORCH_VERSION: ${{ matrix.torch-version }}
+          MATRIX_CUDA_VERSION: ${{ matrix.cuda-version }}
       - name: Stop EC2 runner
         if: steps.find-instance.outputs.instance-id != ''
         uses: machulav/ec2-github-runner@v2

--- a/.github/workflows/sync-doc-version.yml
+++ b/.github/workflows/sync-doc-version.yml
@@ -17,7 +17,7 @@ jobs:
     if: github.repository == 'openvdb/fvdb-core'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
 
@@ -60,7 +60,7 @@ jobs:
         if: >-
           steps.release.outputs.skip != 'true' &&
           steps.release.outputs.version != steps.current.outputs.version
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           commit-message: "Update doc stable version to ${{ steps.release.outputs.version }}"
           signoff: true

--- a/.github/workflows/sync-doc-version.yml
+++ b/.github/workflows/sync-doc-version.yml
@@ -19,6 +19,9 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
+          # `release: published` checks out the tag (detached HEAD); pin to the
+          # default branch so the doc-version PR is always based on main.
+          ref: main
           persist-credentials: false
 
       - name: Get latest release version

--- a/.github/workflows/sync-doc-version.yml
+++ b/.github/workflows/sync-doc-version.yml
@@ -18,6 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Get latest release version
         id: release
@@ -48,8 +50,11 @@ jobs:
           steps.release.outputs.skip != 'true' &&
           steps.release.outputs.version != steps.current.outputs.version
         run: |
-          echo "Updating doc version from ${{ steps.current.outputs.version }} to ${{ steps.release.outputs.version }}"
-          ./devtools/update-doc-versions.sh "${{ steps.release.outputs.version }}"
+          echo "Updating doc version from ${STEPS_CURRENT_OUTPUTS_VERSION} to ${STEPS_RELEASE_OUTPUTS_VERSION}"
+          ./devtools/update-doc-versions.sh "${STEPS_RELEASE_OUTPUTS_VERSION}"
+        env:
+          STEPS_CURRENT_OUTPUTS_VERSION: ${{ steps.current.outputs.version }}
+          STEPS_RELEASE_OUTPUTS_VERSION: ${{ steps.release.outputs.version }}
 
       - name: Create pull request
         if: >-

--- a/.github/workflows/sync-doc-version.yml
+++ b/.github/workflows/sync-doc-version.yml
@@ -4,8 +4,8 @@
 name: Sync Doc Version
 
 on:
-  schedule:
-    - cron: "0 8 * * *"
+  release:
+    types: [published]
   workflow_dispatch:
 
 permissions:
@@ -57,7 +57,6 @@ jobs:
           steps.release.outputs.version != steps.current.outputs.version
         uses: peter-evans/create-pull-request@v8
         with:
-          token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
           commit-message: "Update doc stable version to ${{ steps.release.outputs.version }}"
           signoff: true
           branch: auto/sync-doc-version

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,13 +49,13 @@ jobs:
       ec2-instance-id: ${{ steps.start-build-runner.outputs.ec2-instance-id }}
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b # v6.2.1
         with:
           role-to-assume: ${{ needs.versions.outputs.aws-role }}
           aws-region: ${{ needs.versions.outputs.aws-region }}
       - name: Start EC2 runner
         id: start-build-runner
-        uses: machulav/ec2-github-runner@v2
+        uses: machulav/ec2-github-runner@343a1b2ae682e681c3cec9a235d882da17ff04ef # v2.6.1
         with:
           mode: start
           github-token: ${{ secrets.EC2_RUNNER_TOKEN }}
@@ -81,7 +81,7 @@ jobs:
       - name: Install system dependencies
         run: dnf install -y git procps-ng findutils
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0 # Fetch all history for all branches
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha }}
@@ -122,7 +122,7 @@ jobs:
       #     git merge --no-ff $CURRENT_COMMIT --message "CI: Simulating merge of $CURRENT_COMMIT into $TARGET_BRANCH"
 
       - name: Set up fvdb_build Conda env
-        uses: mamba-org/setup-micromamba@v3
+        uses: mamba-org/setup-micromamba@d7c9bd84e824b79d2af72a2d4196c7f4300d3476 # v3.0.0
         with:
           post-cleanup: 'all'
           environment-name: fvdb_build
@@ -136,7 +136,7 @@ jobs:
           ./build.sh wheel verbose gtests benchmarks --cuda-arch-list '8.9+PTX'
 
       - name: Upload wheel
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
             name: fvdb-test-package
             path: dist/*.whl
@@ -148,7 +148,7 @@ jobs:
         run: tar -cvf fvdb-gtest.tar build/
 
       - name: Upload gtests
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
             name: fvdb-gtest
             path: fvdb-gtest.tar
@@ -166,12 +166,12 @@ jobs:
     if: ${{ always() && needs.start-build-runner.result != 'skipped' }}
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b # v6.2.1
         with:
           role-to-assume: ${{ needs.versions.outputs.aws-role }}
           aws-region: ${{ needs.versions.outputs.aws-region }}
       - name: Stop EC2 runner
-        uses: machulav/ec2-github-runner@v2
+        uses: machulav/ec2-github-runner@343a1b2ae682e681c3cec9a235d882da17ff04ef # v2.6.1
         with:
           mode: stop
           github-token: ${{ secrets.EC2_RUNNER_TOKEN }}
@@ -191,13 +191,13 @@ jobs:
       ec2-instance-id: ${{ steps.start-tests-gpu-runner.outputs.ec2-instance-id }}
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b # v6.2.1
         with:
           role-to-assume: ${{ needs.versions.outputs.aws-role }}
           aws-region: ${{ needs.versions.outputs.aws-region }}
       - name: Start EC2 GPU runner
         id: start-tests-gpu-runner
-        uses: machulav/ec2-github-runner@v2
+        uses: machulav/ec2-github-runner@343a1b2ae682e681c3cec9a235d882da17ff04ef # v2.6.1
         with:
           mode: start
           github-token: ${{ secrets.EC2_RUNNER_TOKEN }}
@@ -227,7 +227,7 @@ jobs:
       - name: Install system dependencies
         run: dnf install -y git procps-ng findutils
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0 # Fetch all history for all branches
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha }}
@@ -250,7 +250,7 @@ jobs:
           git merge pr_branch
 
       - name: Set up fvdb_test Conda env
-        uses: mamba-org/setup-micromamba@v3
+        uses: mamba-org/setup-micromamba@d7c9bd84e824b79d2af72a2d4196c7f4300d3476 # v3.0.0
         with:
           cache-environment: false
           post-cleanup: 'all'
@@ -258,7 +258,7 @@ jobs:
           environment-file: env/test_environment.yml
 
       - name: Download gtests
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
             name: fvdb-gtest
             path: .
@@ -294,7 +294,7 @@ jobs:
       - name: Install system dependencies
         run: dnf install -y git procps-ng findutils
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0 # Fetch all history for all branches
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha }}
@@ -318,7 +318,7 @@ jobs:
           git merge pr_branch
 
       - name: Set up fvdb_test Conda env
-        uses: mamba-org/setup-micromamba@v3
+        uses: mamba-org/setup-micromamba@d7c9bd84e824b79d2af72a2d4196c7f4300d3476 # v3.0.0
         with:
           cache-environment: false
           post-cleanup: 'all'
@@ -326,7 +326,7 @@ jobs:
           environment-file: env/test_environment.yml
 
       - name: Download package
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
             name: fvdb-test-package
             path: ./dist
@@ -364,7 +364,7 @@ jobs:
       - name: Install system dependencies
         run: dnf install -y git procps-ng findutils
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0 # Fetch all history for all branches
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha }}
@@ -388,7 +388,7 @@ jobs:
           git merge pr_branch
 
       - name: Set up fvdb_test Conda env
-        uses: mamba-org/setup-micromamba@v3
+        uses: mamba-org/setup-micromamba@d7c9bd84e824b79d2af72a2d4196c7f4300d3476 # v3.0.0
         with:
           cache-environment: false
           post-cleanup: 'all'
@@ -396,7 +396,7 @@ jobs:
           environment-file: env/test_environment.yml
 
       - name: Download package
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
             name: fvdb-test-package
             path: ./dist
@@ -443,12 +443,12 @@ jobs:
     if: ${{ always() && needs.start-tests-gpu-runner.result != 'skipped' }}
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b # v6.2.1
         with:
           role-to-assume: ${{ needs.versions.outputs.aws-role }}
           aws-region: ${{ needs.versions.outputs.aws-region }}
       - name: Stop EC2 runner
-        uses: machulav/ec2-github-runner@v2
+        uses: machulav/ec2-github-runner@343a1b2ae682e681c3cec9a235d882da17ff04ef # v2.6.1
         with:
           mode: stop
           github-token: ${{ secrets.EC2_RUNNER_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,7 @@
 name: fVDB Conda Build and Test
 
 on:
+  # zizmor: ignore[dangerous-triggers] pull_request_target is required to provision AWS runners; privileged credentials are scoped to runner lifecycle jobs.
   pull_request_target:
     branches:
       - '**'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,8 +21,6 @@ permissions:
   deployments: read
   pull-requests: read
   issues: read
-  # Need ID token write permission to use OIDC
-  id-token: write
 
 jobs:
   ##############################################################################
@@ -41,6 +39,8 @@ jobs:
     name: Start CPU-only EC2 runner for build
     needs: [check-changes, versions]
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # Required for AWS OIDC
     if: >-
       needs.check-changes.outputs.should_test == 'true'
       && (github.event.pull_request.draft == false || github.event_name != 'pull_request_target')
@@ -161,6 +161,8 @@ jobs:
       - fvdb-build # required to wait when the main job is done
       - versions
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # Required for AWS OIDC
     # required to stop the runner even if the error happened in the previous jobs, but only if the
     # start-build-runner job was not skipped
     if: ${{ always() && needs.start-build-runner.result != 'skipped' }}
@@ -186,6 +188,8 @@ jobs:
     name: Start EC2 GPU runner for tests
     needs: [fvdb-build, versions]
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # Required for AWS OIDC
     outputs:
       label: ${{ steps.start-tests-gpu-runner.outputs.label }}
       ec2-instance-id: ${{ steps.start-tests-gpu-runner.outputs.ec2-instance-id }}
@@ -438,6 +442,8 @@ jobs:
       - fvdb-docs-test # required to wait when the main job is done
       - versions
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # Required for AWS OIDC
     # required to stop the runner even if the error happened in the previous jobs
     # but only if the start-tests-gpu-runner job was not skipped
     if: ${{ always() && needs.start-tests-gpu-runner.result != 'skipped' }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -85,6 +85,7 @@ jobs:
         with:
           fetch-depth: 0 # Fetch all history for all branches
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha }}
+          persist-credentials: false
 
       - name: Fetch PR branch
         if: github.event_name == 'pull_request_target'
@@ -230,6 +231,7 @@ jobs:
         with:
           fetch-depth: 0 # Fetch all history for all branches
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha }}
+          persist-credentials: false
 
       - name: Fetch PR branch
         if: github.event_name == 'pull_request_target'
@@ -296,6 +298,7 @@ jobs:
         with:
           fetch-depth: 0 # Fetch all history for all branches
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha }}
+          persist-credentials: false
 
       - name: Fetch PR branch
         if: github.event_name == 'pull_request_target'
@@ -365,6 +368,7 @@ jobs:
         with:
           fetch-depth: 0 # Fetch all history for all branches
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha }}
+          persist-credentials: false
 
       - name: Fetch PR branch
         if: github.event_name == 'pull_request_target'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,7 +58,7 @@ jobs:
         uses: machulav/ec2-github-runner@v2
         with:
           mode: start
-          github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+          github-token: ${{ secrets.EC2_RUNNER_TOKEN }}
           ec2-image-id: ${{ needs.versions.outputs.aws-cpu-ami }}
           ec2-instance-type: m6a.8xlarge
           subnet-id: ${{ needs.versions.outputs.aws-subnet }}
@@ -173,7 +173,7 @@ jobs:
         uses: machulav/ec2-github-runner@v2
         with:
           mode: stop
-          github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+          github-token: ${{ secrets.EC2_RUNNER_TOKEN }}
           label: ${{ needs.start-build-runner.outputs.label }}
           ec2-instance-id: ${{ needs.start-build-runner.outputs.ec2-instance-id }}
 
@@ -199,7 +199,7 @@ jobs:
         uses: machulav/ec2-github-runner@v2
         with:
           mode: start
-          github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+          github-token: ${{ secrets.EC2_RUNNER_TOKEN }}
           ec2-image-id: ${{ needs.versions.outputs.aws-gpu-ami }}
           ec2-instance-type: g6.xlarge # 4 CPU-core, L4 GPU
           subnet-id: ${{ needs.versions.outputs.aws-subnet }}
@@ -447,6 +447,6 @@ jobs:
         uses: machulav/ec2-github-runner@v2
         with:
           mode: stop
-          github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+          github-token: ${{ secrets.EC2_RUNNER_TOKEN }}
           label: ${{ needs.start-tests-gpu-runner.outputs.label }}
           ec2-instance-id: ${{ needs.start-tests-gpu-runner.outputs.ec2-instance-id }}

--- a/.github/workflows/workflow-security.yml
+++ b/.github/workflows/workflow-security.yml
@@ -29,9 +29,9 @@ jobs:
     name: Scan workflows + enforce runner-token policy
     runs-on: ubuntu-latest
     env:
-      # Pinned tool versions. Bump deliberately; new releases may surface new
-      # findings.
-      ZIZMOR_VERSION: "1.*"
+      # Exact tool versions so the gate is deterministic. Bump deliberately;
+      # new releases may surface new findings that fail unrelated PRs.
+      ZIZMOR_VERSION: "1.26.1"
       ACTIONLINT_VERSION: "v1.7.7"
     steps:
       # 1. Trusted tree from BASE: the policy script lives here and is never

--- a/.github/workflows/workflow-security.yml
+++ b/.github/workflows/workflow-security.yml
@@ -33,6 +33,8 @@ jobs:
       # new releases may surface new findings that fail unrelated PRs.
       ZIZMOR_VERSION: "1.26.1"
       ACTIONLINT_VERSION: "v1.7.7"
+      PYYAML_VERSION: "6.0.3"
+      PYTEST_VERSION: "9.0.3"
     steps:
       # 1. Trusted tree from BASE: the policy script lives here and is never
       #    overwritten by the PR.
@@ -71,7 +73,7 @@ jobs:
       - name: Enforce EC2 runner token policy
         run: |
           set -euo pipefail
-          python3 -m pip install --quiet 'pyyaml==6.*' 'pytest>=8,<9'
+          python3 -m pip install --quiet "pyyaml==${PYYAML_VERSION}" "pytest==${PYTEST_VERSION}"
           python3 -m pytest .github/scripts/test_check_runner_token_policy.py -q
           leak_ref_args=()
           if [ "${GITHUB_EVENT_NAME}" = "pull_request_target" ]; then

--- a/.github/workflows/workflow-security.yml
+++ b/.github/workflows/workflow-security.yml
@@ -1,0 +1,84 @@
+name: Workflow Security
+
+# Why pull_request_target (not pull_request):
+#   This is a SECURITY GATE protecting tokens used for runner registration. With
+#   pull_request_target the workflow definition, the policy script, and the
+#   tooling all come from the BASE branch, so a malicious PR cannot edit the
+#   check to make it pass. We then overlay ONLY the PR head's proposed
+#   .github/workflows files as inert data and scan them -- we never execute any
+#   PR-provided code and expose no secrets (permissions are read-only).
+on:
+  # zizmor: ignore[dangerous-triggers] No secrets are used and no PR code is executed; the PR's workflow YAML is checked out as data only and scanned by base-controlled tooling.
+  pull_request_target:
+    branches:
+      - '**'
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  workflow-security:
+    name: Scan workflows + enforce runner-token policy
+    runs-on: ubuntu-latest
+    env:
+      # Pinned tool versions. Bump deliberately; new releases may surface new
+      # findings.
+      ZIZMOR_VERSION: "1.*"
+      ACTIONLINT_VERSION: "v1.7.7"
+    steps:
+      # 1. Trusted tree from BASE: the policy script lives here and is never
+      #    overwritten by the PR.
+      - name: Checkout base (trusted)
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      # 2. Overlay ONLY the PR head's proposed workflow files as data to scan.
+      #    Nothing from the PR is executed; the trusted scripts above are kept.
+      - name: Overlay PR workflow files (data only)
+        if: github.event_name == 'pull_request_target'
+        env:
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags --depth=1 origin "$HEAD_SHA"
+          # Replace the workflows dir with the PR's version; keep everything
+          # else (including .github/scripts) at the trusted base revision.
+          rm -rf .github/workflows
+          git checkout "$HEAD_SHA" -- .github/workflows
+          echo "Scanning PR workflow files from $HEAD_SHA:"
+          ls -1 .github/workflows
+
+      # 3a. Repo-specific policy: the admin runner token may only be used as the
+      #     github-token input to machulav/ec2-github-runner.
+      - name: Enforce EC2 runner token policy
+        run: |
+          set -euo pipefail
+          python3 -m pip install --quiet 'pyyaml==6.*'
+          python3 .github/scripts/check_runner_token_policy.py .github/workflows
+
+      # 3b. actionlint: workflow syntax / type / shell-injection issues.
+      - name: Run actionlint
+        run: |
+          set -euo pipefail
+          go install "github.com/rhysd/actionlint/cmd/actionlint@${ACTIONLINT_VERSION}"
+          "$(go env GOPATH)/bin/actionlint" -color
+
+      # 3c. zizmor: dangerous triggers, unpinned actions, credential exposure,
+      #     template injection, excessive permissions, etc.
+      - name: Run zizmor
+        env:
+          # Read-only default token enables zizmor's online audits.
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          python3 -m pip install --quiet "zizmor==${ZIZMOR_VERSION}"
+          zizmor --persona=regular .github/workflows

--- a/.github/workflows/workflow-security.yml
+++ b/.github/workflows/workflow-security.yml
@@ -43,29 +43,41 @@ jobs:
 
       # 2. Overlay ONLY the PR head's proposed workflow files as data to scan.
       #    Nothing from the PR is executed; the trusted scripts above are kept.
+      #    Fetch via the pull ref (refs/pull/<n>/head) rather than by SHA from
+      #    origin so this works for forked PRs too, where the head SHA is not
+      #    reachable from the base repo's branches.
       - name: Overlay PR workflow files (data only)
         if: github.event_name == 'pull_request_target'
         env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
-          git fetch --no-tags --depth=1 origin "$HEAD_SHA"
+          git fetch --no-tags --depth=1 origin "refs/pull/${PR_NUMBER}/head"
+          echo "Fetched PR #${PR_NUMBER} head $(git rev-parse FETCH_HEAD) (event head: ${HEAD_SHA})"
           # Replace the workflows dir with the PR's version; keep everything
           # else (including .github/scripts) at the trusted base revision.
           rm -rf .github/workflows
-          git checkout "$HEAD_SHA" -- .github/workflows
-          echo "Scanning PR workflow files from $HEAD_SHA:"
+          git checkout FETCH_HEAD -- .github/workflows
+          echo "Scanning PR workflow files:"
           ls -1 .github/workflows
 
       # 3a. Repo-specific policy: the admin runner token may only be used as the
       #     github-token input to machulav/ec2-github-runner. The policy script
       #     and its tests run from the trusted base checkout (not the PR).
+      #     Rules 2-4 scan the overlaid PR workflow files; the Rule 1 leak check
+      #     runs against the PR head commit tree (read-only) so it also catches
+      #     runner-token references the PR adds outside .github/workflows.
       - name: Enforce EC2 runner token policy
         run: |
           set -euo pipefail
           python3 -m pip install --quiet 'pyyaml==6.*' 'pytest>=8,<9'
           python3 -m pytest .github/scripts/test_check_runner_token_policy.py -q
-          python3 .github/scripts/check_runner_token_policy.py .github/workflows
+          leak_ref_args=()
+          if [ "${GITHUB_EVENT_NAME}" = "pull_request_target" ]; then
+            leak_ref_args=(--leak-check-ref FETCH_HEAD)
+          fi
+          python3 .github/scripts/check_runner_token_policy.py .github/workflows "${leak_ref_args[@]}"
 
       # 3b. actionlint: workflow syntax / type / shell-injection issues.
       - name: Run actionlint

--- a/.github/workflows/workflow-security.yml
+++ b/.github/workflows/workflow-security.yml
@@ -58,11 +58,13 @@ jobs:
           ls -1 .github/workflows
 
       # 3a. Repo-specific policy: the admin runner token may only be used as the
-      #     github-token input to machulav/ec2-github-runner.
+      #     github-token input to machulav/ec2-github-runner. The policy script
+      #     and its tests run from the trusted base checkout (not the PR).
       - name: Enforce EC2 runner token policy
         run: |
           set -euo pipefail
-          python3 -m pip install --quiet 'pyyaml==6.*'
+          python3 -m pip install --quiet 'pyyaml==6.*' 'pytest>=8,<9'
+          python3 -m pytest .github/scripts/test_check_runner_token_policy.py -q
           python3 .github/scripts/check_runner_token_policy.py .github/workflows
 
       # 3b. actionlint: workflow syntax / type / shell-injection issues.


### PR DESCRIPTION
This PR hardens our GitHub Actions CI, centered on the admin-scoped token used to register self-hosted EC2 runners. It migrates that token to a fine-grained, purpose-scoped credential; completes a zizmor/actionlint audit pass across all workflows (pin actions to commit SHAs, scope `id-token` permissions, justified trigger exemptions); and adds a new **Workflow Security** gate that enforces — automatically, on every PR — that the runner token can only ever be used as the `github-token` input to `machulav/ec2-github-runner`.

## Motivation

`secrets.EC2_RUNNER_TOKEN` has **Administration: Read/Write** on the repository — it has to, so `machulav/ec2-github-runner` can register and de-register runners. Our CI runs on `pull_request_target`, which is required to provision runners for PRs (by making the `EC2_RUNNER_TOKEN` available to PRs). This PR reduces the blast radius of that token and makes its safe usage a checked, enforceable invariant rather than a convention.

### The specific threat the new gate stops

A single PR cannot exfiltrate the token: under `pull_request_target` the *workflow definition* runs from the `base` branch (not the PR), and the token only ever lives in the runner start/stop jobs, which run on GitHub-hosted runners and never check out or execute PR code. The real risk is a **two-stage, time-of-merge attack**: a PR adds the token to a code-running job / `env:` / `run:` step (dormant — the base definition runs on the PR, so it looks harmless), a maintainer merges it, and the *next* run executes the now-poisoned base definition and leaks the token. The new scan catches that dangerous edit against the PR's proposed workflow files before it can land on `main`.

## What's in this PR

### 1. Token hardening

- Replace `GH_PERSONAL_ACCESS_TOKEN` with the fine-grained `EC2_RUNNER_TOKEN` for starting/stopping EC2 runners across `tests.yml`, `cu128.yml`, `cu130.yml`, `publish.yml`, and `nightly-publish.yml`.
- Remove unnecessary token usage from `sync-doc-version.yml` and only sync doc versions on publish.

### 2. zizmor / actionlint audit hardening

- Pin every third-party action to a commit SHA across all workflows.
- General zizmor audit fixes (credential handling, permissions, template-injection-prone patterns).
- Scope `id-token: write` (AWS OIDC) down to only the jobs/steps that actually assume an AWS role, instead of granting it workflow-wide.
- Add justified `zizmor: ignore[dangerous-triggers]` annotations on the `pull_request_target` triggers that are genuinely required to provision runners.

### 3. New Workflow Security gate

- `.github/workflows/workflow-security.yml` — runs on every PR (`pull_request_target`) and on push to `main`. Three scans: the repo-specific token policy (+ its unit tests), `actionlint`, and `zizmor`.
- `.github/scripts/check_runner_token_policy.py` — the repo-specific policy (rules below). Passes cleanly on all current workflows.
- `.github/scripts/test_check_runner_token_policy.py` — unit tests for the policy (compliant baseline, each violation class, the real repo workflows, and a fail-closed test for the leak check). Run by the Workflow Security job on every PR; needs only `pyyaml` + `pytest`, no fvdb build.
- Added `permissions: contents: read` to `codestyle.yml` and `docs-build-test.yml` so the whole workflow set passes `zizmor` at full strictness (no severity-threshold weakening).

#### The token policy (enforced by `check_runner_token_policy.py`)

1. The token name may appear **only** inside `.github/workflows/*.{yml,yaml}` (plus the enforcement script and its tests) — never in product source, etc.
2. Every textual occurrence in a workflow must be exactly `github-token: ${{ secrets.EC2_RUNNER_TOKEN }}`. This single rule forbids putting the token in `env:`, `GH_TOKEN`/`GITHUB_TOKEN`, `with.token`, a `run:` script, or a reusable-workflow `secrets:` block.
3. The step that consumes the token must `uses: machulav/ec2-github-runner`.
4. A job that references the token must not pull untrusted code into its workspace alongside the privileged context: no local actions (`uses: ./...`) and no `actions/checkout`.

#### Why `pull_request_target` (not `pull_request`) for the gate

Under `pull_request_target` the workflow definition, the policy script, and the scanner config all come from the `base` branch, so a malicious PR cannot edit the check to make it pass. The job overlays only the PR head's proposed `.github/workflows` files as inert data to scan — no PR code is executed and no secrets are exposed (`permissions: contents: read`).

## Required follow-up (repository admin — not code)

The scan only stops the two-stage attack if it **blocks the merge**. After this merges, make the check **`Scan workflows + enforce runner-token policy`** a **required status check** on `main` (and any release branches), via a branch ruleset or classic branch protection, and **do not allow admins to bypass it**. Because the workflow triggers on `pull_request_target` for every branch, it runs on every PR, so requiring it will not leave PRs stuck "waiting for status". Optionally add a `CODEOWNERS` entry on `.github/` so a human also reviews workflow diffs.