### PR TITLE
Add native level-set and fog-volume rendering to fvdb.viz

### DIFF
--- a/fvdb/_fvdb_cpp.pyi
+++ b/fvdb/_fvdb_cpp.pyi
@@ -1331,6 +1331,21 @@ class Viewer:
         width: int,
         height: int,
     ) -> None: ...
+    def add_level_set_view(
+        self,
+        scene_name: str,
+        name: str,
+        grid: GridBatchData,
+        sdf: JaggedTensor,
+    ) -> None: ...
+    def add_fog_volume_view(
+        self,
+        scene_name: str,
+        name: str,
+        grid: GridBatchData,
+        density: JaggedTensor,
+    ) -> None: ...
+    def has_nanovdb_view(self, name: str) -> bool: ...
     def wait_for_interrupt(self) -> None: ...
 
 class config:

--- a/fvdb/viz/__init__.py
+++ b/fvdb/viz/__init__.py
@@ -2,8 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 from ._camera_view import CamerasView
+from ._fog_volume_view import FogVolumeView
 from ._gaussian_splat_3d_view import GaussianSplat3dView, ShOrderingMode
 from ._image_view import ImageView
+from ._level_set_view import LevelSetView
 from ._point_cloud_view import PointCloudView
 from ._scene import Scene, get_scene
 from ._utils import grid_edge_network, gridbatch_edge_network
@@ -13,9 +15,11 @@ __all__ = [
     "init",
     "show",
     "wait_for_interrupt",
+    "FogVolumeView",
     "GaussianSplat3dView",
     "CamerasView",
     "ImageView",
+    "LevelSetView",
     "get_scene",
     "ShOrderingMode",
     "PointCloudView",

--- a/fvdb/viz/_fog_volume_view.py
+++ b/fvdb/viz/_fog_volume_view.py
@@ -1,0 +1,72 @@
+# Copyright Contributors to the OpenVDB Project
+# SPDX-License-Identifier: Apache-2.0
+#
+from typing import TYPE_CHECKING, Any
+
+import torch
+
+from ._nanovdb_grid_view import update_nanovdb_grid_views
+
+if TYPE_CHECKING:
+    from .. import Grid, GridBatch, JaggedTensor
+
+
+class FogVolumeView:
+    """
+    A view for rendering an fvdb :class:`~fvdb.Grid` (or :class:`~fvdb.GridBatch`) as a
+    volumetric fog in the viewer.
+
+    The grid is rendered via ray-marching using the ``nanovdb_render`` pipeline.  Per-voxel
+    density values are stored as float32 blind metadata on the ONINDEX NanoVDB grid.
+
+    The nanovdb-editor renders one grid per view.  A :class:`~fvdb.GridBatch` with more
+    than one grid is therefore expanded into one view per grid, named ``name[i]``.
+    """
+
+    __PRIVATE__ = object()
+
+    def __init__(
+        self,
+        scene_name: str,
+        name: str,
+        view_names: list[str],
+        _private: Any = None,
+    ):
+        """
+        .. warning::
+
+            This constructor is private.  Use :meth:`fvdb.viz.Scene.add_fog_volume` instead.
+        """
+        if _private is not self.__PRIVATE__:
+            raise ValueError("FogVolumeView constructor is private. Use Scene.add_fog_volume().")
+        self._scene_name = scene_name
+        self._name = name
+        # The editor view names backing this fog volume (one per grid in the batch).
+        self._view_names = view_names
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def scene_name(self) -> str:
+        return self._scene_name
+
+    @torch.no_grad()
+    def update(self, grid: "Grid | GridBatch", density: "JaggedTensor") -> None:
+        """
+        Replace the fog-volume data in the viewer.
+
+        Args:
+            grid: The sparse grid (or batch of grids) the density field lives on.
+            density: Per-voxel float32 density values (one per active voxel, non-negative).
+        """
+        self._view_names = update_nanovdb_grid_views(
+            self._scene_name,
+            self._name,
+            self._view_names,
+            grid,
+            density,
+            "add_fog_volume_view",
+            "density",
+        )

--- a/fvdb/viz/_level_set_view.py
+++ b/fvdb/viz/_level_set_view.py
@@ -1,0 +1,73 @@
+# Copyright Contributors to the OpenVDB Project
+# SPDX-License-Identifier: Apache-2.0
+#
+from typing import TYPE_CHECKING, Any
+
+import torch
+
+from ._nanovdb_grid_view import update_nanovdb_grid_views
+
+if TYPE_CHECKING:
+    from .. import Grid, GridBatch, JaggedTensor
+
+
+class LevelSetView:
+    """
+    A view for rendering an fvdb :class:`~fvdb.Grid` (or :class:`~fvdb.GridBatch`) as an
+    isosurface in the viewer.
+
+    The grid is rendered via HDDA zero-crossing of the signed distance field using the
+    ``nanovdb_surface`` pipeline.  The SDF values are stored as float32 blind metadata
+    on the ONINDEX NanoVDB grid so no tree reconstruction is required.
+
+    The nanovdb-editor renders one grid per view.  A :class:`~fvdb.GridBatch` with more
+    than one grid is therefore expanded into one view per grid, named ``name[i]``.
+    """
+
+    __PRIVATE__ = object()
+
+    def __init__(
+        self,
+        scene_name: str,
+        name: str,
+        view_names: list[str],
+        _private: Any = None,
+    ):
+        """
+        .. warning::
+
+            This constructor is private.  Use :meth:`fvdb.viz.Scene.add_level_set` instead.
+        """
+        if _private is not self.__PRIVATE__:
+            raise ValueError("LevelSetView constructor is private. Use Scene.add_level_set().")
+        self._scene_name = scene_name
+        self._name = name
+        # The editor view names backing this level set (one per grid in the batch).
+        self._view_names = view_names
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def scene_name(self) -> str:
+        return self._scene_name
+
+    @torch.no_grad()
+    def update(self, grid: "Grid | GridBatch", sdf: "JaggedTensor") -> None:
+        """
+        Replace the level-set data in the viewer.
+
+        Args:
+            grid: The sparse grid (or batch of grids) the SDF lives on.
+            sdf: Per-voxel float32 SDF values (one per active voxel, world-space units).
+        """
+        self._view_names = update_nanovdb_grid_views(
+            self._scene_name,
+            self._name,
+            self._view_names,
+            grid,
+            sdf,
+            "add_level_set_view",
+            "sdf",
+        )

--- a/fvdb/viz/_nanovdb_grid_view.py
+++ b/fvdb/viz/_nanovdb_grid_view.py
@@ -1,0 +1,113 @@
+# Copyright Contributors to the OpenVDB Project
+# SPDX-License-Identifier: Apache-2.0
+#
+"""Shared helpers for adding fvdb grids to the viewer as NanoVDB grid views.
+
+The nanovdb-editor renders exactly one grid per view (the shader decodes a single
+grid anchored at byte offset 0 of the uploaded buffer). A :class:`~fvdb.GridBatch`
+may hold many grids, so a batch is expanded into one named editor view per grid:
+the base ``name`` when the batch holds a single grid, or ``name[i]`` for grid ``i``
+of a multi-grid batch.
+"""
+from typing import TYPE_CHECKING
+
+import torch
+
+from ._viewer_server import _get_viewer_server_cpp
+
+if TYPE_CHECKING:
+    from .. import Grid, GridBatch, JaggedTensor
+
+
+def _to_grid_batch(grid: "Grid | GridBatch") -> "GridBatch":
+    """Normalize a :class:`~fvdb.Grid` or :class:`~fvdb.GridBatch` to a ``GridBatch``."""
+    from .. import Grid, GridBatch
+
+    if isinstance(grid, Grid):
+        return grid.to_gridbatch()
+    if isinstance(grid, GridBatch):
+        return grid
+    raise TypeError(f"grid must be a fvdb.Grid or fvdb.GridBatch, got {type(grid).__name__}")
+
+
+def _validate_values(values: "JaggedTensor", grid_batch: "GridBatch", arg_name: str) -> None:
+    """Validate that ``values`` holds one float32 value per active voxel in ``grid_batch``."""
+    from .. import JaggedTensor
+
+    if not isinstance(values, JaggedTensor):
+        raise TypeError(f"{arg_name} must be a fvdb.JaggedTensor, got {type(values).__name__}")
+    if values.jdata.dtype != torch.float32:
+        raise TypeError(f"{arg_name} must be a float32 JaggedTensor, got {values.jdata.dtype}")
+    if values.jdata.ndim != 1 or values.jdata.shape[0] != grid_batch.total_voxels:
+        raise ValueError(
+            f"{arg_name} must be 1D with {grid_batch.total_voxels} entries "
+            f"(one per active voxel across the batch), got shape {tuple(values.jdata.shape)}"
+        )
+
+
+def _sub_view_name(name: str, index: int, count: int) -> str:
+    """Return the per-grid view name: ``name`` for a single grid, else ``name[index]``."""
+    return name if count == 1 else f"{name}[{index}]"
+
+
+def add_nanovdb_grid_views(
+    scene_name: str,
+    name: str,
+    grid: "Grid | GridBatch",
+    values: "JaggedTensor",
+    server_method: str,
+    arg_name: str,
+) -> list[str]:
+    """Add one NanoVDB grid view per grid in ``grid`` and return the created view names.
+
+    Args:
+        scene_name: The scene to add the views to.
+        name: Base name for the view(s). A single grid uses ``name``; a multi-grid
+            batch uses ``name[i]`` for grid ``i``.
+        grid: A :class:`~fvdb.Grid` or :class:`~fvdb.GridBatch` defining the domain.
+        values: A float32 :class:`~fvdb.JaggedTensor` with one value per active voxel
+            across the whole batch.
+        server_method: Name of the viewer-server method to call per grid, which selects the
+            render pipeline (e.g. ``"add_level_set_view"`` or ``"add_fog_volume_view"``).
+        arg_name: Name of the ``values`` argument, used in error messages (e.g. ``"sdf"``).
+
+    Returns:
+        view_names (list[str]): The names of the editor views that were created.
+    """
+    grid_batch = _to_grid_batch(grid)
+    _validate_values(values, grid_batch, arg_name)
+
+    server = _get_viewer_server_cpp()
+    add_one = getattr(server, server_method)
+    count = grid_batch.grid_count
+    view_names: list[str] = []
+    for i in range(count):
+        sub_name = _sub_view_name(name, i, count)
+        add_one(scene_name, sub_name, grid_batch[i].data, values[i]._impl)
+        view_names.append(sub_name)
+    return view_names
+
+
+def update_nanovdb_grid_views(
+    scene_name: str,
+    name: str,
+    prev_view_names: list[str],
+    grid: "Grid | GridBatch",
+    values: "JaggedTensor",
+    server_method: str,
+    arg_name: str,
+) -> list[str]:
+    """Re-add grid views for ``grid``/``values``, removing views left stale by a topology change.
+
+    Views that share a name with the previous set are overwritten in place (no flicker);
+    any previous view whose name is no longer produced (e.g. the batch shrank) is removed.
+
+    Returns:
+        view_names (list[str]): The names of the editor views after the update.
+    """
+    view_names = add_nanovdb_grid_views(scene_name, name, grid, values, server_method, arg_name)
+
+    server = _get_viewer_server_cpp()
+    for stale in set(prev_view_names) - set(view_names):
+        server.remove_view(scene_name, stale)
+    return view_names

--- a/fvdb/viz/_scene.py
+++ b/fvdb/viz/_scene.py
@@ -242,9 +242,7 @@ class Scene:
         Returns:
             level_set_view (LevelSetView): The newly created view.
         """
-        view_names = add_nanovdb_grid_views(
-            self._name, name, grid, sdf, "add_level_set_view", "sdf"
-        )
+        view_names = add_nanovdb_grid_views(self._name, name, grid, sdf, "add_level_set_view", "sdf")
         return LevelSetView(
             scene_name=self._name,
             name=name,
@@ -282,9 +280,7 @@ class Scene:
         Returns:
             fog_volume_view (FogVolumeView): The newly created view.
         """
-        view_names = add_nanovdb_grid_views(
-            self._name, name, grid, density, "add_fog_volume_view", "density"
-        )
+        view_names = add_nanovdb_grid_views(self._name, name, grid, density, "add_fog_volume_view", "density")
         return FogVolumeView(
             scene_name=self._name,
             name=name,

--- a/fvdb/viz/_scene.py
+++ b/fvdb/viz/_scene.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 import logging
+from typing import TYPE_CHECKING
 
 import numpy as np
 import torch
@@ -18,10 +19,16 @@ from ..types import (
     to_Vec3fBatch,
 )
 from ._camera_view import CamerasView
+from ._fog_volume_view import FogVolumeView
 from ._gaussian_splat_3d_view import GaussianSplat3dView
 from ._image_view import ImageView
+from ._level_set_view import LevelSetView
+from ._nanovdb_grid_view import add_nanovdb_grid_views
 from ._point_cloud_view import PointCloudView
 from ._viewer_server import _get_viewer_server_cpp
+
+if TYPE_CHECKING:
+    from .. import Grid, GridBatch, JaggedTensor
 
 
 def get_scene(name: str = "fVDB Scene") -> "Scene":
@@ -202,6 +209,87 @@ class Scene:
             width=width,
             height=height,
             _private=ImageView.__PRIVATE__,
+        )
+
+    @torch.no_grad()
+    def add_level_set(
+        self,
+        name: str,
+        grid: "Grid | GridBatch",
+        sdf: "JaggedTensor",
+    ) -> LevelSetView:
+        """
+        Add an fvdb sparse grid with per-voxel SDF values to the viewer as an isosurface.
+
+        The surface is rendered by the ``nanovdb_surface`` pipeline (HDDA zero-crossing).
+        If a view with ``name`` already exists it is replaced.
+
+        .. note::
+
+            The nanovdb-editor renders one grid per view.  If ``grid`` is a
+            :class:`~fvdb.GridBatch` with more than one grid, one view is created per
+            grid, named ``name[i]`` for grid ``i``.
+
+        Args:
+            name (str): Unique name for this view within the scene.
+            grid: A :class:`~fvdb.Grid` or :class:`~fvdb.GridBatch` whose active voxels
+                define the domain.
+            sdf: A :class:`~fvdb.JaggedTensor` of shape ``(N,)`` and dtype ``float32``
+                containing one signed-distance value per active voxel (summed over the
+                batch), in world-space units.  Negative values are inside the surface,
+                positive values are outside.
+
+        Returns:
+            level_set_view (LevelSetView): The newly created view.
+        """
+        view_names = add_nanovdb_grid_views(
+            self._name, name, grid, sdf, "add_level_set_view", "sdf"
+        )
+        return LevelSetView(
+            scene_name=self._name,
+            name=name,
+            view_names=view_names,
+            _private=LevelSetView.__PRIVATE__,
+        )
+
+    @torch.no_grad()
+    def add_fog_volume(
+        self,
+        name: str,
+        grid: "Grid | GridBatch",
+        density: "JaggedTensor",
+    ) -> FogVolumeView:
+        """
+        Add an fvdb sparse grid with per-voxel density values to the viewer as a fog volume.
+
+        The volume is rendered by the ``nanovdb_render`` pipeline (ray-marcher).
+        If a view with ``name`` already exists it is replaced.
+
+        .. note::
+
+            The nanovdb-editor renders one grid per view.  If ``grid`` is a
+            :class:`~fvdb.GridBatch` with more than one grid, one view is created per
+            grid, named ``name[i]`` for grid ``i``.
+
+        Args:
+            name (str): Unique name for this view within the scene.
+            grid: A :class:`~fvdb.Grid` or :class:`~fvdb.GridBatch` whose active voxels
+                define the domain.
+            density: A :class:`~fvdb.JaggedTensor` of shape ``(N,)`` and dtype ``float32``
+                containing one non-negative density value per active voxel (summed over
+                the batch).
+
+        Returns:
+            fog_volume_view (FogVolumeView): The newly created view.
+        """
+        view_names = add_nanovdb_grid_views(
+            self._name, name, grid, density, "add_fog_volume_view", "density"
+        )
+        return FogVolumeView(
+            scene_name=self._name,
+            name=name,
+            view_names=view_names,
+            _private=FogVolumeView.__PRIVATE__,
         )
 
     @torch.no_grad()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "torch>=2.8",
     "numpy",
 ]
