### PR TITLE
Expand intersection offsets to 64-bit

### DIFF
--- a/src/fvdb/detail/ops/gsplat/CountContributingGaussians.cu
+++ b/src/fvdb/detail/ops/gsplat/CountContributingGaussians.cu
@@ -87,8 +87,8 @@ template <typename ScalarType, bool IS_PACKED> struct RasterizeNumContributingGa
     volumeRenderTileForward(const uint32_t cameraId,
                             const uint32_t row,
                             const uint32_t col,
-                            const uint32_t firstGaussianIdInBlock,
-                            const uint32_t lastGaussianIdInBlock,
+                            const int64_t firstGaussianIdInBlock,
+                            const int64_t lastGaussianIdInBlock,
                             const uint32_t blockSize,
                             const bool pixelIsActive,
                             const uint32_t activePixelIndex) {
@@ -104,7 +104,7 @@ template <typename ScalarType, bool IS_PACKED> struct RasterizeNumContributingGa
         // this thread to load gaussians into shared memory
         bool done = !pixelIsActive;
 
-        const uint32_t numBatches =
+        const int64_t numBatches =
             (lastGaussianIdInBlock - firstGaussianIdInBlock + blockSize - 1) / blockSize;
 
         // (row, col) coordinates are relative to the specified image origin which may
@@ -115,7 +115,7 @@ template <typename ScalarType, bool IS_PACKED> struct RasterizeNumContributingGa
         // collect and process batches of gaussians
         // each thread loads one gaussian at a time before rasterizing its
         // designated pixel
-        for (uint32_t b = 0; b < numBatches; ++b) {
+        for (int64_t b = 0; b < numBatches; ++b) {
             // Sync threads before we start integrating the next batch
             // If all threads are done, we can break early
             if (__syncthreads_count(done) == blockSize) {
@@ -124,8 +124,8 @@ template <typename ScalarType, bool IS_PACKED> struct RasterizeNumContributingGa
 
             // Each thread fetches one gaussian from front to back (tile_gaussian_ids is depth
             // sorted)
-            const uint32_t batchStart = firstGaussianIdInBlock + blockSize * b;
-            const uint32_t idx        = batchStart + tidx;
+            const int64_t batchStart = firstGaussianIdInBlock + blockSize * b;
+            const int64_t idx        = batchStart + tidx;
             if (idx < lastGaussianIdInBlock) {
                 const int32_t g =
                     commonArgs.mTileGaussianIds[idx]; // which gaussian we're rendering
@@ -137,7 +137,9 @@ template <typename ScalarType, bool IS_PACKED> struct RasterizeNumContributingGa
 
             // Volume render Gaussians in this batch
             if (pixelIsActive) { // skip inactive sparse pixels
-                const uint32_t batchSize = min(blockSize, lastGaussianIdInBlock - batchStart);
+                const int64_t remaining = lastGaussianIdInBlock - batchStart;
+                const uint32_t batchSize =
+                    static_cast<uint32_t>(remaining < blockSize ? remaining : blockSize);
                 for (uint32_t t = 0; (t < batchSize) && !done; ++t) {
                     const Gaussian2D<ScalarType> &gaussian = sharedGaussians[t];
 
@@ -209,8 +211,8 @@ rasterizeNumContributingGaussiansForward(
         return;
     }
 
-    int32_t firstGaussianIdInBlock;
-    int32_t lastGaussianIdInBlock;
+    int64_t firstGaussianIdInBlock;
+    int64_t lastGaussianIdInBlock;
     cuda::std::tie(firstGaussianIdInBlock, lastGaussianIdInBlock) =
         commonArgs.tileGaussianRange(cameraId, tileRow, tileCol);
 

--- a/src/fvdb/detail/ops/gsplat/IdentifyContributingGaussians.cu
+++ b/src/fvdb/detail/ops/gsplat/IdentifyContributingGaussians.cu
@@ -326,8 +326,8 @@ template <typename ScalarType, bool IS_PACKED> struct RasterizeContributingGauss
     volumeRenderTileForward(const uint32_t cameraId,
                             const uint32_t row,
                             const uint32_t col,
-                            const uint32_t firstGaussianIdInBlock,
-                            const uint32_t lastGaussianIdInBlock,
+                            const int64_t firstGaussianIdInBlock,
+                            const int64_t lastGaussianIdInBlock,
                             const uint32_t blockSize,
                             const bool pixelIsActive,
                             const uint32_t activePixelIndex) {
@@ -349,7 +349,7 @@ template <typename ScalarType, bool IS_PACKED> struct RasterizeContributingGauss
         // this thread to load gaussians into shared memory
         bool done = !pixelIsActive;
 
-        const uint32_t numBatches =
+        const int64_t numBatches =
             (lastGaussianIdInBlock - firstGaussianIdInBlock + blockSize - 1) / blockSize;
 
         // TODO: This condition seems to be met when batch size is >1.  Kept here for debugging.
@@ -370,7 +370,7 @@ template <typename ScalarType, bool IS_PACKED> struct RasterizeContributingGauss
         // collect and process batches of gaussians
         // each thread loads one gaussian at a time before rasterizing its
         // designated pixel
-        for (uint32_t b = 0; b < numBatches; ++b) {
+        for (int64_t b = 0; b < numBatches; ++b) {
             // Sync threads before we start integrating the next batch
             // If all threads are done, we can break early
             if (__syncthreads_count(done) == blockSize) {
@@ -379,8 +379,8 @@ template <typename ScalarType, bool IS_PACKED> struct RasterizeContributingGauss
 
             // Each thread fetches one gaussian from front to back (tile_gaussian_ids is depth
             // sorted)
-            const uint32_t batchStart = firstGaussianIdInBlock + blockSize * b;
-            const uint32_t idx        = batchStart + tidx;
+            const int64_t batchStart = firstGaussianIdInBlock + blockSize * b;
+            const int64_t idx        = batchStart + tidx;
             if (idx < lastGaussianIdInBlock) {
                 const int32_t g =
                     commonArgs.mTileGaussianIds[idx]; // which gaussian we're rendering
@@ -392,7 +392,9 @@ template <typename ScalarType, bool IS_PACKED> struct RasterizeContributingGauss
 
             // Volume render Gaussians in this batch
             if (pixelIsActive) { // skip inactive sparse pixels
-                const uint32_t batchSize = min(blockSize, lastGaussianIdInBlock - batchStart);
+                const int64_t remaining = lastGaussianIdInBlock - batchStart;
+                const uint32_t batchSize =
+                    static_cast<uint32_t>(remaining < blockSize ? remaining : blockSize);
                 for (uint32_t t = 0; (t < batchSize) && !done; ++t) {
                     const Gaussian2D<ScalarType> gaussian = sharedGaussians[t];
 
@@ -489,8 +491,8 @@ rasterizeContributingGaussianIdsForward(
         return;
     }
 
-    int32_t firstGaussianIdInBlock;
-    int32_t lastGaussianIdInBlock;
+    int64_t firstGaussianIdInBlock;
+    int64_t lastGaussianIdInBlock;
     cuda::std::tie(firstGaussianIdInBlock, lastGaussianIdInBlock) =
         commonArgs.tileGaussianRange(cameraId, tileRow, tileCol);
 

--- a/src/fvdb/detail/ops/gsplat/IdentifyTopContributingGaussians.cu
+++ b/src/fvdb/detail/ops/gsplat/IdentifyTopContributingGaussians.cu
@@ -145,8 +145,8 @@ template <typename ScalarType, bool IS_PACKED> struct RasterizeTopContributingGa
     volumeRenderTileForward(const uint32_t cameraId,
                             const uint32_t row,
                             const uint32_t col,
-                            const uint32_t firstGaussianIdInBlock,
-                            const uint32_t lastGaussianIdInBlock,
+                            const int64_t firstGaussianIdInBlock,
+                            const int64_t lastGaussianIdInBlock,
                             const uint32_t blockSize,
                             const bool pixelIsActive,
                             const uint32_t activePixelIndex) {
@@ -186,7 +186,7 @@ template <typename ScalarType, bool IS_PACKED> struct RasterizeTopContributingGa
         // this thread to load gaussians into shared memory
         bool done = !pixelIsActive;
 
-        const uint32_t numBatches =
+        const int64_t numBatches =
             (lastGaussianIdInBlock - firstGaussianIdInBlock + blockSize - 1) / blockSize;
 
         // TODO: This condition seems to be met when batch size is >1.  Kept here for debugging.
@@ -204,7 +204,7 @@ template <typename ScalarType, bool IS_PACKED> struct RasterizeTopContributingGa
         // collect and process batches of gaussians
         // each thread loads one gaussian at a time before rasterizing its
         // designated pixel
-        for (uint32_t b = 0; b < numBatches; ++b) {
+        for (int64_t b = 0; b < numBatches; ++b) {
             // Sync threads before we start integrating the next batch
             // If all threads are done, we can break early
             if (__syncthreads_count(done) == blockSize) {
@@ -213,8 +213,8 @@ template <typename ScalarType, bool IS_PACKED> struct RasterizeTopContributingGa
 
             // Each thread fetches one gaussian from front to back (tile_gaussian_ids is depth
             // sorted)
-            const uint32_t batchStart = firstGaussianIdInBlock + blockSize * b;
-            const uint32_t idx        = batchStart + tidx;
+            const int64_t batchStart = firstGaussianIdInBlock + blockSize * b;
+            const int64_t idx        = batchStart + tidx;
             if (idx < lastGaussianIdInBlock) {
                 const int32_t g =
                     commonArgs.mTileGaussianIds[idx]; // which gaussian we're rendering
@@ -226,7 +226,9 @@ template <typename ScalarType, bool IS_PACKED> struct RasterizeTopContributingGa
 
             // Volume render Gaussians in this batch
             if (pixelIsActive) { // skip inactive sparse pixels
-                const uint32_t batchSize = min(blockSize, lastGaussianIdInBlock - batchStart);
+                const int64_t remaining = lastGaussianIdInBlock - batchStart;
+                const uint32_t batchSize =
+                    static_cast<uint32_t>(remaining < blockSize ? remaining : blockSize);
                 for (uint32_t t = 0; (t < batchSize) && !done; ++t) {
                     const Gaussian2D<ScalarType> gaussian = sharedGaussians[t];
 
@@ -331,8 +333,8 @@ rasterizeTopContributingGaussianIdsForward(
         return;
     }
 
-    int32_t firstGaussianIdInBlock;
-    int32_t lastGaussianIdInBlock;
+    int64_t firstGaussianIdInBlock;
+    int64_t lastGaussianIdInBlock;
     cuda::std::tie(firstGaussianIdInBlock, lastGaussianIdInBlock) =
         commonArgs.tileGaussianRange(cameraId, tileRow, tileCol);
 

--- a/src/fvdb/detail/ops/gsplat/IntersectGaussianTiles.cu
+++ b/src/fvdb/detail/ops/gsplat/IntersectGaussianTiles.cu
@@ -18,8 +18,6 @@
 #include <cub/cub.cuh>
 #include <cuda/std/functional>
 
-#include <limits>
-
 #define FVDB_CUB_WRAPPER(func, ...)                                             \
     do {                                                                        \
         size_t tempStorageBytes = 0;                                            \
@@ -491,14 +489,8 @@ intersectGaussianTilesCudaImpl(
                           "activeTiles must have 1 dimension (numActiveTiles)");
     }
 
-    const int64_t numGaussians64 = isPacked ? means2d.size(0) : means2d.size(1);
-    const int64_t totalGaussians64 =
-        isPacked ? means2d.size(0) : static_cast<int64_t>(numCameras) * numGaussians64;
-    TORCH_CHECK_VALUE(
-        totalGaussians64 <= std::numeric_limits<int32_t>::max(),
-        "The number of Gaussians must fit in int32 because tile Gaussian IDs use int32");
-    const uint32_t numGaussians   = static_cast<uint32_t>(numGaussians64);
-    const uint32_t totalGaussians = static_cast<uint32_t>(totalGaussians64);
+    const uint32_t numGaussians   = isPacked ? means2d.size(0) : means2d.size(1);
+    const uint32_t totalGaussians = isPacked ? means2d.size(0) : numCameras * numGaussians;
 
     // const uint32_t numCameras      = means2d.size(0);
     const uint32_t totalTiles    = numTilesH * numTilesW;
@@ -740,14 +732,8 @@ intersectGaussianTilesPrivateUse1Impl(
                           "activeTiles must have 1 dimension (numActiveTiles)");
     }
 
-    const int64_t numGaussians64 = isPacked ? means2d.size(0) : means2d.size(1);
-    const int64_t totalGaussians64 =
-        isPacked ? means2d.size(0) : static_cast<int64_t>(numCameras) * numGaussians64;
-    TORCH_CHECK_VALUE(
-        totalGaussians64 <= std::numeric_limits<int32_t>::max(),
-        "The number of Gaussians must fit in int32 because tile Gaussian IDs use int32");
-    const uint32_t numGaussians   = static_cast<uint32_t>(numGaussians64);
-    const uint32_t totalGaussians = static_cast<uint32_t>(totalGaussians64);
+    const uint32_t numGaussians   = isPacked ? means2d.size(0) : means2d.size(1);
+    const uint32_t totalGaussians = isPacked ? means2d.size(0) : numCameras * numGaussians;
 
     // const uint32_t numCameras      = means2d.size(0);
     const uint32_t totalTiles    = numTilesH * numTilesW;

--- a/src/fvdb/detail/ops/gsplat/IntersectGaussianTiles.cu
+++ b/src/fvdb/detail/ops/gsplat/IntersectGaussianTiles.cu
@@ -18,6 +18,8 @@
 #include <cub/cub.cuh>
 #include <cuda/std/functional>
 
+#include <limits>
+
 #define FVDB_CUB_WRAPPER(func, ...)                                             \
     do {                                                                        \
         size_t tempStorageBytes = 0;                                            \
@@ -226,7 +228,7 @@ computeGaussianTileIntersections(
     const T *__restrict__ means2d,                   // [C, N, 2] or [M, 2]
     const int32_t *__restrict__ radii,               // [C, N, 2] or [M, 2]
     const T *__restrict__ depths,                    // [C, N]    or [M]
-    const int32_t *__restrict__ cumTilesPerGaussian, // [ C * N ] or [ M ]
+    const int64_t *__restrict__ cumTilesPerGaussian, // [ C * N ] or [ M ]
     const bool *__restrict__ tileMask,               // [C, H, W] or nullptr
     const int32_t *__restrict__ cameraJIdx,          // NULL or [M]
     int64_t *__restrict__ intersectionKeys,          // [ C * N * numTiles ] or [ M * numTiles ]
@@ -302,13 +304,13 @@ computeGaussianTileIntersections(
 }
 
 __global__ __launch_bounds__(NUM_THREADS) void
-computeTileOffsetsSparse(const uint32_t numIntersections,
+computeTileOffsetsSparse(const int64_t numIntersections,
                          const uint32_t numTiles,
                          const uint32_t tileIdBits,
                          const int64_t *__restrict__ sortedIntersectionKeys,
                          const int32_t *__restrict__ activeTiles,
                          const uint32_t numActiveTiles,
-                         int32_t *__restrict__ outOffsets) { // [C, n_tiles] or [num_active_tiles]
+                         int64_t *__restrict__ outOffsets) { // [C, n_tiles] or [num_active_tiles]
 
     // parallelize over active tiles
     for (auto idx = blockIdx.x * blockDim.x + threadIdx.x; idx <= numActiveTiles;
@@ -354,18 +356,18 @@ computeTileOffsetsSparse(const uint32_t numIntersections,
 // i.e. gaussians[out_offsets[c, i, j]:out_offsets[c, i, j+1]] are the Gaussians that
 // intersect tile (i, j) in camera c.
 __global__ __launch_bounds__(NUM_THREADS) void
-computeTileOffsets(const uint32_t offset,
-                   const uint32_t count,
+computeTileOffsets(const int64_t offset,
+                   const int64_t count,
                    const uint32_t tileOffset,
                    const uint32_t tileCount,
                    const uint32_t numTiles,
                    const uint32_t tileIdBits,
                    const int64_t *__restrict__ sortedIntersectionKeys,
-                   int32_t *__restrict__ outOffsets) { // [C, numTiles]
+                   int64_t *__restrict__ outOffsets) { // [C, numTiles]
     if (count == 0) {
-        for (auto idx = blockIdx.x * blockDim.x + threadIdx.x; idx < tileCount;
-             idx += blockDim.x * gridDim.x) {
-            outOffsets[tileOffset + idx] = static_cast<int32_t>(offset);
+        for (int64_t idx = blockIdx.x * blockDim.x + threadIdx.x; idx < tileCount;
+             idx += static_cast<int64_t>(blockDim.x) * gridDim.x) {
+            outOffsets[tileOffset + idx] = offset;
         }
         return;
     }
@@ -380,8 +382,8 @@ computeTileOffsets(const uint32_t offset,
     // tile (cid, ti, tj) sorted by depth.
 
     // Parallelize over intersections
-    for (auto idx = blockIdx.x * blockDim.x + threadIdx.x; idx < count;
-         idx += blockDim.x * gridDim.x) {
+    for (int64_t idx = blockIdx.x * blockDim.x + threadIdx.x; idx < count;
+         idx += static_cast<int64_t>(blockDim.x) * gridDim.x) {
         auto isectIdx = idx + offset;
         // Bit-packed key for the camera/tile part of the this intersection
         // i.e. tile_id | camera_id << tile_id_bits
@@ -395,14 +397,14 @@ computeTileOffsets(const uint32_t offset,
             // The first tile in this range writes out offset until the first valid tile
             // (inclusive). Tiles before this one have no intersections in the range.
             for (uint32_t i = tileOffset; i < tileStartIdx + 1; ++i) {
-                outOffsets[i] = static_cast<int32_t>(offset);
+                outOffsets[i] = offset;
             }
         }
 
         if (isectIdx == offset + count - 1) {
             const uint32_t rangeEnd = tileOffset + tileCount;
             for (uint32_t i = tileStartIdx + 1; i < rangeEnd; ++i) {
-                outOffsets[i] = static_cast<int32_t>(offset + count);
+                outOffsets[i] = offset + count;
             }
         }
 
@@ -418,7 +420,7 @@ computeTileOffsets(const uint32_t offset,
             const int64_t prevTileStartIdx = prevCamIdx * numTiles + prevTileIdx;
 
             for (uint32_t i = prevTileStartIdx + 1; i < tileStartIdx + 1; ++i) {
-                outOffsets[i] = static_cast<int32_t>(isectIdx);
+                outOffsets[i] = isectIdx;
             }
         }
     }
@@ -489,8 +491,14 @@ intersectGaussianTilesCudaImpl(
                           "activeTiles must have 1 dimension (numActiveTiles)");
     }
 
-    const uint32_t numGaussians   = isPacked ? means2d.size(0) : means2d.size(1);
-    const uint32_t totalGaussians = isPacked ? means2d.size(0) : numCameras * numGaussians;
+    const int64_t numGaussians64 = isPacked ? means2d.size(0) : means2d.size(1);
+    const int64_t totalGaussians64 =
+        isPacked ? means2d.size(0) : static_cast<int64_t>(numCameras) * numGaussians64;
+    TORCH_CHECK_VALUE(
+        totalGaussians64 <= std::numeric_limits<int32_t>::max(),
+        "The number of Gaussians must fit in int32 because tile Gaussian IDs use int32");
+    const uint32_t numGaussians   = static_cast<uint32_t>(numGaussians64);
+    const uint32_t totalGaussians = static_cast<uint32_t>(totalGaussians64);
 
     // const uint32_t numCameras      = means2d.size(0);
     const uint32_t totalTiles    = numTilesH * numTilesW;
@@ -512,21 +520,21 @@ intersectGaussianTilesCudaImpl(
     auto outputDims = at::IntArrayRef(dims);
 
     if (totalGaussians == 0) {
-        return std::make_tuple(torch::zeros(outputDims, means2d.options().dtype(torch::kInt32)),
+        return std::make_tuple(torch::zeros(outputDims, means2d.options().dtype(torch::kInt64)),
                                torch::empty({0}, means2d.options().dtype(torch::kInt32)));
     }
     using scalar_t = float;
 
     // Allocate tensor to store the number of tiles each gaussian intersects
     torch::Tensor tilesPerGaussianCumsum =
-        torch::empty({totalGaussians}, means2d.options().dtype(torch::kInt32));
+        torch::empty({totalGaussians}, means2d.options().dtype(torch::kInt64));
 
     const auto tileMaskPtr =
         tileMask.has_value() ? tileMask.value().const_data_ptr<bool>() : nullptr;
 
     // Count the number of tiles each Gaussian intersects, store in tiles_per_gaussian_cumsum
     const int NUM_BLOCKS = (totalGaussians + NUM_THREADS - 1) / NUM_THREADS;
-    countTilesPerGaussian<scalar_t, int32_t>
+    countTilesPerGaussian<scalar_t, int64_t>
         <<<NUM_BLOCKS, NUM_THREADS, 0, stream>>>(0,
                                                  totalGaussians,
                                                  numGaussians,
@@ -540,16 +548,16 @@ intersectGaussianTilesCudaImpl(
                                                  radii.const_data_ptr<int32_t>(),
                                                  tileMaskPtr,
                                                  cameraJIdxPtr,
-                                                 tilesPerGaussianCumsum.data_ptr<int32_t>());
+                                                 tilesPerGaussianCumsum.data_ptr<int64_t>());
     C10_CUDA_KERNEL_LAUNCH_CHECK();
 
     // cumulative sum to get the total number of intersections
-    tilesPerGaussianCumsum = torch::cumsum(tilesPerGaussianCumsum, 0, torch::kInt32);
+    tilesPerGaussianCumsum = torch::cumsum(tilesPerGaussianCumsum, 0, torch::kInt64);
 
     // Allocate tensors to store the intersections
     const int64_t totalIntersections = tilesPerGaussianCumsum[-1].item<int64_t>();
     if (totalIntersections == 0) {
-        return std::make_tuple(torch::zeros(outputDims, means2d.options().dtype(torch::kInt32)),
+        return std::make_tuple(torch::zeros(outputDims, means2d.options().dtype(torch::kInt64)),
                                torch::empty({0}, means2d.options().dtype(torch::kInt32)));
     } else {
         torch::Tensor intersectionKeys =
@@ -576,7 +584,7 @@ intersectGaussianTilesCudaImpl(
             means2d.const_data_ptr<scalar_t>(),
             radii.const_data_ptr<int32_t>(),
             depths.const_data_ptr<scalar_t>(),
-            tilesPerGaussianCumsum.const_data_ptr<int32_t>(),
+            tilesPerGaussianCumsum.const_data_ptr<int64_t>(),
             tileMaskPtr,
             cameraJIdxPtr,
             intersectionKeys.data_ptr<int64_t>(),
@@ -621,7 +629,7 @@ intersectGaussianTilesCudaImpl(
             // Compute a joffsets tensor that stores the offsets into the sorted Gaussian
             // intersections
             torch::Tensor tileJOffsets =
-                torch::empty({outputNumTiles}, means2d.options().dtype(torch::kInt32));
+                torch::empty({outputNumTiles}, means2d.options().dtype(torch::kInt64));
             const int NUM_BLOCKS_2 = (outputNumTiles + NUM_THREADS - 1) / NUM_THREADS;
             computeTileOffsetsSparse<<<NUM_BLOCKS_2, NUM_THREADS, 0, stream>>>(
                 totalIntersections,
@@ -630,7 +638,7 @@ intersectGaussianTilesCudaImpl(
                 intersectionKeys.const_data_ptr<int64_t>(),
                 activeTiles.value().const_data_ptr<int32_t>(),
                 numActiveTiles,
-                tileJOffsets.data_ptr<int32_t>());
+                tileJOffsets.data_ptr<int64_t>());
             C10_CUDA_KERNEL_LAUNCH_CHECK();
 
             return std::make_tuple(tileJOffsets, intersectionValues);
@@ -638,8 +646,9 @@ intersectGaussianTilesCudaImpl(
             // Compute a joffsets tensor that stores the offsets into the sorted Gaussian
             // intersections
             torch::Tensor tileJOffsets = torch::empty({numCameras, numTilesH, numTilesW},
-                                                      means2d.options().dtype(torch::kInt32));
-            const int NUM_BLOCKS_2     = (totalIntersections + NUM_THREADS - 1) / NUM_THREADS;
+                                                      means2d.options().dtype(torch::kInt64));
+            const int NUM_BLOCKS_2 =
+                cuda::ceil_div<int64_t>(totalIntersections, NUM_THREADS);
             computeTileOffsets<<<NUM_BLOCKS_2, NUM_THREADS, 0, stream>>>(
                 0,
                 totalIntersections,
@@ -648,7 +657,7 @@ intersectGaussianTilesCudaImpl(
                 totalTiles,
                 numTileIdBits,
                 intersectionKeys.const_data_ptr<int64_t>(),
-                tileJOffsets.data_ptr<int32_t>());
+                tileJOffsets.data_ptr<int64_t>());
             C10_CUDA_KERNEL_LAUNCH_CHECK();
 
             return std::make_tuple(tileJOffsets, intersectionValues);
@@ -732,8 +741,14 @@ intersectGaussianTilesPrivateUse1Impl(
                           "activeTiles must have 1 dimension (numActiveTiles)");
     }
 
-    const uint32_t numGaussians   = isPacked ? means2d.size(0) : means2d.size(1);
-    const uint32_t totalGaussians = isPacked ? means2d.size(0) : numCameras * numGaussians;
+    const int64_t numGaussians64 = isPacked ? means2d.size(0) : means2d.size(1);
+    const int64_t totalGaussians64 =
+        isPacked ? means2d.size(0) : static_cast<int64_t>(numCameras) * numGaussians64;
+    TORCH_CHECK_VALUE(
+        totalGaussians64 <= std::numeric_limits<int32_t>::max(),
+        "The number of Gaussians must fit in int32 because tile Gaussian IDs use int32");
+    const uint32_t numGaussians   = static_cast<uint32_t>(numGaussians64);
+    const uint32_t totalGaussians = static_cast<uint32_t>(totalGaussians64);
 
     // const uint32_t numCameras      = means2d.size(0);
     const uint32_t totalTiles    = numTilesH * numTilesW;
@@ -751,7 +766,7 @@ intersectGaussianTilesPrivateUse1Impl(
     auto outputDims = at::IntArrayRef(dims);
 
     if (totalGaussians == 0) {
-        return std::make_tuple(torch::zeros(outputDims, means2d.options().dtype(torch::kInt32)),
+        return std::make_tuple(torch::zeros(outputDims, means2d.options().dtype(torch::kInt64)),
                                torch::empty({0}, means2d.options().dtype(torch::kInt32)));
     }
     using scalar_t = float;
@@ -773,14 +788,14 @@ intersectGaussianTilesPrivateUse1Impl(
     // [deviceCount, totalGaussians] tensor, which the multi-GPU allocator would stripe) so its row
     // stays device-local; count and scan share the per-device stream, so no merge is needed, and a
     // single-device CUB scan avoids torch::cumsum dispatching to the multi-GPU cumsum.
-    std::vector<int32_t *> deviceTilesPerGaussianCumsum(deviceCount, nullptr);
+    std::vector<int64_t *> deviceTilesPerGaussianCumsum(deviceCount, nullptr);
 
     for (const auto deviceId: c10::irange(deviceCount)) {
         C10_CUDA_CHECK(cudaSetDevice(deviceId));
         auto stream = c10::cuda::getCurrentCUDAStream(deviceId);
 
         C10_CUDA_CHECK(cudaMallocAsync(
-            &deviceTilesPerGaussianCumsum[deviceId], totalGaussians * sizeof(int32_t), stream));
+            &deviceTilesPerGaussianCumsum[deviceId], totalGaussians * sizeof(int64_t), stream));
 
         size_t deviceKeyOffset, deviceKeyCount;
         std::tie(deviceKeyOffset, deviceKeyCount) = deviceChunk(totalTileKeys, deviceId);
@@ -790,7 +805,7 @@ intersectGaussianTilesPrivateUse1Impl(
         // Every device scans all Gaussians but counts only the tiles that fall in its tile-key
         // range.
         const int NUM_BLOCKS = (totalGaussians + NUM_THREADS - 1) / NUM_THREADS;
-        countTilesPerGaussian<scalar_t, int32_t>
+        countTilesPerGaussian<scalar_t, int64_t>
             <<<NUM_BLOCKS, NUM_THREADS, 0, stream>>>(0,
                                                      totalGaussians,
                                                      numGaussians,
@@ -823,8 +838,8 @@ intersectGaussianTilesPrivateUse1Impl(
     std::vector<int64_t> deviceIntersectionOffset(deviceCount);
     std::vector<int64_t> deviceIntersectionCount(deviceCount);
     int64_t totalIntersections = 0;
-    int32_t *deviceTotals      = nullptr;
-    C10_CUDA_CHECK(cudaMallocHost(&deviceTotals, deviceCount * sizeof(int32_t)));
+    int64_t *deviceTotals = nullptr;
+    C10_CUDA_CHECK(cudaMallocHost(&deviceTotals, deviceCount * sizeof(int64_t)));
     for (const auto deviceId: c10::irange(deviceCount)) {
         C10_CUDA_CHECK(cudaSetDevice(deviceId));
         auto stream = c10::cuda::getCurrentCUDAStream(deviceId);
@@ -833,7 +848,7 @@ intersectGaussianTilesPrivateUse1Impl(
         // completed before we read deviceTotals on the host.
         C10_CUDA_CHECK(cudaMemcpyAsync(&deviceTotals[deviceId],
                                        deviceTilesPerGaussianCumsum[deviceId] + totalGaussians - 1,
-                                       sizeof(int32_t),
+                                       sizeof(int64_t),
                                        cudaMemcpyDeviceToHost,
                                        stream));
     }
@@ -853,7 +868,7 @@ intersectGaussianTilesPrivateUse1Impl(
             auto stream = c10::cuda::getCurrentCUDAStream(deviceId);
             C10_CUDA_CHECK(cudaFreeAsync(deviceTilesPerGaussianCumsum[deviceId], stream));
         }
-        return std::make_tuple(torch::zeros(outputDims, means2d.options().dtype(torch::kInt32)),
+        return std::make_tuple(torch::zeros(outputDims, means2d.options().dtype(torch::kInt64)),
                                torch::empty({0}, means2d.options().dtype(torch::kInt32)));
     } else {
         // Keys are temporary and each device only reads or writes its own independently sorted
@@ -864,7 +879,7 @@ intersectGaussianTilesPrivateUse1Impl(
 
         // Compute a joffsets tensor that stores the offsets into the sorted Gaussian intersections
         torch::Tensor tileJOffsets = torch::empty({numCameras, numTilesH, numTilesW},
-                                                  means2d.options().dtype(torch::kInt32));
+                                                  means2d.options().dtype(torch::kInt64));
 
         // The use of cudaMallocAsync/cudaMallocFree as opposed to a torch::Tensor with a kCUDA
         // device is intentional. PyTorch does not support mixing the use of multiple accelerators,
@@ -995,7 +1010,7 @@ intersectGaussianTilesPrivateUse1Impl(
                     totalTiles,
                     numTileIdBits,
                     deviceIntersectionKeys[deviceId],
-                    tileJOffsets.data_ptr<int32_t>());
+                    tileJOffsets.data_ptr<int64_t>());
                 C10_CUDA_KERNEL_LAUNCH_CHECK();
             }
             if (deviceIntersectionKeys[deviceId] != nullptr) {

--- a/src/fvdb/detail/ops/gsplat/IntersectGaussianTiles.cu
+++ b/src/fvdb/detail/ops/gsplat/IntersectGaussianTiles.cu
@@ -647,8 +647,7 @@ intersectGaussianTilesCudaImpl(
             // intersections
             torch::Tensor tileJOffsets = torch::empty({numCameras, numTilesH, numTilesW},
                                                       means2d.options().dtype(torch::kInt64));
-            const int NUM_BLOCKS_2 =
-                cuda::ceil_div<int64_t>(totalIntersections, NUM_THREADS);
+            const int NUM_BLOCKS_2     = cuda::ceil_div<int64_t>(totalIntersections, NUM_THREADS);
             computeTileOffsets<<<NUM_BLOCKS_2, NUM_THREADS, 0, stream>>>(
                 0,
                 totalIntersections,
@@ -838,7 +837,7 @@ intersectGaussianTilesPrivateUse1Impl(
     std::vector<int64_t> deviceIntersectionOffset(deviceCount);
     std::vector<int64_t> deviceIntersectionCount(deviceCount);
     int64_t totalIntersections = 0;
-    int64_t *deviceTotals = nullptr;
+    int64_t *deviceTotals      = nullptr;
     C10_CUDA_CHECK(cudaMallocHost(&deviceTotals, deviceCount * sizeof(int64_t)));
     for (const auto deviceId: c10::irange(deviceCount)) {
         C10_CUDA_CHECK(cudaSetDevice(deviceId));

--- a/src/fvdb/detail/ops/gsplat/IntersectGaussianTiles.cu
+++ b/src/fvdb/detail/ops/gsplat/IntersectGaussianTiles.cu
@@ -380,7 +380,7 @@ computeTileOffsets(const int64_t offset,
     // tile (cid, ti, tj) sorted by depth.
 
     // Parallelize over intersections
-    for (int64_t idx = blockIdx.x * blockDim.x + threadIdx.x; idx < count;
+    for (int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x; idx < count;
          idx += static_cast<int64_t>(blockDim.x) * gridDim.x) {
         auto isectIdx = idx + offset;
         // Bit-packed key for the camera/tile part of the this intersection

--- a/src/fvdb/detail/ops/gsplat/IntersectGaussianTiles.cu
+++ b/src/fvdb/detail/ops/gsplat/IntersectGaussianTiles.cu
@@ -647,7 +647,7 @@ intersectGaussianTilesCudaImpl(
             // intersections
             torch::Tensor tileJOffsets = torch::empty({numCameras, numTilesH, numTilesW},
                                                       means2d.options().dtype(torch::kInt64));
-            const int NUM_BLOCKS_2     = cuda::ceil_div<int64_t>(totalIntersections, NUM_THREADS);
+            const int NUM_BLOCKS_2     = (totalIntersections + NUM_THREADS - 1) / NUM_THREADS;
             computeTileOffsets<<<NUM_BLOCKS_2, NUM_THREADS, 0, stream>>>(
                 0,
                 totalIntersections,

--- a/src/fvdb/detail/ops/gsplat/IntersectGaussianTiles.h
+++ b/src/fvdb/detail/ops/gsplat/IntersectGaussianTiles.h
@@ -13,7 +13,7 @@ namespace detail {
 namespace ops {
 
 /// @brief Compute the intersection of 2D Gaussians with image tiles for efficient rasterization
-/// @return int64 tile offsets and int32 Gaussian IDs
+/// @return tile offsets and Gaussian IDs
 std::tuple<torch::Tensor, torch::Tensor>
 intersectGaussianTiles(const torch::Tensor &means2d,                 // [C, N, 2] or [M, 2]
                        const torch::Tensor &radii,                   // [C, N, 2] or [M, 2]
@@ -25,7 +25,7 @@ intersectGaussianTiles(const torch::Tensor &means2d,                 // [C, N, 2
                        const uint32_t numTilesW);
 
 /// @brief Compute the intersection of 2D Gaussians with image tiles for sparse rendering
-/// @return int64 tile offsets and int32 Gaussian IDs
+/// @return tile offsets and Gaussian IDs
 std::tuple<torch::Tensor, torch::Tensor>
 intersectGaussianTilesSparse(const torch::Tensor &means2d,                 // [C, N, 2] or [M, 2]
                              const torch::Tensor &radii,                   // [C, N, 2] or [M, 2]

--- a/src/fvdb/detail/ops/gsplat/IntersectGaussianTiles.h
+++ b/src/fvdb/detail/ops/gsplat/IntersectGaussianTiles.h
@@ -13,6 +13,7 @@ namespace detail {
 namespace ops {
 
 /// @brief Compute the intersection of 2D Gaussians with image tiles for efficient rasterization
+/// @return int64 tile offsets and int32 Gaussian IDs
 std::tuple<torch::Tensor, torch::Tensor>
 intersectGaussianTiles(const torch::Tensor &means2d,                 // [C, N, 2] or [M, 2]
                        const torch::Tensor &radii,                   // [C, N, 2] or [M, 2]
@@ -24,6 +25,7 @@ intersectGaussianTiles(const torch::Tensor &means2d,                 // [C, N, 2
                        const uint32_t numTilesW);
 
 /// @brief Compute the intersection of 2D Gaussians with image tiles for sparse rendering
+/// @return int64 tile offsets and int32 Gaussian IDs
 std::tuple<torch::Tensor, torch::Tensor>
 intersectGaussianTilesSparse(const torch::Tensor &means2d,                 // [C, N, 2] or [M, 2]
                              const torch::Tensor &radii,                   // [C, N, 2] or [M, 2]

--- a/src/fvdb/detail/ops/gsplat/RasterizeScreenSpaceGaussiansBackward.cu
+++ b/src/fvdb/detail/ops/gsplat/RasterizeScreenSpaceGaussiansBackward.cu
@@ -38,7 +38,7 @@ struct RasterizeBackwardArgs {
     // where AP_i is the number of active pixels in the i-th camera image and X is [], null, or
     // [NUM_CHANNELS]. In dense mode, they have dimensions {1, [C, H, W, X]}
     fvdb::JaggedRAcc64<ScalarType, 2> mRenderedAlphas; // {1, [C, H, W, 1]} or {C, [AP_i, 1]}
-    fvdb::JaggedRAcc64<int64_t, 1> mLastGaussianIds;   // {1, [C, H, W]} or {C, [AP_i]}
+    fvdb::JaggedRAcc64<int32_t, 1> mLastGaussianIds;   // {1, [C, H, W]} or {C, [AP_i]}
     fvdb::JaggedRAcc64<ScalarType, 2>
         mDLossDRenderedFeatures; // {1, [C, H, W, NUM_CHANNELS]} or {C, [numPixels, NUM_CHANNELS]}
     fvdb::JaggedRAcc64<ScalarType, 2>
@@ -94,7 +94,7 @@ struct RasterizeBackwardArgs {
                      pixelMap),
           mAbsGrad(outDLossDMeans2dAbs.has_value()),
           mRenderedAlphas(initJaggedAccessor<ScalarType, 2>(renderedAlphas, "renderedAlphas")),
-          mLastGaussianIds(initJaggedAccessor<int64_t, 1>(lastGaussianIds, "lastGaussianIds")),
+          mLastGaussianIds(initJaggedAccessor<int32_t, 1>(lastGaussianIds, "lastGaussianIds")),
           mDLossDRenderedFeatures(
               initJaggedAccessor<ScalarType, 2>(dLossDRenderedFeatures, "dLossDRenderedFeatures")),
           mDLossDRenderedAlphas(
@@ -217,7 +217,7 @@ struct RasterizeBackwardArgs {
     /// @brief Read the last ID for a pixel
     /// @param pixelIndex The index of the pixel
     /// @return The last ID for the pixel
-    __device__ int64_t
+    __device__ int32_t
     readLastId(uint64_t pixelIndex) {
         return mLastGaussianIds.data()[pixelIndex];
     }
@@ -631,7 +631,7 @@ struct RasterizeBackwardArgs {
         // Only access memory if the pixel is active (within image bounds)
         ScalarType finalTransmittance  = ScalarType{1};
         ScalarType dLossDRenderedAlpha = ScalarType{0};
-        int64_t lastGaussianId         = 0;
+        int32_t lastIntersectionOffset = -1;
 
         if (pixelIsActive) {
             // this is the T AFTER the last gaussian in this pixel
@@ -641,8 +641,8 @@ struct RasterizeBackwardArgs {
             // pixel
             dLossDRenderedAlpha = readDLossDRenderedAlpha(pixIdx);
 
-            // ID of the last Gaussian to contribute to this pixel
-            lastGaussianId = readLastId(pixIdx);
+            // Tile-relative offset of the last Gaussian intersection to contribute to this pixel.
+            lastIntersectionOffset = readLastId(pixIdx);
         }
 
         namespace cg = cooperative_groups;
@@ -650,12 +650,12 @@ struct RasterizeBackwardArgs {
         const cg::thread_block_tile<WARP_TILE_SIZE> warp =
             cg::tiled_partition<WARP_TILE_SIZE>(block);
 
-        const int64_t lastGaussianIdInWarp = warpMax(lastGaussianId, warp);
+        const int32_t lastIntersectionOffsetInWarp = warpMax(lastIntersectionOffset, warp);
 
         // Process Gaussians in batches of block size (i.e. one Gaussian per thread in the block)
-        const uint32_t tidx = threadIdx.y * blockDim.x + threadIdx.x;
-        const int64_t numBatches =
-            (lastGaussianIdInBlock - firstGaussianIdInBlock + blockSize - 1) / blockSize;
+        const uint32_t tidx            = threadIdx.y * blockDim.x + threadIdx.x;
+        const int64_t numIntersections = lastGaussianIdInBlock - firstGaussianIdInBlock;
+        const int64_t numBatches       = (numIntersections + blockSize - 1) / blockSize;
 
         constexpr size_t NUM_CHUNKS =
             (NUM_CHANNELS + NUM_SHARED_CHANNELS - 1) / NUM_SHARED_CHANNELS;
@@ -692,11 +692,11 @@ struct RasterizeBackwardArgs {
                 // Each thread fetches one gaussian into shared memory.
                 // Gaussians are stored in shared memory locations in order of decreasing
                 // distance from the camera. Gaussians are processed in batches of size
-                // blockSize (i.e. one Gaussian per thread in the block), and batchEnd is the
-                // index of the last gaussian. NOTE: These values can be negative so must be
-                // signed instead of unsigned
-                const int64_t batchEnd = lastGaussianIdInBlock - 1 - blockSize * b;
-                const int64_t idx      = batchEnd - tidx;
+                // blockSize (i.e. one Gaussian per thread in the block). batchEndOffset is relative
+                // to the tile's first intersection. NOTE: These values can be negative so must be
+                // signed instead of unsigned.
+                const int64_t batchEndOffset = numIntersections - 1 - blockSize * b;
+                const int64_t idx            = firstGaussianIdInBlock + batchEndOffset - tidx;
                 if (idx >= firstGaussianIdInBlock) {
                     const int32_t g =
                         commonArgs.mTileGaussianIds[idx]; // Gaussian index in [C * N] or [nnz]
@@ -718,11 +718,12 @@ struct RasterizeBackwardArgs {
                 // 0 index is the furthest back gaussian in the batch
                 // For each Gaussian which contributes to this pixel, compute this pixel's
                 // gradient contribution to that Gaussian
-                const int64_t remaining = batchEnd + 1 - firstGaussianIdInBlock;
+                const int64_t remaining = batchEndOffset + 1;
                 const uint32_t batchSize =
                     static_cast<uint32_t>(remaining < blockSize ? remaining : blockSize);
-                const int64_t firstT64 =
-                    batchEnd > lastGaussianIdInWarp ? batchEnd - lastGaussianIdInWarp : 0;
+                const int64_t firstT64 = batchEndOffset > lastIntersectionOffsetInWarp
+                                             ? batchEndOffset - lastIntersectionOffsetInWarp
+                                             : 0;
                 const uint32_t firstT =
                     firstT64 < batchSize ? static_cast<uint32_t>(firstT64) : batchSize;
                 for (uint32_t t = firstT; t < batchSize; ++t) {
@@ -733,7 +734,7 @@ struct RasterizeBackwardArgs {
                     const ScalarType py =
                         row + ScalarType(commonArgs.renderOriginY()) + ScalarType{0.5};
 
-                    bool valid = pixelIsActive && (batchEnd - t <= lastGaussianId);
+                    bool valid = pixelIsActive && (batchEndOffset - t <= lastIntersectionOffset);
 
                     const auto [gaussianIsValid, delta, expMinusSigma, alpha] = [&]() {
                         if (valid) {
@@ -1755,7 +1756,7 @@ rasterizeScreenSpaceGaussiansBwd(const torch::Tensor &means2d,
                                  const at::optional<torch::Tensor> &masks) {
     TORCH_CHECK_VALUE(tileOffsets.scalar_type() == torch::kInt64,
                       "tileOffsets must have dtype int64");
-    TORCH_CHECK_VALUE(lastIds.scalar_type() == torch::kInt64, "lastIds must have dtype int64");
+    TORCH_CHECK_VALUE(lastIds.scalar_type() == torch::kInt32, "lastIds must have dtype int32");
     const RenderWindow2D renderWindow{imageWidth, imageHeight, imageOriginW, imageOriginH};
     return FVDB_DISPATCH_KERNEL(means2d.device(), [&]() {
         return dispatchRasterizeScreenSpaceGaussiansBwd<DeviceTag>(means2d,
@@ -1804,8 +1805,8 @@ rasterizeScreenSpaceGaussiansSparseBwd(const fvdb::JaggedTensor &pixelsToRender,
                                        const at::optional<torch::Tensor> &masks) {
     TORCH_CHECK_VALUE(tileOffsets.scalar_type() == torch::kInt64,
                       "tileOffsets must have dtype int64");
-    TORCH_CHECK_VALUE(lastIds.jdata().scalar_type() == torch::kInt64,
-                      "lastIds must have dtype int64");
+    TORCH_CHECK_VALUE(lastIds.jdata().scalar_type() == torch::kInt32,
+                      "lastIds must have dtype int32");
     const RenderWindow2D renderWindow{imageWidth, imageHeight, imageOriginW, imageOriginH};
     return FVDB_DISPATCH_KERNEL(means2d.device(), [&]() {
         return dispatchRasterizeScreenSpaceGaussiansSparseBwd<DeviceTag>(pixelsToRender,

--- a/src/fvdb/detail/ops/gsplat/RasterizeScreenSpaceGaussiansBackward.cu
+++ b/src/fvdb/detail/ops/gsplat/RasterizeScreenSpaceGaussiansBackward.cu
@@ -38,7 +38,7 @@ struct RasterizeBackwardArgs {
     // where AP_i is the number of active pixels in the i-th camera image and X is [], null, or
     // [NUM_CHANNELS]. In dense mode, they have dimensions {1, [C, H, W, X]}
     fvdb::JaggedRAcc64<ScalarType, 2> mRenderedAlphas; // {1, [C, H, W, 1]} or {C, [AP_i, 1]}
-    fvdb::JaggedRAcc64<int32_t, 1> mLastGaussianIds;   // {1, [C, H, W]} or {C, [AP_i]}
+    fvdb::JaggedRAcc64<int64_t, 1> mLastGaussianIds;   // {1, [C, H, W]} or {C, [AP_i]}
     fvdb::JaggedRAcc64<ScalarType, 2>
         mDLossDRenderedFeatures; // {1, [C, H, W, NUM_CHANNELS]} or {C, [numPixels, NUM_CHANNELS]}
     fvdb::JaggedRAcc64<ScalarType, 2>
@@ -94,7 +94,7 @@ struct RasterizeBackwardArgs {
                      pixelMap),
           mAbsGrad(outDLossDMeans2dAbs.has_value()),
           mRenderedAlphas(initJaggedAccessor<ScalarType, 2>(renderedAlphas, "renderedAlphas")),
-          mLastGaussianIds(initJaggedAccessor<int32_t, 1>(lastGaussianIds, "lastGaussianIds")),
+          mLastGaussianIds(initJaggedAccessor<int64_t, 1>(lastGaussianIds, "lastGaussianIds")),
           mDLossDRenderedFeatures(
               initJaggedAccessor<ScalarType, 2>(dLossDRenderedFeatures, "dLossDRenderedFeatures")),
           mDLossDRenderedAlphas(
@@ -217,7 +217,7 @@ struct RasterizeBackwardArgs {
     /// @brief Read the last ID for a pixel
     /// @param pixelIndex The index of the pixel
     /// @return The last ID for the pixel
-    __device__ int32_t
+    __device__ int64_t
     readLastId(uint64_t pixelIndex) {
         return mLastGaussianIds.data()[pixelIndex];
     }
@@ -610,8 +610,8 @@ struct RasterizeBackwardArgs {
         const uint32_t cameraId,
         const uint32_t row,
         const uint32_t col,
-        const int32_t firstGaussianIdInBlock,
-        const int32_t lastGaussianIdInBlock,
+        const int64_t firstGaussianIdInBlock,
+        const int64_t lastGaussianIdInBlock,
         const uint32_t blockSize,
         const bool pixelIsActive,
         const uint32_t activePixelIndex) {
@@ -631,7 +631,7 @@ struct RasterizeBackwardArgs {
         // Only access memory if the pixel is active (within image bounds)
         ScalarType finalTransmittance  = ScalarType{1};
         ScalarType dLossDRenderedAlpha = ScalarType{0};
-        int32_t lastGaussianId         = 0;
+        int64_t lastGaussianId         = 0;
 
         if (pixelIsActive) {
             // this is the T AFTER the last gaussian in this pixel
@@ -650,11 +650,11 @@ struct RasterizeBackwardArgs {
         const cg::thread_block_tile<WARP_TILE_SIZE> warp =
             cg::tiled_partition<WARP_TILE_SIZE>(block);
 
-        const int32_t lastGaussianIdInWarp = warpMax(lastGaussianId, warp);
+        const int64_t lastGaussianIdInWarp = warpMax(lastGaussianId, warp);
 
         // Process Gaussians in batches of block size (i.e. one Gaussian per thread in the block)
         const uint32_t tidx = threadIdx.y * blockDim.x + threadIdx.x;
-        const uint32_t numBatches =
+        const int64_t numBatches =
             (lastGaussianIdInBlock - firstGaussianIdInBlock + blockSize - 1) / blockSize;
 
         constexpr size_t NUM_CHUNKS =
@@ -685,7 +685,7 @@ struct RasterizeBackwardArgs {
                 dLossDRenderedFeature[k] = ScalarType{0};
             }
 
-            for (uint32_t b = 0; b < numBatches; ++b) {
+            for (int64_t b = 0; b < numBatches; ++b) {
                 // resync all threads before writing next batch of shared mem
                 __syncthreads();
 
@@ -694,9 +694,9 @@ struct RasterizeBackwardArgs {
                 // distance from the camera. Gaussians are processed in batches of size
                 // blockSize (i.e. one Gaussian per thread in the block), and batchEnd is the
                 // index of the last gaussian. NOTE: These values can be negative so must be
-                // int32 instead of uint32
-                const int32_t batchEnd = lastGaussianIdInBlock - 1 - blockSize * b;
-                const int32_t idx      = batchEnd - tidx;
+                // signed instead of unsigned
+                const int64_t batchEnd = lastGaussianIdInBlock - 1 - blockSize * b;
+                const int64_t idx      = batchEnd - tidx;
                 if (idx >= firstGaussianIdInBlock) {
                     const int32_t g =
                         commonArgs.mTileGaussianIds[idx]; // Gaussian index in [C * N] or [nnz]
@@ -718,8 +718,14 @@ struct RasterizeBackwardArgs {
                 // 0 index is the furthest back gaussian in the batch
                 // For each Gaussian which contributes to this pixel, compute this pixel's
                 // gradient contribution to that Gaussian
-                const int32_t batchSize = min(blockSize, batchEnd + 1 - firstGaussianIdInBlock);
-                for (uint32_t t = max(0, batchEnd - lastGaussianIdInWarp); t < batchSize; ++t) {
+                const int64_t remaining = batchEnd + 1 - firstGaussianIdInBlock;
+                const uint32_t batchSize =
+                    static_cast<uint32_t>(remaining < blockSize ? remaining : blockSize);
+                const int64_t firstT64 =
+                    batchEnd > lastGaussianIdInWarp ? batchEnd - lastGaussianIdInWarp : 0;
+                const uint32_t firstT =
+                    firstT64 < batchSize ? static_cast<uint32_t>(firstT64) : batchSize;
+                for (uint32_t t = firstT; t < batchSize; ++t) {
                     // (row, col) coordinates are relative to the specified image origin which may
                     // be a crop so we need to add the origin to get the absolute pixel coordinates
                     const ScalarType px =
@@ -849,8 +855,8 @@ rasterizeGaussiansBackward(
         return;
     }
 
-    int32_t firstGaussianIdInBlock;
-    int32_t lastGaussianIdInBlock;
+    int64_t firstGaussianIdInBlock;
+    int64_t lastGaussianIdInBlock;
     cuda::std::tie(firstGaussianIdInBlock, lastGaussianIdInBlock) =
         commonArgs.tileGaussianRange(cameraId, tileRow, tileCol);
 
@@ -1747,6 +1753,10 @@ rasterizeScreenSpaceGaussiansBwd(const torch::Tensor &means2d,
                                  const int64_t numSharedChannelsOverride,
                                  const at::optional<torch::Tensor> &backgrounds,
                                  const at::optional<torch::Tensor> &masks) {
+    TORCH_CHECK_VALUE(tileOffsets.scalar_type() == torch::kInt64,
+                      "tileOffsets must have dtype int64");
+    TORCH_CHECK_VALUE(lastIds.scalar_type() == torch::kInt64,
+                      "lastIds must have dtype int64");
     const RenderWindow2D renderWindow{imageWidth, imageHeight, imageOriginW, imageOriginH};
     return FVDB_DISPATCH_KERNEL(means2d.device(), [&]() {
         return dispatchRasterizeScreenSpaceGaussiansBwd<DeviceTag>(means2d,
@@ -1793,6 +1803,10 @@ rasterizeScreenSpaceGaussiansSparseBwd(const fvdb::JaggedTensor &pixelsToRender,
                                        const int64_t numSharedChannelsOverride,
                                        const at::optional<torch::Tensor> &backgrounds,
                                        const at::optional<torch::Tensor> &masks) {
+    TORCH_CHECK_VALUE(tileOffsets.scalar_type() == torch::kInt64,
+                      "tileOffsets must have dtype int64");
+    TORCH_CHECK_VALUE(lastIds.jdata().scalar_type() == torch::kInt64,
+                      "lastIds must have dtype int64");
     const RenderWindow2D renderWindow{imageWidth, imageHeight, imageOriginW, imageOriginH};
     return FVDB_DISPATCH_KERNEL(means2d.device(), [&]() {
         return dispatchRasterizeScreenSpaceGaussiansSparseBwd<DeviceTag>(pixelsToRender,

--- a/src/fvdb/detail/ops/gsplat/RasterizeScreenSpaceGaussiansBackward.cu
+++ b/src/fvdb/detail/ops/gsplat/RasterizeScreenSpaceGaussiansBackward.cu
@@ -1755,8 +1755,7 @@ rasterizeScreenSpaceGaussiansBwd(const torch::Tensor &means2d,
                                  const at::optional<torch::Tensor> &masks) {
     TORCH_CHECK_VALUE(tileOffsets.scalar_type() == torch::kInt64,
                       "tileOffsets must have dtype int64");
-    TORCH_CHECK_VALUE(lastIds.scalar_type() == torch::kInt64,
-                      "lastIds must have dtype int64");
+    TORCH_CHECK_VALUE(lastIds.scalar_type() == torch::kInt64, "lastIds must have dtype int64");
     const RenderWindow2D renderWindow{imageWidth, imageHeight, imageOriginW, imageOriginH};
     return FVDB_DISPATCH_KERNEL(means2d.device(), [&]() {
         return dispatchRasterizeScreenSpaceGaussiansBwd<DeviceTag>(means2d,

--- a/src/fvdb/detail/ops/gsplat/RasterizeScreenSpaceGaussiansBackward.h
+++ b/src/fvdb/detail/ops/gsplat/RasterizeScreenSpaceGaussiansBackward.h
@@ -32,11 +32,11 @@ namespace ops {
 /// @param[in] imageOriginW Horizontal origin of the render window
 /// @param[in] imageOriginH Vertical origin of the render window
 /// @param[in] tileSize Size of tiles used for rasterization optimization
-/// @param[in] tileOffsets Offsets for tiles [C, tile_height, tile_width]
+/// @param[in] tileOffsets int64 offsets for tiles [C, tile_height, tile_width]
 /// @param[in] tileGaussianIds Flattened Gaussian IDs for tile intersection [n_isects]
 /// @param[in] renderedAlphas Alpha values from forward pass [C, render_height, render_width, 1]
-/// @param[in] lastIds Last Gaussian IDs per pixel from forward pass [C, render_height,
-/// render_width]
+/// @param[in] lastIds Last flattened intersection indices per pixel from forward pass as int64
+/// [C, render_height, render_width]
 /// @param[out] dLossDRenderedFeatures Gradients of loss with respect to rendered features [C,
 /// render_height, render_width, D]
 /// @param[out] dLossDRenderedAlphas Gradients of loss with respect to rendered alphas [C,
@@ -95,10 +95,11 @@ rasterizeScreenSpaceGaussiansBwd(const torch::Tensor &means2d,
 /// @param[in] imageOriginW Horizontal origin of the render window
 /// @param[in] imageOriginH Vertical origin of the render window
 /// @param[in] tileSize Size of tiles used for rasterization optimization
-/// @param[in] tileOffsets Offsets for tiles [C, tile_height, tile_width]
+/// @param[in] tileOffsets int64 offsets for tiles [C, tile_height, tile_width]
 /// @param[in] tileGaussianIds Flattened Gaussian IDs for tile intersection [n_isects]
 /// @param[in] renderedAlphas Alpha values from sparse forward pass [JaggedTensor]
-/// @param[in] lastIds Last Gaussian IDs per pixel from sparse forward pass [JaggedTensor]
+/// @param[in] lastIds Last flattened intersection indices per pixel from sparse forward pass as an
+/// int64 JaggedTensor
 /// @param[in] dLossDRenderedFeatures Gradients of loss w.r.t sparse rendered features
 /// [JaggedTensor]
 /// @param[in] dLossDRenderedAlphas Gradients of loss w.r.t sparse rendered alphas [JaggedTensor]

--- a/src/fvdb/detail/ops/gsplat/RasterizeScreenSpaceGaussiansBackward.h
+++ b/src/fvdb/detail/ops/gsplat/RasterizeScreenSpaceGaussiansBackward.h
@@ -35,8 +35,8 @@ namespace ops {
 /// @param[in] tileOffsets offsets for tiles [C, tile_height, tile_width]
 /// @param[in] tileGaussianIds Flattened Gaussian IDs for tile intersection [n_isects]
 /// @param[in] renderedAlphas Alpha values from forward pass [C, render_height, render_width, 1]
-/// @param[in] lastIds Last flattened intersection indices per pixel from forward pass
-/// [C, render_height, render_width]
+/// @param[in] lastIds Last tile-relative intersection indices per pixel from forward pass
+/// [C, render_height, render_width], with -1 where no intersection contributed
 /// @param[out] dLossDRenderedFeatures Gradients of loss with respect to rendered features [C,
 /// render_height, render_width, D]
 /// @param[out] dLossDRenderedAlphas Gradients of loss with respect to rendered alphas [C,
@@ -98,8 +98,8 @@ rasterizeScreenSpaceGaussiansBwd(const torch::Tensor &means2d,
 /// @param[in] tileOffsets offsets for tiles [C, tile_height, tile_width]
 /// @param[in] tileGaussianIds Flattened Gaussian IDs for tile intersection [n_isects]
 /// @param[in] renderedAlphas Alpha values from sparse forward pass [JaggedTensor]
-/// @param[in] lastIds Last flattened intersection indices per pixel from sparse forward pass as a
-/// JaggedTensor
+/// @param[in] lastIds Last tile-relative intersection indices per pixel from sparse forward pass as
+/// a JaggedTensor, with -1 where no intersection contributed
 /// @param[in] dLossDRenderedFeatures Gradients of loss w.r.t sparse rendered features
 /// [JaggedTensor]
 /// @param[in] dLossDRenderedAlphas Gradients of loss w.r.t sparse rendered alphas [JaggedTensor]

--- a/src/fvdb/detail/ops/gsplat/RasterizeScreenSpaceGaussiansBackward.h
+++ b/src/fvdb/detail/ops/gsplat/RasterizeScreenSpaceGaussiansBackward.h
@@ -32,10 +32,10 @@ namespace ops {
 /// @param[in] imageOriginW Horizontal origin of the render window
 /// @param[in] imageOriginH Vertical origin of the render window
 /// @param[in] tileSize Size of tiles used for rasterization optimization
-/// @param[in] tileOffsets int64 offsets for tiles [C, tile_height, tile_width]
+/// @param[in] tileOffsets offsets for tiles [C, tile_height, tile_width]
 /// @param[in] tileGaussianIds Flattened Gaussian IDs for tile intersection [n_isects]
 /// @param[in] renderedAlphas Alpha values from forward pass [C, render_height, render_width, 1]
-/// @param[in] lastIds Last flattened intersection indices per pixel from forward pass as int64
+/// @param[in] lastIds Last flattened intersection indices per pixel from forward pass
 /// [C, render_height, render_width]
 /// @param[out] dLossDRenderedFeatures Gradients of loss with respect to rendered features [C,
 /// render_height, render_width, D]
@@ -95,11 +95,11 @@ rasterizeScreenSpaceGaussiansBwd(const torch::Tensor &means2d,
 /// @param[in] imageOriginW Horizontal origin of the render window
 /// @param[in] imageOriginH Vertical origin of the render window
 /// @param[in] tileSize Size of tiles used for rasterization optimization
-/// @param[in] tileOffsets int64 offsets for tiles [C, tile_height, tile_width]
+/// @param[in] tileOffsets offsets for tiles [C, tile_height, tile_width]
 /// @param[in] tileGaussianIds Flattened Gaussian IDs for tile intersection [n_isects]
 /// @param[in] renderedAlphas Alpha values from sparse forward pass [JaggedTensor]
-/// @param[in] lastIds Last flattened intersection indices per pixel from sparse forward pass as an
-/// int64 JaggedTensor
+/// @param[in] lastIds Last flattened intersection indices per pixel from sparse forward pass as a
+/// JaggedTensor
 /// @param[in] dLossDRenderedFeatures Gradients of loss w.r.t sparse rendered features
 /// [JaggedTensor]
 /// @param[in] dLossDRenderedAlphas Gradients of loss w.r.t sparse rendered alphas [JaggedTensor]

--- a/src/fvdb/detail/ops/gsplat/RasterizeScreenSpaceGaussiansForward.cu
+++ b/src/fvdb/detail/ops/gsplat/RasterizeScreenSpaceGaussiansForward.cu
@@ -39,7 +39,7 @@ struct RasterizeForwardArgs {
 
     JaggedRAcc64<ScalarType, 2> mOutFeatures; // [[nPixels, NUM_CHANNELS]_0..._C]
     JaggedRAcc64<ScalarType, 2> mOutAlphas;   // [[nPixels, 1]_0..._C]
-    JaggedRAcc64<int64_t, 1> mOutLastIds;     // [[nPixels]_0..._C]
+    JaggedRAcc64<int32_t, 1> mOutLastIds;     // [[nPixels]_0..._C]
 
     RasterizeForwardArgs(
         const torch::Tensor &means2d,         // [C, N, 2] or [nnz, 2]
@@ -81,7 +81,7 @@ struct RasterizeForwardArgs {
                      pixelMap),
           mOutFeatures(initJaggedAccessor<ScalarType, 2>(outFeatures, "outFeatures")),
           mOutAlphas(initJaggedAccessor<ScalarType, 2>(outAlphas, "outAlphas")),
-          mOutLastIds(initJaggedAccessor<int64_t, 1>(outLastIds, "outLastIds")) {}
+          mOutLastIds(initJaggedAccessor<int32_t, 1>(outLastIds, "outLastIds")) {}
 
     /// @brief Write the alpha value for a pixel
     /// @param pixelIndex The index of the pixel
@@ -95,7 +95,7 @@ struct RasterizeForwardArgs {
     /// @param pixelIndex The index of the pixel
     /// @param lastId The last ID to write
     __device__ void
-    writeLastId(uint64_t pixelIndex, int64_t lastId) {
+    writeLastId(uint64_t pixelIndex, int32_t lastId) {
         mOutLastIds.data()[pixelIndex] = lastId;
     }
 
@@ -182,10 +182,10 @@ struct RasterizeForwardArgs {
         ScalarType pixOut[NUM_CHANNELS] = {0.f};
 
         // The alpha sequence is feature-independent (depends only on opacity + conic + position),
-        // so the per-chunk accumTransmittance and curIdx are identical across chunks. Capture them
-        // from the first chunk and write them out at the end.
-        ScalarType accumTransmittanceFinal = 1.0f;
-        int64_t curIdxFinal                = -1;
+        // so the per-chunk accumTransmittance and last intersection offset are identical across
+        // chunks. Capture them from the first chunk and write them out at the end.
+        ScalarType accumTransmittanceFinal  = 1.0f;
+        int32_t lastIntersectionOffsetFinal = -1;
 
         constexpr size_t NUM_CHUNKS =
             (NUM_CHANNELS + NUM_SHARED_CHANNELS - 1) / NUM_SHARED_CHANNELS;
@@ -200,8 +200,9 @@ struct RasterizeForwardArgs {
             // However, this makes the backward pass 1.5x slower, so we stick with float for now
             // and sort of just ignore small impact gaussians ¯\_(ツ)_/¯.
             ScalarType accumTransmittance = 1.0f;
-            // index of most recent gaussian to write to this thread's pixel
-            int64_t curIdx = -1;
+            // Tile-relative intersection offset of the most recent Gaussian written to this
+            // thread's pixel.
+            int32_t lastIntersectionOffset = -1;
             // We don't return right away if the pixel is not in the image since we want
             // to use this thread to load gaussians into shared memory
             bool done = !pixelIsActive;
@@ -216,8 +217,9 @@ struct RasterizeForwardArgs {
 
                 // Each thread fetches one gaussian from front to back (mTileGaussianIds is depth
                 // sorted)
-                const int64_t batchStart = firstGaussianIdInBlock + blockSize * b;
-                const int64_t idx        = batchStart + tidx;
+                const int64_t batchOffset = blockSize * b;
+                const int64_t batchStart  = firstGaussianIdInBlock + batchOffset;
+                const int64_t idx         = batchStart + tidx;
                 if (idx < lastGaussianIdInBlock) {
                     const int32_t g =
                         commonArgs.mTileGaussianIds[idx]; // which gaussian we're rendering
@@ -273,22 +275,22 @@ struct RasterizeForwardArgs {
                             }
                         }
 
-                        curIdx             = batchStart + t;
-                        accumTransmittance = nextTransmittance;
+                        lastIntersectionOffset = static_cast<int32_t>(batchOffset + t);
+                        accumTransmittance     = nextTransmittance;
                     }
                 }
             }
 
             if (chunk == 0) {
-                accumTransmittanceFinal = accumTransmittance;
-                curIdxFinal             = curIdx;
+                accumTransmittanceFinal     = accumTransmittance;
+                lastIntersectionOffsetFinal = lastIntersectionOffset;
             }
         }
 
         if (pixelIsActive) {
             const auto pixIdx = commonArgs.pixelIndex(cameraId, row, col, activePixelIndex);
             writeAlpha(pixIdx, 1.0f - accumTransmittanceFinal);
-            writeLastId(pixIdx, curIdxFinal);
+            writeLastId(pixIdx, lastIntersectionOffsetFinal);
             writeFeatures(pixIdx, [&](uint32_t k) {
                 return commonArgs.mHasBackgrounds
                            ? pixOut[k] +
@@ -426,7 +428,7 @@ launchRasterizeForwardKernelWithTemplatedSharedChannels(
     for (const auto &size: sizes) {
         featuresToRenderVec.push_back(torch::empty({size, channels}, features.options()));
         alphasToRenderVec.push_back(torch::empty({size, 1}, features.options()));
-        lastIdsToRenderVec.push_back(torch::empty({size}, features.options().dtype(torch::kInt64)));
+        lastIdsToRenderVec.push_back(torch::empty({size}, features.options().dtype(torch::kInt32)));
     }
 
     auto outFeatures = fvdb::JaggedTensor(featuresToRenderVec);
@@ -679,7 +681,7 @@ launchRasterizeForwardKernels(
     for (const auto &size: sizes) {
         featuresToRenderVec.push_back(torch::empty({size, channels}, features.options()));
         alphasToRenderVec.push_back(torch::empty({size, 1}, features.options()));
-        lastIdsToRenderVec.push_back(torch::empty({size}, features.options().dtype(torch::kInt64)));
+        lastIdsToRenderVec.push_back(torch::empty({size}, features.options().dtype(torch::kInt32)));
     }
 
     auto outFeatures = fvdb::JaggedTensor(featuresToRenderVec);

--- a/src/fvdb/detail/ops/gsplat/RasterizeScreenSpaceGaussiansForward.cu
+++ b/src/fvdb/detail/ops/gsplat/RasterizeScreenSpaceGaussiansForward.cu
@@ -39,7 +39,7 @@ struct RasterizeForwardArgs {
 
     JaggedRAcc64<ScalarType, 2> mOutFeatures; // [[nPixels, NUM_CHANNELS]_0..._C]
     JaggedRAcc64<ScalarType, 2> mOutAlphas;   // [[nPixels, 1]_0..._C]
-    JaggedRAcc64<int32_t, 1> mOutLastIds;     // [[nPixels]_0..._C]
+    JaggedRAcc64<int64_t, 1> mOutLastIds;     // [[nPixels]_0..._C]
 
     RasterizeForwardArgs(
         const torch::Tensor &means2d,         // [C, N, 2] or [nnz, 2]
@@ -81,7 +81,7 @@ struct RasterizeForwardArgs {
                      pixelMap),
           mOutFeatures(initJaggedAccessor<ScalarType, 2>(outFeatures, "outFeatures")),
           mOutAlphas(initJaggedAccessor<ScalarType, 2>(outAlphas, "outAlphas")),
-          mOutLastIds(initJaggedAccessor<int32_t, 1>(outLastIds, "outLastIds")) {}
+          mOutLastIds(initJaggedAccessor<int64_t, 1>(outLastIds, "outLastIds")) {}
 
     /// @brief Write the alpha value for a pixel
     /// @param pixelIndex The index of the pixel
@@ -95,7 +95,7 @@ struct RasterizeForwardArgs {
     /// @param pixelIndex The index of the pixel
     /// @param lastId The last ID to write
     __device__ void
-    writeLastId(uint64_t pixelIndex, int32_t lastId) {
+    writeLastId(uint64_t pixelIndex, int64_t lastId) {
         mOutLastIds.data()[pixelIndex] = lastId;
     }
 
@@ -155,8 +155,8 @@ struct RasterizeForwardArgs {
     volumeRenderTileForward(const uint32_t cameraId,
                             const uint32_t row,
                             const uint32_t col,
-                            const uint32_t firstGaussianIdInBlock,
-                            const uint32_t lastGaussianIdInBlock,
+                            const int64_t firstGaussianIdInBlock,
+                            const int64_t lastGaussianIdInBlock,
                             const uint32_t blockSize,
                             const bool pixelIsActive,
                             const uint32_t activePixelIndex) {
@@ -168,7 +168,7 @@ struct RasterizeForwardArgs {
 
         // Process Gaussians in batches of block size (i.e. one Gaussian per thread in the block)
         const uint32_t tidx = threadIdx.y * blockDim.x + threadIdx.x;
-        const uint32_t numBatches =
+        const int64_t numBatches =
             (lastGaussianIdInBlock - firstGaussianIdInBlock + blockSize - 1) / blockSize;
 
         // (row, col) coordinates are relative to the specified image origin which may
@@ -185,7 +185,7 @@ struct RasterizeForwardArgs {
         // so the per-chunk accumTransmittance and curIdx are identical across chunks. Capture them
         // from the first chunk and write them out at the end.
         ScalarType accumTransmittanceFinal = 1.0f;
-        int32_t curIdxFinal                = -1;
+        int64_t curIdxFinal                = -1;
 
         constexpr size_t NUM_CHUNKS =
             (NUM_CHANNELS + NUM_SHARED_CHANNELS - 1) / NUM_SHARED_CHANNELS;
@@ -201,12 +201,12 @@ struct RasterizeForwardArgs {
             // and sort of just ignore small impact gaussians ¯\_(ツ)_/¯.
             ScalarType accumTransmittance = 1.0f;
             // index of most recent gaussian to write to this thread's pixel
-            int32_t curIdx = -1;
+            int64_t curIdx = -1;
             // We don't return right away if the pixel is not in the image since we want
             // to use this thread to load gaussians into shared memory
             bool done = !pixelIsActive;
 
-            for (uint32_t b = 0; b < numBatches; ++b) {
+            for (int64_t b = 0; b < numBatches; ++b) {
                 // Sync threads before we start integrating the next batch (and between chunks).
                 // If all threads are done, we can break early.
                 __syncthreads();
@@ -216,8 +216,8 @@ struct RasterizeForwardArgs {
 
                 // Each thread fetches one gaussian from front to back (mTileGaussianIds is depth
                 // sorted)
-                const uint32_t batchStart = firstGaussianIdInBlock + blockSize * b;
-                const uint32_t idx        = batchStart + tidx;
+                const int64_t batchStart = firstGaussianIdInBlock + blockSize * b;
+                const int64_t idx        = batchStart + tidx;
                 if (idx < lastGaussianIdInBlock) {
                     const int32_t g =
                         commonArgs.mTileGaussianIds[idx]; // which gaussian we're rendering
@@ -240,7 +240,9 @@ struct RasterizeForwardArgs {
                 // already done (saturated or outside image bounds). Block-level
                 // __syncthreads_and above only fires once all 8 warps finish.
                 if (!__all_sync(0xffffffffu, done)) {
-                    const uint32_t batchSize = min(blockSize, lastGaussianIdInBlock - batchStart);
+                    const int64_t remaining = lastGaussianIdInBlock - batchStart;
+                    const uint32_t batchSize =
+                        static_cast<uint32_t>(remaining < blockSize ? remaining : blockSize);
                     for (uint32_t t = 0; (t < batchSize) && !done; ++t) {
                         const Gaussian2D<ScalarType> gaussian = sharedGaussians[t];
 
@@ -342,8 +344,8 @@ rasterizeGaussiansForward(
         return;
     }
 
-    int32_t firstGaussianIdInBlock;
-    int32_t lastGaussianIdInBlock;
+    int64_t firstGaussianIdInBlock;
+    int64_t lastGaussianIdInBlock;
     cuda::std::tie(firstGaussianIdInBlock, lastGaussianIdInBlock) =
         commonArgs.tileGaussianRange(cameraId, tileRow, tileCol);
 
@@ -424,7 +426,7 @@ launchRasterizeForwardKernelWithTemplatedSharedChannels(
     for (const auto &size: sizes) {
         featuresToRenderVec.push_back(torch::empty({size, channels}, features.options()));
         alphasToRenderVec.push_back(torch::empty({size, 1}, features.options()));
-        lastIdsToRenderVec.push_back(torch::empty({size}, features.options().dtype(torch::kInt32)));
+        lastIdsToRenderVec.push_back(torch::empty({size}, features.options().dtype(torch::kInt64)));
     }
 
     auto outFeatures = fvdb::JaggedTensor(featuresToRenderVec);
@@ -677,7 +679,7 @@ launchRasterizeForwardKernels(
     for (const auto &size: sizes) {
         featuresToRenderVec.push_back(torch::empty({size, channels}, features.options()));
         alphasToRenderVec.push_back(torch::empty({size, 1}, features.options()));
-        lastIdsToRenderVec.push_back(torch::empty({size}, features.options().dtype(torch::kInt32)));
+        lastIdsToRenderVec.push_back(torch::empty({size}, features.options().dtype(torch::kInt64)));
     }
 
     auto outFeatures = fvdb::JaggedTensor(featuresToRenderVec);
@@ -1196,6 +1198,8 @@ rasterizeScreenSpaceGaussiansFwd(const torch::Tensor &means2d,
                                  const int64_t numSharedChannelsOverride,
                                  const at::optional<torch::Tensor> &backgrounds,
                                  const at::optional<torch::Tensor> &masks) {
+    TORCH_CHECK_VALUE(tileOffsets.scalar_type() == torch::kInt64,
+                      "tileOffsets must have dtype int64");
     const RenderWindow2D renderWindow{imageWidth, imageHeight, imageOriginW, imageOriginH};
     return FVDB_DISPATCH_KERNEL(means2d.device(), [&]() {
         return dispatchRasterizeScreenSpaceGaussiansFwd<DeviceTag>(means2d,
@@ -1232,6 +1236,8 @@ rasterizeScreenSpaceGaussiansSparseFwd(const fvdb::JaggedTensor &pixelsToRender,
                                        const int64_t numSharedChannelsOverride,
                                        const at::optional<torch::Tensor> &backgrounds,
                                        const at::optional<torch::Tensor> &masks) {
+    TORCH_CHECK_VALUE(tileOffsets.scalar_type() == torch::kInt64,
+                      "tileOffsets must have dtype int64");
     const RenderWindow2D renderWindow{imageWidth, imageHeight, imageOriginW, imageOriginH};
     return FVDB_DISPATCH_KERNEL(means2d.device(), [&]() {
         return dispatchRasterizeScreenSpaceGaussiansSparseFwd<DeviceTag>(pixelsToRender,

--- a/src/fvdb/detail/ops/gsplat/RasterizeScreenSpaceGaussiansForward.h
+++ b/src/fvdb/detail/ops/gsplat/RasterizeScreenSpaceGaussiansForward.h
@@ -48,7 +48,7 @@ namespace ops {
 /// @return std::tuple containing:
 ///         - Rendered image features/colors [C, render_height, render_width, D]
 ///         - Alpha values [C, render_height, render_width, 1]
-///         - Last flattened intersection index rendered at each pixel
+///         - Last tile-relative intersection index rendered at each pixel, or -1 if none
 ///           [C, render_height, render_width]
 std::tuple<torch::Tensor, torch::Tensor, torch::Tensor>
 rasterizeScreenSpaceGaussiansFwd(const torch::Tensor &means2d,
@@ -93,7 +93,8 @@ rasterizeScreenSpaceGaussiansFwd(const torch::Tensor &means2d,
 /// @return A tuple containing:
 ///         - Output colors JaggedTensor for the specified pixels.
 ///         - Output alphas JaggedTensor for the specified pixels.
-///         - Output last flattened intersection indices as a JaggedTensor.
+///         - Output last tile-relative intersection indices as a JaggedTensor, with -1 where no
+///           intersection contributed.
 std::tuple<fvdb::JaggedTensor, fvdb::JaggedTensor, fvdb::JaggedTensor>
 rasterizeScreenSpaceGaussiansSparseFwd(const fvdb::JaggedTensor &pixelsToRender,
                                        const torch::Tensor &means2d,

--- a/src/fvdb/detail/ops/gsplat/RasterizeScreenSpaceGaussiansForward.h
+++ b/src/fvdb/detail/ops/gsplat/RasterizeScreenSpaceGaussiansForward.h
@@ -34,8 +34,8 @@ namespace ops {
 /// @param[in] imageOriginW Horizontal origin of the render window
 /// @param[in] imageOriginH Vertical origin of the render window
 /// @param[in] tileSize Size of tiles used for rasterization optimization
-/// @param[in] tileOffsets Offsets for tiles [C, tile_height, tile_width] indicating for each tile
-/// where its Gaussians start
+/// @param[in] tileOffsets int64 offsets for tiles [C, tile_height, tile_width] indicating for each
+/// tile where its intersections start
 /// @param[in] tileGaussianIds Flattened Gaussian IDs for tile intersection [n_isects] indicating
 /// which Gaussians affect each tile
 /// @param[in] numSharedChannelsOverride Override for number of shared memory channels (-1 means
@@ -48,7 +48,8 @@ namespace ops {
 /// @return std::tuple containing:
 ///         - Rendered image features/colors [C, render_height, render_width, D]
 ///         - Alpha values [C, render_height, render_width, 1]
-///         - Last Gaussian ID rendered at each pixel [C, render_height, render_width]
+///         - Last flattened intersection index rendered at each pixel as int64
+///           [C, render_height, render_width]
 std::tuple<torch::Tensor, torch::Tensor, torch::Tensor>
 rasterizeScreenSpaceGaussiansFwd(const torch::Tensor &means2d,
                                  const torch::Tensor &conics,
@@ -77,7 +78,7 @@ rasterizeScreenSpaceGaussiansFwd(const torch::Tensor &means2d,
 /// @param imageOriginW Horizontal origin of the render window
 /// @param imageOriginH Vertical origin of the render window
 /// @param tileSize Size of the tiles used for processing.
-/// @param tileOffsets Tensor containing offsets for each tile.
+/// @param tileOffsets int64 tensor containing offsets for each tile.
 /// @param tileGaussianIds Tensor mapping tiles to Gaussian IDs.
 /// @param activeTiles Tensor containing the indices of active tiles.
 /// @param tilePixelMask Tensor containing the mask for each tile pixel.
@@ -92,7 +93,7 @@ rasterizeScreenSpaceGaussiansFwd(const torch::Tensor &means2d,
 /// @return A tuple containing:
 ///         - Output colors JaggedTensor for the specified pixels.
 ///         - Output alphas JaggedTensor for the specified pixels.
-///         - Output last Gaussian IDs JaggedTensor for the specified pixels.
+///         - Output last flattened intersection indices as an int64 JaggedTensor.
 std::tuple<fvdb::JaggedTensor, fvdb::JaggedTensor, fvdb::JaggedTensor>
 rasterizeScreenSpaceGaussiansSparseFwd(const fvdb::JaggedTensor &pixelsToRender,
                                        const torch::Tensor &means2d,

--- a/src/fvdb/detail/ops/gsplat/RasterizeScreenSpaceGaussiansForward.h
+++ b/src/fvdb/detail/ops/gsplat/RasterizeScreenSpaceGaussiansForward.h
@@ -34,7 +34,7 @@ namespace ops {
 /// @param[in] imageOriginW Horizontal origin of the render window
 /// @param[in] imageOriginH Vertical origin of the render window
 /// @param[in] tileSize Size of tiles used for rasterization optimization
-/// @param[in] tileOffsets int64 offsets for tiles [C, tile_height, tile_width] indicating for each
+/// @param[in] tileOffsets offsets for tiles [C, tile_height, tile_width] indicating for each
 /// tile where its intersections start
 /// @param[in] tileGaussianIds Flattened Gaussian IDs for tile intersection [n_isects] indicating
 /// which Gaussians affect each tile
@@ -48,7 +48,7 @@ namespace ops {
 /// @return std::tuple containing:
 ///         - Rendered image features/colors [C, render_height, render_width, D]
 ///         - Alpha values [C, render_height, render_width, 1]
-///         - Last flattened intersection index rendered at each pixel as int64
+///         - Last flattened intersection index rendered at each pixel
 ///           [C, render_height, render_width]
 std::tuple<torch::Tensor, torch::Tensor, torch::Tensor>
 rasterizeScreenSpaceGaussiansFwd(const torch::Tensor &means2d,
@@ -78,7 +78,7 @@ rasterizeScreenSpaceGaussiansFwd(const torch::Tensor &means2d,
 /// @param imageOriginW Horizontal origin of the render window
 /// @param imageOriginH Vertical origin of the render window
 /// @param tileSize Size of the tiles used for processing.
-/// @param tileOffsets int64 tensor containing offsets for each tile.
+/// @param tileOffsets tensor containing offsets for each tile.
 /// @param tileGaussianIds Tensor mapping tiles to Gaussian IDs.
 /// @param activeTiles Tensor containing the indices of active tiles.
 /// @param tilePixelMask Tensor containing the mask for each tile pixel.
@@ -93,7 +93,7 @@ rasterizeScreenSpaceGaussiansFwd(const torch::Tensor &means2d,
 /// @return A tuple containing:
 ///         - Output colors JaggedTensor for the specified pixels.
 ///         - Output alphas JaggedTensor for the specified pixels.
-///         - Output last flattened intersection indices as an int64 JaggedTensor.
+///         - Output last flattened intersection indices as a JaggedTensor.
 std::tuple<fvdb::JaggedTensor, fvdb::JaggedTensor, fvdb::JaggedTensor>
 rasterizeScreenSpaceGaussiansSparseFwd(const fvdb::JaggedTensor &pixelsToRender,
                                        const torch::Tensor &means2d,

--- a/src/fvdb/detail/ops/gsplat/RasterizeWorldSpaceGaussiansBackward.cu
+++ b/src/fvdb/detail/ops/gsplat/RasterizeWorldSpaceGaussiansBackward.cu
@@ -36,7 +36,7 @@ template <uint32_t NUM_CHANNELS, typename Camera> struct RasterizeFromWorldBackw
     Camera camera;
     // Forward outputs
     fvdb::TorchRAcc64<float, 4> renderedAlphas; // [C,H,W,1]
-    fvdb::TorchRAcc64<int32_t, 3> lastIds;      // [C,H,W]
+    fvdb::TorchRAcc64<int64_t, 3> lastIds;      // [C,H,W]
     // Grad outputs
     fvdb::TorchRAcc64<float, 4> dLossDRenderedFeatures; // [C,H,W,D]
     fvdb::TorchRAcc64<float, 4> dLossDRenderedAlphas;   // [C,H,W,1]
@@ -94,7 +94,7 @@ rasterizeFromWorld3DGSBackwardKernel(
     }
 
     // Forward state for this pixel.
-    int32_t binFinal = -1;
+    int64_t binFinal = -1;
     float T_final    = 1.0f;
     float T          = 1.0f;
 
@@ -136,17 +136,19 @@ rasterizeFromWorld3DGSBackwardKernel(
     const uint32_t threadRank      = block.thread_rank();
     cg::thread_block_tile<32> warp = cg::tiled_partition<32>(block);
 
-    const int32_t nIsects   = rangeEnd - rangeStart;
-    const uint32_t nBatches = (nIsects + (int32_t)blockSize - 1) / (int32_t)blockSize;
+    const int64_t nIsects  = rangeEnd - rangeStart;
+    const int64_t nBatches = (nIsects + blockSize - 1) / blockSize;
 
     // Reduce max binFinal within warp (used to early-skip).
-    const int32_t warpBinFinal = cg::reduce(warp, binFinal, cg::greater<int32_t>());
+    const int64_t warpBinFinal = cg::reduce(warp, binFinal, cg::greater<int64_t>());
 
-    for (uint32_t b = 0; b < nBatches; ++b) {
+    for (int64_t b = 0; b < nBatches; ++b) {
         block.sync();
-        const int32_t batchEnd  = rangeEnd - 1 - (int32_t)(blockSize * b);
-        const int32_t batchSize = min((int32_t)blockSize, batchEnd + 1 - rangeStart);
-        const int32_t idx       = batchEnd - (int32_t)threadRank;
+        const int64_t batchEnd  = rangeEnd - 1 - blockSize * b;
+        const int64_t remaining = batchEnd + 1 - rangeStart;
+        const uint32_t batchSize =
+            static_cast<uint32_t>(remaining < blockSize ? remaining : blockSize);
+        const int64_t idx = batchEnd - threadRank;
 
         if (idx >= rangeStart) {
             const int32_t flatId = common.tileGaussianIds[idx];
@@ -177,8 +179,10 @@ rasterizeFromWorld3DGSBackwardKernel(
         block.sync();
 
         // Process gaussians in this batch, from back-to-front.
-        const int32_t startT = max(0, batchEnd - warpBinFinal);
-        for (int32_t t = startT; t < batchSize; ++t) {
+        const int64_t startT64 = batchEnd > warpBinFinal ? batchEnd - warpBinFinal : 0;
+        const uint32_t startT =
+            startT64 < batchSize ? static_cast<uint32_t>(startT64) : batchSize;
+        for (uint32_t t = startT; t < batchSize; ++t) {
             bool valid = done;
             if (batchEnd - t > binFinal) {
                 valid = false;
@@ -406,7 +410,7 @@ launchBackward(const torch::Tensor &means,
     const uint32_t tileExtentH = (imageHeight + tileSize - 1) / tileSize;
     const dim3 blockDim(tileSize, tileSize, 1);
     const dim3 gridDim(C * tileExtentH * tileExtentW, 1, 1);
-    const int32_t totalIntersections = static_cast<int32_t>(tileGaussianIds.size(0));
+    const int64_t totalIntersections = tileGaussianIds.size(0);
 
     RasterizeFromWorldCommonArgs args{
         imageWidth,
@@ -418,7 +422,7 @@ launchBackward(const torch::Tensor &means,
         tileExtentH,
         NUM_CHANNELS,
         totalIntersections,
-        tileOffsets.packed_accessor64<int32_t, 3, torch::RestrictPtrTraits>(),
+        tileOffsets.packed_accessor64<int64_t, 3, torch::RestrictPtrTraits>(),
         tileGaussianIds.packed_accessor64<int32_t, 1, torch::RestrictPtrTraits>(),
         nullptr,
         nullptr,
@@ -443,7 +447,7 @@ launchBackward(const torch::Tensor &means,
         args,
         camera,
         renderedAlphas.packed_accessor64<float, 4, torch::RestrictPtrTraits>(),
-        lastIds.packed_accessor64<int32_t, 3, torch::RestrictPtrTraits>(),
+        lastIds.packed_accessor64<int64_t, 3, torch::RestrictPtrTraits>(),
         dLossDRenderedFeatures.packed_accessor64<float, 4, torch::RestrictPtrTraits>(),
         dLossDRenderedAlphas.packed_accessor64<float, 4, torch::RestrictPtrTraits>(),
         dMeans.packed_accessor64<float, 2, torch::RestrictPtrTraits>(),
@@ -524,6 +528,10 @@ dispatchGaussianRasterizeFromWorld3DGSBackward<torch::kCUDA>(
     TORCH_CHECK_VALUE(opacities.is_cuda(), "opacities must be CUDA");
     TORCH_CHECK_VALUE(renderedAlphas.is_cuda(), "renderedAlphas must be CUDA");
     TORCH_CHECK_VALUE(lastIds.is_cuda(), "lastIds must be CUDA");
+    TORCH_CHECK_VALUE(tileOffsets.scalar_type() == torch::kInt64,
+                      "tileOffsets must have dtype int64");
+    TORCH_CHECK_VALUE(lastIds.scalar_type() == torch::kInt64,
+                      "lastIds must have dtype int64");
 
     const int64_t C = features.size(0);
     const int64_t N = means.size(0);

--- a/src/fvdb/detail/ops/gsplat/RasterizeWorldSpaceGaussiansBackward.cu
+++ b/src/fvdb/detail/ops/gsplat/RasterizeWorldSpaceGaussiansBackward.cu
@@ -36,7 +36,7 @@ template <uint32_t NUM_CHANNELS, typename Camera> struct RasterizeFromWorldBackw
     Camera camera;
     // Forward outputs
     fvdb::TorchRAcc64<float, 4> renderedAlphas; // [C,H,W,1]
-    fvdb::TorchRAcc64<int64_t, 3> lastIds;      // [C,H,W]
+    fvdb::TorchRAcc64<int32_t, 3> lastIds;      // [C,H,W]
     // Grad outputs
     fvdb::TorchRAcc64<float, 4> dLossDRenderedFeatures; // [C,H,W,D]
     fvdb::TorchRAcc64<float, 4> dLossDRenderedAlphas;   // [C,H,W,1]
@@ -94,9 +94,9 @@ rasterizeFromWorld3DGSBackwardKernel(
     }
 
     // Forward state for this pixel.
-    int64_t binFinal = -1;
-    float T_final    = 1.0f;
-    float T          = 1.0f;
+    int32_t lastIntersectionOffset = -1;
+    float T_final                  = 1.0f;
+    float T                        = 1.0f;
 
     float v_render_c[NUM_CHANNELS];
 #pragma unroll
@@ -106,7 +106,7 @@ rasterizeFromWorld3DGSBackwardKernel(
     float v_render_a = 0.f;
 
     if (done) {
-        binFinal = args.lastIds[camId][row][col];
+        lastIntersectionOffset = args.lastIds[camId][row][col];
 
         const float alphaFinal = args.renderedAlphas[camId][row][col][0];
         T_final                = 1.0f - alphaFinal;
@@ -139,16 +139,17 @@ rasterizeFromWorld3DGSBackwardKernel(
     const int64_t nIsects  = rangeEnd - rangeStart;
     const int64_t nBatches = (nIsects + blockSize - 1) / blockSize;
 
-    // Reduce max binFinal within warp (used to early-skip).
-    const int64_t warpBinFinal = cg::reduce(warp, binFinal, cg::greater<int64_t>());
+    // Reduce the last tile-relative intersection offset within the warp for early skipping.
+    const int32_t lastIntersectionOffsetInWarp =
+        cg::reduce(warp, lastIntersectionOffset, cg::greater<int32_t>());
 
     for (int64_t b = 0; b < nBatches; ++b) {
         block.sync();
-        const int64_t batchEnd  = rangeEnd - 1 - blockSize * b;
-        const int64_t remaining = batchEnd + 1 - rangeStart;
+        const int64_t batchEndOffset = nIsects - 1 - blockSize * b;
+        const int64_t remaining      = batchEndOffset + 1;
         const uint32_t batchSize =
             static_cast<uint32_t>(remaining < blockSize ? remaining : blockSize);
-        const int64_t idx = batchEnd - threadRank;
+        const int64_t idx = rangeStart + batchEndOffset - threadRank;
 
         if (idx >= rangeStart) {
             const int32_t flatId = common.tileGaussianIds[idx];
@@ -179,11 +180,13 @@ rasterizeFromWorld3DGSBackwardKernel(
         block.sync();
 
         // Process gaussians in this batch, from back-to-front.
-        const int64_t startT64 = batchEnd > warpBinFinal ? batchEnd - warpBinFinal : 0;
+        const int64_t startT64 = batchEndOffset > lastIntersectionOffsetInWarp
+                                     ? batchEndOffset - lastIntersectionOffsetInWarp
+                                     : 0;
         const uint32_t startT  = startT64 < batchSize ? static_cast<uint32_t>(startT64) : batchSize;
         for (uint32_t t = startT; t < batchSize; ++t) {
             bool valid = done;
-            if (batchEnd - t > binFinal) {
+            if (batchEndOffset - t > lastIntersectionOffset) {
                 valid = false;
             }
 
@@ -446,7 +449,7 @@ launchBackward(const torch::Tensor &means,
         args,
         camera,
         renderedAlphas.packed_accessor64<float, 4, torch::RestrictPtrTraits>(),
-        lastIds.packed_accessor64<int64_t, 3, torch::RestrictPtrTraits>(),
+        lastIds.packed_accessor64<int32_t, 3, torch::RestrictPtrTraits>(),
         dLossDRenderedFeatures.packed_accessor64<float, 4, torch::RestrictPtrTraits>(),
         dLossDRenderedAlphas.packed_accessor64<float, 4, torch::RestrictPtrTraits>(),
         dMeans.packed_accessor64<float, 2, torch::RestrictPtrTraits>(),
@@ -529,7 +532,7 @@ dispatchGaussianRasterizeFromWorld3DGSBackward<torch::kCUDA>(
     TORCH_CHECK_VALUE(lastIds.is_cuda(), "lastIds must be CUDA");
     TORCH_CHECK_VALUE(tileOffsets.scalar_type() == torch::kInt64,
                       "tileOffsets must have dtype int64");
-    TORCH_CHECK_VALUE(lastIds.scalar_type() == torch::kInt64, "lastIds must have dtype int64");
+    TORCH_CHECK_VALUE(lastIds.scalar_type() == torch::kInt32, "lastIds must have dtype int32");
 
     const int64_t C = features.size(0);
     const int64_t N = means.size(0);

--- a/src/fvdb/detail/ops/gsplat/RasterizeWorldSpaceGaussiansBackward.cu
+++ b/src/fvdb/detail/ops/gsplat/RasterizeWorldSpaceGaussiansBackward.cu
@@ -180,8 +180,7 @@ rasterizeFromWorld3DGSBackwardKernel(
 
         // Process gaussians in this batch, from back-to-front.
         const int64_t startT64 = batchEnd > warpBinFinal ? batchEnd - warpBinFinal : 0;
-        const uint32_t startT =
-            startT64 < batchSize ? static_cast<uint32_t>(startT64) : batchSize;
+        const uint32_t startT  = startT64 < batchSize ? static_cast<uint32_t>(startT64) : batchSize;
         for (uint32_t t = startT; t < batchSize; ++t) {
             bool valid = done;
             if (batchEnd - t > binFinal) {
@@ -530,8 +529,7 @@ dispatchGaussianRasterizeFromWorld3DGSBackward<torch::kCUDA>(
     TORCH_CHECK_VALUE(lastIds.is_cuda(), "lastIds must be CUDA");
     TORCH_CHECK_VALUE(tileOffsets.scalar_type() == torch::kInt64,
                       "tileOffsets must have dtype int64");
-    TORCH_CHECK_VALUE(lastIds.scalar_type() == torch::kInt64,
-                      "lastIds must have dtype int64");
+    TORCH_CHECK_VALUE(lastIds.scalar_type() == torch::kInt64, "lastIds must have dtype int64");
 
     const int64_t C = features.size(0);
     const int64_t N = means.size(0);

--- a/src/fvdb/detail/ops/gsplat/RasterizeWorldSpaceGaussiansBackward.h
+++ b/src/fvdb/detail/ops/gsplat/RasterizeWorldSpaceGaussiansBackward.h
@@ -35,10 +35,10 @@ namespace fvdb::detail::ops {
 /// @param[in] rollingShutterType Rolling shutter policy
 /// @param[in] cameraModel Camera/distortion model
 /// @param[in] settings Render settings (image dimensions, tile size, etc.)
-/// @param[in] tileOffsets int64 tile offsets [C, tileH, tileW]
+/// @param[in] tileOffsets tile offsets [C, tileH, tileW]
 /// @param[in] tileGaussianIds Tile Gaussian IDs [n_isects]
 /// @param[in] renderedAlphas Alpha values from forward pass [C, H, W, 1]
-/// @param[in] lastIds Last flattened intersection index per pixel as int64 [C, H, W]
+/// @param[in] lastIds Last flattened intersection index per pixel [C, H, W]
 /// @param[in] dLossDRenderedFeatures Gradients w.r.t. rendered features [C, H, W, D]
 /// @param[in] dLossDRenderedAlphas Gradients w.r.t. rendered alphas [C, H, W, 1]
 /// @param[in] backgrounds Optional per-camera background [C, D]

--- a/src/fvdb/detail/ops/gsplat/RasterizeWorldSpaceGaussiansBackward.h
+++ b/src/fvdb/detail/ops/gsplat/RasterizeWorldSpaceGaussiansBackward.h
@@ -38,7 +38,7 @@ namespace fvdb::detail::ops {
 /// @param[in] tileOffsets tile offsets [C, tileH, tileW]
 /// @param[in] tileGaussianIds Tile Gaussian IDs [n_isects]
 /// @param[in] renderedAlphas Alpha values from forward pass [C, H, W, 1]
-/// @param[in] lastIds Last flattened intersection index per pixel [C, H, W]
+/// @param[in] lastIds Last tile-relative intersection index per pixel [C, H, W], or -1 if none
 /// @param[in] dLossDRenderedFeatures Gradients w.r.t. rendered features [C, H, W, D]
 /// @param[in] dLossDRenderedAlphas Gradients w.r.t. rendered alphas [C, H, W, 1]
 /// @param[in] backgrounds Optional per-camera background [C, D]

--- a/src/fvdb/detail/ops/gsplat/RasterizeWorldSpaceGaussiansBackward.h
+++ b/src/fvdb/detail/ops/gsplat/RasterizeWorldSpaceGaussiansBackward.h
@@ -35,10 +35,10 @@ namespace fvdb::detail::ops {
 /// @param[in] rollingShutterType Rolling shutter policy
 /// @param[in] cameraModel Camera/distortion model
 /// @param[in] settings Render settings (image dimensions, tile size, etc.)
-/// @param[in] tileOffsets Tile offsets [C, tileH, tileW]
+/// @param[in] tileOffsets int64 tile offsets [C, tileH, tileW]
 /// @param[in] tileGaussianIds Tile Gaussian IDs [n_isects]
 /// @param[in] renderedAlphas Alpha values from forward pass [C, H, W, 1]
-/// @param[in] lastIds Last Gaussian ID per pixel [C, H, W]
+/// @param[in] lastIds Last flattened intersection index per pixel as int64 [C, H, W]
 /// @param[in] dLossDRenderedFeatures Gradients w.r.t. rendered features [C, H, W, D]
 /// @param[in] dLossDRenderedAlphas Gradients w.r.t. rendered alphas [C, H, W, 1]
 /// @param[in] backgrounds Optional per-camera background [C, D]

--- a/src/fvdb/detail/ops/gsplat/RasterizeWorldSpaceGaussiansForward.cu
+++ b/src/fvdb/detail/ops/gsplat/RasterizeWorldSpaceGaussiansForward.cu
@@ -32,7 +32,7 @@ template <uint32_t NUM_CHANNELS, typename Camera> struct RasterizeFromWorldForwa
     Camera camera;
     fvdb::TorchRAcc64<float, 4> outFeatures;  // [C,H,W,D]
     fvdb::TorchRAcc64<float, 4> outAlphas;    // [C,H,W,1]
-    fvdb::TorchRAcc64<int64_t, 3> outLastIds; // [C,H,W]
+    fvdb::TorchRAcc64<int32_t, 3> outLastIds; // [C,H,W]
 
     inline __device__ void
     volumeRenderTileForward() const {
@@ -47,7 +47,7 @@ template <uint32_t NUM_CHANNELS, typename Camera> struct RasterizeFromWorldForwa
                                 row * outFeatures.stride(1) + col * outFeatures.stride(2);
         float *outAlphaPtr = outAlphas.data() + camId * outAlphas.stride(0) +
                              row * outAlphas.stride(1) + col * outAlphas.stride(2);
-        int64_t *outLastIdPtr = outLastIds.data() + camId * outLastIds.stride(0) +
+        int32_t *outLastIdPtr = outLastIds.data() + camId * outLastIds.stride(0) +
                                 row * outLastIds.stride(1) + col * outLastIds.stride(2);
 
         // Parity with classic rasterizer: masked tiles write background and exit.
@@ -109,8 +109,8 @@ template <uint32_t NUM_CHANNELS, typename Camera> struct RasterizeFromWorldForwa
         auto *gaussBatch =
             reinterpret_cast<SharedGaussian<NUM_CHANNELS> *>(gaussAddr); // [blockSize]
 
-        float transmittance = 1.0f;
-        int64_t curIdx      = -1;
+        float transmittance            = 1.0f;
+        int32_t lastIntersectionOffset = -1;
         float pixOut[NUM_CHANNELS];
 #pragma unroll
         for (uint32_t k = 0; k < NUM_CHANNELS; ++k) {
@@ -126,8 +126,9 @@ template <uint32_t NUM_CHANNELS, typename Camera> struct RasterizeFromWorldForwa
                 break;
             }
 
-            const int64_t batchStart = rangeStart + blockSize * b;
-            const int64_t idx        = batchStart + threadRank;
+            const int64_t batchOffset = blockSize * b;
+            const int64_t batchStart  = rangeStart + batchOffset;
+            const int64_t idx         = batchStart + threadRank;
             if (idx < rangeEnd) {
                 const int32_t flatId = common.tileGaussianIds[idx];
                 idBatch[threadRank]  = flatId;
@@ -185,8 +186,8 @@ template <uint32_t NUM_CHANNELS, typename Camera> struct RasterizeFromWorldForwa
                 for (uint32_t k = 0; k < NUM_CHANNELS; ++k) {
                     pixOut[k] += common.features[cid][gid][k] * contrib;
                 }
-                curIdx        = batchStart + t;
-                transmittance = nextTransmittance;
+                lastIntersectionOffset = static_cast<int32_t>(batchOffset + t);
+                transmittance          = nextTransmittance;
             }
         }
 
@@ -195,7 +196,7 @@ template <uint32_t NUM_CHANNELS, typename Camera> struct RasterizeFromWorldForwa
         }
 
         outAlphaPtr[0]  = 1.0f - transmittance;
-        outLastIdPtr[0] = curIdx;
+        outLastIdPtr[0] = lastIntersectionOffset;
 #pragma unroll
         for (uint32_t k = 0; k < NUM_CHANNELS; ++k) {
             outFeaturesPtr[k * outFeatures.stride(3)] =
@@ -235,7 +236,7 @@ launchForward(const torch::Tensor &means,
     torch::Tensor outAlphas = torch::zeros({C, (int64_t)imageHeight, (int64_t)imageWidth, 1}, opts);
     torch::Tensor outLastIds =
         torch::zeros({C, (int64_t)imageHeight, (int64_t)imageWidth},
-                     torch::TensorOptions().dtype(torch::kInt64).device(features.device()));
+                     torch::TensorOptions().dtype(torch::kInt32).device(features.device()));
 
     const uint32_t tileExtentW = (imageWidth + tileSize - 1) / tileSize;
     const uint32_t tileExtentH = (imageHeight + tileSize - 1) / tileSize;
@@ -274,7 +275,7 @@ launchForward(const torch::Tensor &means,
         camera,
         outFeatures.packed_accessor64<float, 4, torch::RestrictPtrTraits>(),
         outAlphas.packed_accessor64<float, 4, torch::RestrictPtrTraits>(),
-        outLastIds.packed_accessor64<int64_t, 3, torch::RestrictPtrTraits>()};
+        outLastIds.packed_accessor64<int32_t, 3, torch::RestrictPtrTraits>()};
 
     const size_t blockSize = (size_t)tileSize * (size_t)tileSize;
     size_t sharedMem       = (alignof(nanovdb::math::Mat3<float>) - 1) + camera.numSharedMemBytes();

--- a/src/fvdb/detail/ops/gsplat/RasterizeWorldSpaceGaussiansForward.cu
+++ b/src/fvdb/detail/ops/gsplat/RasterizeWorldSpaceGaussiansForward.cu
@@ -32,7 +32,7 @@ template <uint32_t NUM_CHANNELS, typename Camera> struct RasterizeFromWorldForwa
     Camera camera;
     fvdb::TorchRAcc64<float, 4> outFeatures;  // [C,H,W,D]
     fvdb::TorchRAcc64<float, 4> outAlphas;    // [C,H,W,1]
-    fvdb::TorchRAcc64<int32_t, 3> outLastIds; // [C,H,W]
+    fvdb::TorchRAcc64<int64_t, 3> outLastIds; // [C,H,W]
 
     inline __device__ void
     volumeRenderTileForward() const {
@@ -47,7 +47,7 @@ template <uint32_t NUM_CHANNELS, typename Camera> struct RasterizeFromWorldForwa
                                 row * outFeatures.stride(1) + col * outFeatures.stride(2);
         float *outAlphaPtr = outAlphas.data() + camId * outAlphas.stride(0) +
                              row * outAlphas.stride(1) + col * outAlphas.stride(2);
-        int32_t *outLastIdPtr = outLastIds.data() + camId * outLastIds.stride(0) +
+        int64_t *outLastIdPtr = outLastIds.data() + camId * outLastIds.stride(0) +
                                 row * outLastIds.stride(1) + col * outLastIds.stride(2);
 
         // Parity with classic rasterizer: masked tiles write background and exit.
@@ -110,24 +110,24 @@ template <uint32_t NUM_CHANNELS, typename Camera> struct RasterizeFromWorldForwa
             reinterpret_cast<SharedGaussian<NUM_CHANNELS> *>(gaussAddr); // [blockSize]
 
         float transmittance = 1.0f;
-        int32_t curIdx      = -1;
+        int64_t curIdx      = -1;
         float pixOut[NUM_CHANNELS];
 #pragma unroll
         for (uint32_t k = 0; k < NUM_CHANNELS; ++k) {
             pixOut[k] = 0.f;
         }
 
-        const int32_t nIsects     = rangeEnd - rangeStart;
-        const uint32_t nBatches   = (nIsects + blockSize - 1) / blockSize;
+        const int64_t nIsects     = rangeEnd - rangeStart;
+        const int64_t nBatches    = (nIsects + blockSize - 1) / blockSize;
         const uint32_t threadRank = block.thread_rank();
 
-        for (uint32_t b = 0; b < nBatches; ++b) {
+        for (int64_t b = 0; b < nBatches; ++b) {
             if (__syncthreads_count(done) >= (int)blockSize) {
                 break;
             }
 
-            const int32_t batchStart = rangeStart + (int32_t)(blockSize * b);
-            const int32_t idx        = batchStart + (int32_t)threadRank;
+            const int64_t batchStart = rangeStart + blockSize * b;
+            const int64_t idx        = batchStart + threadRank;
             if (idx < rangeEnd) {
                 const int32_t flatId = common.tileGaussianIds[idx];
                 idBatch[threadRank]  = flatId;
@@ -154,8 +154,9 @@ template <uint32_t NUM_CHANNELS, typename Camera> struct RasterizeFromWorldForwa
 
             __syncthreads();
 
+            const int64_t remaining = rangeEnd - batchStart;
             const uint32_t batchSize =
-                min((uint32_t)blockSize, (uint32_t)max(0, rangeEnd - batchStart));
+                static_cast<uint32_t>(remaining < blockSize ? remaining : blockSize);
             for (uint32_t t = 0; (t < batchSize) && !done; ++t) {
                 const SharedGaussian<NUM_CHANNELS> g = gaussBatch[t];
                 // 3DGS ray-ellipsoid visibility in "whitened" coordinates (see 3D-GUT paper
@@ -184,7 +185,7 @@ template <uint32_t NUM_CHANNELS, typename Camera> struct RasterizeFromWorldForwa
                 for (uint32_t k = 0; k < NUM_CHANNELS; ++k) {
                     pixOut[k] += common.features[cid][gid][k] * contrib;
                 }
-                curIdx        = (uint32_t)(batchStart + (int32_t)t);
+                curIdx        = batchStart + t;
                 transmittance = nextTransmittance;
             }
         }
@@ -234,14 +235,14 @@ launchForward(const torch::Tensor &means,
     torch::Tensor outAlphas = torch::zeros({C, (int64_t)imageHeight, (int64_t)imageWidth, 1}, opts);
     torch::Tensor outLastIds =
         torch::zeros({C, (int64_t)imageHeight, (int64_t)imageWidth},
-                     torch::TensorOptions().dtype(torch::kInt32).device(features.device()));
+                     torch::TensorOptions().dtype(torch::kInt64).device(features.device()));
 
     const uint32_t tileExtentW = (imageWidth + tileSize - 1) / tileSize;
     const uint32_t tileExtentH = (imageHeight + tileSize - 1) / tileSize;
     const dim3 blockDim(tileSize, tileSize, 1);
     const dim3 gridDim(C * tileExtentH * tileExtentW, 1, 1);
 
-    const int32_t totalIntersections = (int32_t)tileGaussianIds.size(0);
+    const int64_t totalIntersections = tileGaussianIds.size(0);
 
     RasterizeFromWorldCommonArgs commonArgs{
         imageWidth,
@@ -253,7 +254,7 @@ launchForward(const torch::Tensor &means,
         tileExtentH,
         NUM_CHANNELS,
         totalIntersections,
-        tileOffsets.packed_accessor64<int32_t, 3, torch::RestrictPtrTraits>(),
+        tileOffsets.packed_accessor64<int64_t, 3, torch::RestrictPtrTraits>(),
         tileGaussianIds.packed_accessor64<int32_t, 1, torch::RestrictPtrTraits>(),
         nullptr,
         nullptr,
@@ -273,7 +274,7 @@ launchForward(const torch::Tensor &means,
         camera,
         outFeatures.packed_accessor64<float, 4, torch::RestrictPtrTraits>(),
         outAlphas.packed_accessor64<float, 4, torch::RestrictPtrTraits>(),
-        outLastIds.packed_accessor64<int32_t, 3, torch::RestrictPtrTraits>()};
+        outLastIds.packed_accessor64<int64_t, 3, torch::RestrictPtrTraits>()};
 
     const size_t blockSize = (size_t)tileSize * (size_t)tileSize;
     size_t sharedMem       = (alignof(nanovdb::math::Mat3<float>) - 1) + camera.numSharedMemBytes();
@@ -345,6 +346,8 @@ dispatchGaussianRasterizeFromWorld3DGSForward<torch::kCUDA>(
     TORCH_CHECK_VALUE(features.is_cuda(), "features must be CUDA");
     TORCH_CHECK_VALUE(tileOffsets.is_cuda(), "tileOffsets must be CUDA");
     TORCH_CHECK_VALUE(tileGaussianIds.is_cuda(), "tileGaussianIds must be CUDA");
+    TORCH_CHECK_VALUE(tileOffsets.scalar_type() == torch::kInt64,
+                      "tileOffsets must have dtype int64");
 
     TORCH_CHECK_VALUE(means.dim() == 2 && means.size(1) == 3, "means must have shape [N,3]");
     TORCH_CHECK_VALUE(quats.dim() == 2 && quats.size(1) == 4, "quats must have shape [N,4]");

--- a/src/fvdb/detail/ops/gsplat/RasterizeWorldSpaceGaussiansForward.h
+++ b/src/fvdb/detail/ops/gsplat/RasterizeWorldSpaceGaussiansForward.h
@@ -40,7 +40,7 @@ namespace fvdb::detail::ops {
 /// @param[in] rollingShutterType Rolling shutter policy
 /// @param[in] cameraModel Camera/distortion model
 /// @param[in] settings Render settings (image dimensions, tile size, etc.)
-/// @param[in] tileOffsets int64 tile offsets [C, tileH, tileW]
+/// @param[in] tileOffsets tile offsets [C, tileH, tileW]
 /// @param[in] tileGaussianIds Tile Gaussian IDs [n_isects]
 /// @param[in] backgrounds Optional per-camera background [C, D]
 /// @param[in] masks Optional per-tile boolean mask [C, tileH, tileW]
@@ -48,7 +48,7 @@ namespace fvdb::detail::ops {
 /// @return std::tuple containing:
 ///         - Rendered features [C, H, W, D]
 ///         - Alpha values [C, H, W, 1]
-///         - Last flattened intersection index per pixel as int64 [C, H, W]
+///         - Last flattened intersection index per pixel [C, H, W]
 std::tuple<torch::Tensor, torch::Tensor, torch::Tensor>
 rasterizeWorldSpaceGaussiansFwd(const torch::Tensor &means,
                                 const torch::Tensor &quats,

--- a/src/fvdb/detail/ops/gsplat/RasterizeWorldSpaceGaussiansForward.h
+++ b/src/fvdb/detail/ops/gsplat/RasterizeWorldSpaceGaussiansForward.h
@@ -48,7 +48,7 @@ namespace fvdb::detail::ops {
 /// @return std::tuple containing:
 ///         - Rendered features [C, H, W, D]
 ///         - Alpha values [C, H, W, 1]
-///         - Last flattened intersection index per pixel [C, H, W]
+///         - Last tile-relative intersection index per pixel, or -1 if none [C, H, W]
 std::tuple<torch::Tensor, torch::Tensor, torch::Tensor>
 rasterizeWorldSpaceGaussiansFwd(const torch::Tensor &means,
                                 const torch::Tensor &quats,

--- a/src/fvdb/detail/ops/gsplat/RasterizeWorldSpaceGaussiansForward.h
+++ b/src/fvdb/detail/ops/gsplat/RasterizeWorldSpaceGaussiansForward.h
@@ -40,7 +40,7 @@ namespace fvdb::detail::ops {
 /// @param[in] rollingShutterType Rolling shutter policy
 /// @param[in] cameraModel Camera/distortion model
 /// @param[in] settings Render settings (image dimensions, tile size, etc.)
-/// @param[in] tileOffsets Tile offsets [C, tileH, tileW]
+/// @param[in] tileOffsets int64 tile offsets [C, tileH, tileW]
 /// @param[in] tileGaussianIds Tile Gaussian IDs [n_isects]
 /// @param[in] backgrounds Optional per-camera background [C, D]
 /// @param[in] masks Optional per-tile boolean mask [C, tileH, tileW]
@@ -48,7 +48,7 @@ namespace fvdb::detail::ops {
 /// @return std::tuple containing:
 ///         - Rendered features [C, H, W, D]
 ///         - Alpha values [C, H, W, 1]
-///         - Last Gaussian ID per pixel [C, H, W]
+///         - Last flattened intersection index per pixel as int64 [C, H, W]
 std::tuple<torch::Tensor, torch::Tensor, torch::Tensor>
 rasterizeWorldSpaceGaussiansFwd(const torch::Tensor &means,
                                 const torch::Tensor &quats,

--- a/src/fvdb/detail/utils/gsplat/GaussianRasterize.cuh
+++ b/src/fvdb/detail/utils/gsplat/GaussianRasterize.cuh
@@ -10,6 +10,7 @@
 #include <fvdb/detail/utils/cuda/math/Rotation.cuh>
 #include <fvdb/detail/utils/gsplat/Gaussian2D.cuh>
 #include <fvdb/detail/utils/gsplat/GaussianMath.cuh>
+#include <fvdb/detail/utils/gsplat/GaussianTileRange.cuh>
 
 #include <nanovdb/math/Math.h>
 
@@ -96,7 +97,7 @@ template <typename ScalarType, size_t NUM_CHANNELS, bool IS_PACKED> struct Raste
     uint32_t mBlockOffset;
     uint32_t mNumCameras;
     uint32_t mNumGaussiansPerCamera;
-    uint32_t mTotalIntersections;
+    int64_t mTotalIntersections;
     // Raster window (crop) dimensions/origin. These are render-target coordinates, not full camera
     // sensor dimensions.
     RenderWindow2D mRenderWindow;
@@ -114,9 +115,9 @@ template <typename ScalarType, size_t NUM_CHANNELS, bool IS_PACKED> struct Raste
     // Tile offsets: can be 3D [C, nTilesH, nTilesW] (dense) or 1D [AT + 1] (sparse)
     // We store both accessor types but only one is valid based on mTileOffsetsAreSparse
     bool mTileOffsetsAreSparse;
-    TorchRAcc64<int32_t, 3>
+    TorchRAcc64<int64_t, 3>
         mTileOffsets; // [C, nTilesH, nTilesW] - used when !mTileOffsetsAreSparse
-    TorchRAcc64<int32_t, 1> mSparseTileOffsets; // [AT + 1] - used when mTileOffsetsAreSparse
+    TorchRAcc64<int64_t, 1> mSparseTileOffsets; // [AT + 1] - used when mTileOffsetsAreSparse
     // Common optional input tensors
     bool mHasFeatures;
     VectorAccessor mFeatures;                // [C, N, NUM_CHANNELS] or [nnz, NUM_CHANNELS]
@@ -158,14 +159,14 @@ template <typename ScalarType, size_t NUM_CHANNELS, bool IS_PACKED> struct Raste
           mTileOffsetsAreSparse(tileOffsets.dim() == 1),
           // Initialize 3D accessor for dense mode, or placeholder for sparse mode
           mTileOffsets(mTileOffsetsAreSparse
-                           ? initAccessor<int32_t, 3>(
+                           ? initAccessor<int64_t, 3>(
                                  torch::empty({0, 0, 0}, tileOffsets.options()), "tileOffsets")
-                           : initAccessor<int32_t, 3>(tileOffsets, "tileOffsets")),
+                           : initAccessor<int64_t, 3>(tileOffsets, "tileOffsets")),
           // Initialize 1D accessor for sparse mode, or placeholder for dense mode
           mSparseTileOffsets(
               mTileOffsetsAreSparse
-                  ? initAccessor<int32_t, 1>(tileOffsets, "sparseTileOffsets")
-                  : initAccessor<int32_t, 1>(torch::empty({0}, tileOffsets.options()),
+                  ? initAccessor<int64_t, 1>(tileOffsets, "sparseTileOffsets")
+                  : initAccessor<int64_t, 1>(torch::empty({0}, tileOffsets.options()),
                                              "sparseTileOffsets")),
           mHasFeatures(features.has_value()),
           mFeatures(initAccessor<ScalarType, NUM_OUTER_DIMS + 1>(
@@ -175,7 +176,8 @@ template <typename ScalarType, size_t NUM_CHANNELS, bool IS_PACKED> struct Raste
           mMasks(initAccessor<bool, 3>(masks, means2d.options().dtype(torch::kBool), "masks")),
           mHasMasks(masks.has_value()), mBlockOffset(blockOffset),
           mIsSparse(activeTiles.has_value()),
-          mActiveTiles(initAccessor<int32_t, 1>(activeTiles, tileOffsets.options(), "activeTiles")),
+          mActiveTiles(initAccessor<int32_t, 1>(
+              activeTiles, tileOffsets.options().dtype(torch::kInt32), "activeTiles")),
           mTilePixelMask(initAccessor<uint64_t, 2>(
               tilePixelMask, means2d.options().dtype(torch::kUInt64), "tilePixelMask")),
           mTilePixelCumsum(initAccessor<int64_t, 1>(
@@ -421,7 +423,7 @@ template <typename ScalarType, size_t NUM_CHANNELS, bool IS_PACKED> struct Raste
     }
 
     // Get the first and last Gaussian ID in the current tile
-    inline __device__ cuda::std::tuple<int32_t, int32_t>
+    inline __device__ cuda::std::tuple<int64_t, int64_t>
     tileGaussianRange(uint32_t cameraId, uint32_t tileRow, uint32_t tileCol) {
         // In sparse mode with 1D tile offsets, use the sparse offsets directly
         // indexed by the tile ordinal (blockIdx.x + mBlockOffset)
@@ -430,16 +432,14 @@ template <typename ScalarType, size_t NUM_CHANNELS, bool IS_PACKED> struct Raste
             return {mSparseTileOffsets[tileOrdinal], mSparseTileOffsets[tileOrdinal + 1]};
         }
 
-        // Dense mode: look up by (cameraId, tileRow, tileCol)
-        const int32_t firstGaussianIdInBlock = mTileOffsets[cameraId][tileRow][tileCol];
-        auto [nextTileRow, nextTileCol]      = (tileCol < mNumTilesW - 1)
-                                                   ? std::make_tuple(tileRow, tileCol + 1)
-                                                   : std::make_tuple(tileRow + 1, 0u); // wrap around
-        const int32_t lastGaussianIdInBlock =
-            ((cameraId == mNumCameras - 1) && (nextTileRow == mNumTilesH))
-                ? mTotalIntersections
-                : mTileOffsets[cameraId][nextTileRow][nextTileCol];
-        return {firstGaussianIdInBlock, lastGaussianIdInBlock};
+        return fvdb::detail::ops::tileGaussianRange(mTileOffsets,
+                                                    mTotalIntersections,
+                                                    mNumCameras,
+                                                    mNumTilesH,
+                                                    mNumTilesW,
+                                                    cameraId,
+                                                    tileRow,
+                                                    tileCol);
     }
 
     /// @brief Get the block dimensions for the forward/backward pass

--- a/src/fvdb/detail/utils/gsplat/GaussianRasterizeFromWorld.cuh
+++ b/src/fvdb/detail/utils/gsplat/GaussianRasterizeFromWorld.cuh
@@ -10,6 +10,7 @@
 #include <fvdb/detail/utils/cuda/math/Rotation.cuh>
 #include <fvdb/detail/utils/gsplat/GaussianCameras.cuh>
 #include <fvdb/detail/utils/gsplat/GaussianMath.cuh>
+#include <fvdb/detail/utils/gsplat/GaussianTileRange.cuh>
 
 #include <nanovdb/math/Math.h>
 #include <nanovdb/math/Ray.h>
@@ -25,7 +26,7 @@ constexpr __device__ float kAlphaThreshold = 0.99f;
 
 /// Common dense-tile rasterization arguments shared by from-world forward/backward kernels.
 struct RasterizeFromWorldCommonArgs {
-    using TileOffsetsAccessor     = fvdb::TorchRAcc64<int32_t, 3>;
+    using TileOffsetsAccessor     = fvdb::TorchRAcc64<int64_t, 3>;
     using TileGaussianIdsAccessor = fvdb::TorchRAcc64<int32_t, 1>;
     using Acc2f                   = fvdb::TorchRAcc64<float, 2>;
     using Acc3f                   = fvdb::TorchRAcc64<float, 3>;
@@ -38,7 +39,7 @@ struct RasterizeFromWorldCommonArgs {
     uint32_t numTilesW;
     uint32_t numTilesH;
     uint32_t numChannels;
-    int32_t totalIntersections;
+    int64_t totalIntersections;
 
     TileOffsetsAccessor tileOffsets;         // [C, TH, TW]
     TileGaussianIdsAccessor tileGaussianIds; // [n_isects]
@@ -80,20 +81,18 @@ struct RasterizeFromWorldCommonArgs {
         return (masks != nullptr) && (!masks[tileId(cameraId, tileRow, tileCol)]);
     }
 
-    inline __device__ cuda::std::tuple<int32_t, int32_t>
+    inline __device__ cuda::std::tuple<int64_t, int64_t>
     tileGaussianRange(const uint32_t cameraId,
                       const uint32_t tileRow,
                       const uint32_t tileCol) const {
-        const uint32_t numCameras            = tileOffsets.size(0);
-        const int32_t firstGaussianIdInBlock = tileOffsets[cameraId][tileRow][tileCol];
-        auto [nextTileRow, nextTileCol]      = (tileCol < numTilesW - 1)
-                                                   ? cuda::std::make_tuple(tileRow, tileCol + 1)
-                                                   : cuda::std::make_tuple(tileRow + 1, 0u);
-        const int32_t lastGaussianIdInBlock =
-            ((cameraId == numCameras - 1) && (nextTileRow == numTilesH))
-                ? totalIntersections
-                : tileOffsets[cameraId][nextTileRow][nextTileCol];
-        return {firstGaussianIdInBlock, lastGaussianIdInBlock};
+        return fvdb::detail::ops::tileGaussianRange(tileOffsets,
+                                                    totalIntersections,
+                                                    tileOffsets.size(0),
+                                                    numTilesH,
+                                                    numTilesW,
+                                                    cameraId,
+                                                    tileRow,
+                                                    tileCol);
     }
 
     inline __device__ float

--- a/src/fvdb/detail/utils/gsplat/GaussianTileRange.cuh
+++ b/src/fvdb/detail/utils/gsplat/GaussianTileRange.cuh
@@ -1,0 +1,46 @@
+// Copyright Contributors to the OpenVDB Project
+// SPDX-License-Identifier: Apache-2.0
+//
+#ifndef FVDB_DETAIL_UTILS_GSPLAT_GAUSSIANTILERANGE_CUH
+#define FVDB_DETAIL_UTILS_GSPLAT_GAUSSIANTILERANGE_CUH
+
+#include <cuda/std/tuple>
+
+#include <cstdint>
+
+namespace fvdb::detail::ops {
+
+template <typename TileOffsetsAccessor>
+inline __device__ cuda::std::tuple<int64_t, int64_t>
+tileGaussianRange(const TileOffsetsAccessor &tileOffsets,
+                  const int64_t totalIntersections,
+                  const uint32_t numCameras,
+                  const uint32_t numTilesH,
+                  const uint32_t numTilesW,
+                  const uint32_t cameraId,
+                  const uint32_t tileRow,
+                  const uint32_t tileCol) {
+    const int64_t firstIntersection = tileOffsets[cameraId][tileRow][tileCol];
+    const bool isLastTile =
+        cameraId == numCameras - 1 && tileRow == numTilesH - 1 && tileCol == numTilesW - 1;
+    if (isLastTile) {
+        return {firstIntersection, totalIntersections};
+    }
+
+    uint32_t nextCameraId = cameraId;
+    uint32_t nextTileRow  = tileRow;
+    uint32_t nextTileCol  = tileCol + 1;
+    if (nextTileCol == numTilesW) {
+        nextTileCol = 0;
+        ++nextTileRow;
+    }
+    if (nextTileRow == numTilesH) {
+        nextTileRow = 0;
+        ++nextCameraId;
+    }
+    return {firstIntersection, tileOffsets[nextCameraId][nextTileRow][nextTileCol]};
+}
+
+} // namespace fvdb::detail::ops
+
+#endif // FVDB_DETAIL_UTILS_GSPLAT_GAUSSIANTILERANGE_CUH

--- a/src/tests/GaussianRasterizeBackwardTest.cpp
+++ b/src/tests/GaussianRasterizeBackwardTest.cpp
@@ -110,10 +110,10 @@ class GaussianTestHelper {
         const int32_t numGaussians = (int32_t)gaussianPositions.size();
 
         auto tileOffsets = torch::zeros({numCameras, numTilesH, numTilesW},
-                                        torch::dtype(torch::kInt32).device(torch::kCUDA));
+                                        torch::dtype(torch::kInt64).device(torch::kCUDA));
 
         std::vector<int32_t> tileGaussianIds;
-        int32_t currentOffset = 0;
+        int64_t currentOffset = 0;
 
         // Create tile intersections for each camera
         for (int cameraIdx = 0; cameraIdx < numCameras; ++cameraIdx) {
@@ -376,10 +376,10 @@ struct GaussianRasterizeTestFixture : public ::testing::Test {
         conics                  = inputs[1].cuda();
         colors                  = inputs[2].cuda();
         opacities               = inputs[3].cuda();
-        tileOffsets             = inputs[4].cuda();
+        tileOffsets             = inputs[4].to(torch::kInt64).cuda();
         tileGaussianIds         = inputs[5].cuda();
         renderedAlphas          = inputs[6].cuda();
-        lastGaussianIdsPerPixel = inputs[7].cuda();
+        lastGaussianIdsPerPixel = inputs[7].to(torch::kInt64).cuda();
         dLossDRenderedColors    = inputs[8].cuda();
         dLossDRenderedAlphas    = inputs[9].cuda();
 

--- a/src/tests/GaussianRasterizeBackwardTest.cpp
+++ b/src/tests/GaussianRasterizeBackwardTest.cpp
@@ -15,10 +15,51 @@
 #include <gtest/gtest.h>
 
 #include <cstdlib>
+#include <limits>
 
 #ifndef FVDB_EXTERNAL_TEST_DATA_PATH
 #error "FVDB_EXTERNAL_TEST_DATA_PATH must be defined"
 #endif
+
+namespace {
+
+torch::Tensor
+toTileRelativeLastIds(const torch::Tensor &lastIds,
+                      const torch::Tensor &tileOffsets,
+                      const uint32_t tileSize) {
+    auto relative = lastIds.to(torch::kCPU).to(torch::kInt64).contiguous();
+    auto offsets  = tileOffsets.to(torch::kCPU).to(torch::kInt64).contiguous();
+
+    TORCH_CHECK_VALUE(relative.dim() == 3, "lastIds must have shape [C, H, W]");
+    TORCH_CHECK_VALUE(offsets.dim() == 3, "tileOffsets must have shape [C, TH, TW]");
+    TORCH_CHECK_VALUE(relative.size(0) <= offsets.size(0),
+                      "lastIds cannot have more cameras than tileOffsets");
+
+    auto relativeAcc      = relative.accessor<int64_t, 3>();
+    const auto offsetsAcc = offsets.accessor<int64_t, 3>();
+    for (int64_t camera = 0; camera < relative.size(0); ++camera) {
+        for (int64_t row = 0; row < relative.size(1); ++row) {
+            const int64_t tileRow = row / tileSize;
+            TORCH_CHECK_VALUE(tileRow < offsets.size(1), "lastIds height exceeds tileOffsets");
+            for (int64_t col = 0; col < relative.size(2); ++col) {
+                int64_t &lastId = relativeAcc[camera][row][col];
+                if (lastId < 0) {
+                    continue;
+                }
+
+                const int64_t tileCol = col / tileSize;
+                TORCH_CHECK_VALUE(tileCol < offsets.size(2), "lastIds width exceeds tileOffsets");
+                lastId -= offsetsAcc[camera][tileRow][tileCol];
+                TORCH_CHECK_VALUE(lastId >= 0 && lastId <= std::numeric_limits<int32_t>::max(),
+                                  "Tile-relative lastIds value must fit in int32");
+            }
+        }
+    }
+
+    return relative.to(torch::kInt32).to(lastIds.device());
+}
+
+} // namespace
 
 // Helper class to reduce test code repetition
 class GaussianTestHelper {
@@ -372,6 +413,12 @@ struct GaussianRasterizeTestFixture : public ::testing::Test {
 
         auto inputs = fvdb::test::loadTensors(inputsPath, inputNames);
 
+        imageWidth   = 1297;
+        imageHeight  = 840;
+        imageOriginW = 0;
+        imageOriginH = 0;
+        tileSize     = 16;
+
         means2d                 = inputs[0].cuda();
         conics                  = inputs[1].cuda();
         colors                  = inputs[2].cuda();
@@ -379,7 +426,7 @@ struct GaussianRasterizeTestFixture : public ::testing::Test {
         tileOffsets             = inputs[4].to(torch::kInt64).cuda();
         tileGaussianIds         = inputs[5].cuda();
         renderedAlphas          = inputs[6].cuda();
-        lastGaussianIdsPerPixel = inputs[7].to(torch::kInt64).cuda();
+        lastGaussianIdsPerPixel = toTileRelativeLastIds(inputs[7], inputs[4], tileSize).cuda();
         dLossDRenderedColors    = inputs[8].cuda();
         dLossDRenderedAlphas    = inputs[9].cuda();
 
@@ -388,12 +435,6 @@ struct GaussianRasterizeTestFixture : public ::testing::Test {
         expectedDLossDConics    = expectedOutputs[1].cuda();
         expectedDLossDColors    = expectedOutputs[2].cuda();
         expectedDLossDOpacities = expectedOutputs[3].cuda();
-
-        imageWidth   = 1297;
-        imageHeight  = 840;
-        imageOriginW = 0;
-        imageOriginH = 0;
-        tileSize     = 16;
     }
 
     void

--- a/src/tests/GaussianRasterizeContributingGaussianIdsTest.cpp
+++ b/src/tests/GaussianRasterizeContributingGaussianIdsTest.cpp
@@ -31,7 +31,7 @@ struct GaussianRasterizeContributingGaussianIdsTestFixture : public ::testing::T
         means2d                           = inputs[0].cuda();
         conics                            = inputs[1].cuda();
         opacities                         = inputs[2].cuda();
-        tileOffsets                       = inputs[3].cuda();
+        tileOffsets                       = inputs[3].to(torch::kInt64).cuda();
         tileGaussianIds                   = inputs[4].cuda();
         imageDims                         = inputs[5];
 

--- a/src/tests/GaussianRasterizeForwardTest.cpp
+++ b/src/tests/GaussianRasterizeForwardTest.cpp
@@ -24,6 +24,7 @@
 #endif
 
 #include <cstdlib>
+#include <limits>
 #include <string>
 #include <vector>
 
@@ -33,11 +34,66 @@
 
 namespace {
 constexpr const char *kMaskedEdgeTileChildEnv = "FVDB_GSPLAT_MASKED_EDGE_TILE_CHILD";
+
+torch::Tensor
+convertLastIds(const torch::Tensor &lastIds,
+               const torch::Tensor &tileOffsets,
+               const uint32_t tileSize,
+               const bool toTileRelative) {
+    auto converted = lastIds.to(torch::kCPU).to(torch::kInt64).contiguous();
+    auto offsets   = tileOffsets.to(torch::kCPU).to(torch::kInt64).contiguous();
+
+    TORCH_CHECK_VALUE(converted.dim() == 3, "lastIds must have shape [C, H, W]");
+    TORCH_CHECK_VALUE(offsets.dim() == 3, "tileOffsets must have shape [C, TH, TW]");
+    TORCH_CHECK_VALUE(converted.size(0) <= offsets.size(0),
+                      "lastIds cannot have more cameras than tileOffsets");
+
+    auto convertedAcc     = converted.accessor<int64_t, 3>();
+    const auto offsetsAcc = offsets.accessor<int64_t, 3>();
+    for (int64_t camera = 0; camera < converted.size(0); ++camera) {
+        for (int64_t row = 0; row < converted.size(1); ++row) {
+            const int64_t tileRow = row / tileSize;
+            TORCH_CHECK_VALUE(tileRow < offsets.size(1), "lastIds height exceeds tileOffsets");
+            for (int64_t col = 0; col < converted.size(2); ++col) {
+                int64_t &lastId = convertedAcc[camera][row][col];
+                if (lastId < 0) {
+                    continue;
+                }
+
+                const int64_t tileCol = col / tileSize;
+                TORCH_CHECK_VALUE(tileCol < offsets.size(2), "lastIds width exceeds tileOffsets");
+                const int64_t tileStart = offsetsAcc[camera][tileRow][tileCol];
+                lastId                  = toTileRelative ? lastId - tileStart : lastId + tileStart;
+                TORCH_CHECK_VALUE(lastId >= 0 && lastId <= std::numeric_limits<int32_t>::max(),
+                                  "Converted lastIds value must fit in int32");
+            }
+        }
+    }
+
+    return converted.to(torch::kInt32).to(lastIds.device());
+}
+
+torch::Tensor
+toTileRelativeLastIds(const torch::Tensor &lastIds,
+                      const torch::Tensor &tileOffsets,
+                      const uint32_t tileSize) {
+    return convertLastIds(lastIds, tileOffsets, tileSize, true);
+}
+
+torch::Tensor
+toAbsoluteLastIds(const torch::Tensor &lastIds,
+                  const torch::Tensor &tileOffsets,
+                  const uint32_t tileSize) {
+    return convertLastIds(lastIds, tileOffsets, tileSize, false);
+}
 } // namespace
 
 struct GaussianRasterizeForwardTestFixture : public ::testing::Test {
     void
     loadInputData(const std::string insPath) {
+        // Set the random seed for reproducibility.
+        torch::manual_seed(0);
+
         const std::string dataPath =
             std::string(FVDB_EXTERNAL_TEST_DATA_PATH) + std::string("/unit_tests/gsplat");
         const std::string inputsPath = dataPath + std::string("/") + insPath;
@@ -69,9 +125,6 @@ struct GaussianRasterizeForwardTestFixture : public ::testing::Test {
 
     void
     loadTestData(const std::string insPath, const std::string outsPath) {
-        // Set the random seed for reproducibility.
-        torch::manual_seed(0);
-
         loadInputData(insPath);
 
         const std::string dataPath =
@@ -89,7 +142,7 @@ struct GaussianRasterizeForwardTestFixture : public ::testing::Test {
 
         expectedRenderedColors = expectedOutputs[0].cuda();
         expectedRenderedAlphas = expectedOutputs[1].cuda();
-        expectedLastIds        = expectedOutputs[2].to(torch::kInt64).cuda();
+        expectedLastIds = toTileRelativeLastIds(expectedOutputs[2], tileOffsets, tileSize).cuda();
     }
 
     fvdb::JaggedTensor
@@ -425,6 +478,28 @@ TEST(GaussianRasterizeForwardMaskedEdgeTile, NoDeadlock) {
 #endif
 }
 
+TEST(GaussianRasterizeForwardLastIds, AreTileRelativeInt32) {
+    const auto floats = torch::TensorOptions().device(torch::kCUDA).dtype(torch::kFloat32);
+    const auto ints   = torch::TensorOptions().device(torch::kCUDA).dtype(torch::kInt32);
+    const auto longs  = torch::TensorOptions().device(torch::kCUDA).dtype(torch::kInt64);
+
+    const auto means2d =
+        torch::tensor({{{8.5f, 8.5f}, {24.5f, 8.5f}}}, floats); // One Gaussian per tile.
+    const auto conics          = torch::tensor({{{1.0f, 0.0f, 1.0f}, {1.0f, 0.0f, 1.0f}}}, floats);
+    const auto features        = torch::tensor({{{1.0f, 0.0f, 0.0f}, {0.0f, 1.0f, 0.0f}}}, floats);
+    const auto opacities       = torch::tensor({{0.5f, 0.5f}}, floats);
+    const auto tileOffsets     = torch::tensor({{{0, 1}}}, longs);
+    const auto tileGaussianIds = torch::tensor({0, 1}, ints);
+
+    const auto result = fvdb::detail::ops::rasterizeScreenSpaceGaussiansFwd(
+        means2d, conics, features, opacities, 32, 16, 0, 0, 16, tileOffsets, tileGaussianIds);
+    const auto &lastIds = std::get<2>(result);
+
+    EXPECT_EQ(lastIds.scalar_type(), torch::kInt32);
+    EXPECT_EQ(lastIds[0][8][8].item<int32_t>(), 0);
+    EXPECT_EQ(lastIds[0][8][24].item<int32_t>(), 0);
+}
+
 // This is a helper function to generate the output data for the test cases.
 // Only enable this test when you want to update the output data.
 TEST_F(GaussianRasterizeForwardTestFixture, DISABLED_GenerateOutputData) {
@@ -446,7 +521,8 @@ TEST_F(GaussianRasterizeForwardTestFixture, DISABLED_GenerateOutputData) {
                                                                 tileOffsets,
                                                                 tileGaussianIds);
 
-        std::vector<torch::Tensor> outputData = {renderedColors, renderedAlphas, lastIds};
+        std::vector<torch::Tensor> outputData = {
+            renderedColors, renderedAlphas, toAbsoluteLastIds(lastIds, tileOffsets, tileSize)};
 
         auto outputFilename = std::string("rasterize_forward_outputs.pt");
 
@@ -471,7 +547,8 @@ TEST_F(GaussianRasterizeForwardTestFixture, DISABLED_GenerateOutputData) {
                 tileOffsets,
                 tileGaussianIds);
 
-        std::vector<torch::Tensor> outputData = {renderedColors, renderedAlphas, lastIds};
+        std::vector<torch::Tensor> outputData = {
+            renderedColors, renderedAlphas, toAbsoluteLastIds(lastIds, tileOffsets, tileSize)};
 
         auto outputFilename = std::string("rasterize_forward_outputs_64.pt");
         storeData(outputFilename, outputData);
@@ -496,7 +573,7 @@ TEST_F(GaussianRasterizeForwardTestFixture, TestBasicInputsAndOutputs) {
 
     EXPECT_TRUE(torch::allclose(outColors, expectedRenderedColors));
     EXPECT_TRUE(torch::allclose(outAlphas, expectedRenderedAlphas));
-    EXPECT_EQ(outLastIds.scalar_type(), torch::kInt64);
+    EXPECT_EQ(outLastIds.scalar_type(), torch::kInt32);
     EXPECT_TRUE(torch::equal(outLastIds, expectedLastIds));
 }
 
@@ -527,8 +604,7 @@ TEST_F(GaussianRasterizeForwardTestFixture, TestConcatenatedChannels) {
 // Compares the output of multi-camera rasterization with the output of sequential single-camera
 // rasterization.
 TEST_F(GaussianRasterizeForwardTestFixture, TestMultipleCameras) {
-    // the output here is not used in this test.
-    loadTestData("rasterize_forward_inputs_3cams.pt", "rasterize_forward_outputs.pt");
+    loadInputData("rasterize_forward_inputs_3cams.pt");
 
     // run all 3 cameras at once
     const auto [outColorsAll, outAlphasAll, outLastIdsAll] =
@@ -584,15 +660,9 @@ TEST_F(GaussianRasterizeForwardTestFixture, TestMultipleCameras) {
                                                                 tileOffsets_1cam,
                                                                 tileGaussianIds_1cam);
 
-        // add start offset back to non-background pixels
-        outLastIds = outLastIds + start;
-        // mask out the background pixels
-        auto background_mask = (outLastIdsAll[i].unsqueeze(0) == -1);
-        outLastIds.masked_fill_(background_mask, -1);
-
         outColorsList.push_back(outColors);
         outAlphasList.push_back(outAlphas);
-        outLastIdsList.push_back(outLastIds); // Store the raw output index
+        outLastIdsList.push_back(outLastIds);
 
 // Uncomment to dump binarized lastIds images for comparison
 #if 0
@@ -646,7 +716,7 @@ TEST_F(GaussianRasterizeForwardTestFixture, TestMultipleCameras) {
 }
 
 TEST_F(GaussianRasterizeForwardTestFixture, TestMultipleCamerasWithBackgrounds) {
-    loadTestData("rasterize_forward_inputs_3cams.pt", "rasterize_forward_outputs.pt");
+    loadInputData("rasterize_forward_inputs_3cams.pt");
 
     const int numCameras  = means2d.size(0);
     const int numChannels = colors.size(-1);
@@ -797,8 +867,7 @@ TEST_F(GaussianRasterizeForwardTestFixture, TestSparseRasterizationConcatenatedC
 }
 
 TEST_F(GaussianRasterizeForwardTestFixture, TestSparseRasterizationMultipleCameras) {
-    // the output here is not used in this test.
-    loadTestData("rasterize_forward_inputs_3cams.pt", "rasterize_forward_outputs.pt");
+    loadInputData("rasterize_forward_inputs_3cams.pt");
 
     const int numCameras = means2d.size(0);
 
@@ -851,7 +920,7 @@ TEST_F(GaussianRasterizeForwardTestFixture, TestSparseRasterizationMultipleCamer
 }
 
 TEST_F(GaussianRasterizeForwardTestFixture, TestSparseRasterizationMultipleCamerasWithBackgrounds) {
-    loadTestData("rasterize_forward_inputs_3cams.pt", "rasterize_forward_outputs.pt");
+    loadInputData("rasterize_forward_inputs_3cams.pt");
 
     const int numCameras  = means2d.size(0);
     const int numChannels = colors.size(-1);
@@ -960,7 +1029,7 @@ TEST_F(GaussianRasterizeForwardTestFixture, TestSparseRasterizationMultipleCamer
 // the rasterization produces the same results as non-packed mode.
 // This specifically tests the fix for deriving numCameras from tileOffsets instead of means2d.
 TEST_F(GaussianRasterizeForwardTestFixture, TestPackedModeMultipleCameras) {
-    loadTestData("rasterize_forward_inputs_3cams.pt", "rasterize_forward_outputs.pt");
+    loadInputData("rasterize_forward_inputs_3cams.pt");
 
     const int numCameras         = means2d.size(0);
     const int numGaussiansPerCam = means2d.size(1);
@@ -1020,14 +1089,14 @@ TEST_F(GaussianRasterizeForwardTestFixture, TestPackedModeMultipleCameras) {
     EXPECT_TRUE(torch::allclose(outAlphasPacked, expectedAlphas, 1e-4, 1e-4))
         << "Packed mode alphas don't match non-packed mode";
 
-    // lastIds should be identical since both modes use the same global indices
+    // lastIds should be identical since both modes use the same tile-relative indices.
     EXPECT_TRUE(torch::equal(outLastIdsPacked, expectedLastIds))
         << "Packed mode lastIds don't match non-packed mode";
 }
 
 // Test packed mode with sparse rasterization and multiple cameras
 TEST_F(GaussianRasterizeForwardTestFixture, TestPackedModeSparseMultipleCameras) {
-    loadTestData("rasterize_forward_inputs_3cams.pt", "rasterize_forward_outputs.pt");
+    loadInputData("rasterize_forward_inputs_3cams.pt");
 
     const int numCameras         = means2d.size(0);
     const int numGaussiansPerCam = means2d.size(1);

--- a/src/tests/GaussianRasterizeForwardTest.cpp
+++ b/src/tests/GaussianRasterizeForwardTest.cpp
@@ -47,7 +47,7 @@ struct GaussianRasterizeForwardTestFixture : public ::testing::Test {
         conics                            = inputs[1].cuda();
         colors                            = inputs[2].cuda();
         opacities                         = inputs[3].cuda();
-        tileOffsets                       = inputs[4].cuda();
+        tileOffsets                       = inputs[4].to(torch::kInt64).cuda();
         tileGaussianIds                   = inputs[5].cuda();
         imageDims                         = inputs[6].cuda();
 
@@ -89,7 +89,7 @@ struct GaussianRasterizeForwardTestFixture : public ::testing::Test {
 
         expectedRenderedColors = expectedOutputs[0].cuda();
         expectedRenderedAlphas = expectedOutputs[1].cuda();
-        expectedLastIds        = expectedOutputs[2].cuda();
+        expectedLastIds        = expectedOutputs[2].to(torch::kInt64).cuda();
     }
 
     fvdb::JaggedTensor
@@ -496,6 +496,7 @@ TEST_F(GaussianRasterizeForwardTestFixture, TestBasicInputsAndOutputs) {
 
     EXPECT_TRUE(torch::allclose(outColors, expectedRenderedColors));
     EXPECT_TRUE(torch::allclose(outAlphas, expectedRenderedAlphas));
+    EXPECT_EQ(outLastIds.scalar_type(), torch::kInt64);
     EXPECT_TRUE(torch::equal(outLastIds, expectedLastIds));
 }
 
@@ -1129,4 +1130,22 @@ TEST_F(GaussianRasterizeForwardTestFixture, CPUThrows) {
                                                             tileOffsets,
                                                             tileGaussianIds),
         c10::NotImplementedError);
+}
+
+TEST_F(GaussianRasterizeForwardTestFixture, RejectsInt32TileOffsets) {
+    loadTestData("rasterize_forward_inputs.pt", "rasterize_forward_outputs.pt");
+    tileOffsets = tileOffsets.to(torch::kInt32);
+    EXPECT_THROW(
+        fvdb::detail::ops::rasterizeScreenSpaceGaussiansFwd(means2d,
+                                                            conics,
+                                                            colors,
+                                                            opacities,
+                                                            static_cast<uint32_t>(imageWidth),
+                                                            static_cast<uint32_t>(imageHeight),
+                                                            static_cast<uint32_t>(imageOriginW),
+                                                            static_cast<uint32_t>(imageOriginH),
+                                                            tileSize,
+                                                            tileOffsets,
+                                                            tileGaussianIds),
+        c10::ValueError);
 }

--- a/src/tests/GaussianRasterizeTopContributorsTest.cpp
+++ b/src/tests/GaussianRasterizeTopContributorsTest.cpp
@@ -30,7 +30,7 @@ struct GaussianRasterizeTopContributorsTestFixture : public ::testing::Test {
         means2d                           = inputs[0].cuda();
         conics                            = inputs[1].cuda();
         opacities                         = inputs[2].cuda();
-        tileOffsets                       = inputs[3].cuda();
+        tileOffsets                       = inputs[3].to(torch::kInt64).cuda();
         tileGaussianIds                   = inputs[4].cuda();
         imageDims                         = inputs[5];
 

--- a/src/tests/GaussianRasterizeWorldSpaceTest.cpp
+++ b/src/tests/GaussianRasterizeWorldSpaceTest.cpp
@@ -138,7 +138,7 @@ expectFiniteRaster(const RasterResult &result, const int64_t channels) {
                 torch::IntArrayRef({1, kImageHeight, kImageWidth, 1}));
     EXPECT_TRUE(torch::isfinite(std::get<0>(result)).all().item<bool>());
     EXPECT_TRUE(torch::isfinite(std::get<1>(result)).all().item<bool>());
-    EXPECT_EQ(std::get<2>(result).scalar_type(), torch::kInt64);
+    EXPECT_EQ(std::get<2>(result).scalar_type(), torch::kInt32);
     EXPECT_GT(std::get<1>(result).sum().item<float>(), 0.0f);
 }
 

--- a/src/tests/GaussianRasterizeWorldSpaceTest.cpp
+++ b/src/tests/GaussianRasterizeWorldSpaceTest.cpp
@@ -41,6 +41,7 @@ WorldSpaceInputs
 makeInputs() {
     const auto floats = torch::TensorOptions().dtype(torch::kFloat32).device(torch::kCUDA);
     const auto ints   = torch::TensorOptions().dtype(torch::kInt32).device(torch::kCUDA);
+    const auto longs  = torch::TensorOptions().dtype(torch::kInt64).device(torch::kCUDA);
     auto intrinsics =
         torch::tensor({{{12.0f, 0.0f, 3.5f}, {0.0f, 12.0f, 3.5f}, {0.0f, 0.0f, 1.0f}}}, floats);
     return {
@@ -52,7 +53,7 @@ makeInputs() {
         torch::eye(4, floats).unsqueeze(0),
         intrinsics,
         torch::zeros({1, 12}, floats),
-        torch::zeros({1, 1, 1}, ints),
+        torch::zeros({1, 1, 1}, longs),
         torch::tensor({0}, ints),
     };
 }
@@ -137,6 +138,7 @@ expectFiniteRaster(const RasterResult &result, const int64_t channels) {
                 torch::IntArrayRef({1, kImageHeight, kImageWidth, 1}));
     EXPECT_TRUE(torch::isfinite(std::get<0>(result)).all().item<bool>());
     EXPECT_TRUE(torch::isfinite(std::get<1>(result)).all().item<bool>());
+    EXPECT_EQ(std::get<2>(result).scalar_type(), torch::kInt64);
     EXPECT_GT(std::get<1>(result).sum().item<float>(), 0.0f);
 }
 

--- a/src/tests/GaussianTileIntersectionTest.cpp
+++ b/src/tests/GaussianTileIntersectionTest.cpp
@@ -69,19 +69,20 @@ class GaussianTileIntersectionTest : public ::testing::Test {
                        const torch::Tensor &intersection_values,
                        const torch::Tensor &depths,
                        const torch::Tensor &tile_mask = torch::Tensor()) {
+        EXPECT_EQ(tile_offsets.scalar_type(), torch::kInt64);
         // Handle dense case - iterate through 3D tensor
         if (tile_offsets.dim() == 3) {
             for (uint32_t c = 0; c < num_cameras; c++) {
                 for (uint32_t h = 0; h < num_tiles_h; h++) {
                     for (uint32_t w = 0; w < num_tiles_w; w++) {
-                        int start = tile_offsets[c][h][w].item<int32_t>();
-                        int end;
+                        int64_t start = tile_offsets[c][h][w].item<int64_t>();
+                        int64_t end;
                         if (w < num_tiles_w - 1) {
-                            end = tile_offsets[c][h][w + 1].item<int32_t>();
+                            end = tile_offsets[c][h][w + 1].item<int64_t>();
                         } else if (h < num_tiles_h - 1) {
-                            end = tile_offsets[c][h + 1][0].item<int32_t>();
+                            end = tile_offsets[c][h + 1][0].item<int64_t>();
                         } else {
-                            end = (c < num_cameras - 1) ? tile_offsets[c + 1][0][0].item<int32_t>()
+                            end = (c < num_cameras - 1) ? tile_offsets[c + 1][0][0].item<int64_t>()
                                                         : intersection_values.size(0);
                         }
                         verifyTileDepthOrder(start, end, intersection_values, depths);
@@ -91,10 +92,11 @@ class GaussianTileIntersectionTest : public ::testing::Test {
         }
         // Handle sparse case - iterate through 1D tensor
         else {
-            for (int i = 0; i < tile_offsets.size(0); i++) {
-                int start = tile_offsets[i].item<int32_t>();
-                int end   = (i < tile_offsets.size(0) - 1) ? tile_offsets[i + 1].item<int32_t>()
-                                                           : intersection_values.size(0);
+            for (int64_t i = 0; i < tile_offsets.size(0); i++) {
+                int64_t start = tile_offsets[i].item<int64_t>();
+                int64_t end   = (i < tile_offsets.size(0) - 1)
+                                    ? tile_offsets[i + 1].item<int64_t>()
+                                    : intersection_values.size(0);
                 verifyTileDepthOrder(start, end, intersection_values, depths);
             }
         }
@@ -102,11 +104,11 @@ class GaussianTileIntersectionTest : public ::testing::Test {
 
     // Helper to verify depth order within a single tile's range
     void
-    verifyTileDepthOrder(int start,
-                         int end,
+    verifyTileDepthOrder(int64_t start,
+                         int64_t end,
                          const torch::Tensor &intersection_values,
                          const torch::Tensor &depths) {
-        for (int i = start + 1; i < end; i++) {
+        for (int64_t i = start + 1; i < end; i++) {
             int global_idx1 = intersection_values[i - 1].item<int32_t>();
             int global_idx2 = intersection_values[i].item<int32_t>();
 
@@ -133,6 +135,7 @@ class GaussianTileIntersectionTest : public ::testing::Test {
                             const torch::Tensor &radii,
                             const torch::Tensor &depths,
                             const torch::Tensor &active_tiles) {
+        EXPECT_EQ(tile_offsets.scalar_type(), torch::kInt64);
         // Generate expected output by computing intersections for each active tile
         std::vector<std::vector<int32_t>> expected_intersections;
         int32_t total_expected = 0;
@@ -188,16 +191,16 @@ class GaussianTileIntersectionTest : public ::testing::Test {
 
         EXPECT_EQ(intersection_values.size(0), total_expected);
 
-        int32_t curr_offset = 0;
-        for (int32_t i = 0; i < num_active_tiles; i++) {
-            int32_t next_offset = tile_offsets[i + 1].item<int32_t>();
+        int64_t curr_offset = 0;
+        for (int64_t i = 0; i < num_active_tiles; i++) {
+            int64_t next_offset = tile_offsets[i + 1].item<int64_t>();
             EXPECT_GE(next_offset, curr_offset) << "Tile offsets must be monotonically increasing";
-            int32_t num_intersections = next_offset - curr_offset;
+            int64_t num_intersections = next_offset - curr_offset;
 
             EXPECT_EQ(static_cast<std::size_t>(num_intersections), expected_intersections[i].size())
                 << "Number of intersections mismatch for tile " << i;
 
-            for (int32_t j = 0; j < num_intersections; j++) {
+            for (int64_t j = 0; j < num_intersections; j++) {
                 EXPECT_EQ(intersection_values[curr_offset + j].item<int32_t>(),
                           expected_intersections[i][j])
                     << "Intersection mismatch at tile " << i << " index " << j;
@@ -252,6 +255,7 @@ TEST_F(GaussianTileIntersectionTest, ZeroLengthGaussianTest) {
 
     // For zero Gaussians, we should still get a valid tile_offsets tensor filled with zeros
     EXPECT_EQ(tile_offsets.sizes(), std::vector<int64_t>({numCameras, num_tiles_h, num_tiles_w}));
+    EXPECT_EQ(tile_offsets.scalar_type(), torch::kInt64);
     EXPECT_TRUE(tile_offsets.equal(torch::zeros_like(tile_offsets)));
     EXPECT_EQ(intersection_values.numel(), 0);
 }
@@ -349,7 +353,8 @@ TEST_F(GaussianTileIntersectionTest, ZeroRadiusGaussianTest) {
                                                   num_tiles_w);
 
     // Verify that there are no intersections
-    EXPECT_EQ(tile_offsets.sum().item<int32_t>(), 0);
+    EXPECT_EQ(tile_offsets.scalar_type(), torch::kInt64);
+    EXPECT_EQ(tile_offsets.sum().item<int64_t>(), 0);
 }
 
 TEST_F(GaussianTileIntersectionTest, BasicIntersectionTest) {
@@ -371,6 +376,7 @@ TEST_F(GaussianTileIntersectionTest, BasicIntersectionTest) {
 
     // Verify dimensions
     EXPECT_EQ(tile_offsets.sizes(), std::vector<int64_t>({num_cameras, num_tiles_h, num_tiles_w}));
+    EXPECT_EQ(tile_offsets.scalar_type(), torch::kInt64);
 
     // Verify depth sorting
     verifyDepthSorting(tile_offsets, intersection_values, depths);
@@ -443,15 +449,16 @@ TEST_F(GaussianTileIntersectionTest, DenseViaSparseTest) {
 
     // Verify dimensions
     EXPECT_EQ(tile_offsets.sizes(), std::vector<int64_t>({num_active_tiles + 1}));
+    EXPECT_EQ(tile_offsets.scalar_type(), torch::kInt64);
 
     // Verify that offsets are monotonically increasing
     for (int64_t i = 1; i < tile_offsets.size(0); i++) {
-        EXPECT_GE(tile_offsets[i].item<int32_t>(), tile_offsets[i - 1].item<int32_t>())
+        EXPECT_GE(tile_offsets[i].item<int64_t>(), tile_offsets[i - 1].item<int64_t>())
             << "Tile offsets must be monotonically increasing";
     }
 
     // Verify that the last offset equals the size of intersection_values
-    EXPECT_EQ(tile_offsets[tile_offsets.size(0) - 1].item<int32_t>(), intersection_values.size(0))
+    EXPECT_EQ(tile_offsets[tile_offsets.size(0) - 1].item<int64_t>(), intersection_values.size(0))
         << "Last offset should equal number of intersections";
 
     // Verify depth sorting
@@ -487,17 +494,18 @@ TEST_F(GaussianTileIntersectionTest, SparseIntersectionTest) {
     tile_mask           = tile_mask.cpu();
 
     EXPECT_EQ(tile_offsets.sizes(), std::vector<int64_t>({num_active_tiles + 1}));
+    EXPECT_EQ(tile_offsets.scalar_type(), torch::kInt64);
 
     // tile_offsets should be: [0 2 3 4 5 5 5 5 7] (note 9 elements)
 
     // Verify that offsets are monotonically increasing
     for (int64_t i = 1; i < tile_offsets.size(0); i++) {
-        EXPECT_GE(tile_offsets[i].item<int32_t>(), tile_offsets[i - 1].item<int32_t>())
+        EXPECT_GE(tile_offsets[i].item<int64_t>(), tile_offsets[i - 1].item<int64_t>())
             << "Tile offsets must be monotonically increasing";
     }
 
     // Verify that the last offset equals the size of intersection_values minus 1
-    EXPECT_EQ(tile_offsets[-1].item<int32_t>(), intersection_values.size(0));
+    EXPECT_EQ(tile_offsets[-1].item<int64_t>(), intersection_values.size(0));
 
     verifyDepthSorting(tile_offsets, intersection_values, depths, tile_mask);
 }
@@ -550,6 +558,7 @@ TEST_F(GaussianTileIntersectionTest, SparseZeroLengthGaussianTest) {
 
     // For zero Gaussians, we should still get a valid tile_offsets tensor
     EXPECT_EQ(tile_offsets.sizes(), std::vector<int64_t>({num_active_tiles + 1}));
+    EXPECT_EQ(tile_offsets.scalar_type(), torch::kInt64);
     EXPECT_TRUE(tile_offsets.equal(torch::zeros_like(tile_offsets)));
     EXPECT_EQ(intersection_values.numel(), 0);
 }

--- a/src/tests/GaussianTileIntersectionTest.cpp
+++ b/src/tests/GaussianTileIntersectionTest.cpp
@@ -94,9 +94,8 @@ class GaussianTileIntersectionTest : public ::testing::Test {
         else {
             for (int64_t i = 0; i < tile_offsets.size(0); i++) {
                 int64_t start = tile_offsets[i].item<int64_t>();
-                int64_t end   = (i < tile_offsets.size(0) - 1)
-                                    ? tile_offsets[i + 1].item<int64_t>()
-                                    : intersection_values.size(0);
+                int64_t end   = (i < tile_offsets.size(0) - 1) ? tile_offsets[i + 1].item<int64_t>()
+                                                               : intersection_values.size(0);
                 verifyTileDepthOrder(start, end, intersection_values, depths);
             }
         }

--- a/src/tests/GaussianUtilsTest.cu
+++ b/src/tests/GaussianUtilsTest.cu
@@ -33,10 +33,9 @@ __global__ void
 readTileGaussianRange(const fvdb::TorchRAcc64<int64_t, 3> tileOffsets,
                       const int64_t totalIntersections,
                       int64_t *range) {
-    const auto [first, last] =
-        tileGaussianRange(tileOffsets, totalIntersections, 1, 1, 2, 0, 0, 0);
-    range[0] = first;
-    range[1] = last;
+    const auto [first, last] = tileGaussianRange(tileOffsets, totalIntersections, 1, 1, 2, 0, 0, 0);
+    range[0]                 = first;
+    range[1]                 = last;
     const auto [finalFirst, finalLast] =
         tileGaussianRange(tileOffsets, totalIntersections, 1, 1, 2, 0, 0, 1);
     range[2] = finalFirst;
@@ -330,9 +329,9 @@ TEST(GaussianUtilsTest, TileGaussianRangePreservesOffsetsAboveInt32) {
     constexpr int64_t first = static_cast<int64_t>(std::numeric_limits<int32_t>::max()) + 17;
     constexpr int64_t last  = first + 29;
     constexpr int64_t total = last + 31;
-    const auto options = torch::TensorOptions().dtype(torch::kInt64).device(torch::kCUDA);
-    const auto tileOffsets = torch::tensor({first, last}, options).view({1, 1, 2});
-    auto range             = torch::empty({4}, options);
+    const auto options      = torch::TensorOptions().dtype(torch::kInt64).device(torch::kCUDA);
+    const auto tileOffsets  = torch::tensor({first, last}, options).view({1, 1, 2});
+    auto range              = torch::empty({4}, options);
 
     readTileGaussianRange<<<1, 1, 0, at::cuda::getDefaultCUDAStream().stream()>>>(
         tileOffsets.packed_accessor64<int64_t, 3, torch::RestrictPtrTraits>(),

--- a/src/tests/GaussianUtilsTest.cu
+++ b/src/tests/GaussianUtilsTest.cu
@@ -1,10 +1,16 @@
 // Copyright Contributors to the OpenVDB Project
 // SPDX-License-Identifier: Apache-2.0
 
+#include <fvdb/detail/utils/AccessorHelpers.cuh>
 #include <fvdb/detail/utils/cuda/BinSearch.cuh>
 #include <fvdb/detail/utils/cuda/math/AffineTransform.cuh>
 #include <fvdb/detail/utils/cuda/math/Rotation.cuh>
 #include <fvdb/detail/utils/gsplat/GaussianMath.cuh>
+#include <fvdb/detail/utils/gsplat/GaussianTileRange.cuh>
+
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAException.h>
+#include <torch/torch.h>
 
 #include <gtest/gtest.h>
 
@@ -14,6 +20,7 @@
 #if !defined(__CUDA_ARCH__)
 #include <cmath>
 #endif
+#include <limits>
 
 namespace fvdb::detail::ops {
 namespace {
@@ -21,6 +28,20 @@ namespace {
 using Mat3f = nanovdb::math::Mat3<float>;
 using Vec4f = nanovdb::math::Vec4<float>;
 using Vec3f = nanovdb::math::Vec3<float>;
+
+__global__ void
+readTileGaussianRange(const fvdb::TorchRAcc64<int64_t, 3> tileOffsets,
+                      const int64_t totalIntersections,
+                      int64_t *range) {
+    const auto [first, last] =
+        tileGaussianRange(tileOffsets, totalIntersections, 1, 1, 2, 0, 0, 0);
+    range[0] = first;
+    range[1] = last;
+    const auto [finalFirst, finalLast] =
+        tileGaussianRange(tileOffsets, totalIntersections, 1, 1, 2, 0, 0, 1);
+    range[2] = finalFirst;
+    range[3] = finalLast;
+}
 
 // Minimal math helpers: CUDA intrinsics on device, `std::` on host.
 __host__ __device__ inline float
@@ -303,6 +324,27 @@ TEST(GaussianUtilsTest, PoseRt_WorldToCamAndBack_RoundTrip) {
     const Vec3f p_world_from_cam = R.transpose() * (p_cam_in - t);
     const Vec3f p_cam_rt         = R * p_world_from_cam + t;
     expectVecNear(p_cam_rt, p_cam_in, 2e-5f);
+}
+
+TEST(GaussianUtilsTest, TileGaussianRangePreservesOffsetsAboveInt32) {
+    constexpr int64_t first = static_cast<int64_t>(std::numeric_limits<int32_t>::max()) + 17;
+    constexpr int64_t last  = first + 29;
+    constexpr int64_t total = last + 31;
+    const auto options = torch::TensorOptions().dtype(torch::kInt64).device(torch::kCUDA);
+    const auto tileOffsets = torch::tensor({first, last}, options).view({1, 1, 2});
+    auto range             = torch::empty({4}, options);
+
+    readTileGaussianRange<<<1, 1, 0, at::cuda::getDefaultCUDAStream().stream()>>>(
+        tileOffsets.packed_accessor64<int64_t, 3, torch::RestrictPtrTraits>(),
+        total,
+        range.data_ptr<int64_t>());
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+
+    const auto rangeCpu = range.cpu();
+    EXPECT_EQ(rangeCpu[0].item<int64_t>(), first);
+    EXPECT_EQ(rangeCpu[1].item<int64_t>(), last);
+    EXPECT_EQ(rangeCpu[2].item<int64_t>(), last);
+    EXPECT_EQ(rangeCpu[3].item<int64_t>(), total);
 }
 
 } // namespace fvdb::detail::ops

--- a/src/tests/scripts/generate_gaussian_splat_dataset.py
+++ b/src/tests/scripts/generate_gaussian_splat_dataset.py
@@ -184,7 +184,7 @@ def generate_gaussian_splat_dataset(
 
     # Generate intersection data
     # Initialize tile offsets
-    tile_offsets = torch.zeros(batch_size, tile_height, tile_width, dtype=torch.int32, device=device)
+    tile_offsets = torch.zeros(batch_size, tile_height, tile_width, dtype=torch.int64, device=device)
 
     # List to collect gaussian IDs that intersect with each tile
     all_gaussian_ids = []

--- a/src/tests/scripts/generate_top_gaussian_contributor_dataset.py
+++ b/src/tests/scripts/generate_top_gaussian_contributor_dataset.py
@@ -175,7 +175,7 @@ def main(output_path: str, h=512, w=1024):
         state.means2d,
         state.inv_covar_2d,
         state.opacities,
-        state.tile_offsets,
+        state.tile_offsets.to(torch.int64),
         state.tile_gaussian_ids,
         image_dims,
     ]


### PR DESCRIPTION
The number of intersections is proportional to the product of the image resolution and number of Gaussians. Thus, the intersection offsets are the largest linear index space within Gaussian splat training pipeline and can easily overflow for a large geospatial scene with high-resolution photography where we refine to obtain fine details. The overflow results in the rasterization operators accessing invalid/concurrently written memory which eventually leads to NaNs in the loss (although the Gaussian parameters blow up long before that.)

This PR addresses this by switching to 64-bit intersection offsets and indices and fixes the incorrect training results.