### PR TITLE
Enable a user override for NVCC_THREADS

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -53,20 +53,27 @@ setup_parallel_build_jobs() {
   if [ "$NUM_ARCH" -lt 1 ]; then
     NUM_ARCH=1
   fi
-  NVCC_THREADS=$NUM_ARCH
 
-  # Check if we have enough RAM for even one job with full NVCC_THREADS
-  # Requirement: JOB_RAM_GB * NVCC_THREADS
-  MIN_RAM_REQUIRED=$((JOB_RAM_GB * NVCC_THREADS))
+  # if NVCC_THREADS is set, use that; otherwise derive from the number of CUDA architectures
+  if [ -n "$NVCC_THREADS" ]; then
+    echo "Using NVCC_THREADS=$NVCC_THREADS"
+  else
+    NVCC_THREADS=$NUM_ARCH
 
-  if [ "$RAM_GB" -lt "$MIN_RAM_REQUIRED" ]; then
-      NVCC_THREADS=1
+    # Check if we have enough RAM for even one job with full NVCC_THREADS
+    # Requirement: JOB_RAM_GB * NVCC_THREADS
+    MIN_RAM_REQUIRED=$((JOB_RAM_GB * NVCC_THREADS))
+
+    if [ "$RAM_GB" -lt "$MIN_RAM_REQUIRED" ]; then
+        NVCC_THREADS=1
+    fi
+
+    # Limit NVCC_THREADS to NPROC to ensure we don't oversubscribe
+    if [ "$NVCC_THREADS" -gt "$NPROC" ]; then
+        NVCC_THREADS=$NPROC
+    fi
   fi
-
-  # Limit NVCC_THREADS to NPROC to ensure we don't oversubscribe
-  if [ "$NVCC_THREADS" -gt "$NPROC" ]; then
-      NVCC_THREADS=$NPROC
-  fi
+  export NVCC_THREADS
 
   # Determine max jobs based on CPU:
   # We want CMAKE_BUILD_PARALLEL_LEVEL * NVCC_THREADS <= NPROC
@@ -88,7 +95,6 @@ setup_parallel_build_jobs() {
   if [ -n "$CMAKE_BUILD_PARALLEL_LEVEL" ]; then
     echo "Using CMAKE_BUILD_PARALLEL_LEVEL=$CMAKE_BUILD_PARALLEL_LEVEL"
   else
-
     CMAKE_BUILD_PARALLEL_LEVEL=$PARALLEL_JOBS
 
     echo "Setting nvcc --threads to $NVCC_THREADS based on the number of CUDA architectures ($NUM_ARCH)"
@@ -97,7 +103,6 @@ setup_parallel_build_jobs() {
     echo "  Constraint: Estimated RAM ($((CMAKE_BUILD_PARALLEL_LEVEL * NVCC_THREADS * JOB_RAM_GB))) GB <= Available RAM ($RAM_GB GB)"
 
     export CMAKE_BUILD_PARALLEL_LEVEL
-    export NVCC_THREADS
   fi
 }
 


### PR DESCRIPTION
Currently, the `NVCC_THREADS` variable is entirely determined by the `TORCH_CUDA_ARCH_LIST`. However, when compiling for multiple archs (in the case of reusable Dockerfiles), `NVCC_THREADS` can become large which then leads to heavy quantization when calculating `CMAKE_BUILD_PARALLEL_LEVEL`. For example, when compiling for six different architectures on a machine with nproc = 10, this results in a non-parallel build (`MAX_JOBS = 1`) which degrades build performance overall since host code compilation and the initial nvcc calls is no longer parallelized.

The solution is to enable the user to set `NVCC_THREADS` in their environment like `CMAKE_BUILD_PARALLEL_LEVEL` and use that in `./build.sh` if set.