### PR TITLE
Release v0.5.0

### DIFF
--- a/.github/versions.json
+++ b/.github/versions.json
@@ -23,7 +23,7 @@
   },
   "cmake_version": "4.0.3",
   "uv": {
-    "version": "0.7.5",
+    "version": "0.11.26",
     "action_sha": "d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86"
   },
   "docker_os": {

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -55,7 +55,7 @@ author = "Contributors to the OpenVDB Project"
 
 # Stable fvdb-core version shown in installation examples.
 # Updated automatically by devtools/update-doc-versions.sh during release.
-fvdb_core_stable_version = "0.4.2"
+fvdb_core_stable_version = "0.5.0"
 
 version = fvdb_core_stable_version
 release = fvdb_core_stable_version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "fvdb-core"
-version = "0.5.0.dev0"
+version = "0.5.0"
 license = { text = "Apache-2.0" }
 requires-python = ">=3.10"
 readme = "README.md"


### PR DESCRIPTION
## Release v0.5.0

Track the release burndown for `release/v0.5`.

**Note:** This PR is intentionally a draft and will **not** be merged directly.
`finish-release.sh` will close this PR and create an `adopt/v0.5`
branch that reconciles the version in `pyproject.toml` before merging into
`main`.

### Checklist

- [x] Publish workflow passing on `release/v0.5` (builds + smoke tests)
- [x] All planned fixes merged into `release/v0.5`
- [ ] Code freeze applied (branch protection tightened)
- [x] Release notes drafted

### Release command

```bash
./devtools/finish-release.sh 0.5.0
```