### PR TITLE
Bump nanovdb-editor minimum requirement to 0.1.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "torch>=2.8",
     "numpy",
 ]
-optional-dependencies = {viewer = ["nanovdb-editor>=0.1.5,<0.2.0"]}
+optional-dependencies = {viewer = ["nanovdb-editor>=0.1.6,<0.2.0"]}
 classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",


### PR DESCRIPTION
We pull nanovdb-editor 0.1.6 in cmake, this just reflects the appropriate version in `pyproject.toml`