### PR TITLE
Guard against SH and projection kernel launches with zero block size

### DIFF
--- a/src/fvdb/detail/ops/gsplat/EvaluateSphericalHarmonicsBackward.cu
+++ b/src/fvdb/detail/ops/gsplat/EvaluateSphericalHarmonicsBackward.cu
@@ -897,114 +897,123 @@ dispatchEvaluateSphericalHarmonicsBwd<torch::kPrivateUse1>(
             int64_t elementOffset, elementCount;
             std::tie(elementOffset, elementCount) = deviceChunk(N, deviceId);
 
+            if (elementCount > 0) {
 #if (CUDART_VERSION < 13000)
-            nanovdb::util::cuda::memPrefetchAsync(
-                dLossDSh0Coeffs.data_ptr<scalar_t>() + elementOffset * dLossDSh0Coeffs.stride(0),
-                elementCount * dLossDSh0Coeffs.stride(0) * sizeof(scalar_t),
-                deviceId,
-                stream);
-            nanovdb::util::cuda::memPrefetchAsync(
-                dLossDShNCoeffs.data_ptr<scalar_t>() + elementOffset * dLossDShNCoeffs.stride(0),
-                elementCount * dLossDShNCoeffs.stride(0) * sizeof(scalar_t),
-                deviceId,
-                stream);
-            if (computeDLossDMeans) {
-                nanovdb::util::cuda::memPrefetchAsync(
-                    dLossDMeans.data_ptr<scalar_t>() + elementOffset * dLossDMeans.stride(0),
-                    elementCount * dLossDMeans.stride(0) * sizeof(scalar_t),
-                    deviceId,
-                    stream);
-            }
-            if (computeDLossDWorldToCamMatrices) {
-                for (int cameraIndex = 0; cameraIndex < C; ++cameraIndex) {
+                nanovdb::util::cuda::memPrefetchAsync(dLossDSh0Coeffs.data_ptr<scalar_t>() +
+                                                          elementOffset * dLossDSh0Coeffs.stride(0),
+                                                      elementCount * dLossDSh0Coeffs.stride(0) *
+                                                          sizeof(scalar_t),
+                                                      deviceId,
+                                                      stream);
+                nanovdb::util::cuda::memPrefetchAsync(dLossDShNCoeffs.data_ptr<scalar_t>() +
+                                                          elementOffset * dLossDShNCoeffs.stride(0),
+                                                      elementCount * dLossDShNCoeffs.stride(0) *
+                                                          sizeof(scalar_t),
+                                                      deviceId,
+                                                      stream);
+                if (computeDLossDMeans) {
                     nanovdb::util::cuda::memPrefetchAsync(
-                        dLossDViewDirs.data_ptr<scalar_t>() +
-                            cameraIndex * dLossDViewDirs.stride(0) +
-                            elementOffset * dLossDViewDirs.stride(1),
-                        elementCount * dLossDViewDirs.stride(1) * sizeof(scalar_t),
+                        dLossDMeans.data_ptr<scalar_t>() + elementOffset * dLossDMeans.stride(0),
+                        elementCount * dLossDMeans.stride(0) * sizeof(scalar_t),
                         deviceId,
                         stream);
                 }
-            }
-            for (int cameraIndex = 0; cameraIndex < C; ++cameraIndex) {
-                nanovdb::util::cuda::memPrefetchAsync(
-                    dLossDRenderQuantities.data_ptr<scalar_t>() +
-                        cameraIndex * dLossDRenderQuantities.stride(0) +
-                        elementOffset * dLossDRenderQuantities.stride(1),
-                    elementCount * dLossDRenderQuantities.stride(1) * sizeof(scalar_t),
-                    deviceId,
-                    stream);
-            }
-#else
-            std::vector<void *> prefetchPtrs;
-            std::vector<size_t> prefetchSizes;
-            const cudaMemLocation location                 = {cudaMemLocationTypeDevice, deviceId};
-            std::vector<cudaMemLocation> prefetchLocations = {location};
-            std::vector<size_t> prefetchLocationIndices    = {0};
-
-            prefetchPtrs.emplace_back(dLossDSh0Coeffs.data_ptr<scalar_t>() +
-                                      elementOffset * dLossDSh0Coeffs.stride(0));
-            prefetchSizes.emplace_back(elementCount * dLossDSh0Coeffs.stride(0) * sizeof(scalar_t));
-            prefetchPtrs.emplace_back(dLossDShNCoeffs.data_ptr<scalar_t>() +
-                                      elementOffset * dLossDShNCoeffs.stride(0));
-            prefetchSizes.emplace_back(elementCount * dLossDShNCoeffs.stride(0) * sizeof(scalar_t));
-            if (computeDLossDMeans) {
-                prefetchPtrs.emplace_back(dLossDMeans.data_ptr<scalar_t>() +
-                                          elementOffset * dLossDMeans.stride(0));
-                prefetchSizes.emplace_back(elementCount * dLossDMeans.stride(0) * sizeof(scalar_t));
-            }
-            if (computeDLossDWorldToCamMatrices) {
+                if (computeDLossDWorldToCamMatrices) {
+                    for (int cameraIndex = 0; cameraIndex < C; ++cameraIndex) {
+                        nanovdb::util::cuda::memPrefetchAsync(
+                            dLossDViewDirs.data_ptr<scalar_t>() +
+                                cameraIndex * dLossDViewDirs.stride(0) +
+                                elementOffset * dLossDViewDirs.stride(1),
+                            elementCount * dLossDViewDirs.stride(1) * sizeof(scalar_t),
+                            deviceId,
+                            stream);
+                    }
+                }
                 for (int cameraIndex = 0; cameraIndex < C; ++cameraIndex) {
-                    prefetchPtrs.emplace_back(dLossDViewDirs.data_ptr<scalar_t>() +
-                                              cameraIndex * dLossDViewDirs.stride(0) +
-                                              elementOffset * dLossDViewDirs.stride(1));
-                    prefetchSizes.emplace_back(elementCount * dLossDViewDirs.stride(1) *
+                    nanovdb::util::cuda::memPrefetchAsync(
+                        dLossDRenderQuantities.data_ptr<scalar_t>() +
+                            cameraIndex * dLossDRenderQuantities.stride(0) +
+                            elementOffset * dLossDRenderQuantities.stride(1),
+                        elementCount * dLossDRenderQuantities.stride(1) * sizeof(scalar_t),
+                        deviceId,
+                        stream);
+                }
+#else
+                std::vector<void *> prefetchPtrs;
+                std::vector<size_t> prefetchSizes;
+                const cudaMemLocation location = {cudaMemLocationTypeDevice, deviceId};
+                std::vector<cudaMemLocation> prefetchLocations = {location};
+                std::vector<size_t> prefetchLocationIndices    = {0};
+
+                prefetchPtrs.emplace_back(dLossDSh0Coeffs.data_ptr<scalar_t>() +
+                                          elementOffset * dLossDSh0Coeffs.stride(0));
+                prefetchSizes.emplace_back(elementCount * dLossDSh0Coeffs.stride(0) *
+                                           sizeof(scalar_t));
+                prefetchPtrs.emplace_back(dLossDShNCoeffs.data_ptr<scalar_t>() +
+                                          elementOffset * dLossDShNCoeffs.stride(0));
+                prefetchSizes.emplace_back(elementCount * dLossDShNCoeffs.stride(0) *
+                                           sizeof(scalar_t));
+                if (computeDLossDMeans) {
+                    prefetchPtrs.emplace_back(dLossDMeans.data_ptr<scalar_t>() +
+                                              elementOffset * dLossDMeans.stride(0));
+                    prefetchSizes.emplace_back(elementCount * dLossDMeans.stride(0) *
                                                sizeof(scalar_t));
                 }
-            }
-            for (int cameraIndex = 0; cameraIndex < C; ++cameraIndex) {
-                prefetchPtrs.emplace_back(dLossDRenderQuantities.data_ptr<scalar_t>() +
-                                          cameraIndex * dLossDRenderQuantities.stride(0) +
-                                          elementOffset * dLossDRenderQuantities.stride(1));
-                prefetchSizes.emplace_back(elementCount * dLossDRenderQuantities.stride(1) *
-                                           sizeof(scalar_t));
-            }
-
-            C10_CUDA_CHECK(cudaMemPrefetchBatchAsync(prefetchPtrs.data(),
-                                                     prefetchSizes.data(),
-                                                     prefetchPtrs.size(),
-                                                     prefetchLocations.data(),
-                                                     prefetchLocationIndices.data(),
-                                                     prefetchLocations.size(),
-                                                     0,
-                                                     stream));
-#endif
-            C10_CUDA_CHECK(cudaMemsetAsync(
-                dLossDSh0Coeffs.data_ptr<scalar_t>() + elementOffset * dLossDSh0Coeffs.stride(0),
-                0,
-                elementCount * dLossDSh0Coeffs.stride(0) * sizeof(scalar_t),
-                stream));
-            C10_CUDA_CHECK(cudaMemsetAsync(
-                dLossDShNCoeffs.data_ptr<scalar_t>() + elementOffset * dLossDShNCoeffs.stride(0),
-                0,
-                elementCount * dLossDShNCoeffs.stride(0) * sizeof(scalar_t),
-                stream));
-            if (computeDLossDMeans) {
-                C10_CUDA_CHECK(cudaMemsetAsync(
-                    dLossDMeans.data_ptr<scalar_t>() + elementOffset * dLossDMeans.stride(0),
-                    0,
-                    elementCount * dLossDMeans.stride(0) * sizeof(scalar_t),
-                    stream));
-            }
-            if (computeDLossDWorldToCamMatrices) {
+                if (computeDLossDWorldToCamMatrices) {
+                    for (int cameraIndex = 0; cameraIndex < C; ++cameraIndex) {
+                        prefetchPtrs.emplace_back(dLossDViewDirs.data_ptr<scalar_t>() +
+                                                  cameraIndex * dLossDViewDirs.stride(0) +
+                                                  elementOffset * dLossDViewDirs.stride(1));
+                        prefetchSizes.emplace_back(elementCount * dLossDViewDirs.stride(1) *
+                                                   sizeof(scalar_t));
+                    }
+                }
                 for (int cameraIndex = 0; cameraIndex < C; ++cameraIndex) {
-                    C10_CUDA_CHECK(
-                        cudaMemsetAsync(dLossDViewDirs.data_ptr<scalar_t>() +
-                                            cameraIndex * dLossDViewDirs.stride(0) +
-                                            elementOffset * dLossDViewDirs.stride(1),
-                                        0,
-                                        elementCount * dLossDViewDirs.stride(1) * sizeof(scalar_t),
-                                        stream));
+                    prefetchPtrs.emplace_back(dLossDRenderQuantities.data_ptr<scalar_t>() +
+                                              cameraIndex * dLossDRenderQuantities.stride(0) +
+                                              elementOffset * dLossDRenderQuantities.stride(1));
+                    prefetchSizes.emplace_back(elementCount * dLossDRenderQuantities.stride(1) *
+                                               sizeof(scalar_t));
+                }
+
+                C10_CUDA_CHECK(cudaMemPrefetchBatchAsync(prefetchPtrs.data(),
+                                                         prefetchSizes.data(),
+                                                         prefetchPtrs.size(),
+                                                         prefetchLocations.data(),
+                                                         prefetchLocationIndices.data(),
+                                                         prefetchLocations.size(),
+                                                         0,
+                                                         stream));
+#endif
+                C10_CUDA_CHECK(
+                    cudaMemsetAsync(dLossDSh0Coeffs.data_ptr<scalar_t>() +
+                                        elementOffset * dLossDSh0Coeffs.stride(0),
+                                    0,
+                                    elementCount * dLossDSh0Coeffs.stride(0) * sizeof(scalar_t),
+                                    stream));
+                C10_CUDA_CHECK(
+                    cudaMemsetAsync(dLossDShNCoeffs.data_ptr<scalar_t>() +
+                                        elementOffset * dLossDShNCoeffs.stride(0),
+                                    0,
+                                    elementCount * dLossDShNCoeffs.stride(0) * sizeof(scalar_t),
+                                    stream));
+                if (computeDLossDMeans) {
+                    C10_CUDA_CHECK(cudaMemsetAsync(
+                        dLossDMeans.data_ptr<scalar_t>() + elementOffset * dLossDMeans.stride(0),
+                        0,
+                        elementCount * dLossDMeans.stride(0) * sizeof(scalar_t),
+                        stream));
+                }
+                if (computeDLossDWorldToCamMatrices) {
+                    for (int cameraIndex = 0; cameraIndex < C; ++cameraIndex) {
+                        C10_CUDA_CHECK(cudaMemsetAsync(dLossDViewDirs.data_ptr<scalar_t>() +
+                                                           cameraIndex * dLossDViewDirs.stride(0) +
+                                                           elementOffset * dLossDViewDirs.stride(1),
+                                                       0,
+                                                       elementCount * dLossDViewDirs.stride(1) *
+                                                           sizeof(scalar_t),
+                                                       stream));
+                    }
                 }
             }
             C10_CUDA_CHECK(cudaEventRecord(events[deviceId], stream));
@@ -1019,41 +1028,45 @@ dispatchEvaluateSphericalHarmonicsBwd<torch::kPrivateUse1>(
             int64_t elementOffset, elementCount;
             std::tie(elementOffset, elementCount) = deviceChunk(N, deviceId);
 
-            const auto NUM_BLOCKS = GET_BLOCKS(C * elementCount * D, DEFAULT_BLOCK_DIM);
+            if (elementCount > 0) {
+                const auto NUM_BLOCKS = GET_BLOCKS(C * elementCount * D, DEFAULT_BLOCK_DIM);
 
-            computeShBackward<scalar_t><<<NUM_BLOCKS, DEFAULT_BLOCK_DIM, 0, stream>>>(
-                elementOffset,
-                elementCount,
-                C,
-                N,
-                K,
-                D,
-                shDegreeToUse,
-                means.data_ptr<scalar_t>(),
-                worldToCamMatrices.data_ptr<scalar_t>(),
-                nullptr,
-                nullptr,
-                shNCoeffs.packed_accessor64<scalar_t, 3, torch::RestrictPtrTraits>(),
-                radiiPtr,
-                dLossDRenderQuantities.packed_accessor64<scalar_t, 3, torch::RestrictPtrTraits>(),
-                dLossDSh0Coeffs.packed_accessor64<scalar_t, 3, torch::RestrictPtrTraits>(),
-                dLossDShNCoeffs.packed_accessor64<scalar_t, 3, torch::RestrictPtrTraits>(),
-                computeDLossDMeans ? dLossDMeans.data_ptr<scalar_t>() : nullptr,
-                computeDLossDWorldToCamMatrices ? dLossDViewDirs.data_ptr<scalar_t>() : nullptr);
-            C10_CUDA_KERNEL_LAUNCH_CHECK();
-
-            if (computeDLossDWorldToCamMatrices) {
-                const auto numWorldToCamMatrices = worldToCamMatrices.size(0);
-                reduceUnpackedViewDirectionGradientsToWorldToCamMatrices<SystemAtomicAddOutput,
-                                                                         scalar_t>
-                    <<<numWorldToCamMatrices, DEFAULT_BLOCK_DIM, 0, stream>>>(
-                        N,
-                        elementOffset,
-                        elementCount,
-                        worldToCamMatrices.data_ptr<scalar_t>(),
-                        dLossDViewDirs.data_ptr<scalar_t>(),
-                        dLossDWorldToCamMatrices.data_ptr<scalar_t>());
+                computeShBackward<scalar_t><<<NUM_BLOCKS, DEFAULT_BLOCK_DIM, 0, stream>>>(
+                    elementOffset,
+                    elementCount,
+                    C,
+                    N,
+                    K,
+                    D,
+                    shDegreeToUse,
+                    means.data_ptr<scalar_t>(),
+                    worldToCamMatrices.data_ptr<scalar_t>(),
+                    nullptr,
+                    nullptr,
+                    shNCoeffs.packed_accessor64<scalar_t, 3, torch::RestrictPtrTraits>(),
+                    radiiPtr,
+                    dLossDRenderQuantities
+                        .packed_accessor64<scalar_t, 3, torch::RestrictPtrTraits>(),
+                    dLossDSh0Coeffs.packed_accessor64<scalar_t, 3, torch::RestrictPtrTraits>(),
+                    dLossDShNCoeffs.packed_accessor64<scalar_t, 3, torch::RestrictPtrTraits>(),
+                    computeDLossDMeans ? dLossDMeans.data_ptr<scalar_t>() : nullptr,
+                    computeDLossDWorldToCamMatrices ? dLossDViewDirs.data_ptr<scalar_t>()
+                                                    : nullptr);
                 C10_CUDA_KERNEL_LAUNCH_CHECK();
+
+                if (computeDLossDWorldToCamMatrices) {
+                    const auto numWorldToCamMatrices = worldToCamMatrices.size(0);
+                    reduceUnpackedViewDirectionGradientsToWorldToCamMatrices<SystemAtomicAddOutput,
+                                                                             scalar_t>
+                        <<<numWorldToCamMatrices, DEFAULT_BLOCK_DIM, 0, stream>>>(
+                            N,
+                            elementOffset,
+                            elementCount,
+                            worldToCamMatrices.data_ptr<scalar_t>(),
+                            dLossDViewDirs.data_ptr<scalar_t>(),
+                            dLossDWorldToCamMatrices.data_ptr<scalar_t>());
+                    C10_CUDA_KERNEL_LAUNCH_CHECK();
+                }
             }
         }
         mergeStreams();
@@ -1086,53 +1099,58 @@ dispatchEvaluateSphericalHarmonicsBwd<torch::kPrivateUse1>(
             int64_t elementOffset, elementCount;
             std::tie(elementOffset, elementCount) = deviceChunk(N, deviceId);
 
+            if (elementCount > 0) {
 #if (CUDART_VERSION < 13000)
-            nanovdb::util::cuda::memPrefetchAsync(
-                dLossDSh0Coeffs.data_ptr<scalar_t>() + elementOffset * dLossDSh0Coeffs.stride(0),
-                elementCount * dLossDSh0Coeffs.stride(0) * sizeof(scalar_t),
-                deviceId,
-                stream);
-            for (int cameraIndex = 0; cameraIndex < C; ++cameraIndex) {
-                nanovdb::util::cuda::memPrefetchAsync(
-                    dLossDRenderQuantities.data_ptr<scalar_t>() +
-                        cameraIndex * dLossDRenderQuantities.stride(0) +
-                        elementOffset * dLossDRenderQuantities.stride(1),
-                    elementCount * dLossDRenderQuantities.stride(1) * sizeof(scalar_t),
-                    deviceId,
-                    stream);
-            }
+                nanovdb::util::cuda::memPrefetchAsync(dLossDSh0Coeffs.data_ptr<scalar_t>() +
+                                                          elementOffset * dLossDSh0Coeffs.stride(0),
+                                                      elementCount * dLossDSh0Coeffs.stride(0) *
+                                                          sizeof(scalar_t),
+                                                      deviceId,
+                                                      stream);
+                for (int cameraIndex = 0; cameraIndex < C; ++cameraIndex) {
+                    nanovdb::util::cuda::memPrefetchAsync(
+                        dLossDRenderQuantities.data_ptr<scalar_t>() +
+                            cameraIndex * dLossDRenderQuantities.stride(0) +
+                            elementOffset * dLossDRenderQuantities.stride(1),
+                        elementCount * dLossDRenderQuantities.stride(1) * sizeof(scalar_t),
+                        deviceId,
+                        stream);
+                }
 #else
-            std::vector<void *> prefetchPtrs;
-            std::vector<size_t> prefetchSizes;
-            const cudaMemLocation location                 = {cudaMemLocationTypeDevice, deviceId};
-            std::vector<cudaMemLocation> prefetchLocations = {location};
-            std::vector<size_t> prefetchLocationIndices    = {0};
+                std::vector<void *> prefetchPtrs;
+                std::vector<size_t> prefetchSizes;
+                const cudaMemLocation location = {cudaMemLocationTypeDevice, deviceId};
+                std::vector<cudaMemLocation> prefetchLocations = {location};
+                std::vector<size_t> prefetchLocationIndices    = {0};
 
-            prefetchPtrs.emplace_back(dLossDSh0Coeffs.data_ptr<scalar_t>() +
-                                      elementOffset * dLossDSh0Coeffs.stride(0));
-            prefetchSizes.emplace_back(elementCount * dLossDSh0Coeffs.stride(0) * sizeof(scalar_t));
-            for (int cameraIndex = 0; cameraIndex < C; ++cameraIndex) {
-                prefetchPtrs.emplace_back(dLossDRenderQuantities.data_ptr<scalar_t>() +
-                                          cameraIndex * dLossDRenderQuantities.stride(0) +
-                                          elementOffset * dLossDRenderQuantities.stride(1));
-                prefetchSizes.emplace_back(elementCount * dLossDRenderQuantities.stride(1) *
+                prefetchPtrs.emplace_back(dLossDSh0Coeffs.data_ptr<scalar_t>() +
+                                          elementOffset * dLossDSh0Coeffs.stride(0));
+                prefetchSizes.emplace_back(elementCount * dLossDSh0Coeffs.stride(0) *
                                            sizeof(scalar_t));
-            }
+                for (int cameraIndex = 0; cameraIndex < C; ++cameraIndex) {
+                    prefetchPtrs.emplace_back(dLossDRenderQuantities.data_ptr<scalar_t>() +
+                                              cameraIndex * dLossDRenderQuantities.stride(0) +
+                                              elementOffset * dLossDRenderQuantities.stride(1));
+                    prefetchSizes.emplace_back(elementCount * dLossDRenderQuantities.stride(1) *
+                                               sizeof(scalar_t));
+                }
 
-            C10_CUDA_CHECK(cudaMemPrefetchBatchAsync(prefetchPtrs.data(),
-                                                     prefetchSizes.data(),
-                                                     prefetchPtrs.size(),
-                                                     prefetchLocations.data(),
-                                                     prefetchLocationIndices.data(),
-                                                     prefetchLocations.size(),
-                                                     0,
-                                                     stream));
+                C10_CUDA_CHECK(cudaMemPrefetchBatchAsync(prefetchPtrs.data(),
+                                                         prefetchSizes.data(),
+                                                         prefetchPtrs.size(),
+                                                         prefetchLocations.data(),
+                                                         prefetchLocationIndices.data(),
+                                                         prefetchLocations.size(),
+                                                         0,
+                                                         stream));
 #endif
-            C10_CUDA_CHECK(cudaMemsetAsync(
-                dLossDSh0Coeffs.data_ptr<scalar_t>() + elementOffset * dLossDSh0Coeffs.stride(0),
-                0,
-                elementCount * dLossDSh0Coeffs.stride(0) * sizeof(scalar_t),
-                stream));
+                C10_CUDA_CHECK(
+                    cudaMemsetAsync(dLossDSh0Coeffs.data_ptr<scalar_t>() +
+                                        elementOffset * dLossDSh0Coeffs.stride(0),
+                                    0,
+                                    elementCount * dLossDSh0Coeffs.stride(0) * sizeof(scalar_t),
+                                    stream));
+            }
             C10_CUDA_CHECK(cudaEventRecord(events[deviceId], stream));
         }
 
@@ -1145,18 +1163,22 @@ dispatchEvaluateSphericalHarmonicsBwd<torch::kPrivateUse1>(
             int64_t elementOffset, elementCount;
             std::tie(elementOffset, elementCount) = deviceChunk(N, deviceId);
 
-            const auto NUM_BLOCKS = GET_BLOCKS(C * elementCount * D, DEFAULT_BLOCK_DIM);
+            if (elementCount > 0) {
+                const auto NUM_BLOCKS = GET_BLOCKS(C * elementCount * D, DEFAULT_BLOCK_DIM);
 
-            computeShDiffuseOnlyBackward<scalar_t><<<NUM_BLOCKS, DEFAULT_BLOCK_DIM, 0, stream>>>(
-                elementOffset,
-                elementCount,
-                C,
-                N,
-                D,
-                dLossDRenderQuantities.packed_accessor64<scalar_t, 3, torch::RestrictPtrTraits>(),
-                radiiPtr,
-                dLossDSh0Coeffs.packed_accessor64<scalar_t, 3, torch::RestrictPtrTraits>());
-            C10_CUDA_KERNEL_LAUNCH_CHECK();
+                computeShDiffuseOnlyBackward<scalar_t>
+                    <<<NUM_BLOCKS, DEFAULT_BLOCK_DIM, 0, stream>>>(
+                        elementOffset,
+                        elementCount,
+                        C,
+                        N,
+                        D,
+                        dLossDRenderQuantities
+                            .packed_accessor64<scalar_t, 3, torch::RestrictPtrTraits>(),
+                        radiiPtr,
+                        dLossDSh0Coeffs.packed_accessor64<scalar_t, 3, torch::RestrictPtrTraits>());
+                C10_CUDA_KERNEL_LAUNCH_CHECK();
+            }
         }
         mergeStreams();
 

--- a/src/fvdb/detail/ops/gsplat/EvaluateSphericalHarmonicsForward.cu
+++ b/src/fvdb/detail/ops/gsplat/EvaluateSphericalHarmonicsForward.cu
@@ -472,36 +472,38 @@ dispatchEvaluateSphericalHarmonicsFwd<torch::kPrivateUse1>(const int64_t shDegre
         int64_t elementOffset, elementCount;
         std::tie(elementOffset, elementCount) = deviceChunk(N, deviceId);
 
-        const auto NUM_BLOCKS = GET_BLOCKS(C * elementCount * D, DEFAULT_BLOCK_DIM);
+        if (elementCount > 0) {
+            const auto NUM_BLOCKS = GET_BLOCKS(C * elementCount * D, DEFAULT_BLOCK_DIM);
 
-        if (hasShNCoeffs && shDegreeToUse > 0) {
-            computeSh<scalar_t><<<NUM_BLOCKS, DEFAULT_BLOCK_DIM, 0, stream>>>(
-                elementOffset,
-                elementCount,
-                C,
-                N,
-                D,
-                shDegreeToUse,
-                means.data_ptr<scalar_t>(),
-                worldToCamMatrices.data_ptr<scalar_t>(),
-                nullptr,
-                nullptr,
-                sh0Coeffs.packed_accessor64<scalar_t, 3, torch::RestrictPtrTraits>(),
-                shNCoeffs.packed_accessor64<scalar_t, 3, torch::RestrictPtrTraits>(),
-                radiiPtr,
-                renderQuantities.data_ptr<scalar_t>());
-            C10_CUDA_KERNEL_LAUNCH_CHECK();
-        } else {
-            computeShDiffuseOnly<scalar_t><<<NUM_BLOCKS, DEFAULT_BLOCK_DIM, 0, stream>>>(
-                elementOffset,
-                elementCount,
-                C,
-                N,
-                D,
-                sh0Coeffs.packed_accessor64<scalar_t, 3, torch::RestrictPtrTraits>(),
-                radiiPtr,
-                renderQuantities.data_ptr<scalar_t>());
-            C10_CUDA_KERNEL_LAUNCH_CHECK();
+            if (hasShNCoeffs && shDegreeToUse > 0) {
+                computeSh<scalar_t><<<NUM_BLOCKS, DEFAULT_BLOCK_DIM, 0, stream>>>(
+                    elementOffset,
+                    elementCount,
+                    C,
+                    N,
+                    D,
+                    shDegreeToUse,
+                    means.data_ptr<scalar_t>(),
+                    worldToCamMatrices.data_ptr<scalar_t>(),
+                    nullptr,
+                    nullptr,
+                    sh0Coeffs.packed_accessor64<scalar_t, 3, torch::RestrictPtrTraits>(),
+                    shNCoeffs.packed_accessor64<scalar_t, 3, torch::RestrictPtrTraits>(),
+                    radiiPtr,
+                    renderQuantities.data_ptr<scalar_t>());
+                C10_CUDA_KERNEL_LAUNCH_CHECK();
+            } else {
+                computeShDiffuseOnly<scalar_t><<<NUM_BLOCKS, DEFAULT_BLOCK_DIM, 0, stream>>>(
+                    elementOffset,
+                    elementCount,
+                    C,
+                    N,
+                    D,
+                    sh0Coeffs.packed_accessor64<scalar_t, 3, torch::RestrictPtrTraits>(),
+                    radiiPtr,
+                    renderQuantities.data_ptr<scalar_t>());
+                C10_CUDA_KERNEL_LAUNCH_CHECK();
+            }
         }
     }
 

--- a/src/fvdb/detail/ops/gsplat/ProjectGaussiansAnalyticBackward.cu
+++ b/src/fvdb/detail/ops/gsplat/ProjectGaussiansAnalyticBackward.cu
@@ -467,84 +467,89 @@ dispatchProjectGaussiansAnalyticBwd<torch::kPrivateUse1>(
             int64_t elementOffset, elementCount;
             std::tie(elementOffset, elementCount) = deviceChunk(N, deviceId);
 
+            if (elementCount > 0) {
 #if (CUDART_VERSION < 13000)
-            nanovdb::util::cuda::memPrefetchAsync(
-                dLossDMeans.data_ptr<float>() + elementOffset * dLossDMeans.stride(0),
-                elementCount * dLossDMeans.stride(0) * sizeof(float),
-                deviceId,
-                stream);
-            if (covars.has_value()) {
                 nanovdb::util::cuda::memPrefetchAsync(
-                    dLossDCovars.data_ptr<float>() + elementOffset * dLossDCovars.stride(0),
-                    elementCount * dLossDCovars.stride(0) * sizeof(float),
+                    dLossDMeans.data_ptr<float>() + elementOffset * dLossDMeans.stride(0),
+                    elementCount * dLossDMeans.stride(0) * sizeof(float),
                     deviceId,
                     stream);
-            } else {
-                nanovdb::util::cuda::memPrefetchAsync(
-                    dLossDQuats.data_ptr<float>() + elementOffset * dLossDQuats.stride(0),
-                    elementCount * dLossDQuats.stride(0) * sizeof(float),
-                    deviceId,
-                    stream);
-                nanovdb::util::cuda::memPrefetchAsync(
-                    dLossDScales.data_ptr<float>() + elementOffset * dLossDScales.stride(0),
-                    elementCount * dLossDScales.stride(0) * sizeof(float),
-                    deviceId,
-                    stream);
-            }
+                if (covars.has_value()) {
+                    nanovdb::util::cuda::memPrefetchAsync(
+                        dLossDCovars.data_ptr<float>() + elementOffset * dLossDCovars.stride(0),
+                        elementCount * dLossDCovars.stride(0) * sizeof(float),
+                        deviceId,
+                        stream);
+                } else {
+                    nanovdb::util::cuda::memPrefetchAsync(
+                        dLossDQuats.data_ptr<float>() + elementOffset * dLossDQuats.stride(0),
+                        elementCount * dLossDQuats.stride(0) * sizeof(float),
+                        deviceId,
+                        stream);
+                    nanovdb::util::cuda::memPrefetchAsync(
+                        dLossDScales.data_ptr<float>() + elementOffset * dLossDScales.stride(0),
+                        elementCount * dLossDScales.stride(0) * sizeof(float),
+                        deviceId,
+                        stream);
+                }
 #else
-            std::vector<void *> prefetchPtrs;
-            std::vector<size_t> prefetchSizes;
-            const cudaMemLocation location                 = {cudaMemLocationTypeDevice, deviceId};
-            std::vector<cudaMemLocation> prefetchLocations = {location};
-            std::vector<size_t> prefetchLocationIndices    = {0};
+                std::vector<void *> prefetchPtrs;
+                std::vector<size_t> prefetchSizes;
+                const cudaMemLocation location = {cudaMemLocationTypeDevice, deviceId};
+                std::vector<cudaMemLocation> prefetchLocations = {location};
+                std::vector<size_t> prefetchLocationIndices    = {0};
 
-            prefetchPtrs.emplace_back(dLossDMeans.data_ptr<float>() +
-                                      elementOffset * dLossDMeans.stride(0));
-            prefetchSizes.emplace_back(elementCount * dLossDMeans.stride(0) * sizeof(float));
-            if (covars.has_value()) {
-                prefetchPtrs.emplace_back(dLossDCovars.data_ptr<float>() +
-                                          elementOffset * dLossDCovars.stride(0));
-                prefetchSizes.emplace_back(elementCount * dLossDCovars.stride(0) * sizeof(float));
-            } else {
-                prefetchPtrs.emplace_back(dLossDQuats.data_ptr<float>() +
-                                          elementOffset * dLossDQuats.stride(0));
-                prefetchSizes.emplace_back(elementCount * dLossDQuats.stride(0) * sizeof(float));
-                prefetchPtrs.emplace_back(dLossDScales.data_ptr<float>() +
-                                          elementOffset * dLossDScales.stride(0));
-                prefetchSizes.emplace_back(elementCount * dLossDScales.stride(0) * sizeof(float));
-            }
+                prefetchPtrs.emplace_back(dLossDMeans.data_ptr<float>() +
+                                          elementOffset * dLossDMeans.stride(0));
+                prefetchSizes.emplace_back(elementCount * dLossDMeans.stride(0) * sizeof(float));
+                if (covars.has_value()) {
+                    prefetchPtrs.emplace_back(dLossDCovars.data_ptr<float>() +
+                                              elementOffset * dLossDCovars.stride(0));
+                    prefetchSizes.emplace_back(elementCount * dLossDCovars.stride(0) *
+                                               sizeof(float));
+                } else {
+                    prefetchPtrs.emplace_back(dLossDQuats.data_ptr<float>() +
+                                              elementOffset * dLossDQuats.stride(0));
+                    prefetchSizes.emplace_back(elementCount * dLossDQuats.stride(0) *
+                                               sizeof(float));
+                    prefetchPtrs.emplace_back(dLossDScales.data_ptr<float>() +
+                                              elementOffset * dLossDScales.stride(0));
+                    prefetchSizes.emplace_back(elementCount * dLossDScales.stride(0) *
+                                               sizeof(float));
+                }
 
-            C10_CUDA_CHECK(cudaMemPrefetchBatchAsync(prefetchPtrs.data(),
-                                                     prefetchSizes.data(),
-                                                     prefetchPtrs.size(),
-                                                     prefetchLocations.data(),
-                                                     prefetchLocationIndices.data(),
-                                                     prefetchLocations.size(),
-                                                     0,
-                                                     stream));
+                C10_CUDA_CHECK(cudaMemPrefetchBatchAsync(prefetchPtrs.data(),
+                                                         prefetchSizes.data(),
+                                                         prefetchPtrs.size(),
+                                                         prefetchLocations.data(),
+                                                         prefetchLocationIndices.data(),
+                                                         prefetchLocations.size(),
+                                                         0,
+                                                         stream));
 #endif
-            C10_CUDA_CHECK(cudaMemsetAsync(dLossDMeans.data_ptr<float>() +
-                                               elementOffset * dLossDMeans.stride(0),
-                                           0,
-                                           elementCount * dLossDMeans.stride(0) * sizeof(float),
-                                           stream));
-            if (covars.has_value()) {
-                C10_CUDA_CHECK(cudaMemsetAsync(
-                    dLossDCovars.data_ptr<float>() + elementOffset * dLossDCovars.stride(0),
-                    0,
-                    elementCount * dLossDCovars.stride(0) * sizeof(float),
-                    stream));
-            } else {
-                C10_CUDA_CHECK(cudaMemsetAsync(dLossDQuats.data_ptr<float>() +
-                                                   elementOffset * dLossDQuats.stride(0),
+                C10_CUDA_CHECK(cudaMemsetAsync(dLossDMeans.data_ptr<float>() +
+                                                   elementOffset * dLossDMeans.stride(0),
                                                0,
-                                               elementCount * dLossDQuats.stride(0) * sizeof(float),
+                                               elementCount * dLossDMeans.stride(0) * sizeof(float),
                                                stream));
-                C10_CUDA_CHECK(cudaMemsetAsync(
-                    dLossDScales.data_ptr<float>() + elementOffset * dLossDScales.stride(0),
-                    0,
-                    elementCount * dLossDScales.stride(0) * sizeof(float),
-                    stream));
+                if (covars.has_value()) {
+                    C10_CUDA_CHECK(cudaMemsetAsync(
+                        dLossDCovars.data_ptr<float>() + elementOffset * dLossDCovars.stride(0),
+                        0,
+                        elementCount * dLossDCovars.stride(0) * sizeof(float),
+                        stream));
+                } else {
+                    C10_CUDA_CHECK(cudaMemsetAsync(
+                        dLossDQuats.data_ptr<float>() + elementOffset * dLossDQuats.stride(0),
+                        0,
+                        elementCount * dLossDQuats.stride(0) * sizeof(float),
+                        stream));
+                    C10_CUDA_CHECK(cudaMemsetAsync(
+                        dLossDScales.data_ptr<float>() + elementOffset * dLossDScales.stride(0),
+                        0,
+                        elementCount * dLossDScales.stride(0) * sizeof(float),
+                        stream));
+                }
             }
             C10_CUDA_CHECK(cudaEventRecord(events[deviceId], stream));
         }
@@ -557,102 +562,107 @@ dispatchProjectGaussiansAnalyticBwd<torch::kPrivateUse1>(
 
             int64_t deviceProblemOffset, deviceProblemSize;
             std::tie(deviceProblemOffset, deviceProblemSize) = deviceChunk(N, deviceId);
-            const dim3 NUM_BLOCKS(GET_BLOCKS(deviceProblemSize, DEFAULT_BLOCK_DIM), C);
 
-            if (ortho) {
-                const auto camera = OrthographicCamera<float>{projectionMatrices,
-                                                              worldToCamMatrices,
-                                                              static_cast<int32_t>(imageWidth),
-                                                              static_cast<int32_t>(imageHeight),
-                                                              kBackwardProjectionNearPlane,
-                                                              kBackwardProjectionFarPlane};
-                projectionBackwardKernel<float, OrthographicCamera<float>>
-                    <<<NUM_BLOCKS, DEFAULT_BLOCK_DIM, camera.numSharedMemBytes(), stream>>>(
-                        deviceProblemOffset,
-                        deviceProblemSize,
-                        C,
-                        N,
-                        means.data_ptr<float>(),
-                        covars.has_value() ? covars.value().data_ptr<float>() : nullptr,
-                        covars.has_value() ? nullptr : quats.data_ptr<float>(),
-                        covars.has_value() ? nullptr : logScales.data_ptr<float>(),
-                        camera,
-                        eps2d,
-                        radii.data_ptr<int32_t>(),
-                        conics.data_ptr<float>(),
-                        compensations.has_value() ? compensations.value().data_ptr<float>()
-                                                  : nullptr,
-                        dLossDMeans2d.data_ptr<float>(),
-                        dLossDDepths.data_ptr<float>(),
-                        dLossDConics.data_ptr<float>(),
-                        dLossDCompensations.has_value()
-                            ? dLossDCompensations.value().data_ptr<float>()
-                            : nullptr,
-                        dLossDMeans.data_ptr<float>(),
-                        covars.has_value() ? dLossDCovars.data_ptr<float>() : nullptr,
-                        covars.has_value() ? nullptr : dLossDQuats.data_ptr<float>(),
-                        covars.has_value() ? nullptr : dLossDScales.data_ptr<float>(),
-                        worldToCamMatricesRequiresGrad ? dLossDWorldToCamMatrices.data_ptr<float>()
-                                                       : nullptr,
-                        static_cast<int32_t>(imageWidth),
-                        static_cast<int32_t>(imageHeight),
-                        outNormalizeddLossdMeans2dNormAccum.has_value()
-                            ? outNormalizeddLossdMeans2dNormAccum.value().data_ptr<float>()
-                            : nullptr,
-                        outNormalizedMaxRadiiAccum.has_value()
-                            ? outNormalizedMaxRadiiAccum.value().data_ptr<int32_t>()
-                            : nullptr,
-                        outGradientStepCounts.has_value()
-                            ? outGradientStepCounts.value().data_ptr<int32_t>()
-                            : nullptr);
-            } else {
-                const auto camera = PerspectiveCamera<float>{projectionMatrices,
-                                                             worldToCamMatrices,
-                                                             static_cast<int32_t>(imageWidth),
-                                                             static_cast<int32_t>(imageHeight),
-                                                             kBackwardProjectionNearPlane,
-                                                             kBackwardProjectionFarPlane};
-                projectionBackwardKernel<float, PerspectiveCamera<float>>
-                    <<<NUM_BLOCKS, DEFAULT_BLOCK_DIM, camera.numSharedMemBytes(), stream>>>(
-                        deviceProblemOffset,
-                        deviceProblemSize,
-                        C,
-                        N,
-                        means.data_ptr<float>(),
-                        covars.has_value() ? covars.value().data_ptr<float>() : nullptr,
-                        covars.has_value() ? nullptr : quats.data_ptr<float>(),
-                        covars.has_value() ? nullptr : logScales.data_ptr<float>(),
-                        camera,
-                        eps2d,
-                        radii.data_ptr<int32_t>(),
-                        conics.data_ptr<float>(),
-                        compensations.has_value() ? compensations.value().data_ptr<float>()
-                                                  : nullptr,
-                        dLossDMeans2d.data_ptr<float>(),
-                        dLossDDepths.data_ptr<float>(),
-                        dLossDConics.data_ptr<float>(),
-                        dLossDCompensations.has_value()
-                            ? dLossDCompensations.value().data_ptr<float>()
-                            : nullptr,
-                        dLossDMeans.data_ptr<float>(),
-                        covars.has_value() ? dLossDCovars.data_ptr<float>() : nullptr,
-                        covars.has_value() ? nullptr : dLossDQuats.data_ptr<float>(),
-                        covars.has_value() ? nullptr : dLossDScales.data_ptr<float>(),
-                        worldToCamMatricesRequiresGrad ? dLossDWorldToCamMatrices.data_ptr<float>()
-                                                       : nullptr,
-                        static_cast<int32_t>(imageWidth),
-                        static_cast<int32_t>(imageHeight),
-                        outNormalizeddLossdMeans2dNormAccum.has_value()
-                            ? outNormalizeddLossdMeans2dNormAccum.value().data_ptr<float>()
-                            : nullptr,
-                        outNormalizedMaxRadiiAccum.has_value()
-                            ? outNormalizedMaxRadiiAccum.value().data_ptr<int32_t>()
-                            : nullptr,
-                        outGradientStepCounts.has_value()
-                            ? outGradientStepCounts.value().data_ptr<int32_t>()
-                            : nullptr);
+            if (deviceProblemSize > 0) {
+                const dim3 NUM_BLOCKS(GET_BLOCKS(deviceProblemSize, DEFAULT_BLOCK_DIM), C);
+
+                if (ortho) {
+                    const auto camera = OrthographicCamera<float>{projectionMatrices,
+                                                                  worldToCamMatrices,
+                                                                  static_cast<int32_t>(imageWidth),
+                                                                  static_cast<int32_t>(imageHeight),
+                                                                  kBackwardProjectionNearPlane,
+                                                                  kBackwardProjectionFarPlane};
+                    projectionBackwardKernel<float, OrthographicCamera<float>>
+                        <<<NUM_BLOCKS, DEFAULT_BLOCK_DIM, camera.numSharedMemBytes(), stream>>>(
+                            deviceProblemOffset,
+                            deviceProblemSize,
+                            C,
+                            N,
+                            means.data_ptr<float>(),
+                            covars.has_value() ? covars.value().data_ptr<float>() : nullptr,
+                            covars.has_value() ? nullptr : quats.data_ptr<float>(),
+                            covars.has_value() ? nullptr : logScales.data_ptr<float>(),
+                            camera,
+                            eps2d,
+                            radii.data_ptr<int32_t>(),
+                            conics.data_ptr<float>(),
+                            compensations.has_value() ? compensations.value().data_ptr<float>()
+                                                      : nullptr,
+                            dLossDMeans2d.data_ptr<float>(),
+                            dLossDDepths.data_ptr<float>(),
+                            dLossDConics.data_ptr<float>(),
+                            dLossDCompensations.has_value()
+                                ? dLossDCompensations.value().data_ptr<float>()
+                                : nullptr,
+                            dLossDMeans.data_ptr<float>(),
+                            covars.has_value() ? dLossDCovars.data_ptr<float>() : nullptr,
+                            covars.has_value() ? nullptr : dLossDQuats.data_ptr<float>(),
+                            covars.has_value() ? nullptr : dLossDScales.data_ptr<float>(),
+                            worldToCamMatricesRequiresGrad
+                                ? dLossDWorldToCamMatrices.data_ptr<float>()
+                                : nullptr,
+                            static_cast<int32_t>(imageWidth),
+                            static_cast<int32_t>(imageHeight),
+                            outNormalizeddLossdMeans2dNormAccum.has_value()
+                                ? outNormalizeddLossdMeans2dNormAccum.value().data_ptr<float>()
+                                : nullptr,
+                            outNormalizedMaxRadiiAccum.has_value()
+                                ? outNormalizedMaxRadiiAccum.value().data_ptr<int32_t>()
+                                : nullptr,
+                            outGradientStepCounts.has_value()
+                                ? outGradientStepCounts.value().data_ptr<int32_t>()
+                                : nullptr);
+                } else {
+                    const auto camera = PerspectiveCamera<float>{projectionMatrices,
+                                                                 worldToCamMatrices,
+                                                                 static_cast<int32_t>(imageWidth),
+                                                                 static_cast<int32_t>(imageHeight),
+                                                                 kBackwardProjectionNearPlane,
+                                                                 kBackwardProjectionFarPlane};
+                    projectionBackwardKernel<float, PerspectiveCamera<float>>
+                        <<<NUM_BLOCKS, DEFAULT_BLOCK_DIM, camera.numSharedMemBytes(), stream>>>(
+                            deviceProblemOffset,
+                            deviceProblemSize,
+                            C,
+                            N,
+                            means.data_ptr<float>(),
+                            covars.has_value() ? covars.value().data_ptr<float>() : nullptr,
+                            covars.has_value() ? nullptr : quats.data_ptr<float>(),
+                            covars.has_value() ? nullptr : logScales.data_ptr<float>(),
+                            camera,
+                            eps2d,
+                            radii.data_ptr<int32_t>(),
+                            conics.data_ptr<float>(),
+                            compensations.has_value() ? compensations.value().data_ptr<float>()
+                                                      : nullptr,
+                            dLossDMeans2d.data_ptr<float>(),
+                            dLossDDepths.data_ptr<float>(),
+                            dLossDConics.data_ptr<float>(),
+                            dLossDCompensations.has_value()
+                                ? dLossDCompensations.value().data_ptr<float>()
+                                : nullptr,
+                            dLossDMeans.data_ptr<float>(),
+                            covars.has_value() ? dLossDCovars.data_ptr<float>() : nullptr,
+                            covars.has_value() ? nullptr : dLossDQuats.data_ptr<float>(),
+                            covars.has_value() ? nullptr : dLossDScales.data_ptr<float>(),
+                            worldToCamMatricesRequiresGrad
+                                ? dLossDWorldToCamMatrices.data_ptr<float>()
+                                : nullptr,
+                            static_cast<int32_t>(imageWidth),
+                            static_cast<int32_t>(imageHeight),
+                            outNormalizeddLossdMeans2dNormAccum.has_value()
+                                ? outNormalizeddLossdMeans2dNormAccum.value().data_ptr<float>()
+                                : nullptr,
+                            outNormalizedMaxRadiiAccum.has_value()
+                                ? outNormalizedMaxRadiiAccum.value().data_ptr<int32_t>()
+                                : nullptr,
+                            outGradientStepCounts.has_value()
+                                ? outGradientStepCounts.value().data_ptr<int32_t>()
+                                : nullptr);
+                }
+                C10_CUDA_KERNEL_LAUNCH_CHECK();
             }
-            C10_CUDA_KERNEL_LAUNCH_CHECK();
         }
 
         mergeStreams();

--- a/src/fvdb/detail/ops/gsplat/ProjectGaussiansAnalyticForward.cu
+++ b/src/fvdb/detail/ops/gsplat/ProjectGaussiansAnalyticForward.cu
@@ -349,56 +349,58 @@ dispatchProjectGaussiansAnalyticFwd<torch::kPrivateUse1>(
         int64_t deviceProblemOffset, deviceProblemSize;
         std::tie(deviceProblemOffset, deviceProblemSize) = deviceChunk(N, deviceId);
 
-        const dim3 NUM_BLOCKS(GET_BLOCKS(deviceProblemSize, DEFAULT_BLOCK_DIM), C);
+        if (deviceProblemSize > 0) {
+            const dim3 NUM_BLOCKS(GET_BLOCKS(deviceProblemSize, DEFAULT_BLOCK_DIM), C);
 
-        if (ortho) {
-            const auto camera = OrthographicCamera<scalar_t>{projectionMatrices,
-                                                             worldToCamMatrices,
-                                                             static_cast<int32_t>(imageWidth),
-                                                             static_cast<int32_t>(imageHeight),
-                                                             nearPlane,
-                                                             farPlane};
-            ProjectionForward<scalar_t, OrthographicCamera<scalar_t>> projectionForward(
-                camera,
-                eps2d,
-                radiusClip,
-                calcCompensations,
-                means,
-                quats,
-                logScales,
-                outRadii,
-                outMeans2d,
-                outDepths,
-                outConics,
-                outCompensations);
-            projectionForwardKernel<scalar_t, OrthographicCamera<scalar_t>>
-                <<<NUM_BLOCKS, DEFAULT_BLOCK_DIM, camera.numSharedMemBytes(), stream>>>(
-                    deviceProblemOffset, deviceProblemSize, projectionForward);
-            C10_CUDA_KERNEL_LAUNCH_CHECK();
-        } else {
-            const auto camera = PerspectiveCamera<scalar_t>{projectionMatrices,
-                                                            worldToCamMatrices,
-                                                            static_cast<int32_t>(imageWidth),
-                                                            static_cast<int32_t>(imageHeight),
-                                                            nearPlane,
-                                                            farPlane};
-            ProjectionForward<scalar_t, PerspectiveCamera<scalar_t>> projectionForward(
-                camera,
-                eps2d,
-                radiusClip,
-                calcCompensations,
-                means,
-                quats,
-                logScales,
-                outRadii,
-                outMeans2d,
-                outDepths,
-                outConics,
-                outCompensations);
-            projectionForwardKernel<scalar_t, PerspectiveCamera<scalar_t>>
-                <<<NUM_BLOCKS, DEFAULT_BLOCK_DIM, camera.numSharedMemBytes(), stream>>>(
-                    deviceProblemOffset, deviceProblemSize, projectionForward);
-            C10_CUDA_KERNEL_LAUNCH_CHECK();
+            if (ortho) {
+                const auto camera = OrthographicCamera<scalar_t>{projectionMatrices,
+                                                                 worldToCamMatrices,
+                                                                 static_cast<int32_t>(imageWidth),
+                                                                 static_cast<int32_t>(imageHeight),
+                                                                 nearPlane,
+                                                                 farPlane};
+                ProjectionForward<scalar_t, OrthographicCamera<scalar_t>> projectionForward(
+                    camera,
+                    eps2d,
+                    radiusClip,
+                    calcCompensations,
+                    means,
+                    quats,
+                    logScales,
+                    outRadii,
+                    outMeans2d,
+                    outDepths,
+                    outConics,
+                    outCompensations);
+                projectionForwardKernel<scalar_t, OrthographicCamera<scalar_t>>
+                    <<<NUM_BLOCKS, DEFAULT_BLOCK_DIM, camera.numSharedMemBytes(), stream>>>(
+                        deviceProblemOffset, deviceProblemSize, projectionForward);
+                C10_CUDA_KERNEL_LAUNCH_CHECK();
+            } else {
+                const auto camera = PerspectiveCamera<scalar_t>{projectionMatrices,
+                                                                worldToCamMatrices,
+                                                                static_cast<int32_t>(imageWidth),
+                                                                static_cast<int32_t>(imageHeight),
+                                                                nearPlane,
+                                                                farPlane};
+                ProjectionForward<scalar_t, PerspectiveCamera<scalar_t>> projectionForward(
+                    camera,
+                    eps2d,
+                    radiusClip,
+                    calcCompensations,
+                    means,
+                    quats,
+                    logScales,
+                    outRadii,
+                    outMeans2d,
+                    outDepths,
+                    outConics,
+                    outCompensations);
+                projectionForwardKernel<scalar_t, PerspectiveCamera<scalar_t>>
+                    <<<NUM_BLOCKS, DEFAULT_BLOCK_DIM, camera.numSharedMemBytes(), stream>>>(
+                        deviceProblemOffset, deviceProblemSize, projectionForward);
+                C10_CUDA_KERNEL_LAUNCH_CHECK();
+            }
         }
     }
 


### PR DESCRIPTION
If the number of Gaussians is less than the number of GPUs, then some GPUs will process a chunk of zero Gaussians which leads to a invalid block size and prefetch size of zero. This PR adds the missing `elementCount > 0` and `deviceProblemSize > 0` checks.