### PR TITLE
Build point grids through a transform iterator instead of a coordinate tensor

### DIFF
--- a/src/fvdb/detail/ops/BuildGridFromPoints.cu
+++ b/src/fvdb/detail/ops/BuildGridFromPoints.cu
@@ -127,7 +127,7 @@ dispatchBuildGridFromPoints<torch::kCUDA>(const JaggedTensor &points,
     // offsets on the host in order to slice the point array. Ideally this would be a single
     // invocation over the whole batch.
     const torch::Tensor pointsBOffsetTensor = points.joffsets().cpu();
-    const auto pointsBOffset = pointsBOffsetTensor.accessor<fvdb::JOffsetsType, 1>();
+    const auto pointsBOffset                = pointsBOffsetTensor.accessor<fvdb::JOffsetsType, 1>();
 
     // TransformedPointPtr indexes the points as a flat (N, 3) array, so it needs the standard
     // contiguous layout. This is a no-op for the contiguous inputs we expect in practice.

--- a/src/fvdb/detail/ops/BuildGridFromPoints.cu
+++ b/src/fvdb/detail/ops/BuildGridFromPoints.cu
@@ -7,10 +7,7 @@
 #include <fvdb/detail/ops/BuildGridFromPoints.h>
 #include <fvdb/detail/utils/AccessorHelpers.cuh>
 #include <fvdb/detail/utils/Utils.h>
-#include <fvdb/detail/utils/cuda/ForEachCUDA.cuh>
 #include <fvdb/detail/utils/cuda/ForEachPrivateUse1.cuh>
-#include <fvdb/detail/utils/cuda/GridDim.h>
-#include <fvdb/detail/utils/cuda/RAIIRawDeviceBuffer.h>
 #include <fvdb/detail/utils/nanovdb/CreateEmptyGridHandle.h>
 
 #include <nanovdb/cuda/GridHandle.cuh>
@@ -72,11 +69,13 @@ template <typename ScalarT> class TransformedPointPtr {
             .round();
     }
 
-    /// @brief Required by `pointer_traits` to deduce `element_type`. Only the return type is used
-    ///        (it is called in an unevaluated context), so returning by value is fine.
+    /// @brief Required by `pointer_traits` to deduce `element_type` -- only the return *type* is
+    ///        used. Deliberately does not read `mPoints`: `pointer_traits` never evaluates this,
+    ///        and returning a default coordinate keeps it well defined for an empty point set if
+    ///        some future code path (or debug instrumentation) ever does evaluate it.
     __hostdev__ inline nanovdb::Coord
     operator*() const {
-        return (*this)[0];
+        return nanovdb::Coord();
     }
 
   private:
@@ -128,6 +127,18 @@ dispatchBuildGridFromPoints<torch::kCUDA>(const JaggedTensor &points,
     // invocation over the whole batch.
     const torch::Tensor pointsBOffsetTensor = points.joffsets().cpu();
     const auto pointsBOffset                = pointsBOffsetTensor.accessor<fvdb::JOffsetsType, 1>();
+
+    // The loop below indexes txs by batch item, so make the invariant explicit rather than
+    // relying on the caller. joffsets holds one offset per batch item plus a terminating entry.
+    TORCH_CHECK(pointsBOffset.size(0) >= 1,
+                "Expected joffsets to have at least one entry, got ",
+                pointsBOffset.size(0));
+    TORCH_CHECK(static_cast<int64_t>(txs.size()) == pointsBOffset.size(0) - 1,
+                "Expected one transform per batch item, but got ",
+                txs.size(),
+                " transforms for ",
+                pointsBOffset.size(0) - 1,
+                " batch items");
 
     // TransformedPointPtr indexes the points as a flat (N, 3) array, so it needs the standard
     // contiguous layout. This is a no-op for the contiguous inputs we expect in practice.

--- a/src/fvdb/detail/ops/BuildGridFromPoints.cu
+++ b/src/fvdb/detail/ops/BuildGridFromPoints.cu
@@ -11,7 +11,9 @@
 #include <fvdb/detail/utils/cuda/ForEachPrivateUse1.cuh>
 #include <fvdb/detail/utils/cuda/GridDim.h>
 #include <fvdb/detail/utils/cuda/RAIIRawDeviceBuffer.h>
+#include <fvdb/detail/utils/nanovdb/CreateEmptyGridHandle.h>
 
+#include <nanovdb/cuda/GridHandle.cuh>
 #include <nanovdb/tools/CreateNanoGrid.h>
 #include <nanovdb/tools/cuda/PointsToGrid.cuh>
 
@@ -21,6 +23,8 @@
 
 #include <thrust/universal_vector.h>
 
+#include <limits>
+
 namespace fvdb {
 namespace detail {
 namespace ops {
@@ -29,6 +33,58 @@ template <torch::DeviceType>
 nanovdb::GridHandle<TorchDeviceBuffer>
 dispatchBuildGridFromPoints(const JaggedTensor &points,
                             const std::vector<VoxelCoordTransform> &txs);
+
+namespace {
+
+/// @brief Pointer-like adaptor that yields index-space voxel coordinates from world-space points
+///        on demand, so the coordinates never have to be materialized in memory.
+///
+/// `nanovdb::tools::cuda::voxelsToGrid` reads its input through a pointer-like type rather than a
+/// raw pointer (see `nanovdb::tools::cuda::fancy_ptr`, which documents the contract): `operator[]`
+/// is what the kernels actually call, and `operator*` exists only so `pointer_traits` can deduce
+/// `element_type` from its return type. Returning `nanovdb::Coord` by value satisfies both and
+/// selects the `is_same<Vec3T, Coord>` branch of `TileKeyFunctor` — the same branch a raw
+/// `nanovdb::Coord *` takes — so the resulting topology is bit-for-bit what the previous
+/// materialize-then-sort path produced.
+///
+/// This replaces a `torch::empty({N, 3}, kInt32)` coordinate tensor (12 B per input point) that
+/// was written once and read once.
+///
+/// @tparam ScalarT Scalar type of the input points (floating point or half)
+template <typename ScalarT> class TransformedPointPtr {
+  public:
+    using MathT = typename at::opmath_type<ScalarT>;
+
+    /// @param points Pointer to contiguous world-space points with shape (N, 3)
+    /// @param transform World-space to index-space transform for this batch item
+    __hostdev__
+    TransformedPointPtr(const ScalarT *points, const VoxelCoordTransform &transform)
+        : mPoints(points), mTransform(transform) {}
+
+    /// @brief Return the index-space voxel coordinate of the i'th point. Required by PointsToGrid.
+    __hostdev__ inline nanovdb::Coord
+    operator[](size_t i) const {
+        const ScalarT *point = mPoints + 3 * i;
+        return mTransform
+            .apply(static_cast<MathT>(point[0]),
+                   static_cast<MathT>(point[1]),
+                   static_cast<MathT>(point[2]))
+            .round();
+    }
+
+    /// @brief Required by `pointer_traits` to deduce `element_type`. Only the return type is used
+    ///        (it is called in an unevaluated context), so returning by value is fine.
+    __hostdev__ inline nanovdb::Coord
+    operator*() const {
+        return (*this)[0];
+    }
+
+  private:
+    const ScalarT *mPoints;
+    VoxelCoordTransform mTransform;
+};
+
+} // namespace
 
 template <typename ScalarT>
 __device__ void
@@ -50,45 +106,76 @@ ijkForPointsCallback(int32_t bidx,
     outIJKData[eidx][2] = ijk0[2];
 }
 
-JaggedTensor
-ijkForPoints(const JaggedTensor &jaggedPoints, const std::vector<VoxelCoordTransform> &transforms) {
-    TORCH_CHECK(jaggedPoints.device().is_cuda(), "GridBatchData must be on CUDA device");
-    TORCH_CHECK(jaggedPoints.device().has_index(), "GridBatchData must have a valid index");
-
-    const torch::TensorOptions optsData =
-        torch::TensorOptions().dtype(torch::kInt32).device(jaggedPoints.device());
-    torch::Tensor outIJK = torch::empty({jaggedPoints.jdata().size(0), 3}, optsData);
-
-    AT_DISPATCH_V2(
-        jaggedPoints.scalar_type(),
-        "ijkForPoints",
-        AT_WRAP([&] {
-            RAIIRawDeviceBuffer<VoxelCoordTransform> transformsDVec(transforms.size(),
-                                                                    jaggedPoints.device());
-            transformsDVec.setData((VoxelCoordTransform *)transforms.data(), true /* blocking */);
-            const VoxelCoordTransform *transformDevPtr = transformsDVec.devicePtr;
-
-            auto outIJKAcc = outIJK.packed_accessor64<int32_t, 2, torch::RestrictPtrTraits>();
-
-            auto cb = [=] __device__(int32_t bidx,
-                                     int32_t eidx,
-                                     int32_t cidx,
-                                     JaggedRAcc64<scalar_t, 2> pacc) {
-                ijkForPointsCallback(bidx, eidx, pacc, transformDevPtr, outIJKAcc);
-            };
-            forEachJaggedElementChannelCUDA<scalar_t, 2, 1024>(1, jaggedPoints, cb);
-        }),
-        AT_EXPAND(AT_FLOATING_TYPES),
-        c10::kHalf);
-    return jaggedPoints.jagged_like(outIJK);
-}
-
 template <>
 nanovdb::GridHandle<TorchDeviceBuffer>
 dispatchBuildGridFromPoints<torch::kCUDA>(const JaggedTensor &points,
                                           const std::vector<VoxelCoordTransform> &txs) {
-    JaggedTensor coords = ijkForPoints(points, txs);
-    return ops::_createNanoGridFromIJK(coords);
+    using GridT = nanovdb::ValueOnIndex;
+
+    TORCH_CHECK(points.device().is_cuda(), "points must be on a CUDA device");
+    TORCH_CHECK(points.device().has_index(), "points device must have a valid index");
+
+    c10::cuda::CUDAGuard deviceGuard(points.device());
+
+    // This guide buffer is a hack to pass in a device with an index to the grid building
+    // functions. We can't pass in a device directly but we can pass in a buffer which gets
+    // passed to TorchDeviceBuffer::create. The guide buffer holds the device and effectively
+    // passes it to the created buffer.
+    TorchDeviceBuffer guide(0, points.device());
+
+    // FIXME: Same host sync as _createNanoGridFromIJK -- the per-batch-item loop below needs the
+    // offsets on the host in order to slice the point array. Ideally this would be a single
+    // invocation over the whole batch.
+    const torch::Tensor pointsBOffsetTensor = points.joffsets().cpu();
+    const auto pointsBOffset = pointsBOffsetTensor.accessor<fvdb::JOffsetsType, 1>();
+
+    // TransformedPointPtr indexes the points as a flat (N, 3) array, so it needs the standard
+    // contiguous layout. This is a no-op for the contiguous inputs we expect in practice.
+    const torch::Tensor pointsData = points.jdata().contiguous();
+
+    return AT_DISPATCH_V2(
+        points.scalar_type(),
+        "buildGridFromPoints",
+        AT_WRAP([&]() -> nanovdb::GridHandle<TorchDeviceBuffer> {
+            using PointPtrT = TransformedPointPtr<scalar_t>;
+
+            const scalar_t *pointsPtr = pointsData.data_ptr<scalar_t>();
+
+            // Create a grid for each batch item and store the handles
+            std::vector<nanovdb::GridHandle<TorchDeviceBuffer>> handles;
+            handles.reserve(pointsBOffset.size(0) - 1);
+            for (int64_t i = 0; i < (pointsBOffset.size(0) - 1); i += 1) {
+                const int64_t startIdx = pointsBOffset[i];
+                const int64_t nPoints  = pointsBOffset[i + 1] - startIdx;
+
+                // PointsToGrid casts its element count to int for the segmented radix sort, so
+                // anything at or above 2^31 would silently produce a corrupt grid.
+                TORCH_CHECK(nPoints <= std::numeric_limits<int32_t>::max(),
+                            "Cannot build a grid from ",
+                            nPoints,
+                            " points in a single batch item (limit is ",
+                            std::numeric_limits<int32_t>::max(),
+                            ")");
+
+                handles.push_back(
+                    nPoints == 0
+                        ? createEmptyGridHandle(guide.device())
+                        : nanovdb::tools::cuda::voxelsToGrid<GridT, PointPtrT, TorchDeviceBuffer>(
+                              PointPtrT(pointsPtr + 3 * startIdx, txs[i]), nPoints, 1.0, guide));
+                C10_CUDA_KERNEL_LAUNCH_CHECK();
+            }
+
+            if (handles.size() == 1) {
+                // If there's only one handle, just return it
+                return std::move(handles[0]);
+            } else {
+                // This copies all the handles into a single handle -- only do it if there are
+                // multiple grids
+                return nanovdb::cuda::mergeGridHandles(handles, &guide);
+            }
+        }),
+        AT_EXPAND(AT_FLOATING_TYPES),
+        c10::kHalf);
 }
 
 template <>

--- a/src/fvdb/detail/ops/BuildGridFromPoints.cu
+++ b/src/fvdb/detail/ops/BuildGridFromPoints.cu
@@ -47,26 +47,45 @@ namespace {
 /// This replaces a `torch::empty({N, 3}, kInt32)` coordinate tensor (12 B per input point) that
 /// was written once and read once.
 ///
+/// The class supports both memory layouts of an (N, 3) tensor so that non-contiguous views --
+/// e.g. the xyz columns of an (N, 6) point cloud, `cloud[:, :3]` -- are read in place rather
+/// than copied. `IsContiguous` selects between compile-time strides (3, 1) and runtime strides
+/// taken from the tensor, so the packed fast path pays nothing for the generality.
+///
 /// @tparam ScalarT Scalar type of the input points (floating point or half)
-template <typename ScalarT> class TransformedPointPtr {
+/// @tparam IsContiguous Whether the points are a packed (N, 3) array; when false, element
+///         strides are supplied at construction
+template <typename ScalarT, bool IsContiguous> class TransformedPointPtr {
   public:
     using MathT = typename at::opmath_type<ScalarT>;
 
-    /// @param points Pointer to contiguous world-space points with shape (N, 3)
+    /// @param points Pointer to the first component of the first point
     /// @param transform World-space to index-space transform for this batch item
+    /// @param rowStride Distance in elements between consecutive points (3 if packed)
+    /// @param colStride Distance in elements between a point's components (1 if packed)
     __hostdev__
-    TransformedPointPtr(const ScalarT *points, const VoxelCoordTransform &transform)
-        : mPoints(points), mTransform(transform) {}
+    TransformedPointPtr(const ScalarT *points,
+                        const VoxelCoordTransform &transform,
+                        int64_t rowStride = 3,
+                        int64_t colStride = 1)
+        : mPoints(points), mTransform(transform), mRowStride(rowStride), mColStride(colStride) {}
 
     /// @brief Return the index-space voxel coordinate of the i'th point. Required by PointsToGrid.
     __hostdev__ inline nanovdb::Coord
     operator[](size_t i) const {
-        const ScalarT *point = mPoints + 3 * i;
-        return mTransform
-            .apply(static_cast<MathT>(point[0]),
-                   static_cast<MathT>(point[1]),
-                   static_cast<MathT>(point[2]))
-            .round();
+        MathT x, y, z;
+        if constexpr (IsContiguous) {
+            const ScalarT *point = mPoints + 3 * i;
+            x                    = static_cast<MathT>(point[0]);
+            y                    = static_cast<MathT>(point[1]);
+            z                    = static_cast<MathT>(point[2]);
+        } else {
+            const ScalarT *point = mPoints + static_cast<int64_t>(i) * mRowStride;
+            x                    = static_cast<MathT>(point[0]);
+            y                    = static_cast<MathT>(point[mColStride]);
+            z                    = static_cast<MathT>(point[2 * mColStride]);
+        }
+        return mTransform.apply(x, y, z).round();
     }
 
     /// @brief Required by `pointer_traits` to deduce `element_type` -- only the return *type* is
@@ -81,6 +100,8 @@ template <typename ScalarT> class TransformedPointPtr {
   private:
     const ScalarT *mPoints;
     VoxelCoordTransform mTransform;
+    int64_t mRowStride;
+    int64_t mColStride;
 };
 
 } // namespace
@@ -140,16 +161,18 @@ dispatchBuildGridFromPoints<torch::kCUDA>(const JaggedTensor &points,
                 pointsBOffset.size(0) - 1,
                 " batch items");
 
-    // TransformedPointPtr indexes the points as a flat (N, 3) array, so it needs the standard
-    // contiguous layout. This is a no-op for the contiguous inputs we expect in practice.
-    const torch::Tensor pointsData = points.jdata().contiguous();
+    // TransformedPointPtr reads the points in place for both layouts: compile-time strides for
+    // a packed (N, 3) array, runtime strides otherwise (e.g. the xyz columns of an (N, 6)
+    // tensor). Neither path copies the point data.
+    const torch::Tensor pointsData = points.jdata();
+    const bool pointsAreContiguous = pointsData.is_contiguous();
+    const int64_t rowStride        = pointsData.stride(0);
+    const int64_t colStride        = pointsData.stride(1);
 
     return AT_DISPATCH_V2(
         points.scalar_type(),
         "buildGridFromPoints",
         AT_WRAP([&]() -> nanovdb::GridHandle<TorchDeviceBuffer> {
-            using PointPtrT = TransformedPointPtr<scalar_t>;
-
             const scalar_t *pointsPtr = pointsData.data_ptr<scalar_t>();
 
             // Create a grid for each batch item and store the handles
@@ -168,11 +191,23 @@ dispatchBuildGridFromPoints<torch::kCUDA>(const JaggedTensor &points,
                             std::numeric_limits<int32_t>::max(),
                             ")");
 
-                handles.push_back(
-                    nPoints == 0
-                        ? createEmptyGridHandle(guide.device())
-                        : nanovdb::tools::cuda::voxelsToGrid<GridT, PointPtrT, TorchDeviceBuffer>(
-                              PointPtrT(pointsPtr + 3 * startIdx, txs[i]), nPoints, 1.0, guide));
+                if (nPoints == 0) {
+                    handles.push_back(createEmptyGridHandle(guide.device()));
+                } else if (pointsAreContiguous) {
+                    using PointPtrT = TransformedPointPtr<scalar_t, true>;
+                    handles.push_back(
+                        nanovdb::tools::cuda::voxelsToGrid<GridT, PointPtrT, TorchDeviceBuffer>(
+                            PointPtrT(pointsPtr + 3 * startIdx, txs[i]), nPoints, 1.0, guide));
+                } else {
+                    using PointPtrT = TransformedPointPtr<scalar_t, false>;
+                    handles.push_back(
+                        nanovdb::tools::cuda::voxelsToGrid<GridT, PointPtrT, TorchDeviceBuffer>(
+                            PointPtrT(
+                                pointsPtr + startIdx * rowStride, txs[i], rowStride, colStride),
+                            nPoints,
+                            1.0,
+                            guide));
+                }
                 C10_CUDA_KERNEL_LAUNCH_CHECK();
             }
 


### PR DESCRIPTION
## Motivation

Building a sparse grid from a point cloud means mapping every point to its voxel coordinate and deduplicating the result. On CUDA, fvdb did this in two passes:

1. `ijkForPoints` launched a kernel that transformed each point and wrote its `(i, j, k)` into an `N x 3` int32 tensor.
2. `_createNanoGridFromIJK` handed that tensor to NanoVDB's `PointsToGrid`, which read it back and radix-sorted it to produce the grid.

The tensor in the middle is written once, read once, and then thrown away. It costs **12 bytes per input point** and exists only to carry values between two kernels that could be fused.

That is not free at the scale this op runs at. `IntegrateTSDF.cu` calls `buildGridFromPoints` once per depth image, unprojecting every pixel into a point — a 6000x4000 depth map is 24M points, so ~288 MB of intermediate per image, allocated and freed on every iteration of the integration loop.

This came out of the topology-builder audit behind #711. That audit deliberately put `BuildGridFromPoints` **out of scope** for the leaf-mask rewrite, and correctly so: unlike `conv_grid`, `dual_grid` or `refined_grid`, it has no `V x K` candidate expansion (K = 1, one coordinate per point), and genuinely unstructured input does require a sort. None of that makes the write-once-read-once intermediate necessary, though — which is what this PR removes.

## What this changes

The key observation is that `nanovdb::tools::cuda::voxelsToGrid` **does not require a raw** `nanovdb::Coord `***.** It is templated on the pointer type and reads its input through a pointer-like interface, with `nanovdb::tools::cuda::fancy_ptr` shipped as the documented example of that extension point. So the coordinates can be produced on demand rather than materialized.

This PR adds `TransformedPointPtr<ScalarT, IsContiguous>`, which holds the raw point array and the batch item's `VoxelCoordTransform`, and applies the transform inside `operator[]`. It is templated on the memory layout: packed `(N, 3)` input uses compile-time strides, and a non-contiguous view — e.g. `cloud[:, :3]`, the xyz columns of a wider point layout — is read in place through the tensor's element strides. Neither layout copies the points. The CUDA path then loops over batch items and calls `voxelsToGrid` directly, instead of building a `JaggedTensor` of coordinates and routing through `_createNanoGridFromIJK`.

Four details make this a drop-in replacement rather than a behaviour change, all verified against the pinned NanoVDB rather than assumed:

- `operator[]` **is the only thing the kernels call.** For `BuildT = ValueOnIndex`, `mPointType` is `PointType::Disable`, and `processPoints(const PtrT, size_t)` ignores its pointer argument entirely — so `points[tid]` inside the key functors is the sole dereference site.
- `operator*` **exists only for type deduction.** `pointer_traits` derives `element_type` from `remove_reference<decltype(*declval<T>())>`, which is an unevaluated context, so only the return *type* matters. It returns a default `nanovdb::Coord` and never touches memory.
- **Returning** `Coord` **selects the identical code path.** `TileKeyFunctor` branches on the element type: `is_same<Vec3T, Coord>` gives `key = coordToKey(points[tid])` with no map applied — exactly the branch a raw `nanovdb::Coord `* takes. Nothing about how keys are computed changes.
- **The rounding convention already matches.** fvdb's existing `ijkForPointsCallback` used `.round()`, as does NanoVDB.

The CPU and PrivateUse1 paths are untouched, which conveniently leaves the CPU implementation as an independent oracle for the CUDA result.

Two smaller things ride along:

- A `TORCH_CHECK` rejecting more than 2^31 points in a single batch item. `PointsToGrid` casts its element count to `int` for the segmented radix sort, so exceeding this silently produces a corrupt grid. The previous path had no guard either.
- The unused `ForEachCUDA.cuh`, `GridDim.h` and `RAIIRawDeviceBuffer.h` includes, which only the removed materialization path needed.



## What we hope to see from it

- **A small, consistent speedup on every point-to-grid construction** — `Grid.from_points`, `GridBatch.from_points`, and the per-image call inside TSDF integration. One less kernel launch and one less round trip through global memory per build.
- **Bit-identical topology and voxel ordering**, so nothing downstream needs to care.
- **One fewer allocation on a hot loop.** This does not currently move peak memory (see below), but it removes the only part of this op's footprint that fvdb controls, which matters for the follow-up in the next section.



## What we measured, including what did not pan out

Both arms built into the same tree from the same source, run back to back on an RTX PRO 6000 Blackwell, and verified by symbol before each run.

**Speed — faster in 7 of 7 cases**, median of 7 iterations, warmed:


| case                                  | before   | after    |            |
| ------------------------------------- | -------- | -------- | ---------- |
| 8M pts, `voxel_size=0.05`             | 5.31 ms  | 4.77 ms  | **-10.2%** |
| 2M pts, `voxel_size=0.5`              | 2.64 ms  | 2.47 ms  | **-6.3%**  |
| 4M pts, `voxel_size=0.5`              | 2.99 ms  | 2.83 ms  | **-5.3%**  |
| 8M pts, `voxel_size=0.01`             | 14.02 ms | 13.31 ms | **-5.1%**  |
| 8M pts, `voxel_size=0.5`              | 4.30 ms  | 4.13 ms  | **-4.0%**  |
| 24M pts, `voxel_size=0.2` (TSDF-like) | 10.53 ms | 10.15 ms | **-3.6%**  |
| 16M pts, `voxel_size=0.5`             | 7.19 ms  | 7.07 ms  | **-1.7%**  |


**Memory — no improvement.** This is worth stating plainly, because "removes an `N x 3` int32 tensor" sounds like it should be a memory win and it is not. Measured at a scale where the tensor cannot hide:


|        | 400M points (input = 4.80 GB) | 700M points (input = 8.40 GB) |
| ------ | ----------------------------- | ----------------------------- |
| before | +4.82 GB                      | +8.42 GB                      |
| after  | +4.82 GB                      | +8.42 GB                      |


Identical. At 400M points the removed tensor alone would have been 4.8 GB, so if it were setting the peak these could not match.

The reason: `PointsToGrid` allocates its own sort scratch — `d_keys` (uint64, 8 B/point) plus `d_indx` (uint32, 4 B/point) = **12 B/point**, precisely the size of the tensor being removed — through its resource abstraction (at the pinned NanoVDB, instance `mResource->allocate_async(...)` calls backed by `DeviceResource`), a pool disjoint from torch's caching allocator. **The high-water mark is set by the sort, not by the tensor feeding it.**

## Follow-up this sets up

The natural next step is a torch-backed resource for `PointsToGrid`. At the pinned NanoVDB, `d_keys`/`d_indx` are allocated through an instance resource (`mResource->allocate_async(...)`; newer NanoVDB reworks this into a static `DeviceResource` interface), and fvdb currently customises neither — so every sort path allocates outside torch's pool, meaning a job can OOM while torch sits on cached blocks. An instance hook should make the torch-backed version straightforward to inject. That change would benefit `from_ijk`, `from_points` and all the non-power-of-two topology fallbacks at once.

It is also what makes this PR's allocation removal pay off: once the scratch is no longer the ceiling, the coordinate tensor would have become the next one.

## Notes for reviewers

- **Non-contiguous inputs are read in place** (70fbbf2f). An earlier revision called `.contiguous()` on the point data, which silently copied non-contiguous views — notably `cloud[:, :3]`, the xyz columns of a wider point layout. `TransformedPointPtr` is now templated on the layout: contiguous input keeps the compile-time-stride fast path, and strided input goes through a variant carrying the tensor's element strides. Neither path copies. Verified bit-identical to a packed copy for four layouts × three dtypes; packed-path timing unchanged within noise.
- **Malformed** `joffsets` **are not validated here, deliberately.** Review raised that a decreasing or out-of-range `joffsets` yields a negative per-item count and an out-of-bounds read. That is real and reachable, but reproduces identically on `main` and affects every op that slices `jdata` by consecutive offsets — so it belongs in `JaggedTensor`, not in each consumer. Filed as **#722**.



## Testing

- **CUDA vs CPU oracle** (the CPU path is untouched by this PR): identical voxel sets for float32 and float64 across `voxel_size` in {0.05, 0.013, 1.0} and non-zero origins.
- **Ordering**: CUDA `ijk` is element-wise identical to CPU `ijk`, not merely set-equal — this matters because downstream consumers map voxels by canonical order.
- **Batched and edge cases**: a 4-item batch containing an empty middle item and a single-point item, plus per-item differing `voxel_sizes`; all match CPU exactly.
- **Non-contiguous input**: `cloud[:, :3]`, every-other-column, column-major, and wide-row-slice layouts each produce grids bit-identical to a packed CUDA copy of the same values (same-device comparison — CPU is not a valid oracle for layout changes because of the #725 boundary-rounding difference, which affects float32 as well as float16).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


