### PR TITLE
Fix spurious near-origin hit in ray_implicit_intersection for no-data (zero) voxels

### DIFF
--- a/src/fvdb/detail/ops/RayImplicitIntersection.cu
+++ b/src/fvdb/detail/ops/RayImplicitIntersection.cu
@@ -18,10 +18,21 @@ namespace {
 
 constexpr int INVALID_SIGN = 10;
 
+// Classify a voxel's SDF value as inside (-1), outside (+1), or "no reference" (INVALID_SIGN).
+//
+// Both NaN and *exactly* zero map to INVALID_SIGN, i.e. they are treated as gaps that neither seed
+// the sign reference nor trigger a crossing. NaN is an explicit gap marker. Exact zero is the
+// background/no-data fill of a sparse narrow band: ops like `reinitialize_sdf` leave every active
+// voxel outside the reinitialised band at 0, so a ray that starts far from the surface walks a long
+// prefix of active-but-uncomputed 0 voxels before reaching real signed data. Mapping 0 to a real
+// sign (the mathematical `sgn(0) == 0`) would let that background seed a bogus reference and report
+// a spurious crossing the instant the ray touched the first genuine +/- voxel (issue #692). A true
+// on-surface voxel is still bracketed by its signed neighbours, so this only costs bracket-entry
+// (rather than interpolated) precision on the vanishingly rare exactly-0 sample.
 template <typename T>
 __forceinline__ __hostdev__ int
 sgn(const T &val) {
-    if (val != val) {
+    if (val != val || val == T(0)) {
         return INVALID_SIGN;
     }
     return (T(0) < val) - (val < T(0));
@@ -29,13 +40,21 @@ sgn(const T &val) {
 
 // Per-ray SDF zero-crossing search.
 //
-// Semantics match nanovdb::ZeroCrossing: the FIRST valid (non-NaN) voxel along the ray seeds the
-// sign reference, and the first subsequent voxel with the opposite sign is reported as the hit.
-// This naturally handles both rays that start outside the surface (first sample positive, hit on
-// crossing into the negative band) AND rays that start inside the surface (first sample negative,
-// hit on crossing back out into the positive band) without baking a fixed "positive = outside"
-// convention into the kernel. NaN voxels are treated as gaps so the band-continuity check will
-// fall back to bracket-entry time on the next valid voxel.
+// Semantics match nanovdb::ZeroCrossing: the FIRST valid (signed, non-gap) voxel along the ray
+// seeds the sign reference, and the first subsequent voxel with the opposite sign is reported as
+// the hit. This naturally handles both rays that start outside the surface (first sample positive,
+// hit on crossing into the negative band) AND rays that start inside the surface (first sample
+// negative, hit on crossing back out into the positive band) without baking a fixed
+// "positive = outside" convention into the kernel.
+//
+// A "gap" voxel is one whose value carries no sign: NaN, or *exactly* zero. Unlike a classic dense
+// nanovdb level set (where inactive voxels carry the signed background value, so the sign field is
+// defined everywhere along the ray), an fvdb OnIndexGrid carries no background sign in inactive
+// voxels, and TSDF-derived grids additionally contain *active* voxels with value 0 -- the
+// unobserved / out-of-band no-data fill left behind by integrate_tsdf + reinitialize_sdf. Seeding
+// the reference from such a 0 would report a spurious crossing the instant the ray reached the
+// first genuine +/- voxel (issue #692), so gaps neither seed the reference nor trigger a hit; the
+// band-continuity check then falls back to bracket-entry time on the next valid voxel. See sgn().
 //
 // Performance notes:
 //

--- a/tests/unit/test_basic_ops.py
+++ b/tests/unit/test_basic_ops.py
@@ -2111,6 +2111,52 @@ class TestBasicOps(unittest.TestCase):
             f"hit-time {isect.item()} expected ~4.5 (linear-interp zero crossing) within quarter voxel",
         )
 
+    @parameterized.expand(all_device_dtype_combos)
+    def test_ray_implicit_intersection_no_data_zero_prefix(self, device, dtype):
+        # Regression test for issue #692: a ray that starts far from the
+        # surface band must report the FIRST genuine sign change, not a
+        # spurious crossing seeded by the no-data prefix.
+        #
+        # Sparse fvdb SDFs (e.g. integrate_tsdf + reinitialize_sdf) leave
+        # active-but-unobserved voxels outside the narrow band at exactly
+        # 0. Mathematically sgn(0) == 0, so if the kernel treated 0 as a
+        # real sign it would latch the very first 0 voxel as its reference
+        # and flag a "sign change" the instant the ray reached the first
+        # signed (+/-) voxel — collapsing the hit to ~a voxel from the
+        # origin regardless of where the real surface is. The kernel must
+        # instead treat 0 as a gap (like NaN): it neither seeds the sign
+        # reference nor triggers a hit.
+        #
+        # Setup along +x (voxel_size=1, origin=0): i in [0,3] = 0 (no-data
+        # prefix), i in [4,5] = +1 (outside band), i in [6,7] = -1 (inside).
+        # The only true crossing is the +1 -> -1 step bracketed by the
+        # samples at world x=5 and x=6, whose symmetric interpolated zero
+        # sits at world x=5.5. A ray from world x=-1 along +x therefore hits
+        # at t=6.5. The buggy kernel instead reported ~t=4.5 (a bogus 0->+1
+        # "crossing" near the start of the signed band).
+        N = 8
+        voxel_size = 1.0
+        sdf_dense = torch.zeros((N, N, N))
+        sdf_dense[4:6, :, :] = 1.0
+        sdf_dense[6:, :, :] = -1.0
+        sdf_dense = sdf_dense.to(device).to(dtype)
+
+        grid = GridBatch.from_dense(1, [N, N, N], [0, 0, 0], voxel_sizes=voxel_size, origins=[0, 0, 0], device=device)
+        sdf_p = grid.inject_from_dense_cminor(sdf_dense.unsqueeze(-1).unsqueeze(0)).jdata.squeeze()
+
+        ray_o = torch.tensor([[-1.0, 4.0, 4.0]]).to(device).to(dtype)
+        ray_d = torch.tensor([[1.0, 0.0, 0.0]]).to(device).to(dtype)
+        isect = grid.ray_implicit_intersection(
+            fvdb.JaggedTensor(ray_o), fvdb.JaggedTensor(ray_d), fvdb.JaggedTensor(sdf_p)
+        ).jdata
+        self.assertTrue((isect >= 0).all().item(), f"unexpected miss, isect={isect}")
+        self.assertLess(
+            abs(isect.item() - 6.5),
+            0.25 * voxel_size,
+            f"hit-time {isect.item()} expected ~6.5 (true +1->-1 crossing); a value near 4.5 means "
+            f"the no-data (0) prefix spuriously seeded the sign reference (issue #692)",
+        )
+
     @parameterized.expand(["cpu", "cuda"])
     def test_ray_implicit_intersection_wrong_scalar_count_errors(self, device):
         # ray_implicit_intersection iterates leaf voxels (HDDALeafVoxelIterator)


### PR DESCRIPTION
Fixes #692.

## Problem

`GridBatch.ray_implicit_intersection` / `Grid.ray_implicit_intersection` returned an **incorrect** intersection for a ray that starts far from the SDF's active narrow band: the reported hit collapsed to a spurious point ~¼ of a voxel from the ray origin instead of the true zero-crossing. Moving the origin close to the surface returned the correct result. This silently breaks ray-marching an SDF from a distant camera/emitter.

## Root cause

`sgn()` returned `0` for an exactly-zero SDF value, and the kernel treated that `0` as a valid, distinct sign.

Sparse SDFs produced by `integrate_tsdf` + `reinitialize_sdf` leave every active voxel outside the reinitialised band at **exactly `0`** — voxels that were never observed (behind the camera, or occluded beyond the truncation distance) carry `weight == 0` / `tsdf == 0`, and a band-limited redistancing cannot invent a sign for a flat-zero region, so it leaves them at `0`. That `0` means "no data", not "on the surface".

A ray from a distant origin therefore walks a long prefix of active-but-uncomputed `0` voxels before reaching real signed data. The first such `0` voxel seeded the sign reference, and the first genuine `+`/`−` voxel then read as an immediate sign change — reporting a hit essentially at the ray origin.

## Fix

Treat an exactly-zero voxel the same as `NaN` in `sgn()`: a **gap** that neither seeds the sign reference nor triggers a crossing. A true on-surface voxel is still bracketed by its signed neighbours, so this only costs bracket-entry (rather than interpolated) precision on the vanishingly rare exactly-`0` sample.

This also aligns the op with the semantics of `nanovdb::math::ZeroCrossing`, whose `v * v0 < 0` product test likewise never treats a zero as a crossing (fvdb `OnIndexGrid`s carry no signed background in inactive voxels, and TSDF-derived grids additionally contain *active* value-`0` no-data voxels, so the "sign field is defined everywhere" assumption of a classic dense level set does not hold here).

```cpp
if (val != val || val == T(0)) {   // NaN or exact-zero (no-data) -> gap
    return INVALID_SIGN;
}
```

## Testing

- Adds `test_ray_implicit_intersection_no_data_zero_prefix`: a synthetic no-data-prefix case (a `0`-valued prefix before a `+1 -> -1` band, no `integrate_tsdf` needed) that reports `~t=4.5` on the pre-fix binary and `~t=6.5` (the true crossing) after — verified to fail before and pass after, on both **CPU and CUDA**.
- All existing `ray_implicit_intersection` tests continue to pass (fp16/fp32/fp64, CPU + CUDA).
- Confirmed against the issue's reproduction: from origin `z=0` the op now returns the true surface (`hit z ≈ 2942`) instead of the spurious `z ≈ 115`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)