### PR TITLE
CI:  Use all 3 us-east-2 availability zones for starting runners

### DIFF
--- a/.github/versions.json
+++ b/.github/versions.json
@@ -35,7 +35,11 @@
     "region": "us-east-2",
     "cpu_ami": "ami-0e14a711dad782a70",
     "gpu_ami": "ami-0f5c0b65fde08ae43",
-    "subnet": "subnet-03f2320d6e6e0005b",
+    "subnets": [
+      { "az": "us-east-2a", "id": "subnet-0b75bb13b6048a2f1" },
+      { "az": "us-east-2b", "id": "subnet-03f2320d6e6e0005b" },
+      { "az": "us-east-2c", "id": "subnet-0c551606873c36095" }
+    ],
     "security_group": "sg-0cd08bd89d6212223",
     "cloudfront_distribution_domain": "d36m13axqqhiit.cloudfront.net"
   },

--- a/.github/workflows/cu128.yml
+++ b/.github/workflows/cu128.yml
@@ -54,10 +54,8 @@ jobs:
         with:
           mode: start
           github-token: ${{ secrets.EC2_RUNNER_TOKEN }}
-          ec2-image-id: ${{ needs.versions.outputs.aws-cpu-ami }}
           ec2-instance-type: m6a.8xlarge
-          subnet-id: ${{ needs.versions.outputs.aws-subnet }}
-          security-group-id: ${{ needs.versions.outputs.aws-security-group }}
+          availability-zones-config: ${{ needs.versions.outputs.aws-cpu-az-config }}
 
   ##############################################################################
   # BUILD FVDB
@@ -251,10 +249,8 @@ jobs:
         with:
           mode: start
           github-token: ${{ secrets.EC2_RUNNER_TOKEN }}
-          ec2-image-id: ${{ needs.versions.outputs.aws-gpu-ami }}
-          ec2-instance-type: g6.2xlarge # 8 CPU-core, L4 GPU
-          subnet-id: ${{ needs.versions.outputs.aws-subnet }}
-          security-group-id: ${{ needs.versions.outputs.aws-security-group }}
+          ec2-instance-type: g6.xlarge # 4 CPU-core, L4 GPU
+          availability-zones-config: ${{ needs.versions.outputs.aws-gpu-az-config }}
 
   ##############################################################################
   # RUN FVDB GTESTS

--- a/.github/workflows/cu130.yml
+++ b/.github/workflows/cu130.yml
@@ -54,10 +54,8 @@ jobs:
         with:
           mode: start
           github-token: ${{ secrets.EC2_RUNNER_TOKEN }}
-          ec2-image-id: ${{ needs.versions.outputs.aws-cpu-ami }}
           ec2-instance-type: m6a.8xlarge
-          subnet-id: ${{ needs.versions.outputs.aws-subnet }}
-          security-group-id: ${{ needs.versions.outputs.aws-security-group }}
+          availability-zones-config: ${{ needs.versions.outputs.aws-cpu-az-config }}
 
   ##############################################################################
   # BUILD FVDB
@@ -251,10 +249,8 @@ jobs:
         with:
           mode: start
           github-token: ${{ secrets.EC2_RUNNER_TOKEN }}
-          ec2-image-id: ${{ needs.versions.outputs.aws-gpu-ami }}
-          ec2-instance-type: g6.2xlarge # 8 CPU-core, L4 GPU
-          subnet-id: ${{ needs.versions.outputs.aws-subnet }}
-          security-group-id: ${{ needs.versions.outputs.aws-security-group }}
+          ec2-instance-type: g6.xlarge # 4 CPU-core, L4 GPU
+          availability-zones-config: ${{ needs.versions.outputs.aws-gpu-az-config }}
 
   ##############################################################################
   # RUN FVDB GTESTS

--- a/.github/workflows/load-versions.yml
+++ b/.github/workflows/load-versions.yml
@@ -50,8 +50,10 @@ on:
         value: ${{ jobs.load.outputs.aws-cpu-ami }}
       aws-gpu-ami:
         value: ${{ jobs.load.outputs.aws-gpu-ami }}
-      aws-subnet:
-        value: ${{ jobs.load.outputs.aws-subnet }}
+      aws-cpu-az-config:
+        value: ${{ jobs.load.outputs.aws-cpu-az-config }}
+      aws-gpu-az-config:
+        value: ${{ jobs.load.outputs.aws-gpu-az-config }}
       aws-security-group:
         value: ${{ jobs.load.outputs.aws-security-group }}
       aws-cloudfront-distribution-domain:
@@ -87,7 +89,8 @@ jobs:
       aws-region: ${{ steps.parse.outputs.aws-region }}
       aws-cpu-ami: ${{ steps.parse.outputs.aws-cpu-ami }}
       aws-gpu-ami: ${{ steps.parse.outputs.aws-gpu-ami }}
-      aws-subnet: ${{ steps.parse.outputs.aws-subnet }}
+      aws-cpu-az-config: ${{ steps.parse.outputs.aws-cpu-az-config }}
+      aws-gpu-az-config: ${{ steps.parse.outputs.aws-gpu-az-config }}
       aws-security-group: ${{ steps.parse.outputs.aws-security-group }}
       aws-cloudfront-distribution-domain: ${{ steps.parse.outputs.aws-cloudfront-distribution-domain }}
       publish-matrix: ${{ steps.parse.outputs.publish-matrix }}
