### PR TITLE
Improve compile times for forward rasterization

### DIFF
--- a/src/fvdb/detail/ops/gsplat/RasterizeScreenSpaceGaussiansForward.cu
+++ b/src/fvdb/detail/ops/gsplat/RasterizeScreenSpaceGaussiansForward.cu
@@ -99,15 +99,23 @@ struct RasterizeForwardArgs {
         mOutLastIds.data()[pixelIndex] = lastId;
     }
 
-    /// @brief Write the features for a pixel
+    /// @brief Write a chunk of features for a pixel
     /// @param pixelIndex The index of the pixel
+    /// @param channelStart The first output channel in the chunk
+    /// @param numChannels The number of output channels in the chunk
     /// @param f The function to write the features
     template <typename F>
     __device__ void
-    writeFeatures(uint64_t pixelIndex, F &&f) {
-#pragma unroll
-        for (uint32_t k = 0; k < NUM_CHANNELS; ++k) {
-            mOutFeatures.data()[pixelIndex][k] = f(k);
+    writeFeatureChunk(uint64_t pixelIndex, size_t channelStart, size_t numChannels, F &&f) {
+        if constexpr (IS_CHUNKED) {
+            for (uint32_t k = 0; k < numChannels; ++k) {
+                mOutFeatures.data()[pixelIndex][channelStart + k] = f(k);
+            }
+        } else {
+#pragma unroll NUM_CHANNELS
+            for (uint32_t k = 0; k < NUM_CHANNELS; ++k) {
+                mOutFeatures.data()[pixelIndex][k] = f(k);
+            }
         }
     }
 
@@ -179,14 +187,6 @@ struct RasterizeForwardArgs {
         // collect and process batches of gaussians
         // each thread loads one gaussian at a time before rasterizing its
         // designated pixel
-        ScalarType pixOut[NUM_CHANNELS] = {0.f};
-
-        // The alpha sequence is feature-independent (depends only on opacity + conic + position),
-        // so the per-chunk accumTransmittance and last intersection offset are identical across
-        // chunks. Capture them from the first chunk and write them out at the end.
-        ScalarType accumTransmittanceFinal  = 1.0f;
-        int32_t lastIntersectionOffsetFinal = -1;
-
         constexpr size_t NUM_CHUNKS =
             (NUM_CHANNELS + NUM_SHARED_CHANNELS - 1) / NUM_SHARED_CHANNELS;
 
@@ -194,6 +194,11 @@ struct RasterizeForwardArgs {
             const size_t channelStart = chunk * NUM_SHARED_CHANNELS;
             const size_t numChannels =
                 min(NUM_CHANNELS - channelStart, static_cast<size_t>(NUM_SHARED_CHANNELS));
+
+            // Keep only the current channel chunk in thread-local storage. In particular, avoid a
+            // NUM_CHANNELS-sized array here: that causes the compiler to scalarize and duplicate
+            // the entire high-channel output state in every shared-memory specialization.
+            ScalarType pixOut[NUM_SHARED_CHANNELS] = {0.f};
 
             // NOTE: The accumulated transmittance is used in the backward pass, and
             // since it's a sum of many small numbers, we should really use double precision.
@@ -264,7 +269,7 @@ struct RasterizeForwardArgs {
                         const ScalarType vis = alpha * accumTransmittance;
                         if constexpr (IS_CHUNKED) {
                             for (uint32_t k = 0; k < numChannels; ++k) {
-                                pixOut[channelStart + k] +=
+                                pixOut[k] +=
                                     sharedGaussianFeatures[t * NUM_SHARED_CHANNELS + k] * vis;
                             }
                         } else {
@@ -281,22 +286,19 @@ struct RasterizeForwardArgs {
                 }
             }
 
-            if (chunk == 0) {
-                accumTransmittanceFinal     = accumTransmittance;
-                lastIntersectionOffsetFinal = lastIntersectionOffset;
+            if (pixelIsActive) {
+                const auto pixIdx = commonArgs.pixelIndex(cameraId, row, col, activePixelIndex);
+                if (chunk == 0) {
+                    writeAlpha(pixIdx, 1.0f - accumTransmittance);
+                    writeLastId(pixIdx, lastIntersectionOffset);
+                }
+                writeFeatureChunk(pixIdx, channelStart, numChannels, [&](uint32_t k) {
+                    return commonArgs.mHasBackgrounds
+                               ? pixOut[k] + accumTransmittance *
+                                                 commonArgs.mBackgrounds[cameraId][channelStart + k]
+                               : pixOut[k];
+                });
             }
-        }
-
-        if (pixelIsActive) {
-            const auto pixIdx = commonArgs.pixelIndex(cameraId, row, col, activePixelIndex);
-            writeAlpha(pixIdx, 1.0f - accumTransmittanceFinal);
-            writeLastId(pixIdx, lastIntersectionOffsetFinal);
-            writeFeatures(pixIdx, [&](uint32_t k) {
-                return commonArgs.mHasBackgrounds
-                           ? pixOut[k] +
-                                 accumTransmittanceFinal * commonArgs.mBackgrounds[cameraId][k]
-                           : pixOut[k];
-            });
         }
     }
 };
@@ -339,7 +341,7 @@ rasterizeGaussiansForward(
             auto pixIdx = commonArgs.pixelIndex(cameraId, row, col, activePixelIndex);
             args.writeAlpha(pixIdx, 0.0f);
             args.writeLastId(pixIdx, -1);
-            args.writeFeatures(pixIdx, [&](uint32_t k) {
+            args.writeFeatureChunk(pixIdx, 0, NUM_CHANNELS, [&](uint32_t k) {
                 return commonArgs.mHasBackgrounds ? commonArgs.mBackgrounds[cameraId][k] : 0.0f;
             });
         }

--- a/src/fvdb/detail/ops/gsplat/RasterizeScreenSpaceGaussiansForward.cu
+++ b/src/fvdb/detail/ops/gsplat/RasterizeScreenSpaceGaussiansForward.cu
@@ -191,6 +191,8 @@ struct RasterizeForwardArgs {
         constexpr size_t NUM_CHUNKS =
             (NUM_CHANNELS + NUM_SHARED_CHANNELS - 1) / NUM_SHARED_CHANNELS;
 
+        const auto pixIdx = commonArgs.pixelIndex(cameraId, row, col, activePixelIndex);
+
         for (size_t chunk = 0; chunk < NUM_CHUNKS; ++chunk) {
             const size_t channelStart = chunk * NUM_SHARED_CHANNELS;
             const size_t numChannels =
@@ -288,7 +290,9 @@ struct RasterizeForwardArgs {
             }
 
             if (pixelIsActive) {
-                const auto pixIdx = commonArgs.pixelIndex(cameraId, row, col, activePixelIndex);
+                // The alpha sequence is feature-independent (depends only on opacity + conic +
+                // position), so the per-chunk accumTransmittance and last intersection offset are
+                // identical across chunks.
                 if (chunk == 0) {
                     writeAlpha(pixIdx, 1.0f - accumTransmittance);
                     writeLastId(pixIdx, lastIntersectionOffset);

--- a/src/fvdb/detail/ops/gsplat/RasterizeScreenSpaceGaussiansForward.cu
+++ b/src/fvdb/detail/ops/gsplat/RasterizeScreenSpaceGaussiansForward.cu
@@ -112,7 +112,7 @@ struct RasterizeForwardArgs {
                 mOutFeatures.data()[pixelIndex][channelStart + k] = f(k);
             }
         } else {
-               assert(channelStart == 0 && numChannels == NUM_CHANNELS);
+            assert(channelStart == 0 && numChannels == NUM_CHANNELS);
 #pragma unroll NUM_CHANNELS
             for (uint32_t k = 0; k < NUM_CHANNELS; ++k) {
                 mOutFeatures.data()[pixelIndex][k] = f(k);

--- a/src/fvdb/detail/ops/gsplat/RasterizeScreenSpaceGaussiansForward.cu
+++ b/src/fvdb/detail/ops/gsplat/RasterizeScreenSpaceGaussiansForward.cu
@@ -112,6 +112,7 @@ struct RasterizeForwardArgs {
                 mOutFeatures.data()[pixelIndex][channelStart + k] = f(k);
             }
         } else {
+               assert(channelStart == 0 && numChannels == NUM_CHANNELS);
 #pragma unroll NUM_CHANNELS
             for (uint32_t k = 0; k < NUM_CHANNELS; ++k) {
                 mOutFeatures.data()[pixelIndex][k] = f(k);

--- a/src/tests/GaussianRasterizeForwardTest.cpp
+++ b/src/tests/GaussianRasterizeForwardTest.cpp
@@ -594,11 +594,36 @@ TEST_F(GaussianRasterizeForwardTestFixture, TestConcatenatedChannels) {
                                                             static_cast<uint32_t>(imageOriginH),
                                                             tileSize,
                                                             tileOffsets,
-                                                            tileGaussianIds);
+                                                            tileGaussianIds,
+                                                            16); // force chunked rendering
 
     EXPECT_TRUE(torch::allclose(outColors, expectedRenderedColors));
     EXPECT_TRUE(torch::allclose(outAlphas, expectedRenderedAlphas));
     EXPECT_TRUE(torch::equal(outLastIds, expectedLastIds));
+
+    const auto backgrounds = torch::linspace(-1.0f, 1.0f, colors.size(-1), colors.options())
+                                 .repeat({means2d.size(0), 1});
+    const auto [outColorsWithBackground, outAlphasWithBackground, outLastIdsWithBackground] =
+        fvdb::detail::ops::rasterizeScreenSpaceGaussiansFwd(means2d,
+                                                            conics,
+                                                            colors,
+                                                            opacities,
+                                                            static_cast<uint32_t>(imageWidth),
+                                                            static_cast<uint32_t>(imageHeight),
+                                                            static_cast<uint32_t>(imageOriginW),
+                                                            static_cast<uint32_t>(imageOriginH),
+                                                            tileSize,
+                                                            tileOffsets,
+                                                            tileGaussianIds,
+                                                            16,
+                                                            backgrounds);
+
+    const auto expectedWithBackground =
+        expectedRenderedColors +
+        (1.0f - expectedRenderedAlphas) * backgrounds.view({means2d.size(0), 1, 1, -1});
+    EXPECT_TRUE(torch::allclose(outColorsWithBackground, expectedWithBackground, 1e-5, 1e-5));
+    EXPECT_TRUE(torch::allclose(outAlphasWithBackground, expectedRenderedAlphas));
+    EXPECT_TRUE(torch::equal(outLastIdsWithBackground, expectedLastIds));
 }
 
 // Compares the output of multi-camera rasterization with the output of sequential single-camera
@@ -855,7 +880,8 @@ TEST_F(GaussianRasterizeForwardTestFixture, TestSparseRasterizationConcatenatedC
             activeTiles,
             tilePixelMask,
             tilePixelCumsum,
-            pixelMap);
+            pixelMap,
+            16); // force chunked rendering
 
     EXPECT_TRUE(compareSparseWithDensePixels(pixelsToRender,
                                              outColorsSparse,

--- a/src/tests/GaussianRasterizeForwardTest.cpp
+++ b/src/tests/GaussianRasterizeForwardTest.cpp
@@ -577,11 +577,19 @@ TEST_F(GaussianRasterizeForwardTestFixture, TestBasicInputsAndOutputs) {
     EXPECT_TRUE(torch::equal(outLastIds, expectedLastIds));
 }
 
-TEST_F(GaussianRasterizeForwardTestFixture, TestConcatenatedChannels) {
+// Parameterized over maxSharedChannels: 16 and 32 exercise chunked rendering (multiple chunks for
+// 64-channel input), 64 exercises the non-chunked path (all channels fit in one chunk).
+struct GaussianRasterizeForwardChunkedTestFixture
+    : public GaussianRasterizeForwardTestFixture,
+      public ::testing::WithParamInterface<uint32_t> {};
+
+TEST_P(GaussianRasterizeForwardChunkedTestFixture, TestConcatenatedChannels) {
     loadTestData("rasterize_forward_inputs.pt", "rasterize_forward_outputs_64.pt");
 
     colors                 = catChannelsToDim(colors, 64);
     expectedRenderedColors = catChannelsToDim(expectedRenderedColors, 64);
+
+    const uint32_t maxSharedChannels = GetParam();
 
     const auto [outColors, outAlphas, outLastIds] =
         fvdb::detail::ops::rasterizeScreenSpaceGaussiansFwd(means2d,
@@ -595,7 +603,7 @@ TEST_F(GaussianRasterizeForwardTestFixture, TestConcatenatedChannels) {
                                                             tileSize,
                                                             tileOffsets,
                                                             tileGaussianIds,
-                                                            16); // force chunked rendering
+                                                            maxSharedChannels);
 
     EXPECT_TRUE(torch::allclose(outColors, expectedRenderedColors));
     EXPECT_TRUE(torch::allclose(outAlphas, expectedRenderedAlphas));
@@ -615,7 +623,7 @@ TEST_F(GaussianRasterizeForwardTestFixture, TestConcatenatedChannels) {
                                                             tileSize,
                                                             tileOffsets,
                                                             tileGaussianIds,
-                                                            16,
+                                                            maxSharedChannels,
                                                             backgrounds);
 
     const auto expectedWithBackground =
@@ -625,6 +633,10 @@ TEST_F(GaussianRasterizeForwardTestFixture, TestConcatenatedChannels) {
     EXPECT_TRUE(torch::allclose(outAlphasWithBackground, expectedRenderedAlphas));
     EXPECT_TRUE(torch::equal(outLastIdsWithBackground, expectedLastIds));
 }
+
+INSTANTIATE_TEST_SUITE_P(ChunkedRendering,
+                         GaussianRasterizeForwardChunkedTestFixture,
+                         ::testing::Values(16u, 32u, 64u));
 
 // Compares the output of multi-camera rasterization with the output of sequential single-camera
 // rasterization.
@@ -849,13 +861,21 @@ TEST_F(GaussianRasterizeForwardTestFixture, TestSparseRasterization) {
                                              expectedLastIds));
 }
 
-TEST_F(GaussianRasterizeForwardTestFixture, TestSparseRasterizationConcatenatedChannels) {
+// Parameterized over maxSharedChannels: 16 and 32 exercise chunked rendering (multiple chunks for
+// 64-channel input), 64 exercises the non-chunked path (all channels fit in one chunk).
+struct GaussianRasterizeForwardSparseChunkedTestFixture
+    : public GaussianRasterizeForwardTestFixture,
+      public ::testing::WithParamInterface<uint32_t> {};
+
+TEST_P(GaussianRasterizeForwardSparseChunkedTestFixture,
+       TestSparseRasterizationConcatenatedChannels) {
     loadTestData("rasterize_forward_inputs.pt", "rasterize_forward_outputs_64.pt");
 
     colors                 = catChannelsToDim(colors, 64);
     expectedRenderedColors = catChannelsToDim(expectedRenderedColors, 64);
 
-    const int numCameras = means2d.size(0);
+    const uint32_t maxSharedChannels = GetParam();
+    const int      numCameras        = means2d.size(0);
 
     auto const pixelsToRender = generateSparsePixelCoords(numCameras, 100).cuda();
 
@@ -881,7 +901,7 @@ TEST_F(GaussianRasterizeForwardTestFixture, TestSparseRasterizationConcatenatedC
             tilePixelMask,
             tilePixelCumsum,
             pixelMap,
-            16); // force chunked rendering
+            maxSharedChannels);
 
     EXPECT_TRUE(compareSparseWithDensePixels(pixelsToRender,
                                              outColorsSparse,
@@ -891,6 +911,10 @@ TEST_F(GaussianRasterizeForwardTestFixture, TestSparseRasterizationConcatenatedC
                                              expectedRenderedAlphas,
                                              expectedLastIds));
 }
+
+INSTANTIATE_TEST_SUITE_P(ChunkedRendering,
+                         GaussianRasterizeForwardSparseChunkedTestFixture,
+                         ::testing::Values(16u, 32u, 64u));
 
 TEST_F(GaussianRasterizeForwardTestFixture, TestSparseRasterizationMultipleCameras) {
     loadInputData("rasterize_forward_inputs_3cams.pt");

--- a/src/tests/GaussianRasterizeForwardTest.cpp
+++ b/src/tests/GaussianRasterizeForwardTest.cpp
@@ -579,9 +579,9 @@ TEST_F(GaussianRasterizeForwardTestFixture, TestBasicInputsAndOutputs) {
 
 // Parameterized over maxSharedChannels: 16 and 32 exercise chunked rendering (multiple chunks for
 // 64-channel input), 64 exercises the non-chunked path (all channels fit in one chunk).
-struct GaussianRasterizeForwardChunkedTestFixture
-    : public GaussianRasterizeForwardTestFixture,
-      public ::testing::WithParamInterface<uint32_t> {};
+struct GaussianRasterizeForwardChunkedTestFixture : public GaussianRasterizeForwardTestFixture,
+                                                    public ::testing::WithParamInterface<uint32_t> {
+};
 
 TEST_P(GaussianRasterizeForwardChunkedTestFixture, TestConcatenatedChannels) {
     loadTestData("rasterize_forward_inputs.pt", "rasterize_forward_outputs_64.pt");
@@ -875,7 +875,7 @@ TEST_P(GaussianRasterizeForwardSparseChunkedTestFixture,
     expectedRenderedColors = catChannelsToDim(expectedRenderedColors, 64);
 
     const uint32_t maxSharedChannels = GetParam();
-    const int      numCameras        = means2d.size(0);
+    const int numCameras             = means2d.size(0);
 
     auto const pixelsToRender = generateSparsePixelCoords(numCameras, 100).cuda();
 


### PR DESCRIPTION
An unintentional side effect of #554 was that the compile times for the forward rasterization TU increased dramatically. This is because the output features array was accidentally specified using `NUM_CHANNELS` instead of the (much) smaller `NUM_SHARED_CHANNELS`, the latter of which mirrors the chunking in the backwards pass. As a result, for each specialization, NVCC needed to unroll the full output values array which resulted in additional duplicated state and unrolling. By switching `pixOut` to `NUM_SHARED_CHANNELS` instead of `NUM_CHANNELS` and writing directly to the slice, we significantly improve compile times and reduce the amount of stack and SASS:

  - Stack: 2,056 → 64 bytes
  - Total rasterizer SASS: 13.7 → 8.3 MB
  - Compile: 616 → 181 seconds