### PR TITLE
Fix nightly publish venv setup

### DIFF
--- a/.github/workflows/nightly-publish.yml
+++ b/.github/workflows/nightly-publish.yml
@@ -161,7 +161,6 @@ jobs:
           CUDA_TAG="cu$(echo "${MATRIX_CUDA_VERSION}" | tr -d '.')"
           TORCH_VERSION="${MATRIX_TORCH_VERSION}"
           echo "Installing PyTorch ${TORCH_VERSION} for ${CUDA_TAG}"
-          uv venv
           # Pin the tested PyTorch via a constraints file so the unbounded torch in
           # build_requirements.txt resolves to the version recorded in versions.json.
           echo "torch==${NEEDS_VERSIONS_OUTPUTS_TORCH_FULL_VERSION}" > "${RUNNER_TEMP}/torch-constraints.txt"


### PR DESCRIPTION
## Summary

Remove the redundant `uv venv` call from the nightly wheel publish dependency install step.

## Root Cause

The nightly job already creates `.venv` during `Set up Python`. Current `uv` fails when asked to create the same virtual environment again, so every nightly matrix job stopped before installing dependencies.

## Validation

Ran the Nightly Wheel Publish job from the PR branch and the nightly wheels have been published.
https://github.com/openvdb/fvdb-core/actions/runs/29497611433