-optional-dependencies = {viewer = ["nanovdb-editor>=0.1.4,<0.2.0"]}
+optional-dependencies = {viewer = ["nanovdb-editor>=0.1.5,<0.2.0"]}
 classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "torch>=2.8",
     "numpy",
 ]
-optional-dependencies = {viewer = ["nanovdb-editor>=0.0.23,<0.2.0"]}
+optional-dependencies = {viewer = ["nanovdb-editor>=0.1.4,<0.2.0"]}
 classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",

--- a/src/cmake/get_nanovdb_editor.cmake
+++ b/src/cmake/get_nanovdb_editor.cmake
@@ -12,8 +12,9 @@ set(NANOVDB_EDITOR_BUILD_TYPE "Release" CACHE STRING "Build type for nanovdb_edi
 # Note: only change this when the interfaces have changed
 # 7efb611: adds add_nanovdb_3 API and pnanovdb_pipeline_type_nanovdb_surface = 12
 #          required for add_level_set / add_fog_volume viewer methods.
-set(NANOVDB_EDITOR_TAG 7efb611da15d0a9b7711c6053227302dd60e12ea)
-set(NANOVDB_EDITOR_VERSION 0.1.4)   # version at this commit
+# 39fb452: adds get_pipeline_type() used to resolve pnanovdb_pipeline_type_t
+set(NANOVDB_EDITOR_TAG 39fb4523db9e4dac50f2e2ac54c3898152101c14)
+set(NANOVDB_EDITOR_VERSION 0.1.5)   # version at this commit
 
 CPMAddPackage(
     NAME nanovdb_editor

--- a/src/cmake/get_nanovdb_editor.cmake
+++ b/src/cmake/get_nanovdb_editor.cmake
@@ -10,8 +10,10 @@ set(NANOVDB_EDITOR_BUILD_TYPE "Release" CACHE STRING "Build type for nanovdb_edi
 
 # fVDB pins NanoVDB Editor headers to an exact source commit via CPM
 # Note: only change this when the interfaces have changed
-set(NANOVDB_EDITOR_TAG c2eeb18b2e381e8e7cf0979b84ef3551620d7f74)
-set(NANOVDB_EDITOR_VERSION 0.0.25)   # version at this commit
+# 7efb611: adds add_nanovdb_3 API and pnanovdb_pipeline_type_nanovdb_surface = 12
+#          required for add_level_set / add_fog_volume viewer methods.
+set(NANOVDB_EDITOR_TAG 7efb611da15d0a9b7711c6053227302dd60e12ea)
+set(NANOVDB_EDITOR_VERSION 0.1.4)   # version at this commit
 
 CPMAddPackage(
     NAME nanovdb_editor

--- a/src/fvdb/detail/io/SaveNanoVDB.cu
+++ b/src/fvdb/detail/io/SaveNanoVDB.cu
@@ -1097,8 +1097,7 @@ toNVDBWithBlindFloat(const GridBatchData &gridBatchData, const JaggedTensor &flo
     std::vector<uint64_t> paddedPayloadBytes;
     paddedPayloadBytes.reserve(gridBatchData.batchSize());
     for (int64_t batchIdx = 0; batchIdx < gridBatchData.batchSize(); ++batchIdx) {
-        const uint64_t valueCount =
-            static_cast<uint64_t>(gridBatchData.numVoxelsAt(batchIdx)) + 1u;
+        const uint64_t valueCount = static_cast<uint64_t>(gridBatchData.numVoxelsAt(batchIdx)) + 1u;
         paddedPayloadBytes.push_back(nanovdb::math::AlignUp<32UL>(valueCount * sizeof(float)));
     }
 

--- a/src/fvdb/detail/io/SaveNanoVDB.cu
+++ b/src/fvdb/detail/io/SaveNanoVDB.cu
@@ -212,6 +212,7 @@ assembleOnIndexBlindBuffer(const GridBatchData &gridBatchData,
                              totalPayload;
     nanovdb::HostBuffer writeBuf(allocSize);
 
+    // Source grid pointer (possibly on the device) and destination host pointer.
     uint8_t *writeHead = static_cast<uint8_t *>(writeBuf.data());
     uint8_t *readHead  = static_cast<uint8_t *>(isCuda ? nanoGridHdl.buffer().deviceData()
                                                       : nanoGridHdl.buffer().data());
@@ -245,6 +246,8 @@ assembleOnIndexBlindBuffer(const GridBatchData &gridBatchData,
         readHead += gridBytes;
         writeHead += gridBytes;
 
+        // Fill the blind-metadata header and its payload (just past the header), then advance past
+        // the header and the full padded payload (the trailing bytes are the 32B alignment pad).
         nanovdb::GridBlindMetaData *blindMeta =
             reinterpret_cast<nanovdb::GridBlindMetaData *>(writeHead);
         writeBlind(batchIdx, blindMeta, writeHead + sizeof(nanovdb::GridBlindMetaData));
@@ -252,6 +255,7 @@ assembleOnIndexBlindBuffer(const GridBatchData &gridBatchData,
         writeHead += sizeof(nanovdb::GridBlindMetaData) + paddedPayloadBytes[batchIdx];
     }
 
+    // Synchronize the CUDA stream if we queued any GPU -> CPU transfers.
     if (isCuda) {
         at::cuda::CUDAStream stream =
             at::cuda::getCurrentCUDAStream(gridBatchData.device().index());
@@ -953,7 +957,10 @@ saveIndexGridWithBlindData(const std::string &path,
     }
 
     const std::string fvdbBlindName = "fvdb_jdata" + TorchScalarTypeToStr(cpuData.scalar_type());
-    const uint8_t *jdataBase        = static_cast<const uint8_t *>(cpuData.jdata().data_ptr());
+
+    // Pointer to the start of jdata for slicing per-batch values without allocating fresh
+    // JaggedTensor objects each iteration.
+    const uint8_t *jdataBase = static_cast<const uint8_t *>(cpuData.jdata().data_ptr());
 
     nanovdb::GridHandle<nanovdb::HostBuffer> writeHandle = assembleOnIndexBlindBuffer(
         gridBatchData,

--- a/src/fvdb/detail/io/SaveNanoVDB.cu
+++ b/src/fvdb/detail/io/SaveNanoVDB.cu
@@ -139,6 +139,122 @@ patchGridWithBlindShape(uint8_t *gridBuf,
     }
 }
 
+/// @brief Patch a freshly-copied index grid's `GridData` into an fvdb ONINDEX tensor grid that
+/// carries a single blind-metadata slot: sets grid class/type, the blind-metadata offset/count,
+/// the world transform (voxel size + origin), the grid name, and the total grid size. Leaves
+/// `mGridIndex`/`mGridCount` untouched so multi-grid handles keep their per-grid indexing.
+///
+/// @param gridData Pointer to the grid's `GridData` (start of the copied grid).
+/// @param gridBytes Size of the copied grid, i.e. the offset of the appended blind metadata.
+/// @param paddedPayloadBytes 32B-aligned size reserved for the blind payload after its header.
+/// @param voxelSize World-space voxel size to write into mMap / mVoxelSize.
+/// @param voxelOrigin World-space voxel origin (center of voxel [0,0,0]) to write into mMap.
+/// @param name Grid name (checked against MaxNameSize); empty string clears the name.
+void
+patchOnIndexTensorGridData(nanovdb::GridData *gridData,
+                           const uint64_t gridBytes,
+                           const uint64_t paddedPayloadBytes,
+                           const nanovdb::Vec3d &voxelSize,
+                           const nanovdb::Vec3d &voxelOrigin,
+                           const std::string &name) {
+    gridData->mGridClass           = nanovdb::GridClass::TensorGrid;
+    gridData->mGridType            = nanovdb::GridType::OnIndex;
+    gridData->mBlindMetadataCount  = 1;
+    gridData->mBlindMetadataOffset = static_cast<int64_t>(gridBytes);
+    gridData->mGridSize = gridBytes + sizeof(nanovdb::GridBlindMetaData) + paddedPayloadBytes;
+
+    const double scaleX            = voxelSize[0];
+    const double scaleY            = voxelSize[1];
+    const double scaleZ            = voxelSize[2];
+    gridData->mVoxelSize           = {scaleX, scaleY, scaleZ};
+    const double scaleMatrix[3][3] = {{scaleX, 0.0, 0.0}, {0.0, scaleY, 0.0}, {0.0, 0.0, scaleZ}};
+    const double inverseScaleMatrix[3][3] = {
+        {1.0 / scaleX, 0.0, 0.0}, {0.0, 1.0 / scaleY, 0.0}, {0.0, 0.0, 1.0 / scaleZ}};
+    nanovdb::Vec3d translation = {voxelOrigin[0], voxelOrigin[1], voxelOrigin[2]};
+    gridData->mMap.set(scaleMatrix, inverseScaleMatrix, translation);
+
+    setFixedSizeStringBuf(
+        gridData->mGridName, nanovdb::GridData::MaxNameSize, name, "Grid name " + name);
+}
+
+/// @brief Assemble a host buffer of ONINDEX tensor grids, one per grid in @p gridBatchData, each
+/// carrying a single blind-metadata slot. This is the shared spine of `saveIndexGridWithBlindData`
+/// (shape-prefixed jdata) and `toNVDBWithBlindFloat` (raw float32 values): it copies each source
+/// grid (from host or device), patches its `GridData`, then hands off to @p writeBlind to fill the
+/// per-grid blind descriptor and payload.
+///
+/// @param gridBatchData Source grids.
+/// @param names Optional per-grid names (empty, or one per grid); written into each grid's name.
+/// @param paddedPayloadBytes Per-grid 32B-aligned blind payload size; must match what @p writeBlind
+///        writes for that grid, and is what the grid's `mGridSize` reserves.
+/// @param writeBlind Callback `(batchIdx, blindMeta, payload)` invoked once per grid: fills the
+///        `GridBlindMetaData` header @p blindMeta and writes the blind payload starting at
+///        @p payload (the byte just past the header). It must not write more than
+///        `paddedPayloadBytes[batchIdx]`.
+/// @return A `GridHandle<HostBuffer>` owning the assembled multi-grid buffer.
+template <typename WriteBlindFn>
+nanovdb::GridHandle<nanovdb::HostBuffer>
+assembleOnIndexBlindBuffer(const GridBatchData &gridBatchData,
+                           const std::vector<std::string> &names,
+                           const std::vector<uint64_t> &paddedPayloadBytes,
+                           WriteBlindFn &&writeBlind) {
+    const nanovdb::GridHandle<TorchDeviceBuffer> &nanoGridHdl = gridBatchData.nanoGridHandle();
+    const bool isCuda = nanoGridHdl.buffer().device().is_cuda();
+
+    uint64_t totalPayload = 0;
+    for (const uint64_t payloadSize: paddedPayloadBytes) {
+        totalPayload += payloadSize;
+    }
+
+    // Grids (already 32B aligned) + one blind-metadata header per grid + padded payloads.
+    const size_t allocSize = nanoGridHdl.buffer().size() +
+                             sizeof(nanovdb::GridBlindMetaData) * gridBatchData.batchSize() +
+                             totalPayload;
+    nanovdb::HostBuffer writeBuf(allocSize);
+
+    uint8_t *writeHead = static_cast<uint8_t *>(writeBuf.data());
+    uint8_t *readHead  = static_cast<uint8_t *>(isCuda ? nanoGridHdl.buffer().deviceData()
+                                                       : nanoGridHdl.buffer().data());
+
+    for (int64_t batchIdx = 0; batchIdx < gridBatchData.batchSize(); ++batchIdx) {
+        // Copy this batch's index grid to the buffer. D2H copies into pageable host memory are
+        // synchronous w.r.t. the host, so the immediate host-side patches below are safe; the
+        // final stream sync is belt-and-suspenders.
+        const size_t gridBytes = nanoGridHdl.gridSize(batchIdx);
+        if (isCuda) {
+            c10::cuda::CUDAGuard deviceGuard(gridBatchData.device());
+            at::cuda::CUDAStream stream =
+                at::cuda::getCurrentCUDAStream(gridBatchData.device().index());
+            cudaMemcpyAsync((void *)writeHead, (void *)readHead, gridBytes, cudaMemcpyDeviceToHost,
+                            stream.stream());
+        } else {
+            std::memcpy((void *)writeHead, (void *)readHead, gridBytes);
+        }
+
+        const std::string name = names.empty() ? std::string() : names[batchIdx];
+        patchOnIndexTensorGridData(reinterpret_cast<nanovdb::GridData *>(writeHead), gridBytes,
+                                   paddedPayloadBytes[batchIdx], gridBatchData.voxelSizeAt(batchIdx),
+                                   gridBatchData.voxelOriginAt(batchIdx), name);
+
+        readHead  += gridBytes;
+        writeHead += gridBytes;
+
+        nanovdb::GridBlindMetaData *blindMeta =
+            reinterpret_cast<nanovdb::GridBlindMetaData *>(writeHead);
+        writeBlind(batchIdx, blindMeta, writeHead + sizeof(nanovdb::GridBlindMetaData));
+        TORCH_CHECK(blindMeta->isValid(), "Invalid blind metadata");
+        writeHead += sizeof(nanovdb::GridBlindMetaData) + paddedPayloadBytes[batchIdx];
+    }
+
+    if (isCuda) {
+        at::cuda::CUDAStream stream =
+            at::cuda::getCurrentCUDAStream(gridBatchData.device().index());
+        cudaStreamSynchronize(stream.stream());
+    }
+
+    return nanovdb::GridHandle<nanovdb::HostBuffer>(std::move(writeBuf));
+}
+
 /// @brief Host-only port of `nanovdb::tools::cuda::indexToGrid` for a single
 /// `nanovdb::NanoGrid<nanovdb::ValueOnIndex>`.
 ///
@@ -803,155 +919,67 @@ saveIndexGridWithBlindData(const std::string &path,
                            const std::vector<std::string> &names,
                            nanovdb::io::Codec codec,
                            bool verbose) {
-    const nanovdb::GridHandle<TorchDeviceBuffer> &nanoGridHdl = gridBatchData.nanoGridHandle();
-
     // Make a CPU-resident contiguous copy of the data jagged tensor when needed.
     JaggedTensor cpuData = data.cpu().contiguous();
     TORCH_CHECK(cpuData.is_contiguous(), "Jagged tensor must be contiguous");
 
-    // Hoist tensor shape info: rdim and tail (everything past dim 0) are constant
-    // across batch entries. Per-batch dim 0 is `numVoxelsAt(bi)`.
-    const int64_t rdim = cpuData.rdim();
+    // Hoist tensor shape info: rank and tail (everything past dim 0) are constant across batch
+    // entries. Per-batch dim 0 is `numVoxelsAt(batchIdx)`.
+    const int64_t rank = cpuData.rdim();
     std::vector<int64_t> tailSizes;
-    tailSizes.reserve(rdim > 0 ? static_cast<size_t>(rdim - 1) : 0);
-    for (int64_t di = 1; di < rdim; ++di) {
-        tailSizes.push_back(cpuData.rsize(di));
+    tailSizes.reserve(rank > 0 ? static_cast<size_t>(rank - 1) : 0);
+    for (int64_t dimIdx = 1; dimIdx < rank; ++dimIdx) {
+        tailSizes.push_back(cpuData.rsize(dimIdx));
     }
     const int64_t elementSize = cpuData.jdata().element_size();
     int64_t tailElems         = 1;
-    for (int64_t s: tailSizes) {
-        tailElems *= s;
+    for (int64_t tailSize: tailSizes) {
+        tailElems *= tailSize;
     }
 
-    // Compute blind data sizes padded to be 32 byte aligned.
-    std::vector<uint64_t> blindDataPadding;     // Padding bytes added after each blind data payload
-    std::vector<uint64_t> paddedBlindDataSizes; // Full padded blind data payload size
-    blindDataPadding.reserve(gridBatchData.batchSize());
-    paddedBlindDataSizes.reserve(gridBatchData.batchSize());
-    uint64_t totalBlindDataSize = 0;
-    for (int64_t bi = 0; bi < gridBatchData.batchSize(); bi += 1) {
-        const int64_t numVoxelsBi            = gridBatchData.numVoxelsAt(bi);
-        const int64_t jdataBytesBi           = numVoxelsBi * tailElems * elementSize;
-        const uint64_t blindDataSizeBi       = jdataBytesBi + sizeof(int64_t) * (rdim + 1);
-        const uint64_t paddedBlindDataSizeBi = nanovdb::math::AlignUp<32UL>(blindDataSizeBi);
-        blindDataPadding.push_back(paddedBlindDataSizeBi - blindDataSizeBi);
-        paddedBlindDataSizes.push_back(paddedBlindDataSizeBi);
-        totalBlindDataSize += paddedBlindDataSizeBi;
+    // Blind payload per grid: [rank+1 shape int64s][jdata bytes], padded to 32B.
+    std::vector<uint64_t> paddedPayloadBytes;
+    paddedPayloadBytes.reserve(gridBatchData.batchSize());
+    for (int64_t batchIdx = 0; batchIdx < gridBatchData.batchSize(); ++batchIdx) {
+        const int64_t jdataBytes     = gridBatchData.numVoxelsAt(batchIdx) * tailElems * elementSize;
+        const uint64_t blindDataSize = jdataBytes + sizeof(int64_t) * (rank + 1);
+        paddedPayloadBytes.push_back(nanovdb::math::AlignUp<32UL>(blindDataSize));
     }
 
-    // Allocate one host buffer large enough to hold the copied index grids plus blind
-    // metadata/data.
-    const size_t allocSize = nanoGridHdl.buffer().size() +   // Grids (32B aligned)
-                             sizeof(nanovdb::GridBlindMetaData) *
-                                 gridBatchData.batchSize() + // Blind metadata (32B aligned)
-                             totalBlindDataSize;             // Blind data (32B aligned)
-    nanovdb::HostBuffer writeBuf(allocSize);
+    const std::string fvdbBlindName = "fvdb_jdata" + TorchScalarTypeToStr(cpuData.scalar_type());
+    const uint8_t *jdataBase        = static_cast<const uint8_t *>(cpuData.jdata().data_ptr());
 
-    // Get the source grid pointer (possibly on the device) and destination host pointer.
-    const bool isCuda  = nanoGridHdl.buffer().device().is_cuda();
-    uint8_t *writeHead = static_cast<uint8_t *>(writeBuf.data());
-    uint8_t *readHead  = static_cast<uint8_t *>(isCuda ? nanoGridHdl.buffer().deviceData()
-                                                      : nanoGridHdl.buffer().data());
+    nanovdb::GridHandle<nanovdb::HostBuffer> writeHandle = assembleOnIndexBlindBuffer(
+        gridBatchData, names, paddedPayloadBytes,
+        [&](int64_t batchIdx, nanovdb::GridBlindMetaData *blindMeta, uint8_t *payload) {
+            const int64_t numVoxels = gridBatchData.numVoxelsAt(batchIdx);
 
-    // Pointer to the start of jdata for slicing per-batch values without allocating fresh
-    // JaggedTensor objects each iteration.
-    const uint8_t *jdataBase = static_cast<const uint8_t *>(cpuData.jdata().data_ptr());
+            blindMeta->mDataOffset = int64_t(sizeof(nanovdb::GridBlindMetaData));
+            blindMeta->mValueCount = paddedPayloadBytes[batchIdx]; // Number of bytes
+            blindMeta->mValueSize  = 1;                            // 1 byte per value
+            blindMeta->mSemantic   = nanovdb::GridBlindDataSemantic::Unknown;
+            blindMeta->mDataClass  = nanovdb::GridBlindDataClass::Unknown;
+            blindMeta->mDataType   = nanovdb::GridType::Unknown;
+            setFixedSizeStringBuf(blindMeta->mName, nanovdb::GridBlindMetaData::MaxNameSize,
+                                  fvdbBlindName, "blind metadata name");
 
-    // Copy each grid and each entry in the jagged tensor
-    for (int64_t bi = 0; bi < gridBatchData.batchSize(); bi += 1) {
-        // Copy the full bi^th index grid to the buffer
-        const size_t sourceGridByteSize = nanoGridHdl.gridSize(bi);
-        if (isCuda) {
-            c10::cuda::CUDAGuard deviceGuard(gridBatchData.device());
-            at::cuda::CUDAStream stream =
-                at::cuda::getCurrentCUDAStream(gridBatchData.device().index());
-            cudaMemcpyAsync((void *)writeHead,
-                            (void *)readHead,
-                            sourceGridByteSize,
-                            cudaMemcpyDeviceToHost,
-                            stream.stream());
-        } else {
-            memcpy((void *)writeHead, (void *)readHead, sourceGridByteSize);
-        }
-        // Update the metadata for the copied grid in the buffer to be a tensor grid with blind data
-        nanovdb::GridData *writeGridData    = reinterpret_cast<nanovdb::GridData *>(writeHead);
-        writeGridData->mGridClass           = nanovdb::GridClass::TensorGrid;
-        writeGridData->mGridType            = nanovdb::GridType::OnIndex;
-        writeGridData->mBlindMetadataCount  = 1;
-        writeGridData->mBlindMetadataOffset = sourceGridByteSize;
-        const std::string name              = names.size() > 0 ? names[bi] : "";
-        setFixedSizeStringBuf(
-            writeGridData->mGridName, nanovdb::GridData::MaxNameSize, name, "Grid name " + name);
-        writeGridData->mGridSize =
-            sourceGridByteSize + sizeof(nanovdb::GridBlindMetaData) + paddedBlindDataSizes[bi];
+            // Shape prefix so the tensor can be reloaded with its original shape. The hoisted
+            // tail sizes are reused; only dim 0 (numVoxels) varies per batch.
+            int64_t *shapeHead = reinterpret_cast<int64_t *>(payload);
+            *shapeHead++       = static_cast<int64_t>(rank);
+            *shapeHead++       = numVoxels;
+            for (int64_t tailSize: tailSizes) {
+                *shapeHead++ = tailSize;
+            }
 
-        // Write voxelSize and origin
-        const nanovdb::Vec3d &vs  = gridBatchData.voxelSizeAt(bi);
-        const nanovdb::Vec3d vo   = gridBatchData.voxelOriginAt(bi);
-        const double sx           = vs[0];
-        const double sy           = vs[1];
-        const double sz           = vs[2];
-        writeGridData->mVoxelSize = {sx, sy, sz};
-        const double mat[3][3]    = {{sx, 0.0, 0.0},        // row 0
-                                     {0.0, sy, 0.0},        // row 1
-                                     {0.0, 0.0, sz}};       // row 2
-        const double invMat[3][3] = {{1.0 / sx, 0.0, 0.0},  // row 0
-                                     {0.0, 1.0 / sy, 0.0},  // row 1
-                                     {0.0, 0.0, 1.0 / sz}}; // row 2
-        nanovdb::Vec3d trans      = {vo[0], vo[1], vo[2]};
-        writeGridData->mMap.set(mat, invMat, trans);
-
-        readHead += sourceGridByteSize;
-        writeHead += sourceGridByteSize;
-
-        // Write out blind metadata to the end of the grid
-        nanovdb::GridBlindMetaData *blindMetadata =
-            reinterpret_cast<nanovdb::GridBlindMetaData *>(writeHead);
-        blindMetadata->mDataOffset = int64_t(sizeof(nanovdb::GridBlindMetaData));
-        blindMetadata->mValueCount = paddedBlindDataSizes[bi]; // Number of bytes
-        blindMetadata->mValueSize  = 1;                        // 1 byte per value
-        blindMetadata->mSemantic   = nanovdb::GridBlindDataSemantic::Unknown;
-        blindMetadata->mDataClass  = nanovdb::GridBlindDataClass::Unknown;
-        blindMetadata->mDataType   = nanovdb::GridType::Unknown;
-        const std::string fvdbBlindName =
-            "fvdb_jdata" + TorchScalarTypeToStr(cpuData.scalar_type());
-        setFixedSizeStringBuf(blindMetadata->mName,
-                              nanovdb::GridBlindMetaData::MaxNameSize,
-                              fvdbBlindName,
-                              "blind metadata name");
-        TORCH_CHECK(blindMetadata->isValid(), "Invalid blind metadata");
-        writeHead += sizeof(nanovdb::GridBlindMetaData);
-
-        // Write the shape of the bi^th jdata tensor so we can load it with the same shape it was
-        // saved with. The hoisted tail sizes are reused; only dim 0 (numVoxelsBi) varies per batch.
-        const int64_t numVoxelsBi               = gridBatchData.numVoxelsAt(bi);
-        *reinterpret_cast<int64_t *>(writeHead) = static_cast<int64_t>(rdim);
-        writeHead += sizeof(int64_t);
-        *reinterpret_cast<int64_t *>(writeHead) = numVoxelsBi;
-        writeHead += sizeof(int64_t);
-        for (int64_t s: tailSizes) {
-            *reinterpret_cast<int64_t *>(writeHead) = s;
-            writeHead += sizeof(int64_t);
-        }
-
-        // Copy the bi^th jdata tensor as blind data to the buffer
-        const int64_t jdataSize = numVoxelsBi * tailElems * elementSize;
-        const uint8_t *srcBytes =
-            jdataBase + gridBatchData.cumVoxelsAt(bi) * tailElems * elementSize;
-        memcpy((void *)writeHead, (const void *)srcBytes, jdataSize);
-        writeHead += jdataSize;
-        writeHead += blindDataPadding[bi]; // Add padding to make sure we're 32 byte aligned
-    }
-
-    // Synchronize the CUDA stream if we queued any GPU -> CPU transfers.
-    if (isCuda) {
-        at::cuda::CUDAStream stream =
-            at::cuda::getCurrentCUDAStream(gridBatchData.device().index());
-        cudaStreamSynchronize(stream.stream());
-    }
+            // jdata bytes for this grid, sliced via the cumulative voxel offset.
+            const int64_t jdataSize = numVoxels * tailElems * elementSize;
+            const uint8_t *srcBytes =
+                jdataBase + gridBatchData.cumVoxelsAt(batchIdx) * tailElems * elementSize;
+            std::memcpy(reinterpret_cast<uint8_t *>(shapeHead), srcBytes, jdataSize);
+        });
 
     // Write the grid to disk
-    nanovdb::GridHandle<nanovdb::HostBuffer> writeHandle(std::move(writeBuf));
     nanovdb::io::writeGrid(path, writeHandle, codec, verbose);
 }
 
@@ -1025,6 +1053,55 @@ saveNVDB(const std::string &path,
         // data
         saveIndexGridWithBlindData(path, gridBatchData, data, names, codec, verbose);
     }
+}
+
+nanovdb::GridHandle<nanovdb::HostBuffer>
+toNVDBWithBlindFloat(const GridBatchData &gridBatchData, const JaggedTensor &floatValues) {
+    TORCH_CHECK_VALUE(floatValues.jdata().scalar_type() == torch::kFloat32,
+                      "toNVDBWithBlindFloat: floatValues must be float32, got ",
+                      floatValues.jdata().scalar_type());
+    TORCH_CHECK_VALUE(floatValues.jdata().ndimension() == 1,
+                      "toNVDBWithBlindFloat: floatValues must be 1D (one float per voxel), got ",
+                      floatValues.jdata().ndimension(), "D");
+    TORCH_CHECK_VALUE(gridBatchData.totalVoxels() == floatValues.jdata().size(0),
+                      "toNVDBWithBlindFloat: floatValues length ", floatValues.jdata().size(0),
+                      " must match total voxel count ", gridBatchData.totalVoxels());
+    checkPerBatchVoxelCounts(gridBatchData, floatValues);
+
+    // Move float values to CPU (contiguous) for the host-side memcopy below.
+    JaggedTensor cpuFloats = floatValues.cpu().contiguous();
+    TORCH_CHECK(cpuFloats.is_contiguous(), "Internal error: float values must be contiguous");
+
+    // Blind payload per grid: raw float32 values (one per voxel), padded to 32B.
+    std::vector<uint64_t> paddedPayloadBytes;
+    paddedPayloadBytes.reserve(gridBatchData.batchSize());
+    for (int64_t batchIdx = 0; batchIdx < gridBatchData.batchSize(); ++batchIdx) {
+        paddedPayloadBytes.push_back(
+            nanovdb::math::AlignUp<32UL>(gridBatchData.numVoxelsAt(batchIdx) * sizeof(float)));
+    }
+
+    const float *floatBase = static_cast<const float *>(cpuFloats.jdata().data_ptr());
+
+    return assembleOnIndexBlindBuffer(
+        gridBatchData, /*names=*/{}, paddedPayloadBytes,
+        [&](int64_t batchIdx, nanovdb::GridBlindMetaData *blindMeta, uint8_t *payload) {
+            const int64_t numVoxels = gridBatchData.numVoxelsAt(batchIdx);
+
+            // float32 values at data_offset from this header. The nanovdb-editor surface shader
+            // reads: val_addr + val_index * 4, interpreting the result as a float.
+            blindMeta->mDataOffset = int64_t(sizeof(nanovdb::GridBlindMetaData));
+            blindMeta->mValueCount = numVoxels;
+            blindMeta->mValueSize  = sizeof(float);
+            blindMeta->mSemantic   = nanovdb::GridBlindDataSemantic::Unknown;
+            blindMeta->mDataClass  = nanovdb::GridBlindDataClass::Unknown;
+            blindMeta->mDataType   = nanovdb::GridType::Float;
+            setFixedSizeStringBuf(blindMeta->mName, nanovdb::GridBlindMetaData::MaxNameSize,
+                                  "fvdb_sdf_float32", "blind metadata name");
+
+            // Raw float values in active-voxel order (val_index == flat active index).
+            const float *srcFloats = floatBase + gridBatchData.cumVoxelsAt(batchIdx);
+            std::memcpy(payload, srcFloats, numVoxels * sizeof(float));
+        });
 }
 
 } // namespace io

--- a/src/fvdb/detail/io/SaveNanoVDB.cu
+++ b/src/fvdb/detail/io/SaveNanoVDB.cu
@@ -214,7 +214,7 @@ assembleOnIndexBlindBuffer(const GridBatchData &gridBatchData,
 
     uint8_t *writeHead = static_cast<uint8_t *>(writeBuf.data());
     uint8_t *readHead  = static_cast<uint8_t *>(isCuda ? nanoGridHdl.buffer().deviceData()
-                                                       : nanoGridHdl.buffer().data());
+                                                      : nanoGridHdl.buffer().data());
 
     for (int64_t batchIdx = 0; batchIdx < gridBatchData.batchSize(); ++batchIdx) {
         // Copy this batch's index grid to the buffer. D2H copies into pageable host memory are
@@ -225,18 +225,24 @@ assembleOnIndexBlindBuffer(const GridBatchData &gridBatchData,
             c10::cuda::CUDAGuard deviceGuard(gridBatchData.device());
             at::cuda::CUDAStream stream =
                 at::cuda::getCurrentCUDAStream(gridBatchData.device().index());
-            cudaMemcpyAsync((void *)writeHead, (void *)readHead, gridBytes, cudaMemcpyDeviceToHost,
+            cudaMemcpyAsync((void *)writeHead,
+                            (void *)readHead,
+                            gridBytes,
+                            cudaMemcpyDeviceToHost,
                             stream.stream());
         } else {
             std::memcpy((void *)writeHead, (void *)readHead, gridBytes);
         }
 
         const std::string name = names.empty() ? std::string() : names[batchIdx];
-        patchOnIndexTensorGridData(reinterpret_cast<nanovdb::GridData *>(writeHead), gridBytes,
-                                   paddedPayloadBytes[batchIdx], gridBatchData.voxelSizeAt(batchIdx),
-                                   gridBatchData.voxelOriginAt(batchIdx), name);
+        patchOnIndexTensorGridData(reinterpret_cast<nanovdb::GridData *>(writeHead),
+                                   gridBytes,
+                                   paddedPayloadBytes[batchIdx],
+                                   gridBatchData.voxelSizeAt(batchIdx),
+                                   gridBatchData.voxelOriginAt(batchIdx),
+                                   name);
 
-        readHead  += gridBytes;
+        readHead += gridBytes;
         writeHead += gridBytes;
 
         nanovdb::GridBlindMetaData *blindMeta =
@@ -941,7 +947,7 @@ saveIndexGridWithBlindData(const std::string &path,
     std::vector<uint64_t> paddedPayloadBytes;
     paddedPayloadBytes.reserve(gridBatchData.batchSize());
     for (int64_t batchIdx = 0; batchIdx < gridBatchData.batchSize(); ++batchIdx) {
-        const int64_t jdataBytes     = gridBatchData.numVoxelsAt(batchIdx) * tailElems * elementSize;
+        const int64_t jdataBytes = gridBatchData.numVoxelsAt(batchIdx) * tailElems * elementSize;
         const uint64_t blindDataSize = jdataBytes + sizeof(int64_t) * (rank + 1);
         paddedPayloadBytes.push_back(nanovdb::math::AlignUp<32UL>(blindDataSize));
     }
@@ -950,7 +956,9 @@ saveIndexGridWithBlindData(const std::string &path,
     const uint8_t *jdataBase        = static_cast<const uint8_t *>(cpuData.jdata().data_ptr());
 
     nanovdb::GridHandle<nanovdb::HostBuffer> writeHandle = assembleOnIndexBlindBuffer(
-        gridBatchData, names, paddedPayloadBytes,
+        gridBatchData,
+        names,
+        paddedPayloadBytes,
         [&](int64_t batchIdx, nanovdb::GridBlindMetaData *blindMeta, uint8_t *payload) {
             const int64_t numVoxels = gridBatchData.numVoxelsAt(batchIdx);
 
@@ -960,8 +968,10 @@ saveIndexGridWithBlindData(const std::string &path,
             blindMeta->mSemantic   = nanovdb::GridBlindDataSemantic::Unknown;
             blindMeta->mDataClass  = nanovdb::GridBlindDataClass::Unknown;
             blindMeta->mDataType   = nanovdb::GridType::Unknown;
-            setFixedSizeStringBuf(blindMeta->mName, nanovdb::GridBlindMetaData::MaxNameSize,
-                                  fvdbBlindName, "blind metadata name");
+            setFixedSizeStringBuf(blindMeta->mName,
+                                  nanovdb::GridBlindMetaData::MaxNameSize,
+                                  fvdbBlindName,
+                                  "blind metadata name");
 
             // Shape prefix so the tensor can be reloaded with its original shape. The hoisted
             // tail sizes are reused; only dim 0 (numVoxels) varies per batch.
@@ -1062,10 +1072,13 @@ toNVDBWithBlindFloat(const GridBatchData &gridBatchData, const JaggedTensor &flo
                       floatValues.jdata().scalar_type());
     TORCH_CHECK_VALUE(floatValues.jdata().ndimension() == 1,
                       "toNVDBWithBlindFloat: floatValues must be 1D (one float per voxel), got ",
-                      floatValues.jdata().ndimension(), "D");
+                      floatValues.jdata().ndimension(),
+                      "D");
     TORCH_CHECK_VALUE(gridBatchData.totalVoxels() == floatValues.jdata().size(0),
-                      "toNVDBWithBlindFloat: floatValues length ", floatValues.jdata().size(0),
-                      " must match total voxel count ", gridBatchData.totalVoxels());
+                      "toNVDBWithBlindFloat: floatValues length ",
+                      floatValues.jdata().size(0),
+                      " must match total voxel count ",
+                      gridBatchData.totalVoxels());
     checkPerBatchVoxelCounts(gridBatchData, floatValues);
 
     // Move float values to CPU (contiguous) for the host-side memcopy below.
@@ -1083,7 +1096,9 @@ toNVDBWithBlindFloat(const GridBatchData &gridBatchData, const JaggedTensor &flo
     const float *floatBase = static_cast<const float *>(cpuFloats.jdata().data_ptr());
 
     return assembleOnIndexBlindBuffer(
-        gridBatchData, /*names=*/{}, paddedPayloadBytes,
+        gridBatchData,
+        /*names=*/{},
+        paddedPayloadBytes,
         [&](int64_t batchIdx, nanovdb::GridBlindMetaData *blindMeta, uint8_t *payload) {
             const int64_t numVoxels = gridBatchData.numVoxelsAt(batchIdx);
 
@@ -1095,8 +1110,10 @@ toNVDBWithBlindFloat(const GridBatchData &gridBatchData, const JaggedTensor &flo
             blindMeta->mSemantic   = nanovdb::GridBlindDataSemantic::Unknown;
             blindMeta->mDataClass  = nanovdb::GridBlindDataClass::Unknown;
             blindMeta->mDataType   = nanovdb::GridType::Float;
-            setFixedSizeStringBuf(blindMeta->mName, nanovdb::GridBlindMetaData::MaxNameSize,
-                                  "fvdb_sdf_float32", "blind metadata name");
+            setFixedSizeStringBuf(blindMeta->mName,
+                                  nanovdb::GridBlindMetaData::MaxNameSize,
+                                  "fvdb_sdf_float32",
+                                  "blind metadata name");
 
             // Raw float values in active-voxel order (val_index == flat active index).
             const float *srcFloats = floatBase + gridBatchData.cumVoxelsAt(batchIdx);

--- a/src/fvdb/detail/io/SaveNanoVDB.cu
+++ b/src/fvdb/detail/io/SaveNanoVDB.cu
@@ -1092,12 +1092,14 @@ toNVDBWithBlindFloat(const GridBatchData &gridBatchData, const JaggedTensor &flo
     JaggedTensor cpuFloats = floatValues.cpu().contiguous();
     TORCH_CHECK(cpuFloats.is_contiguous(), "Internal error: float values must be contiguous");
 
-    // Blind payload per grid: raw float32 values (one per voxel), padded to 32B.
+    // Blind payload per grid: background slot 0 plus one raw float32 value per active voxel,
+    // padded to 32B. ValueOnIndex uses index 0 for background and 1..N for active voxels.
     std::vector<uint64_t> paddedPayloadBytes;
     paddedPayloadBytes.reserve(gridBatchData.batchSize());
     for (int64_t batchIdx = 0; batchIdx < gridBatchData.batchSize(); ++batchIdx) {
-        paddedPayloadBytes.push_back(
-            nanovdb::math::AlignUp<32UL>(gridBatchData.numVoxelsAt(batchIdx) * sizeof(float)));
+        const uint64_t valueCount =
+            static_cast<uint64_t>(gridBatchData.numVoxelsAt(batchIdx)) + 1u;
+        paddedPayloadBytes.push_back(nanovdb::math::AlignUp<32UL>(valueCount * sizeof(float)));
     }
 
     const float *floatBase = static_cast<const float *>(cpuFloats.jdata().data_ptr());
@@ -1109,10 +1111,10 @@ toNVDBWithBlindFloat(const GridBatchData &gridBatchData, const JaggedTensor &flo
         [&](int64_t batchIdx, nanovdb::GridBlindMetaData *blindMeta, uint8_t *payload) {
             const int64_t numVoxels = gridBatchData.numVoxelsAt(batchIdx);
 
-            // float32 values at data_offset from this header. The nanovdb-editor surface shader
-            // reads: val_addr + val_index * 4, interpreting the result as a float.
+            // float32 values at data_offset from this header. The nanovdb-editor shaders read:
+            // val_addr + val_index * 4, interpreting the result as a float.
             blindMeta->mDataOffset = int64_t(sizeof(nanovdb::GridBlindMetaData));
-            blindMeta->mValueCount = numVoxels;
+            blindMeta->mValueCount = static_cast<uint64_t>(numVoxels) + 1u;
             blindMeta->mValueSize  = sizeof(float);
             blindMeta->mSemantic   = nanovdb::GridBlindDataSemantic::Unknown;
             blindMeta->mDataClass  = nanovdb::GridBlindDataClass::Unknown;
@@ -1122,9 +1124,10 @@ toNVDBWithBlindFloat(const GridBatchData &gridBatchData, const JaggedTensor &flo
                                   "fvdb_sdf_float32",
                                   "blind metadata name");
 
-            // Raw float values in active-voxel order (val_index == flat active index).
+            // Slot 0 is the ValueOnIndex background. Active voxels use indices 1..N.
+            std::memset(payload, 0, sizeof(float));
             const float *srcFloats = floatBase + gridBatchData.cumVoxelsAt(batchIdx);
-            std::memcpy(payload, srcFloats, numVoxels * sizeof(float));
+            std::memcpy(payload + sizeof(float), srcFloats, numVoxels * sizeof(float));
         });
 }
 

--- a/src/fvdb/detail/io/SaveNanoVDB.h
+++ b/src/fvdb/detail/io/SaveNanoVDB.h
@@ -22,8 +22,8 @@ toNVDB(const GridBatchData &gridBatchData,
 // The float values are stored directly (no shape prefix) so the nanovdb-editor surface
 // shader can read them via: val_addr = blind_data_base + val_index * sizeof(float).
 // floatValues must be a 1D float32 JaggedTensor with one entry per active voxel.
-nanovdb::GridHandle<nanovdb::HostBuffer>
-toNVDBWithBlindFloat(const GridBatchData &gridBatchData, const JaggedTensor &floatValues);
+nanovdb::GridHandle<nanovdb::HostBuffer> toNVDBWithBlindFloat(const GridBatchData &gridBatchData,
+                                                              const JaggedTensor &floatValues);
 
 void saveNVDB(const std::string &path,
               const GridBatchData &gridBatchData,

--- a/src/fvdb/detail/io/SaveNanoVDB.h
+++ b/src/fvdb/detail/io/SaveNanoVDB.h
@@ -18,6 +18,13 @@ toNVDB(const GridBatchData &gridBatchData,
        const std::optional<JaggedTensor> &maybeData = std::nullopt,
        const std::vector<std::string> &names        = {});
 
+// Build an ONINDEX NanoVDB buffer with float32 values appended as blind metadata slot 0.
+// The float values are stored directly (no shape prefix) so the nanovdb-editor surface
+// shader can read them via: val_addr = blind_data_base + val_index * sizeof(float).
+// floatValues must be a 1D float32 JaggedTensor with one entry per active voxel.
+nanovdb::GridHandle<nanovdb::HostBuffer>
+toNVDBWithBlindFloat(const GridBatchData &gridBatchData, const JaggedTensor &floatValues);
+
 void saveNVDB(const std::string &path,
               const GridBatchData &gridBatchData,
               const std::optional<JaggedTensor> &maybeData,

--- a/src/fvdb/detail/io/SaveNanoVDB.h
+++ b/src/fvdb/detail/io/SaveNanoVDB.h
@@ -19,9 +19,10 @@ toNVDB(const GridBatchData &gridBatchData,
        const std::vector<std::string> &names        = {});
 
 // Build an ONINDEX NanoVDB buffer with float32 values appended as blind metadata slot 0.
-// The float values are stored directly (no shape prefix) so the nanovdb-editor surface
-// shader can read them via: val_addr = blind_data_base + val_index * sizeof(float).
-// floatValues must be a 1D float32 JaggedTensor with one entry per active voxel.
+// ValueOnIndex reserves index 0 for background and stores active voxel indices as 1..N, so the
+// blind payload stores a background float first, followed by the user values. This lets editor
+// shaders read via: val_addr = blind_data_base + val_index * sizeof(float).
+// floatValues must still be a 1D float32 JaggedTensor with one entry per active voxel.
 nanovdb::GridHandle<nanovdb::HostBuffer> toNVDBWithBlindFloat(const GridBatchData &gridBatchData,
                                                               const JaggedTensor &floatValues);
 

--- a/src/fvdb/detail/viewer/Viewer.cpp
+++ b/src/fvdb/detail/viewer/Viewer.cpp
@@ -2,15 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#include <fvdb/detail/io/SaveNanoVDB.h>
 #include <fvdb/detail/viewer/CameraView.h>
 #include <fvdb/detail/viewer/GaussianSplat3dView.h>
 #include <fvdb/detail/viewer/Viewer.h>
-#include <fvdb/detail/io/SaveNanoVDB.h>
-
-#include <editor/PipelineTypes.h>
 
 #include <c10/util/Exception.h>
 
+#include <editor/PipelineTypes.h>
 #include <nanovdb_editor/putil/Raster.h>
 
 #include <cmath>
@@ -598,15 +597,21 @@ Viewer::addNanoVDBGridView(const std::string &scene_name,
     // size is always a multiple of 4.
     const uint64_t bufferBytes = handle.buffer().size();
     TORCH_CHECK(bufferBytes % sizeof(uint32_t) == 0,
-                "Internal error: NanoVDB buffer size ", bufferBytes, " is not 4-byte aligned");
+                "Internal error: NanoVDB buffer size ",
+                bufferBytes,
+                " is not 4-byte aligned");
     pnanovdb_compute_array_t *array = mEditor.compute.create_array(
         sizeof(uint32_t), bufferBytes / sizeof(uint32_t), handle.buffer().data());
 
     pnanovdb_editor_token_t *sceneToken = mEditor.editor.get_token(scene_name.c_str());
     pnanovdb_editor_token_t *nameToken  = mEditor.editor.get_token(name.c_str());
 
-    mEditor.editor.add_nanovdb_3(&mEditor.editor, sceneToken, nameToken, array,
-                                 pnanovdb_pipeline_type_noop, render_pipeline);
+    mEditor.editor.add_nanovdb_3(&mEditor.editor,
+                                 sceneToken,
+                                 nameToken,
+                                 array,
+                                 pnanovdb_pipeline_type_noop,
+                                 render_pipeline);
 
     mEditor.compute.destroy_array(array);
 

--- a/src/fvdb/detail/viewer/Viewer.cpp
+++ b/src/fvdb/detail/viewer/Viewer.cpp
@@ -647,6 +647,8 @@ Viewer::addNanoVDBGridView(const std::string &scene_name,
     // editor/editor.slang), which shades per-voxel scalars. Override it with the shader that
     // matches render_pipeline so level sets draw as an HDDA isosurface. Same map_params pattern as
     // addImage; setting the render pipeline above does not touch the object's shader.
+    // TODO:  Note this is a bug (openvdb/nanovdb-editor#213) and when fixed in NanoVDB Editor (i.e.
+    // setting the pipeline sets the appropriate default shader automatically), this can be removed.
     pnanovdb_editor_shader_name_t *mapped =
         (pnanovdb_editor_shader_name_t *)mEditor.editor.map_params(
             &mEditor.editor,

--- a/src/fvdb/detail/viewer/Viewer.cpp
+++ b/src/fvdb/detail/viewer/Viewer.cpp
@@ -5,6 +5,9 @@
 #include <fvdb/detail/viewer/CameraView.h>
 #include <fvdb/detail/viewer/GaussianSplat3dView.h>
 #include <fvdb/detail/viewer/Viewer.h>
+#include <fvdb/detail/io/SaveNanoVDB.h>
+
+#include <editor/PipelineTypes.h>
 
 #include <c10/util/Exception.h>
 
@@ -555,6 +558,59 @@ Viewer::addImage(const std::string &scene_name,
     }
 
     mEditor.compute.destroy_array(image_nanovdb);
+}
+
+void
+Viewer::addLevelSetView(const std::string &scene_name,
+                        const std::string &name,
+                        const GridBatchData &grid,
+                        const JaggedTensor &sdf) {
+    addNanoVDBGridView(scene_name, name, grid, sdf, pnanovdb_pipeline_type_nanovdb_surface);
+}
+
+void
+Viewer::addFogVolumeView(const std::string &scene_name,
+                         const std::string &name,
+                         const GridBatchData &grid,
+                         const JaggedTensor &density) {
+    addNanoVDBGridView(scene_name, name, grid, density, pnanovdb_pipeline_type_nanovdb_render);
+}
+
+void
+Viewer::addNanoVDBGridView(const std::string &scene_name,
+                           const std::string &name,
+                           const GridBatchData &grid,
+                           const JaggedTensor &floatValues,
+                           pnanovdb_pipeline_type_t render_pipeline) {
+    // The nanovdb-editor renders exactly one grid per view (its shader decodes a single
+    // grid anchored at byte offset 0 of the uploaded buffer). Callers must expand a
+    // multi-grid GridBatch into one view per grid; see fvdb.viz._nanovdb_grid_view.
+    TORCH_CHECK(grid.batchSize() == 1,
+                "addNanoVDBGridView expects a single grid (batchSize == 1), got a batch of ",
+                grid.batchSize(),
+                ". The viewer renders one grid per view; add one view per grid.");
+
+    auto handle = detail::io::toNVDBWithBlindFloat(grid, floatValues);
+
+    // Match the editor's own NanoVDB upload convention (compute.load_nanovdb): a NanoVDB
+    // buffer is a uint32 array, so element_size = 4. This becomes the GPU buffer's
+    // structure_stride at upload time. NanoVDB grids are 32-byte aligned, so the buffer
+    // size is always a multiple of 4.
+    const uint64_t bufferBytes = handle.buffer().size();
+    TORCH_CHECK(bufferBytes % sizeof(uint32_t) == 0,
+                "Internal error: NanoVDB buffer size ", bufferBytes, " is not 4-byte aligned");
+    pnanovdb_compute_array_t *array = mEditor.compute.create_array(
+        sizeof(uint32_t), bufferBytes / sizeof(uint32_t), handle.buffer().data());
+
+    pnanovdb_editor_token_t *sceneToken = mEditor.editor.get_token(scene_name.c_str());
+    pnanovdb_editor_token_t *nameToken  = mEditor.editor.get_token(name.c_str());
+
+    mEditor.editor.add_nanovdb_3(&mEditor.editor, sceneToken, nameToken, array,
+                                 pnanovdb_pipeline_type_noop, render_pipeline);
+
+    mEditor.compute.destroy_array(array);
+
+    mNanoVDBViews[name] = NanoVDBView{name};
 }
 
 } // namespace fvdb::detail::viewer

--- a/src/fvdb/detail/viewer/Viewer.cpp
+++ b/src/fvdb/detail/viewer/Viewer.cpp
@@ -580,7 +580,8 @@ Viewer::addLevelSetView(const std::string &scene_name,
                        name,
                        grid,
                        sdf,
-                       getPipelineType(mEditor.editor, "pnanovdb_pipeline_type_nanovdb_surface"));
+                       getPipelineType(mEditor.editor, "pnanovdb_pipeline_type_nanovdb_surface"),
+                       "editor/editor_surface.slang");
 }
 
 void
@@ -592,7 +593,8 @@ Viewer::addFogVolumeView(const std::string &scene_name,
                        name,
                        grid,
                        density,
-                       getPipelineType(mEditor.editor, "pnanovdb_pipeline_type_nanovdb_render"));
+                       getPipelineType(mEditor.editor, "pnanovdb_pipeline_type_nanovdb_render"),
+                       "editor/editor.slang");
 }
 
 void
@@ -600,7 +602,8 @@ Viewer::addNanoVDBGridView(const std::string &scene_name,
                            const std::string &name,
                            const GridBatchData &grid,
                            const JaggedTensor &floatValues,
-                           pnanovdb_pipeline_type_t render_pipeline) {
+                           pnanovdb_pipeline_type_t render_pipeline,
+                           const std::string &render_shader) {
     // The nanovdb-editor renders exactly one grid per view (its shader decodes a single
     // grid anchored at byte offset 0 of the uploaded buffer). Callers must expand a
     // multi-grid GridBatch into one view per grid; see fvdb.viz._nanovdb_grid_view.
@@ -632,6 +635,28 @@ Viewer::addNanoVDBGridView(const std::string &scene_name,
                                  array,
                                  getPipelineType(mEditor.editor, "pnanovdb_pipeline_type_noop"),
                                  render_pipeline);
+
+    // add_nanovdb_3 only applies render_pipeline as a soft default (apply_default_stage sets it
+    // only when the render stage is not already configured), so the editor's "Render:" dropdown
+    // may not land on it. Force the render stage explicitly, exactly as the editor UI does when
+    // you pick a renderer from that dropdown, so the dropdown shows the surface (SDF) renderer.
+    mEditor.editor.set_pipeline(
+        &mEditor.editor, sceneToken, nameToken, pnanovdb_pipeline_stage_render, render_pipeline);
+
+    // add_nanovdb_3 leaves the object on the editor's default shader (nanovdb_render's
+    // editor/editor.slang), which shades per-voxel scalars. Override it with the shader that
+    // matches render_pipeline so level sets draw as an HDDA isosurface. Same map_params pattern as
+    // addImage; setting the render pipeline above does not touch the object's shader.
+    pnanovdb_editor_shader_name_t *mapped =
+        (pnanovdb_editor_shader_name_t *)mEditor.editor.map_params(
+            &mEditor.editor,
+            sceneToken,
+            nameToken,
+            PNANOVDB_REFLECT_DATA_TYPE(pnanovdb_editor_shader_name_t));
+    if (mapped) {
+        mapped->shader_name = mEditor.editor.get_token(render_shader.c_str());
+        mEditor.editor.unmap_params(&mEditor.editor, sceneToken, nameToken);
+    }
 
     mEditor.compute.destroy_array(array);
 

--- a/src/fvdb/detail/viewer/Viewer.cpp
+++ b/src/fvdb/detail/viewer/Viewer.cpp
@@ -9,7 +9,6 @@
 
 #include <c10/util/Exception.h>
 
-#include <editor/PipelineTypes.h>
 #include <nanovdb_editor/putil/Raster.h>
 
 #include <cmath>
@@ -67,6 +66,19 @@ namespace fvdb::detail::viewer {
 
 constexpr float DEFAULT_CAMERA_FOV_RADIANS  = 60.f * M_PI / 180.f;
 constexpr float DEFAULT_CAMERA_ASPECT_RATIO = 4.f / 3.f;
+
+inline pnanovdb_pipeline_type_t
+getPipelineType(pnanovdb_editor_t &editor, const char *typeId) {
+    pnanovdb_pipeline_type_t type      = 0;
+    pnanovdb_editor_token_t *typeToken = editor.get_token(typeId);
+    TORCH_CHECK(
+        typeToken, "nanovdb-editor could not create token for pipeline type '", typeId, "'");
+    TORCH_CHECK(editor.get_pipeline_type(&editor, typeToken, &type),
+                "nanovdb-editor could not resolve pipeline type '",
+                typeId,
+                "'");
+    return type;
+}
 
 void
 Viewer::updateCamera(const std::string &scene_name) {
@@ -564,7 +576,11 @@ Viewer::addLevelSetView(const std::string &scene_name,
                         const std::string &name,
                         const GridBatchData &grid,
                         const JaggedTensor &sdf) {
-    addNanoVDBGridView(scene_name, name, grid, sdf, pnanovdb_pipeline_type_nanovdb_surface);
+    addNanoVDBGridView(scene_name,
+                       name,
+                       grid,
+                       sdf,
+                       getPipelineType(mEditor.editor, "pnanovdb_pipeline_type_nanovdb_surface"));
 }
 
 void
@@ -572,7 +588,11 @@ Viewer::addFogVolumeView(const std::string &scene_name,
                          const std::string &name,
                          const GridBatchData &grid,
                          const JaggedTensor &density) {
-    addNanoVDBGridView(scene_name, name, grid, density, pnanovdb_pipeline_type_nanovdb_render);
+    addNanoVDBGridView(scene_name,
+                       name,
+                       grid,
+                       density,
+                       getPipelineType(mEditor.editor, "pnanovdb_pipeline_type_nanovdb_render"));
 }
 
 void
@@ -610,7 +630,7 @@ Viewer::addNanoVDBGridView(const std::string &scene_name,
                                  sceneToken,
                                  nameToken,
                                  array,
-                                 pnanovdb_pipeline_type_noop,
+                                 getPipelineType(mEditor.editor, "pnanovdb_pipeline_type_noop"),
                                  render_pipeline);
 
     mEditor.compute.destroy_array(array);

--- a/src/fvdb/detail/viewer/Viewer.h
+++ b/src/fvdb/detail/viewer/Viewer.h
@@ -55,12 +55,16 @@ class Viewer {
 
     // Shared implementation behind addLevelSetView / addFogVolumeView: builds an ONINDEX NanoVDB
     // buffer carrying `floatValues` as blind data and registers it under the given nanovdb-editor
-    // render pipeline. `grid` must contain exactly one grid (batchSize() == 1).
+    // render pipeline and shader. `render_shader` must be the shader that `render_pipeline` uses
+    // (e.g. "editor/editor_surface.slang" for the surface pipeline) since add_nanovdb_3 otherwise
+    // leaves the object on the editor's default scalar shader. `grid` must contain exactly one
+    // grid (batchSize() == 1).
     void addNanoVDBGridView(const std::string &scene_name,
                             const std::string &name,
                             const GridBatchData &grid,
                             const JaggedTensor &floatValues,
-                            pnanovdb_pipeline_type_t render_pipeline);
+                            pnanovdb_pipeline_type_t render_pipeline,
+                            const std::string &render_shader);
 
   public:
     Viewer(const std::string &ipAddress,

--- a/src/fvdb/detail/viewer/Viewer.h
+++ b/src/fvdb/detail/viewer/Viewer.h
@@ -7,6 +7,8 @@
 #include <fvdb/detail/utils/gsplat/GaussianCameras.cuh>
 #include <fvdb/detail/viewer/CameraView.h>
 #include <fvdb/detail/viewer/GaussianSplat3dView.h>
+#include <fvdb/GridBatchData.h>
+#include <fvdb/JaggedTensor.h>
 
 #include <c10/util/Exception.h>
 #include <torch/types.h>
@@ -36,15 +38,29 @@ class Viewer {
     int mPort;
     std::string mCurrentSceneName;
 
+    struct NanoVDBView {
+        std::string name;
+    };
+
     // Views are currently shared by all scenes and need to have unique names
     std::map<std::string, GaussianSplat3dView> mSplat3dViews;
     std::map<std::string, CameraView> mCameraViews;
+    std::map<std::string, NanoVDBView> mNanoVDBViews;
 
     void updateCamera(const std::string &scene_name);
     void getCamera(const std::string &scene_name);
 
     void startServer();
     void stopServer();
+
+    // Shared implementation behind addLevelSetView / addFogVolumeView: builds an ONINDEX NanoVDB
+    // buffer carrying `floatValues` as blind data and registers it under the given nanovdb-editor
+    // render pipeline. `grid` must contain exactly one grid (batchSize() == 1).
+    void addNanoVDBGridView(const std::string &scene_name,
+                            const std::string &name,
+                            const GridBatchData &grid,
+                            const JaggedTensor &floatValues,
+                            pnanovdb_pipeline_type_t render_pipeline);
 
   public:
     Viewer(const std::string &ipAddress,
@@ -95,6 +111,25 @@ class Viewer {
                   const torch::Tensor &rgba_image,
                   int64_t width,
                   int64_t height);
+
+    // Add a single grid (batchSize() == 1) with per-voxel float32 SDF values as a level-set
+    // isosurface, rendered by the nanovdb-editor "surface" pipeline (HDDA zero-crossing).
+    void addLevelSetView(const std::string &scene_name,
+                         const std::string &name,
+                         const GridBatchData &grid,
+                         const JaggedTensor &sdf);
+
+    // Add a single grid (batchSize() == 1) with per-voxel float32 density values as a fog volume,
+    // rendered by the nanovdb-editor "render" pipeline (volumetric ray-marcher).
+    void addFogVolumeView(const std::string &scene_name,
+                          const std::string &name,
+                          const GridBatchData &grid,
+                          const JaggedTensor &density);
+
+    bool
+    hasNanoVDBView(const std::string &name) const {
+        return mNanoVDBViews.find(name) != mNanoVDBViews.end();
+    }
 
     bool
     hasGaussianSplat3dView(const std::string &name) const {

--- a/src/fvdb/detail/viewer/Viewer.h
+++ b/src/fvdb/detail/viewer/Viewer.h
@@ -4,11 +4,11 @@
 #ifndef FVDB_DETAIL_VIEWER_VIEWER_H
 #define FVDB_DETAIL_VIEWER_VIEWER_H
 
+#include <fvdb/GridBatchData.h>
+#include <fvdb/JaggedTensor.h>
 #include <fvdb/detail/utils/gsplat/GaussianCameras.cuh>
 #include <fvdb/detail/viewer/CameraView.h>
 #include <fvdb/detail/viewer/GaussianSplat3dView.h>
-#include <fvdb/GridBatchData.h>
-#include <fvdb/JaggedTensor.h>
 
 #include <c10/util/Exception.h>
 #include <torch/types.h>

--- a/src/python/ViewerBinding.cpp
+++ b/src/python/ViewerBinding.cpp
@@ -277,6 +277,28 @@ bind_viewer(py::module &m) {
              "Add an RGBA8 image as a 2D NanoVDB grid to the viewer. "
              "The rgba_image should be a 1D uint8 tensor of size width * height * 4 "
              "containing packed RGBA values.")
+        .def("add_level_set_view",
+             &fvdb::detail::viewer::Viewer::addLevelSetView,
+             py::arg("scene_name"),
+             py::arg("name"),
+             py::arg("grid"),
+             py::arg("sdf"),
+             "Add a single grid with per-voxel float32 SDF values as a level-set isosurface "
+             "(rendered by the nanovdb-editor surface pipeline). The grid must contain exactly "
+             "one grid.")
+        .def("add_fog_volume_view",
+             &fvdb::detail::viewer::Viewer::addFogVolumeView,
+             py::arg("scene_name"),
+             py::arg("name"),
+             py::arg("grid"),
+             py::arg("density"),
+             "Add a single grid with per-voxel float32 density values as a fog volume "
+             "(rendered by the nanovdb-editor render pipeline). The grid must contain exactly "
+             "one grid.")
+        .def("has_nanovdb_view",
+             &fvdb::detail::viewer::Viewer::hasNanoVDBView,
+             py::arg("name"),
+             "Check if a NanoVDB grid view with the given name exists.")
         .def("wait_for_interrupt",
              &fvdb::detail::viewer::Viewer::waitForInteerrupt,
              "Block until the viewer is interrupted by the user (Ctrl-C or closing the window)");

--- a/src/tests/LoadNanovdbTest.cpp
+++ b/src/tests/LoadNanovdbTest.cpp
@@ -3,6 +3,7 @@
 
 #include <fvdb/FVDB.h>
 #include <fvdb/JaggedTensor.h>
+#include <fvdb/detail/io/SaveNanoVDB.h>
 
 #include <nanovdb/NanoVDB.h>
 
@@ -201,4 +202,34 @@ TEST(LoadNanovdb, TensorGridShapeBlindDataCanFollowGridNameBlindData) {
     nanovdb::GridHandle<nanovdb::HostBuffer> sourceHandle =
         fvdb::to_nanovdb(*grid, std::optional<fvdb::JaggedTensor>(jaggedData), {kGridName});
     expectRoundTripWithLeadingGridNameBlindData(sourceHandle, sourceData);
+}
+
+TEST(SaveNanoVDB, BlindFloatPayloadMatchesValueOnIndexIndexSpace) {
+    auto grid = makeTestGrid();
+    torch::Tensor sourceData =
+        torch::tensor({-3.5f, -1.25f, 2.0f, 7.0f}, torch::TensorOptions().dtype(torch::kFloat32));
+    fvdb::JaggedTensor jaggedData(std::vector<torch::Tensor>{sourceData});
+
+    nanovdb::GridHandle<nanovdb::HostBuffer> handle =
+        fvdb::detail::io::toNVDBWithBlindFloat(*grid, jaggedData);
+
+    const auto *savedGrid = handle.grid<nanovdb::ValueOnIndex>(0);
+    ASSERT_NE(savedGrid, nullptr);
+    ASSERT_EQ(savedGrid->blindDataCount(), 1u);
+
+    const nanovdb::GridBlindMetaData &metadata = savedGrid->blindMetaData(0);
+    EXPECT_EQ(std::string(metadata.mName), "fvdb_sdf_float32");
+    EXPECT_EQ(metadata.mDataType, nanovdb::GridType::Float);
+    EXPECT_EQ(metadata.mValueSize, sizeof(float));
+
+    // ValueOnIndex reserves index 0 for background and active voxel values use
+    // indices 1..N, so the blind payload must live in that same index space.
+    ASSERT_EQ(metadata.mValueCount, static_cast<uint64_t>(sourceData.numel() + 1));
+
+    const float *payload = static_cast<const float *>(metadata.blindData());
+    ASSERT_NE(payload, nullptr);
+    EXPECT_FLOAT_EQ(payload[0], 0.0f);
+    for (int64_t i = 0; i < sourceData.numel(); ++i) {
+        EXPECT_FLOAT_EQ(payload[i + 1], sourceData[i].item<float>());
+    }
 }

--- a/tests/unit/test_viz.py
+++ b/tests/unit/test_viz.py
@@ -125,6 +125,82 @@ class TestViewerScene(unittest.TestCase):
         rgba_flat2 = rgba_data2.reshape(-1)
         view.update(rgba_flat2)
 
+    def test_add_level_set(self):
+        scene = fvdb.viz.Scene("test_level_set")
+
+        ijk = torch.randint(0, 16, (50, 3), dtype=torch.int32)
+        grid = fvdb.Grid.from_ijk(ijk)
+        sdf = fvdb.JaggedTensor([torch.randn(grid.num_voxels, dtype=torch.float32)])
+
+        view = scene.add_level_set("terrain", grid, sdf)
+        assert view is not None
+        assert isinstance(view, fvdb.viz.LevelSetView)
+        assert view.name == "terrain"
+        assert view.scene_name == "test_level_set"
+        # A single grid maps to a single view named exactly `name` (no `[i]` suffix).
+        assert view._view_names == ["terrain"]
+
+        # Update with fresh SDF values on the same grid.
+        sdf2 = fvdb.JaggedTensor([torch.randn(grid.num_voxels, dtype=torch.float32)])
+        view.update(grid, sdf2)
+        assert view._view_names == ["terrain"]
+
+    def test_add_fog_volume(self):
+        scene = fvdb.viz.Scene("test_fog_volume")
+
+        ijk = torch.randint(0, 16, (50, 3), dtype=torch.int32)
+        grid = fvdb.Grid.from_ijk(ijk)
+        density = fvdb.JaggedTensor([torch.rand(grid.num_voxels, dtype=torch.float32)])
+
+        view = scene.add_fog_volume("cloud", grid, density)
+        assert view is not None
+        assert isinstance(view, fvdb.viz.FogVolumeView)
+        assert view.name == "cloud"
+        assert view.scene_name == "test_fog_volume"
+        assert view._view_names == ["cloud"]
+
+    def test_add_level_set_gridbatch(self):
+        # A multi-grid GridBatch is expanded into one editor view per grid, named `name[i]`,
+        # because the nanovdb-editor renders only one grid per view.
+        scene = fvdb.viz.Scene("test_level_set_batch")
+
+        ijk0 = torch.randint(0, 16, (40, 3), dtype=torch.int32)
+        ijk1 = torch.randint(0, 16, (30, 3), dtype=torch.int32)
+        grid_batch = fvdb.GridBatch.from_ijk(fvdb.JaggedTensor([ijk0, ijk1]))
+        assert grid_batch.grid_count == 2
+
+        sdf = grid_batch.jagged_like(torch.randn(grid_batch.total_voxels, dtype=torch.float32))
+
+        view = scene.add_level_set("surf", grid_batch, sdf)
+        assert isinstance(view, fvdb.viz.LevelSetView)
+        assert view._view_names == ["surf[0]", "surf[1]"]
+
+    def test_add_level_set_invalid(self):
+        scene = fvdb.viz.Scene("test_level_set_invalid")
+
+        ijk = torch.randint(0, 16, (50, 3), dtype=torch.int32)
+        grid = fvdb.Grid.from_ijk(ijk)
+
+        # Wrong dtype (float64 instead of float32).
+        with pytest.raises(TypeError):
+            scene.add_level_set(
+                "bad_dtype", grid, fvdb.JaggedTensor([torch.randn(grid.num_voxels, dtype=torch.float64)])
+            )
+
+        # Wrong length (does not match voxel count).
+        with pytest.raises(ValueError):
+            scene.add_level_set(
+                "bad_len", grid, fvdb.JaggedTensor([torch.randn(grid.num_voxels + 1, dtype=torch.float32)])
+            )
+
+        # Not a Grid or GridBatch.
+        with pytest.raises(TypeError):
+            scene.add_level_set(
+                "bad_grid",
+                ijk,  # type: ignore[arg-type]
+                fvdb.JaggedTensor([torch.randn(grid.num_voxels, dtype=torch.float32)]),
+            )
+
     def test_camera_fov(self):
         scene = fvdb.viz.Scene("test_camera_fov")
 


### PR DESCRIPTION
## Summary

Adds native level-set and fog-volume rendering to `fvdb.viz`, so an fvdb `Grid`/`GridBatch` can be visualized directly in the viewer:

```python
scene.add_level_set("terrain", grid, sdf)     # HDDA zero-crossing isosurface
scene.add_fog_volume("cloud",  grid, density) # volumetric ray-march
```

Per-voxel `float32` values are attached to an `ONINDEX` NanoVDB buffer as blind data and handed to the nanovdb-editor `nanovdb_surface` / `nanovdb_render` pipelines. This reuses fvdb's existing per-voxel layout and skips the O(N) `indexToGrid` tree reconstruction.

## Details

- **`SaveNanoVDB`**: new `toNVDBWithBlindFloat()` that builds the `ONINDEX` + blind-float buffer, sharing its assembly spine with `saveIndexGridWithBlindData` via new `assembleOnIndexBlindBuffer` / `patchOnIndexTensorGridData` helpers (the two only differ in their blind descriptor + payload).
- **`Viewer`**: `addLevelSetView` / `addFogVolumeView` select the render pipeline in C++ (the editor pipeline enum stays out of Python). The editor renders one grid per view, so a multi-grid `GridBatch` is expanded to one view per grid (`name[i]`); the C++ entry point guards `batchSize() == 1`.
- **nanovdb-editor**: pin bumped to `0.1.4` for `add_nanovdb_3` and the `nanovdb_surface` pipeline.

## Testing

- New level-set / fog-volume viz tests pass end-to-end against a running viewer (single `Grid`, multi-grid `GridBatch` → `name[i]`, and input validation).
- IO round-trip suite (`test_io.py`) unchanged — the shared-helper refactor keeps the `.nvdb` save format byte-compatible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
