### PR TITLE
Use view() rather than reshape() in dense-mode gsplat repacks

### DIFF
--- a/src/fvdb/detail/ops/gsplat/CountContributingGaussians.cu
+++ b/src/fvdb/detail/ops/gsplat/CountContributingGaussians.cu
@@ -423,9 +423,12 @@ dispatchCountContributingGaussians<torch::kCUDA>(
                                tileSize);
             // Get C from tileOffsets for dense mode
             const auto C = tileOffsets.size(0);
+            // Use view() rather than reshape() here: these tensors are allocated contiguous by
+            // the kernel launch above, so view() cannot copy. If that ever stops being true,
+            // view() throws instead of silently making a copy.
             return std::make_tuple(
-                numContributingGaussians.jdata().reshape({C, imageHeight, imageWidth}),
-                alphas.jdata().reshape({C, imageHeight, imageWidth}));
+                numContributingGaussians.jdata().view({C, imageHeight, imageWidth}),
+                alphas.jdata().view({C, imageHeight, imageWidth}));
         }),
         AT_EXPAND(AT_FLOATING_TYPES),
         c10::kHalf);

--- a/src/fvdb/detail/ops/gsplat/IdentifyContributingGaussians.cu
+++ b/src/fvdb/detail/ops/gsplat/IdentifyContributingGaussians.cu
@@ -584,9 +584,11 @@ launchRasterizeContributingGaussianIdsForwardKernel(
             const auto W = denseIds.size(2);
             const auto K = denseIds.size(3);
 
-            // Reshape to [C*H*W, K] for easier processing
-            denseIds     = denseIds.reshape({C * H * W, K});
-            denseWeights = denseWeights.reshape({C * H * W, K});
+            // Flatten to [C*H*W, K] for easier processing. Use view() rather than reshape():
+            // the dense dispatch above returns contiguous kernel outputs, so view() cannot
+            // copy. If that ever stops being true, view() throws instead of silently copying.
+            denseIds     = denseIds.view({C * H * W, K});
+            denseWeights = denseWeights.view({C * H * W, K});
 
             // Create JaggedTensor with fixed K samples per pixel
             std::vector<torch::Tensor> idsVec, weightsVec;

--- a/src/fvdb/detail/ops/gsplat/IdentifyTopContributingGaussians.cu
+++ b/src/fvdb/detail/ops/gsplat/IdentifyTopContributingGaussians.cu
@@ -586,9 +586,12 @@ dispatchIdentifyTopContributingGaussians<torch::kCUDA>(
                                numDepthSamples);
             // Get C from tileOffsets for dense mode
             const auto C = tileOffsets.size(0);
+            // Use view() rather than reshape() here: these tensors are allocated contiguous by
+            // the kernel launch above, so view() cannot copy. If that ever stops being true,
+            // view() throws instead of silently making a copy.
             return std::make_tuple(
-                ids.jdata().reshape({C, imageHeight, imageWidth, numDepthSamples}),
-                weights.jdata().reshape({C, imageHeight, imageWidth, numDepthSamples}));
+                ids.jdata().view({C, imageHeight, imageWidth, numDepthSamples}),
+                weights.jdata().view({C, imageHeight, imageWidth, numDepthSamples}));
         }),
         AT_EXPAND(AT_FLOATING_TYPES),
         c10::kHalf);


### PR DESCRIPTION
The rasterize forward/backward paths were already converted in 1c931ab1, but the same dense-mode pattern remained in the contributing-Gaussian ops. These tensors are allocated contiguous by the kernels that produce them, so `view()` cannot copy; if that invariant is ever broken, `view()` throws instead of silently making a copy. Added a comment at each site recording the invariant and the rationale.

Fixes #39