### PR TITLE
CI: correct the change-detection gate so docs-only PRs skip cleanly

### DIFF
--- a/.github/workflows/check-changes.yml
+++ b/.github/workflows/check-changes.yml
@@ -1,10 +1,10 @@
 # Copyright Contributors to the OpenVDB Project
 # SPDX-License-Identifier: Apache-2.0
 #
-# Reusable workflow: decide whether a PR touches real source files or only
-# documentation / non-code paths. Callers gate their expensive jobs on the
-# `should_test` output so docs-only PRs skip the work while still reporting
-# the required status checks (skipped == passed).
+# Reusable workflow: decide whether a PR needs testing, or touches only
+# skippable (docs / non-code) paths. Callers gate their expensive jobs on the
+# `should_test` output so skippable-only PRs skip the work while still
+# reporting the required status checks (skipped == passed).
 
 name: Check for relevant changes
 
@@ -12,60 +12,38 @@ on:
   workflow_call:
     outputs:
       should_test:
-        description: "'true' when any non-doc source file changed, 'false' for docs-only"
+        description: "'true' unless every changed file is a skippable (docs/non-code) path"
         value: ${{ jobs.check-changes.outputs.should_test }}
 
-# Permissions are inherited from the calling workflow; it must grant
-# pull-requests: read (or contents: read) so the PR file list can be read.
+# Permissions are inherited from the calling workflow.
 
 jobs:
   check-changes:
     name: Check for relevant changes
     runs-on: ubuntu-latest
     outputs:
-      should_test: ${{ steps.decide.outputs.should_test }}
+      # Run tests unless this is a PR whose files are ALL skippable paths.
+      should_test: ${{ github.event_name != 'pull_request_target' || steps.filter.outputs.skippable_only != 'true' }}
     steps:
-      - name: Decide whether tests should run
-        id: decide
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-
-          # Non-PR events (push to main, manual dispatch) always run the full suite.
-          if [ "${{ github.event_name }}" != "pull_request_target" ]; then
-            echo "Event is ${{ github.event_name }}; running tests."
-            echo "should_test=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          # List the files this PR changes (paginated, in case of large PRs).
-          files="$(gh api --paginate \
-            "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
-            --jq '.[].filename')"
-
-          echo "Changed files:"
-          printf '%s\n' "$files"
-
-          # Drop paths with no associated tests. NOTE: docs/ and notebooks/ are
-          # NOT excluded — the Doc Tests job runs `pytest --markdown-docs docs`
-          # and `pytest --nbmake notebooks/`, so changes there must run the suite.
-          # Only non-docs markdown (README, CHANGES, governance files, ...) and the
-          # tooling dirs are skipped. Anything left means a real source file changed.
-          code="$(printf '%s\n' "$files" | awk '
-            /^CODEOWNERS$/                { next }
-            /^debug\//                    { next }
-            /^devtools\//                 { next }
-            /^scripts\//                  { next }
-            /\.md$/ && $0 !~ /^docs\//    { next }
-            { print }
-          ')"
-
-          if [ -n "$code" ]; then
-            echo "Source files changed -> running tests:"
-            printf '%s\n' "$code"
-            echo "should_test=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "Docs-only change -> skipping build/tests."
-            echo "should_test=false" >> "$GITHUB_OUTPUT"
-          fi
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        id: filter
+        if: github.event_name == 'pull_request_target'
+        with:
+          # 'every' makes the filter true only when EVERY changed file matches one
+          # of these patterns, i.e. the PR touches only skippable paths; we invert
+          # that for should_test. A mixed PR (skippable + real source) has at least
+          # one non-matching file, so skippable_only is false and tests run.
+          #
+          # NOTE: docs/ and notebooks/ are intentionally NOT listed — the Doc Tests
+          # job runs `pytest --markdown-docs docs` and `pytest --nbmake notebooks/`,
+          # so changes there must run the suite. Only root-level `*.md` (README,
+          # CHANGES, governance docs) is skippable; `docs/**/*.md` is not matched by
+          # `*.md` and therefore still triggers tests.
+          predicate-quantifier: 'every'
+          filters: |
+            skippable_only:
+              - '*.md'
+              - 'CODEOWNERS'
+              - 'debug/**'
+              - 'devtools/**'
+              - 'scripts/**'

--- a/.github/workflows/check-changes.yml
+++ b/.github/workflows/check-changes.yml
@@ -1,10 +1,10 @@
 # Copyright Contributors to the OpenVDB Project
 # SPDX-License-Identifier: Apache-2.0
 #
-# Reusable workflow: detect whether a PR touches source files or only
-# documentation / non-code paths. Callers gate their real jobs on the
-# `should_test` output so that docs-only PRs are marked as passed
-# (not perpetually "waiting for status").
+# Reusable workflow: decide whether a PR touches real source files or only
+# documentation / non-code paths. Callers gate their expensive jobs on the
+# `should_test` output so docs-only PRs skip the work while still reporting
+# the required status checks (skipped == passed).
 
 name: Check for relevant changes
 
@@ -12,34 +12,60 @@ on:
   workflow_call:
     outputs:
       should_test:
-        description: "'true' when the change includes source files, 'false' for docs-only"
+        description: "'true' when any non-doc source file changed, 'false' for docs-only"
         value: ${{ jobs.check-changes.outputs.should_test }}
 
