### PR TITLE
Unit Test GPU RAM Reductions

### DIFF
--- a/.github/workflows/cu128.yml
+++ b/.github/workflows/cu128.yml
@@ -445,6 +445,14 @@ jobs:
           pip install ./dist/*.whl
 
       - name: Run tests
+        env:
+          # The whole parametrized matrix shares one process, so the caching allocator's
+          # reserved pool only ever grows and its high-water mark ends up far above any
+          # single test's live footprint. Freeing straight back to the driver keeps the
+          # suite within the runner's VRAM, at the cost of a cudaMalloc/cudaFree per
+          # allocation. See
+          # https://docs.pytorch.org/docs/stable/notes/cuda.html#optimizing-memory-usage-with-pytorch-alloc-conf
+          PYTORCH_NO_CUDA_MEMORY_CACHING: 1
         run: |
           source .venv/bin/activate
           NANOVDB_EDITOR_SPEC=$(python .github/scripts/get_viewer_dependency.py)

--- a/.github/workflows/cu130.yml
+++ b/.github/workflows/cu130.yml
@@ -445,6 +445,14 @@ jobs:
           pip install ./dist/*.whl
 
       - name: Run tests
+        env:
+          # The whole parametrized matrix shares one process, so the caching allocator's
+          # reserved pool only ever grows and its high-water mark ends up far above any
+          # single test's live footprint. Freeing straight back to the driver keeps the
+          # suite within the runner's VRAM, at the cost of a cudaMalloc/cudaFree per
+          # allocation. See
+          # https://docs.pytorch.org/docs/stable/notes/cuda.html#optimizing-memory-usage-with-pytorch-alloc-conf
+          PYTORCH_NO_CUDA_MEMORY_CACHING: 1
         run: |
           source .venv/bin/activate
           NANOVDB_EDITOR_SPEC=$(python .github/scripts/get_viewer_dependency.py)

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -762,6 +762,14 @@ jobs:
           pip install dist/fvdb_core-*.whl
 
       - name: Run unit tests
+        env:
+          # The whole parametrized matrix shares one process, so the caching allocator's
+          # reserved pool only ever grows and its high-water mark ends up far above any
+          # single test's live footprint. Freeing straight back to the driver keeps the
+          # suite within the runner's VRAM, at the cost of a cudaMalloc/cudaFree per
+          # allocation. See
+          # https://docs.pytorch.org/docs/stable/notes/cuda.html#optimizing-memory-usage-with-pytorch-alloc-conf
+          PYTORCH_NO_CUDA_MEMORY_CACHING: 1
         run: |
           micromamba activate fvdb_test
           NANOVDB_EDITOR_SPEC=$(python .github/scripts/get_viewer_dependency.py)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -338,6 +338,14 @@ jobs:
             pip install ./dist/*.whl
 
       - name: Run tests
+        env:
+          # The whole parametrized matrix shares one process, so the caching allocator's
+          # reserved pool only ever grows and its high-water mark ends up far above any
+          # single test's live footprint. Freeing straight back to the driver keeps the
+          # suite within the runner's VRAM, at the cost of a cudaMalloc/cudaFree per
+          # allocation. See
+          # https://docs.pytorch.org/docs/stable/notes/cuda.html#optimizing-memory-usage-with-pytorch-alloc-conf
+          PYTORCH_NO_CUDA_MEMORY_CACHING: 1
         run: |
             micromamba activate fvdb_test
             NANOVDB_EDITOR_SPEC=$(python .github/scripts/get_viewer_dependency.py)

--- a/tests/unit/test_accessors.py
+++ b/tests/unit/test_accessors.py
@@ -6,49 +6,97 @@ import unittest
 import torch
 from parameterized import parameterized
 
-from fvdb import GridBatch, JaggedTensor
+from fvdb import Grid, GridBatch, JaggedTensor
 
 all_device_combos = [
     ["cpu"],
     ["cuda"],
 ]
 
-RESOLUTION = 1292  # over int32_t max limit
+# 1292**3 = 2,156,689,088 elements, just over INT32_MAX. These tests guard
+# against dense accessor/index calculations overflowing for tensors that cannot
+# be described by a signed 32-bit element count.
+RESOLUTION = 1292
 # RESOLUTION = 64 # under int32_t max limit
 
 
 class TestAccessors(unittest.TestCase):
     @parameterized.expand(all_device_combos)
     def test_read_from_dense_cminor(self, device):
+        """Read sparse values from a dense tensor whose element count exceeds INT32_MAX.
+
+        Nonzero values at the active voxels verify that the operation is not a
+        no-op. Both GridBatch and Grid are covered because they expose separate
+        public APIs over the dense accessor implementation.
+        """
         dense_origin = torch.tensor([0, 0, 0], dtype=torch.long, device=device)
+        grid_size = (RESOLUTION, RESOLUTION, RESOLUTION)
+        # FP16 keeps the threshold-crossing dense allocation to about 4.02 GiB.
         dense_grid = torch.zeros(
-            (1, RESOLUTION, RESOLUTION, RESOLUTION, 1),
+            (1, *grid_size, 1),
             dtype=torch.float16,
             device=device,
         )
 
         sparse_points = torch.tensor([[0, 0, 0], [1, 1, 1]], dtype=torch.float16, device=device)
         grid_batch = GridBatch.from_points(JaggedTensor(sparse_points), voxel_sizes=0.1, origins=0.0)
+        batch_ijk = grid_batch.ijk.jdata.to(torch.long)
+        expected_batch_data = torch.arange(
+            1, grid_batch.total_voxels + 1, dtype=torch.float16, device=device
+        ).unsqueeze(1)
+        dense_grid[0, batch_ijk[:, 0], batch_ijk[:, 1], batch_ijk[:, 2]] = expected_batch_data
 
         read_jagged_data = grid_batch.inject_from_dense_cminor(dense_grid, dense_origin)
         self.assertIsInstance(read_jagged_data, JaggedTensor)
+        self.assertTrue(torch.equal(read_jagged_data.jdata, expected_batch_data))
 
-        grid = GridBatch.from_points(JaggedTensor(sparse_points), voxel_sizes=0.1, origins=0.0)
-        read_jagged_data2 = grid.inject_from_dense_cminor(dense_grid, dense_origin)
-        self.assertIsInstance(read_jagged_data2, JaggedTensor)
+        grid = Grid.from_points(sparse_points, voxel_size=0.1, origin=0.0)
+        grid_ijk = grid.ijk.to(torch.long)
+        expected_data = dense_grid[0, grid_ijk[:, 0], grid_ijk[:, 1], grid_ijk[:, 2]]
+        read_data = grid.inject_from_dense_cminor(dense_grid, dense_origin)
+        self.assertIsInstance(read_data, torch.Tensor)
+        self.assertTrue(torch.equal(read_data, expected_data))
 
     @parameterized.expand(all_device_combos)
     def test_write_to_dense_cminor(self, device):
-        dense_origin = torch.tensor([0, 0, 0]).to(torch.long).to(device)
+        """Write sparse values into a dense tensor whose element count exceeds INT32_MAX.
 
-        zero_points = torch.tensor([[0, 0, 0], [1, 1, 1]], dtype=torch.float16, device=device)
-        grid_batch = GridBatch.from_points(JaggedTensor(zero_points), voxel_sizes=0.1, origins=0.0)
+        Shape and active-voxel checks exercise the large tensor's indexing
+        without scanning its entire 4 GiB allocation. The GridBatch and Grid
+        paths are checked independently.
+        """
+        dense_origin = torch.tensor([0, 0, 0], dtype=torch.long, device=device)
+        grid_size = (RESOLUTION, RESOLUTION, RESOLUTION)
+        expected_dense_shape = (*grid_size, 1)
 
-        sparse_data = torch.tensor([[0], [0]], dtype=torch.float16, device=device)
-        grid_batch.inject_to_dense_cminor(JaggedTensor(sparse_data), dense_origin, (RESOLUTION, RESOLUTION, RESOLUTION))
+        sparse_points = torch.tensor([[0, 0, 0], [1, 1, 1]], dtype=torch.float16, device=device)
+        grid_batch = GridBatch.from_points(JaggedTensor(sparse_points), voxel_sizes=0.1, origins=0.0)
+        batch_ijk = grid_batch.ijk.jdata.to(torch.long)
+        batch_sparse_data = torch.arange(1, grid_batch.total_voxels + 1, dtype=torch.float16, device=device).unsqueeze(
+            1
+        )
 
-        grid = GridBatch.from_points(JaggedTensor(zero_points), voxel_sizes=0.1, origins=0.0)
-        grid.inject_to_dense_cminor(JaggedTensor(sparse_data), dense_origin, (RESOLUTION, RESOLUTION, RESOLUTION))
+        dense_batch = grid_batch.inject_to_dense_cminor(
+            JaggedTensor(batch_sparse_data), dense_origin, grid_size
+        ).squeeze(0)
+        self.assertEqual(dense_batch.shape, expected_dense_shape)
+        self.assertTrue(
+            torch.equal(
+                dense_batch[batch_ijk[:, 0], batch_ijk[:, 1], batch_ijk[:, 2]],
+                batch_sparse_data,
+            )
+        )
+        # Release the first 4 GiB view before testing Grid so the CUDA allocator
+        # can reuse its storage instead of requiring two simultaneous outputs.
+        del dense_batch
+
+        grid = Grid.from_points(sparse_points, voxel_size=0.1, origin=0.0)
+        grid_ijk = grid.ijk.to(torch.long)
+        sparse_data = torch.arange(1, grid.num_voxels + 1, dtype=torch.float16, device=device).unsqueeze(1)
+
+        dense = grid.inject_to_dense_cminor(sparse_data, dense_origin, grid_size).squeeze(0)
+        self.assertEqual(dense.shape, expected_dense_shape)
+        self.assertTrue(torch.equal(dense[grid_ijk[:, 0], grid_ijk[:, 1], grid_ijk[:, 2]], sparse_data))
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_basic_ops.py
+++ b/tests/unit/test_basic_ops.py
@@ -2443,13 +2443,13 @@ class TestBasicOps(unittest.TestCase):
             fvdb.GridBatch.from_nearest_voxels_to_points(pts_too_big, voxel_sizes=1.0, origins=[0] * 3)
 
         with self.assertRaises(ValueError):
-            fvdb.GridBatch.from_dense(VAL_BIG, [10, 10, 10], [0, 0, 0], 1.0, [0] * 3)
+            fvdb.GridBatch.from_dense(VAL_BIG, [4, 4, 4], [0, 0, 0], 1.0, [0] * 3)
 
         fvdb.GridBatch.from_points(pts_too_big[:-1], 1.0, [0] * 3)
         fvdb.GridBatch.from_ijk(ijk_too_big[:-1], voxel_sizes=1.0, origins=[0] * 3)
         fvdb.GridBatch.from_mesh(pts_too_big[:-1], faces_too_big[:-1], voxel_sizes=1.0, origins=[0] * 3)
         fvdb.GridBatch.from_nearest_voxels_to_points(pts_too_big[:-1], voxel_sizes=1.0, origins=[0] * 3)
-        fvdb.GridBatch.from_dense(VAL_OKAY, [10, 10, 10], [0, 0, 0], 1.0, [0] * 3, device=device)
+        fvdb.GridBatch.from_dense(VAL_OKAY, [4, 4, 4], [0, 0, 0], 1.0, [0] * 3, device=device)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_batching.py
+++ b/tests/unit/test_batching.py
@@ -16,7 +16,7 @@ all_device_dtype_combos = [
     ["cuda", torch.float32],
 ]
 
-NVOX = 1_000_000
+NVOX = 100_000
 
 
 class TestBatching(unittest.TestCase):

--- a/tests/unit/test_jagged_tensor.py
+++ b/tests/unit/test_jagged_tensor.py
@@ -457,7 +457,7 @@ class TestJaggedTensor(unittest.TestCase):
             device,
             dtype,
             last_dims=(3,),
-            base_num=1_000_000 if device == "cuda" else 1000,
+            base_num=100_000 if device == "cuda" else 1000,
             vary_num=100,
             empty_prob=0.0,
         )
@@ -468,7 +468,7 @@ class TestJaggedTensor(unittest.TestCase):
             device,
             dtype,
             last_dims=(3,),
-            base_num=1_000_000 if device == "cuda" else 1000,
+            base_num=100_000 if device == "cuda" else 1000,
             vary_num=100,
             empty_prob=0.0,
         )


### PR DESCRIPTION
Minor changes to unit tests so that tests run comfortably on a fractional L4 GPU with 6GB of VRAM.

Some tests changed hyper parameter values because the numbers chosen were too large (i.e. the unit test needs 'some significant number' but the test doesn't depend on the number being a specific large value) and a few tests (namely in `test_accessors.py`) are specifically to test that functionality works if the parameters are past some limit.  For the latter, I added documentation so that's clear and made the tests more robust (rather than simply testing they do not crash).

Per @matthewdcong's suggestion, the `conftest.py` periodic `empty_cache()` fixture is replaced by setting `PYTORCH_NO_CUDA_MEMORY_CACHING=1` on the CI unit test steps (`tests.yml`, `cu128.yml`, `cu130.yml`, `publish.yml`). The whole parametrized matrix shares one process, so the caching allocator's reserved pool only ever grows and its high-water mark ends up far above any single test's live footprint. Setting it in the workflows rather than in `conftest.py` means CI pays the cost (a `cudaMalloc`/`cudaFree` per allocation) where VRAM is the constraint, while local test runs keep the caching allocator and its speed.
