### PR TITLE
CI: bump uv to 0.11.26 so Python 3.14 builds use stable CPython

### DIFF
--- a/.github/versions.json
+++ b/.github/versions.json
@@ -23,7 +23,7 @@
   },
   "cmake_version": "4.0.3",
   "uv": {
-    "version": "0.7.5",
+    "version": "0.11.26",
     "action_sha": "d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86"
   },
   "docker_os": {


### PR DESCRIPTION
## Problem

Both Python 3.14 variants of `publish.yml` fail on `release/v0.5` (run [28566079399](https://github.com/openvdb/fvdb-core/actions/runs/28566079399)), and the same two jobs fail in `nightly-publish.yml` on `main` (run [28433783911](https://github.com/openvdb/fvdb-core/actions/runs/28433783911)). The 3.14 lane has never built successfully since it was added in #573.

The CMake error is misleading:

```
Segmentation fault
CMake Error at src/cmake/get_torch.cmake:21 (message):
  Failed to import PyTorch.
```

## Root cause

`.github/versions.json` pins uv 0.7.5 (May 2025), which predates the stable CPython 3.14.0 release. Its bundled python-build-standalone list tops out at the March 2025 alpha, so the build jobs install a pre-release interpreter:

```
Run uv python install 3.14
Downloading cpython-3.14.0a6-linux-x86_64-gnu
Installed Python 3.14.0a6
```

The torch 2.11 `cp314` wheel installs fine (the alpha reports the `cp314` tag) but is compiled against the stable 3.14 ABI, which CPython alphas don't guarantee — so `import torch` segfaults inside the `get_torch.cmake` probe. Python 3.10–3.13 are unaffected because uv 0.7.5 knows stable builds of those series.

## Fix

Bump `uv.version` to 0.11.26. Verified locally that it resolves `3.14` to stable CPython 3.14.6. No workflow changes needed: the pinned `setup-uv` action (v5.4.2) installs whatever uv version is requested, downloading by URL and skipping checksum validation for versions not in its manifest.

Side effect: newer patch releases of 3.10–3.13 will also be picked up.

## After merge

This needs to be cherry-picked to `main` per the burndown process — nightly-publish there hits the same failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)