### PR TITLE
Replace unintended usage of cudaEventCreate with cudaEventCreateWithFlags

### DIFF
--- a/src/fvdb/detail/ops/gsplat/EvaluateSphericalHarmonicsBackward.cu
+++ b/src/fvdb/detail/ops/gsplat/EvaluateSphericalHarmonicsBackward.cu
@@ -573,7 +573,7 @@ dispatchEvaluateSphericalHarmonicsBwd<torch::kPrivateUse1>(
         for (const auto deviceId: c10::irange(c10::cuda::device_count())) {
             C10_CUDA_CHECK(cudaSetDevice(deviceId));
             auto stream = c10::cuda::getCurrentCUDAStream(deviceId);
-            C10_CUDA_CHECK(cudaEventCreate(&events[deviceId], cudaEventDisableTiming));
+            C10_CUDA_CHECK(cudaEventCreateWithFlags(&events[deviceId], cudaEventDisableTiming));
             C10_CUDA_CHECK(cudaEventRecord(events[deviceId], stream));
         }
 
@@ -722,7 +722,7 @@ dispatchEvaluateSphericalHarmonicsBwd<torch::kPrivateUse1>(
         for (const auto deviceId: c10::irange(c10::cuda::device_count())) {
             C10_CUDA_CHECK(cudaSetDevice(deviceId));
             auto stream = c10::cuda::getCurrentCUDAStream(deviceId);
-            C10_CUDA_CHECK(cudaEventCreate(&events[deviceId], cudaEventDisableTiming));
+            C10_CUDA_CHECK(cudaEventCreateWithFlags(&events[deviceId], cudaEventDisableTiming));
             C10_CUDA_CHECK(cudaEventRecord(events[deviceId], stream));
         }
 

--- a/src/fvdb/detail/ops/gsplat/FusedSSIM.cu
+++ b/src/fvdb/detail/ops/gsplat/FusedSSIM.cu
@@ -658,7 +658,7 @@ fusedSSIMPrivateUse1(
     for (const auto deviceId: c10::irange(c10::cuda::device_count())) {
         C10_CUDA_CHECK(cudaSetDevice(deviceId));
         auto stream = c10::cuda::getCurrentCUDAStream(deviceId);
-        C10_CUDA_CHECK(cudaEventCreate(&events[deviceId], cudaEventDisableTiming));
+        C10_CUDA_CHECK(cudaEventCreateWithFlags(&events[deviceId], cudaEventDisableTiming));
         C10_CUDA_CHECK(cudaEventRecord(events[deviceId], stream));
     }
 
@@ -780,7 +780,7 @@ fusedSSIMBackwardPrivateUse1(double C1,
     for (const auto deviceId: c10::irange(c10::cuda::device_count())) {
         C10_CUDA_CHECK(cudaSetDevice(deviceId));
         auto stream = c10::cuda::getCurrentCUDAStream(deviceId);
-        C10_CUDA_CHECK(cudaEventCreate(&events[deviceId], cudaEventDisableTiming));
+        C10_CUDA_CHECK(cudaEventCreateWithFlags(&events[deviceId], cudaEventDisableTiming));
         C10_CUDA_CHECK(cudaEventRecord(events[deviceId], stream));
     }
 

--- a/src/fvdb/detail/ops/gsplat/IntersectGaussianTiles.cu
+++ b/src/fvdb/detail/ops/gsplat/IntersectGaussianTiles.cu
@@ -860,7 +860,7 @@ intersectGaussianTilesPrivateUse1Impl(
         for (const auto deviceId: c10::irange(deviceCount)) {
             C10_CUDA_CHECK(cudaSetDevice(deviceId));
             auto stream = c10::cuda::getCurrentCUDAStream(deviceId);
-            C10_CUDA_CHECK(cudaEventCreate(&events[deviceId], cudaEventDisableTiming));
+            C10_CUDA_CHECK(cudaEventCreateWithFlags(&events[deviceId], cudaEventDisableTiming));
             C10_CUDA_CHECK(cudaEventRecord(events[deviceId], stream));
         }
 

--- a/src/fvdb/detail/ops/gsplat/ProjectGaussiansAnalyticBackward.cu
+++ b/src/fvdb/detail/ops/gsplat/ProjectGaussiansAnalyticBackward.cu
@@ -455,7 +455,7 @@ dispatchProjectGaussiansAnalyticBwd<torch::kPrivateUse1>(
         for (const auto deviceId: c10::irange(c10::cuda::device_count())) {
             C10_CUDA_CHECK(cudaSetDevice(deviceId));
             auto stream = c10::cuda::getCurrentCUDAStream(deviceId);
-            C10_CUDA_CHECK(cudaEventCreate(&events[deviceId], cudaEventDisableTiming));
+            C10_CUDA_CHECK(cudaEventCreateWithFlags(&events[deviceId], cudaEventDisableTiming));
             C10_CUDA_CHECK(cudaEventRecord(events[deviceId], stream));
         }
 

--- a/src/fvdb/detail/ops/gsplat/RasterizeScreenSpaceGaussiansBackward.cu
+++ b/src/fvdb/detail/ops/gsplat/RasterizeScreenSpaceGaussiansBackward.cu
@@ -1225,7 +1225,7 @@ callRasterizeBackwardPrivateUse1(
     for (const auto deviceId: c10::irange(c10::cuda::device_count())) {
         C10_CUDA_CHECK(cudaSetDevice(deviceId));
         auto stream = c10::cuda::getCurrentCUDAStream(deviceId);
-        C10_CUDA_CHECK(cudaEventCreate(&events[deviceId], cudaEventDisableTiming));
+        C10_CUDA_CHECK(cudaEventCreateWithFlags(&events[deviceId], cudaEventDisableTiming));
         C10_CUDA_CHECK(cudaEventRecord(events[deviceId], stream));
     }
 

--- a/src/fvdb/detail/ops/gsplat/RasterizeScreenSpaceGaussiansForward.cu
+++ b/src/fvdb/detail/ops/gsplat/RasterizeScreenSpaceGaussiansForward.cu
@@ -692,7 +692,7 @@ launchRasterizeForwardKernels(
     for (const auto deviceId: c10::irange(c10::cuda::device_count())) {
         C10_CUDA_CHECK(cudaSetDevice(deviceId));
         auto stream = c10::cuda::getCurrentCUDAStream(deviceId);
-        C10_CUDA_CHECK(cudaEventCreate(&events[deviceId], cudaEventDisableTiming));
+        C10_CUDA_CHECK(cudaEventCreateWithFlags(&events[deviceId], cudaEventDisableTiming));
         C10_CUDA_CHECK(cudaEventRecord(events[deviceId], stream));
     }
 

--- a/src/fvdb/detail/utils/cuda/Utils.cuh
+++ b/src/fvdb/detail/utils/cuda/Utils.cuh
@@ -50,13 +50,13 @@ mergeStreams() {
     for (const auto deviceId: c10::irange(c10::cuda::device_count())) {
         C10_CUDA_CHECK(cudaSetDevice(deviceId));
         auto stream = c10::cuda::getCurrentCUDAStream(deviceId);
-        C10_CUDA_CHECK(cudaEventCreate(&events[deviceId], cudaEventDisableTiming));
+        C10_CUDA_CHECK(cudaEventCreateWithFlags(&events[deviceId], cudaEventDisableTiming));
         C10_CUDA_CHECK(cudaEventRecord(events[deviceId], stream));
     }
 
     // Create an event on the merge device
     C10_CUDA_CHECK(cudaSetDevice(mergeDeviceId));
-    C10_CUDA_CHECK(cudaEventCreate(&mergeEvent, cudaEventDisableTiming));
+    C10_CUDA_CHECK(cudaEventCreateWithFlags(&mergeEvent, cudaEventDisableTiming));
     auto mergeStream = c10::cuda::getCurrentCUDAStream(mergeDeviceId);
     // On the merge stream, wait until the per-device events have completed
     for (const auto deviceId: c10::irange(c10::cuda::device_count())) {


### PR DESCRIPTION
Creating a CUDA event with flags requires using `cudaEventCreateWithFlags`.