@@ -125,7 +128,8 @@ jobs:
             echo "aws-region=$(jq -r '.aws.region' $CFG)"
             echo "aws-cpu-ami=$(jq -r '.aws.cpu_ami' $CFG)"
             echo "aws-gpu-ami=$(jq -r '.aws.gpu_ami' $CFG)"
-            echo "aws-subnet=$(jq -r '.aws.subnet' $CFG)"
+            echo "aws-cpu-az-config=$(jq -c '.aws as $a | [$a.subnets[] | {imageId: $a.cpu_ami, subnetId: .id, securityGroupId: $a.security_group}]' $CFG)"
+            echo "aws-gpu-az-config=$(jq -c '.aws as $a | [$a.subnets[] | {imageId: $a.gpu_ami, subnetId: .id, securityGroupId: $a.security_group}]' $CFG)"
             echo "aws-security-group=$(jq -r '.aws.security_group' $CFG)"
             echo "aws-cloudfront-distribution-domain=$(jq -r '.aws.cloudfront_distribution_domain // ""' $CFG)"
             echo "publish-matrix=$(jq -c '.publish_matrix' $CFG)"

--- a/.github/workflows/nightly-publish.yml
+++ b/.github/workflows/nightly-publish.yml
@@ -84,10 +84,8 @@ jobs:
         with:
           mode: start
           github-token: ${{ secrets.EC2_RUNNER_TOKEN }}
-          ec2-image-id: ${{ needs.versions.outputs.aws-cpu-ami }}
           ec2-instance-type: m6a.xlarge
-          subnet-id: ${{ needs.versions.outputs.aws-subnet }}
-          security-group-id: ${{ needs.versions.outputs.aws-security-group }}
+          availability-zones-config: ${{ needs.versions.outputs.aws-cpu-az-config }}
           label: nightly-${{ matrix.python-version }}-pt${{ matrix.torch-version }}-cu${{ matrix.cuda-version }}-${{ github.run_id }}
           aws-resource-tags: >
             [

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -145,10 +145,8 @@ jobs:
         with:
           mode: start
           github-token: ${{ secrets.EC2_RUNNER_TOKEN }}
-          ec2-image-id: ${{ needs.versions.outputs.aws-cpu-ami }}
           ec2-instance-type: m6a.8xlarge
-          subnet-id: ${{ needs.versions.outputs.aws-subnet }}
-          security-group-id: ${{ needs.versions.outputs.aws-security-group }}
+          availability-zones-config: ${{ needs.versions.outputs.aws-cpu-az-config }}
           label: ec2-${{ matrix.python-version }}-pt${{ matrix.torch-version }}-cu${{ matrix.cuda-version }}-${{ github.run_id }}
           aws-resource-tags: >
             [
@@ -643,10 +641,8 @@ jobs:
         with:
           mode: start
           github-token: ${{ secrets.EC2_RUNNER_TOKEN }}
-          ec2-image-id: ${{ needs.versions.outputs.aws-gpu-ami }}
           ec2-instance-type: g6.xlarge
-          subnet-id: ${{ needs.versions.outputs.aws-subnet }}
-          security-group-id: ${{ needs.versions.outputs.aws-security-group }}
+          availability-zones-config: ${{ needs.versions.outputs.aws-gpu-az-config }}
           label: val-${{ matrix.python-version }}-pt${{ matrix.torch-version }}-cu${{ matrix.cuda-version }}-${{ github.run_id }}
           aws-resource-tags: >
             [

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,10 +60,8 @@ jobs:
         with:
           mode: start
           github-token: ${{ secrets.EC2_RUNNER_TOKEN }}
-          ec2-image-id: ${{ needs.versions.outputs.aws-cpu-ami }}
           ec2-instance-type: m6a.8xlarge
-          subnet-id: ${{ needs.versions.outputs.aws-subnet }}
-          security-group-id: ${{ needs.versions.outputs.aws-security-group }}
+          availability-zones-config: ${{ needs.versions.outputs.aws-cpu-az-config }}
   fvdb-build:
     name: fVDB Build (Conda)
     needs: [start-build-runner, versions] # required to start the main job when the runner is ready
@@ -206,10 +204,8 @@ jobs:
         with:
           mode: start
           github-token: ${{ secrets.EC2_RUNNER_TOKEN }}
-          ec2-image-id: ${{ needs.versions.outputs.aws-gpu-ami }}
           ec2-instance-type: g6.xlarge # 4 CPU-core, L4 GPU
-          subnet-id: ${{ needs.versions.outputs.aws-subnet }}
-          security-group-id: ${{ needs.versions.outputs.aws-security-group }}
+          availability-zones-config: ${{ needs.versions.outputs.aws-gpu-az-config }}
 
   ##############################################################################
   # RUN FVDB GTESTS


### PR DESCRIPTION
Change all AWS EC2 start actions to use fallback strategy with all 3 us-east-2 availability zones for runners.  Conformed GPU runner type across jobs.