-# Permissions are inherited from the calling workflow; do not set them here.
+# Permissions are inherited from the calling workflow; it must grant
+# pull-requests: read (or contents: read) so the PR file list can be read.
 
 jobs:
   check-changes:
     name: Check for relevant changes
     runs-on: ubuntu-latest
     outputs:
-      should_test: ${{ github.event_name != 'pull_request_target' || steps.filter.outputs.src == 'true' }}
+      should_test: ${{ steps.decide.outputs.should_test }}
     steps:
-      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
-        id: filter
-        if: github.event_name == 'pull_request_target'
-        with:
-          # Use the default 'some' quantifier: `src` is true when AT LEAST ONE
-          # changed file is outside the excluded paths below. A PR mixing
-          # excluded and non-excluded files therefore still runs the tests; only
-          # a PR whose files are ALL in excluded paths is treated as skippable.
-          # Do NOT use 'every' here — that would skip the tests whenever any file
-          # is excluded (e.g. a code change that also touches a README), leaving
-          # real changes untested.
-          filters: |
-            src:
-              - '**'
-              - '!**/*.md'
-              - '!CODEOWNERS'
-              - '!debug/**'
-              - '!devtools/**'
-              - '!scripts/**'
+      - name: Decide whether tests should run
+        id: decide
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          # Non-PR events (push to main, manual dispatch) always run the full suite.
+          if [ "${{ github.event_name }}" != "pull_request_target" ]; then
+            echo "Event is ${{ github.event_name }}; running tests."
+            echo "should_test=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # List the files this PR changes (paginated, in case of large PRs).
+          files="$(gh api --paginate \
+            "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
+            --jq '.[].filename')"
+
+          echo "Changed files:"
+          printf '%s\n' "$files"
+
+          # Drop paths with no associated tests. NOTE: docs/ and notebooks/ are
+          # NOT excluded — the Doc Tests job runs `pytest --markdown-docs docs`
+          # and `pytest --nbmake notebooks/`, so changes there must run the suite.
+          # Only non-docs markdown (README, CHANGES, governance files, ...) and the
+          # tooling dirs are skipped. Anything left means a real source file changed.
+          code="$(printf '%s\n' "$files" | awk '
+            /^CODEOWNERS$/                { next }
+            /^debug\//                    { next }
+            /^devtools\//                 { next }
+            /^scripts\//                  { next }
+            /\.md$/ && $0 !~ /^docs\//    { next }
+            { print }
+          ')"
+
+          if [ -n "$code" ]; then
+            echo "Source files changed -> running tests:"
+            printf '%s\n' "$code"
+            echo "should_test=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Docs-only change -> skipping build/tests."
+            echo "should_test=false" >> "$GITHUB_OUTPUT"
+          fi

--- a/.github/workflows/check-changes.yml
+++ b/.github/workflows/check-changes.yml
@@ -29,11 +29,12 @@ jobs:
         if: github.event_name == 'pull_request_target'
         with:
           # Use the default 'some' quantifier: `src` is true when AT LEAST ONE
-          # changed file is a source file. A mixed PR (code + docs) therefore
-          # still runs the tests; only a PR whose files are ALL docs/non-code is
-          # treated as docs-only. Do NOT use 'every' here — that would skip the
-          # tests whenever any file is excluded (e.g. a code change that also
-          # touches a README), leaving real source changes untested.
+          # changed file is outside the excluded paths below. A PR mixing
+          # excluded and non-excluded files therefore still runs the tests; only
+          # a PR whose files are ALL in excluded paths is treated as skippable.
+          # Do NOT use 'every' here — that would skip the tests whenever any file
+          # is excluded (e.g. a code change that also touches a README), leaving
+          # real changes untested.
           filters: |
             src:
               - '**'

--- a/.github/workflows/check-changes.yml
+++ b/.github/workflows/check-changes.yml
@@ -28,7 +28,12 @@ jobs:
         id: filter
         if: github.event_name == 'pull_request_target'
         with:
-          predicate-quantifier: 'every'
+          # Use the default 'some' quantifier: `src` is true when AT LEAST ONE
+          # changed file is a source file. A mixed PR (code + docs) therefore
+          # still runs the tests; only a PR whose files are ALL docs/non-code is
+          # treated as docs-only. Do NOT use 'every' here — that would skip the
+          # tests whenever any file is excluded (e.g. a code change that also
+          # touches a README), leaving real source changes untested.
           filters: |
             src:
               - '**'


### PR DESCRIPTION
## Approach

Gate the expensive build/GPU jobs on whether the PR touches anything that needs testing. Uses `dorny/paths-filter` with a **positive allowlist of skippable paths + `predicate-quantifier: every`, inverted**:

- `skippable_only` is true only when *every* changed file is a skippable path (`*.md` root-level only, `CODEOWNERS`, `debug/`, `devtools/`, `scripts/`).
- `should_test = !skippable_only`.

**`docs/` and `notebooks/` are intentionally NOT skippable** — the Doc Tests job runs `pytest --markdown-docs docs` and `pytest --nbmake notebooks/`, so changes there must run the suite. Root-level `*.md` (README/CHANGES/governance) is skippable; `docs/**/*.md`, `examples/**`, etc. are not matched by `*.md` and still trigger tests.

Replaces the earlier `**`+negation `every` form (which also skipped mixed source+docs PRs) and the interim shell script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)