### PR TITLE
Fix workflow security zizmor ref-version-mismatch in publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -380,7 +380,7 @@ jobs:
           echo "Built sdist:"
           ls -lh dist/
       - name: Publish distribution
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           repository-url: ${{ (needs.pr-flags.outputs.release == 'true' && 'https://upload.pypi.org/legacy/') || 'https://test.pypi.org/legacy/' }}
           verbose: true


### PR DESCRIPTION
## Summary
- Fix the stale `# release/v1` comment on the pinned `pypa/gh-action-pypi-publish` action in `publish.yml`.
- The pinned commit is v1.14.0, but the comment still referenced `release/v1`, which now points at v1.14.1.
- zizmor's online audit reports this as `ref-version-mismatch` and fails the Workflow Security gate on `main` and PRs.

## Test plan
- [x] Workflow Security CI passes
- [x] `GH_TOKEN=$(gh auth token) zizmor --persona=regular .github/workflows/publish.yml` reports no findings