### PR TITLE
Add TSDF / ESDF / Occupancy / Decay APIs and a fast marching-cubes variant (on upstream memory-resource seams)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,6 +139,7 @@ set(FVDB_BINDINGS_CPP_FILES
     src/python/GridBatchDataBinding.cpp
     src/python/GridBatchOps.cpp
     src/python/JaggedTensorBinding.cpp
+    src/python/PersistentTSDFStateBinding.cpp
     src/python/ViewerBinding.cpp)
 
 # Build library

--- a/fvdb/functional/__init__.py
+++ b/fvdb/functional/__init__.py
@@ -10,51 +10,6 @@ Every operation has two variants:
 - ``*_single`` -- operates on :class:`~fvdb.Grid` with plain ``torch.Tensor``.
 """
 
-# Grid constructors (batch)
-from ._constructors import (
-    concatenate_grids,
-    gridbatch_from_dense,
-    gridbatch_from_dense_axis_aligned_bounds,
-    gridbatch_from_ijk,
-    gridbatch_from_mesh,
-    gridbatch_from_nearest_voxels_to_points,
-    gridbatch_from_points,
-    gridbatch_from_zero_grids,
-    gridbatch_from_zero_voxels,
-)
-
-# isort: split
-
-# Grid constructors (single)
-from ._constructors import (
-    grid_from_dense,
-    grid_from_dense_axis_aligned_bounds,
-    grid_from_ijk,
-    grid_from_mesh,
-    grid_from_nearest_voxels_to_points,
-    grid_from_points,
-    grid_from_zero_voxels,
-)
-
-# Dense <-> sparse I/O and grid-to-grid injection
-from ._dense import (
-    inject_batch,
-    inject_from_dense_cmajor_batch,
-    inject_from_dense_cmajor_single,
-    inject_from_dense_cminor_batch,
-    inject_from_dense_cminor_single,
-    inject_from_ijk_batch,
-    inject_from_ijk_single,
-    inject_single,
-    inject_to_dense_cmajor_batch,
-    inject_to_dense_cmajor_single,
-    inject_to_dense_cminor_batch,
-    inject_to_dense_cminor_single,
-)
-
-# Grid indexing
-from ._indexing import index_grid_batch
-
 # Interpolation / splatting
 from ._interpolation import (
     sample_bezier_batch,
@@ -73,24 +28,12 @@ from ._interpolation import (
     splat_trilinear_single,
 )
 
-# I/O
-from ._io import (
-    grid_names_in_nanovdb,
-    load_nanovdb,
-    load_nanovdb_single,
-    read_nanovdb_metadata,
-    save_nanovdb,
-    save_nanovdb_single,
-)
-
-# Meshing / TSDF
-from ._meshing import (
-    integrate_tsdf_batch,
-    integrate_tsdf_single,
-    integrate_tsdf_with_features_batch,
-    integrate_tsdf_with_features_single,
-    marching_cubes_batch,
-    marching_cubes_single,
+# Coordinate transforms
+from ._transforms import (
+    voxel_to_world_batch,
+    voxel_to_world_single,
+    world_to_voxel_batch,
+    world_to_voxel_single,
 )
 
 # Signed distance fields
@@ -109,6 +52,22 @@ from ._pooling import (
     max_pool_single,
     refine_batch,
     refine_single,
+)
+
+# Dense <-> sparse I/O and grid-to-grid injection
+from ._dense import (
+    inject_batch,
+    inject_from_dense_cmajor_batch,
+    inject_from_dense_cmajor_single,
+    inject_from_dense_cminor_batch,
+    inject_from_dense_cminor_single,
+    inject_from_ijk_batch,
+    inject_from_ijk_single,
+    inject_single,
+    inject_to_dense_cmajor_batch,
+    inject_to_dense_cmajor_single,
+    inject_to_dense_cminor_batch,
+    inject_to_dense_cminor_single,
 )
 
 # Spatial queries
@@ -145,6 +104,27 @@ from ._ray import (
     voxels_along_rays_single,
 )
 
+# Meshing / TSDF
+from ._meshing import (
+    compute_esdf_incremental_single,
+    compute_esdf_single,
+    integrate_occupancy_from_points_frames_single,
+    integrate_occupancy_from_points_single,
+    integrate_tsdf_batch,
+    integrate_tsdf_frames_single,
+    integrate_tsdf_frames_with_features_single,
+    integrate_tsdf_from_points_batch,
+    integrate_tsdf_from_points_frames_single,
+    integrate_tsdf_from_points_single,
+    integrate_tsdf_from_points_with_features_batch,
+    integrate_tsdf_from_points_with_features_single,
+    integrate_tsdf_single,
+    integrate_tsdf_with_features_batch,
+    integrate_tsdf_with_features_single,
+    marching_cubes_batch,
+    marching_cubes_single,
+)
+
 # Grid topology
 from ._topology import (
     clip_batch,
@@ -163,6 +143,7 @@ from ._topology import (
     conv_transpose_grid_single,
     dilated_grid_batch,
     dilated_grid_single,
+    dirty_mask_from_sidecars_single,
     dual_grid_batch,
     dual_grid_single,
     edge_network_batch,
@@ -183,12 +164,41 @@ from ._topology import (
     refined_grid_single,
 )
 
-# Coordinate transforms
-from ._transforms import (
-    voxel_to_world_batch,
-    voxel_to_world_single,
-    world_to_voxel_batch,
-    world_to_voxel_single,
+# Grid indexing
+from ._indexing import index_grid_batch
+
+# Grid constructors (batch)
+from ._constructors import (
+    concatenate_grids,
+    gridbatch_from_dense,
+    gridbatch_from_dense_axis_aligned_bounds,
+    gridbatch_from_ijk,
+    gridbatch_from_mesh,
+    gridbatch_from_nearest_voxels_to_points,
+    gridbatch_from_points,
+    gridbatch_from_zero_grids,
+    gridbatch_from_zero_voxels,
+)
+
+# Grid constructors (single)
+from ._constructors import (
+    grid_from_dense,
+    grid_from_dense_axis_aligned_bounds,
+    grid_from_ijk,
+    grid_from_mesh,
+    grid_from_nearest_voxels_to_points,
+    grid_from_points,
+    grid_from_zero_voxels,
+)
+
+# I/O
+from ._io import (
+    grid_names_in_nanovdb,
+    load_nanovdb,
+    load_nanovdb_single,
+    read_nanovdb_metadata,
+    save_nanovdb,
+    save_nanovdb_single,
 )
 
 __all__ = [
@@ -262,9 +272,20 @@ __all__ = [
     "ray_implicit_intersection_batch",
     "ray_implicit_intersection_single",
     # Meshing
+    "compute_esdf_incremental_single",
+    "compute_esdf_single",
+    "integrate_occupancy_from_points_frames_single",
+    "integrate_occupancy_from_points_single",
     "marching_cubes_batch",
     "marching_cubes_single",
     "integrate_tsdf_batch",
+    "integrate_tsdf_frames_single",
+    "integrate_tsdf_frames_with_features_single",
+    "integrate_tsdf_from_points_batch",
+    "integrate_tsdf_from_points_frames_single",
+    "integrate_tsdf_from_points_single",
+    "integrate_tsdf_from_points_with_features_batch",
+    "integrate_tsdf_from_points_with_features_single",
     "integrate_tsdf_single",
     "integrate_tsdf_with_features_batch",
     "integrate_tsdf_with_features_single",
@@ -290,6 +311,7 @@ __all__ = [
     "dual_grid_single",
     "dilated_grid_batch",
     "dilated_grid_single",
+    "dirty_mask_from_sidecars_single",
     "merged_grid_batch",
     "merged_grid_single",
     "pruned_grid_batch",

--- a/fvdb/functional/_meshing.py
+++ b/fvdb/functional/_meshing.py
@@ -281,3 +281,626 @@ def integrate_tsdf_with_features_single(
         weight_images,
     )
     return G(data=rg), rt.jdata, rw.jdata, rf.jdata
+
+
+def integrate_tsdf_frames_single(
+    grid: Grid,
+    truncation_distance: float,
+    projection_matrices: torch.Tensor,
+    cam_to_world_matrices: torch.Tensor,
+    tsdf: torch.Tensor,
+    weights: torch.Tensor,
+    depth_images: torch.Tensor,
+    weight_images: torch.Tensor | None = None,
+) -> tuple[Grid, torch.Tensor, torch.Tensor]:
+    """Integrate N depth frames into a single :class:`Grid` with one-shot topology.
+
+    Semantically equivalent to calling :func:`integrate_tsdf_single` N
+    times in sequence (verified bit-identically by
+    ``test_integrate_tsdf_frames_matches_sequential``), but builds the
+    union topology over all N frames ONCE up-front — avoiding the
+    per-frame ``buildPointTruncationShell + mergeGrids`` cost that
+    dominates per-frame wall-clock on small scenes.
+
+    This is the fvdb analog of Open3D's lazy block-hashed allocation:
+    "all frames known up-front, topology built once, fusion runs at
+    fixed topology". For bulk / offline reality-capture reconstruction
+    this is typically 3-5x faster than a per-frame loop.
+
+    The N dimension is carried on ``depth_images.size(0)``. All per-frame
+    tensors (``projection_matrices``, ``cam_to_world_matrices``,
+    ``depth_images``, ``weight_images`` if given) must share that
+    leading dimension.
+
+    Args:
+        grid (Grid): Single-scene grid with initial TSDF topology.
+        truncation_distance (float): TSDF truncation distance.
+        projection_matrices (torch.Tensor): ``[N, 3, 3]`` per-frame intrinsics.
+        cam_to_world_matrices (torch.Tensor): ``[N, 4, 4]`` per-frame poses.
+        tsdf (torch.Tensor): Current TSDF values on ``grid``.
+        weights (torch.Tensor): Current integration weights on ``grid``.
+        depth_images (torch.Tensor): ``[N, H, W]`` or ``[N, H, W, 1]`` depth.
+        weight_images (torch.Tensor | None): Optional ``[N, H, W]`` per-pixel weights.
+
+    Returns:
+        updated_grid (Grid): Union of ``grid`` and the truncation shell of all N frames.
+        updated_tsdf (torch.Tensor): TSDF after integrating all N frames.
+        updated_weights (torch.Tensor): Weights after integrating all N frames.
+
+    .. seealso:: :func:`integrate_tsdf_frames_with_features_single`
+    """
+    from ..grid import Grid as G
+
+    grid_data = grid.data
+    tsdf_jt = JaggedTensor(tsdf)
+    weights_jt = JaggedTensor(weights)
+    rg, rt, rw = _fvdb_cpp.integrate_tsdf_batch(
+        grid_data,
+        truncation_distance,
+        projection_matrices,
+        cam_to_world_matrices,
+        tsdf_jt._impl,
+        weights_jt._impl,
+        depth_images,
+        weight_images,
+    )
+    return G(data=rg), rt.jdata, rw.jdata
+
+
+def integrate_tsdf_frames_with_features_single(
+    grid: Grid,
+    truncation_distance: float,
+    projection_matrices: torch.Tensor,
+    cam_to_world_matrices: torch.Tensor,
+    tsdf: torch.Tensor,
+    features: torch.Tensor,
+    weights: torch.Tensor,
+    depth_images: torch.Tensor,
+    feature_images: torch.Tensor,
+    weight_images: torch.Tensor | None = None,
+) -> tuple[Grid, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """N-frame batched integration with per-voxel features (e.g. RGB) for a :class:`Grid`.
+
+    See :func:`integrate_tsdf_frames_single` for the core semantics.
+    Feature dtype must match ``tsdf.dtype`` or be ``uint8``.
+    """
+    from ..grid import Grid as G
+
+    grid_data = grid.data
+    tsdf_jt = JaggedTensor(tsdf)
+    weights_jt = JaggedTensor(weights)
+    features_jt = JaggedTensor(features)
+    rg, rt, rw, rf = _fvdb_cpp.integrate_tsdf_batch_with_features(
+        grid_data,
+        truncation_distance,
+        projection_matrices,
+        cam_to_world_matrices,
+        tsdf_jt._impl,
+        features_jt._impl,
+        weights_jt._impl,
+        depth_images,
+        feature_images,
+        weight_images,
+    )
+    return G(data=rg), rt.jdata, rw.jdata, rf.jdata
+
+
+def integrate_tsdf_from_points_batch(
+    grid: GridBatch,
+    truncation_distance: float,
+    points: JaggedTensor,
+    sensor_origins: torch.Tensor,
+    tsdf: JaggedTensor,
+    weights: JaggedTensor,
+    carve_free_space: bool = True,
+) -> tuple[GridBatch, JaggedTensor, JaggedTensor]:
+    """Integrate LiDAR / point-cloud sweeps into a TSDF volume for a grid batch.
+
+    Each point is treated as a ray from ``sensor_origins[b]`` to the point
+    endpoint; active voxels along the ray within the truncation band (and
+    optionally the free-space band) are updated via weighted average. No
+    range-image proxy is used — this is a native sparse ray-walk.
+
+    Args:
+        grid (GridBatch): The grid batch defining the TSDF topology.
+        truncation_distance (float): TSDF truncation distance.
+        points (JaggedTensor): Per-batch LiDAR points, shape ``[B, N_i, 3]``.
+        sensor_origins (torch.Tensor): ``[B, 3]`` per-batch sensor origin.
+        tsdf (JaggedTensor): Current TSDF values.
+        weights (JaggedTensor): Current integration weights.
+        carve_free_space (bool): If ``True``, voxels observed as free space
+            (in front of the endpoint, outside the truncation band) are
+            written ``tsdf = +1``. Matches VDBFusion / nvblox default.
+
+    Returns:
+        updated_grid (GridBatch): The updated grid batch (union of input
+            topology and the new point truncation shell).
+        updated_tsdf (JaggedTensor): Updated TSDF values.
+        updated_weights (JaggedTensor): Updated integration weights.
+
+    .. seealso:: :func:`integrate_tsdf_from_points_single`
+    """
+    from ..grid_batch import GridBatch as GB
+
+    grid_data = grid.data
+    rg, rt, rw = _fvdb_cpp.integrate_tsdf_from_points(
+        grid_data,
+        truncation_distance,
+        points._impl,
+        sensor_origins,
+        tsdf._impl,
+        weights._impl,
+        carve_free_space,
+    )
+    return GB(data=rg), JaggedTensor(impl=rt), JaggedTensor(impl=rw)
+
+
+def integrate_tsdf_from_points_single(
+    grid: Grid,
+    truncation_distance: float,
+    points: torch.Tensor,
+    sensor_origin: torch.Tensor,
+    tsdf: torch.Tensor,
+    weights: torch.Tensor,
+    carve_free_space: bool = True,
+) -> tuple[Grid, torch.Tensor, torch.Tensor]:
+    """Integrate a single LiDAR / point-cloud sweep into a TSDF volume.
+
+    See :func:`integrate_tsdf_from_points_batch` for semantics.
+
+    Args:
+        grid (Grid): The single grid defining the TSDF topology.
+        truncation_distance (float): TSDF truncation distance.
+        points (torch.Tensor): ``[N, 3]`` world-space point cloud.
+        sensor_origin (torch.Tensor): ``[3]`` world-space sensor origin.
+        tsdf (torch.Tensor): Current TSDF values.
+        weights (torch.Tensor): Current integration weights.
+        carve_free_space (bool): If ``True``, voxels observed as free
+            space are written ``tsdf = +1``.
+
+    Returns:
+        updated_grid (Grid): The updated grid.
+        updated_tsdf (torch.Tensor): Updated TSDF values.
+        updated_weights (torch.Tensor): Updated integration weights.
+
+    .. seealso:: :func:`integrate_tsdf_from_points_batch`
+    """
+    from ..grid import Grid as G
+
+    grid_data = grid.data
+    points_jt = JaggedTensor(points)
+    tsdf_jt = JaggedTensor(tsdf)
+    weights_jt = JaggedTensor(weights)
+    rg, rt, rw = _fvdb_cpp.integrate_tsdf_from_points(
+        grid_data,
+        truncation_distance,
+        points_jt._impl,
+        sensor_origin.unsqueeze(0) if sensor_origin.dim() == 1 else sensor_origin,
+        tsdf_jt._impl,
+        weights_jt._impl,
+        carve_free_space,
+    )
+    return G(data=rg), rt.jdata, rw.jdata
+
+
+def integrate_tsdf_from_points_frames_single(
+    grid: Grid,
+    truncation_distance: float,
+    points_per_frame: list[torch.Tensor],
+    sensor_origins: torch.Tensor,
+    tsdf: torch.Tensor,
+    weights: torch.Tensor,
+    carve_free_space: bool = True,
+) -> tuple[Grid, torch.Tensor, torch.Tensor]:
+    """Integrate N LiDAR sweeps into a persistent TSDF volume in one C++ call.
+
+    Semantically equivalent to:
+
+    .. code-block:: python
+
+        for i in range(N):
+            grid, tsdf, weights = grid.integrate_tsdf_from_points(
+                truncation_distance, points_per_frame[i],
+                sensor_origins[i], tsdf, weights,
+                carve_free_space=carve_free_space,
+            )
+        return grid, tsdf, weights
+
+    but runs the whole loop inside C++ to eliminate the per-frame
+    Python <-> C++ dispatch + JaggedTensor-rewrap overhead. Measured
+    2-3x speedup on Mai City seq00 (700 frames @ 20 cm voxels,
+    ~130 K pts/sweep) vs the Python-for-loop baseline.
+
+    The output is bit-identical to the sequential reference:
+    `test_integrate_tsdf_from_points_frames_matches_sequential`
+    pins this with ``atol=rtol=0``.
+
+    Args:
+        grid (Grid): Initial grid (may be empty / seed).
+        truncation_distance (float): TSDF truncation distance.
+        points_per_frame (list[torch.Tensor]): Length-N list; each
+            entry is ``[N_i, 3]`` world-frame points.
+        sensor_origins (torch.Tensor): ``[N, 3]`` per-frame sensor
+            origins in world frame.
+        tsdf (torch.Tensor): ``[num_voxels]`` current TSDF values.
+        weights (torch.Tensor): ``[num_voxels]`` current integration
+            weights.
+        carve_free_space (bool): Same semantics as the single-frame
+            ``integrate_tsdf_from_points``.
+
+    Returns:
+        (updated_grid, updated_tsdf, updated_weights).
+    """
+    from ..grid import Grid as G
+
+    grid_data = grid.data
+    tsdf_jt = JaggedTensor(tsdf)
+    weights_jt = JaggedTensor(weights)
+    rg, rt, rw = _fvdb_cpp.integrate_tsdf_from_points_frames(
+        grid_data,
+        truncation_distance,
+        list(points_per_frame),
+        sensor_origins,
+        tsdf_jt._impl,
+        weights_jt._impl,
+        carve_free_space,
+    )
+    return G(data=rg), rt.jdata, rw.jdata
+
+
+def integrate_tsdf_from_points_with_features_batch(
+    grid: GridBatch,
+    truncation_distance: float,
+    points: JaggedTensor,
+    sensor_origins: torch.Tensor,
+    tsdf: JaggedTensor,
+    features: JaggedTensor,
+    weights: JaggedTensor,
+    point_features: JaggedTensor,
+    carve_free_space: bool = True,
+) -> tuple[GridBatch, JaggedTensor, JaggedTensor, JaggedTensor]:
+    """Integrate point clouds with per-point features into a TSDF volume for a grid batch.
+
+    Features are blended into per-voxel features with the same weighted-
+    average formula used by :func:`integrate_tsdf_with_features_batch`.
+    Feature dtype must match ``tsdf.dtype`` or be ``uint8`` (for RGB).
+
+    .. seealso:: :func:`integrate_tsdf_from_points_with_features_single`
+    """
+    from ..grid_batch import GridBatch as GB
+
+    grid_data = grid.data
+    rg, rt, rw, rf = _fvdb_cpp.integrate_tsdf_from_points_with_features(
+        grid_data,
+        truncation_distance,
+        points._impl,
+        sensor_origins,
+        tsdf._impl,
+        features._impl,
+        weights._impl,
+        point_features._impl,
+        carve_free_space,
+    )
+    return GB(data=rg), JaggedTensor(impl=rt), JaggedTensor(impl=rw), JaggedTensor(impl=rf)
+
+
+def integrate_occupancy_from_points_single(
+    grid: Grid,
+    truncation_distance: float,
+    points: torch.Tensor,
+    sensor_origin: torch.Tensor,
+    log_odds: torch.Tensor,
+    log_odds_hit: float = 0.85,
+    log_odds_miss: float = -0.40,
+    log_odds_min: float = -4.0,
+    log_odds_max: float = 4.0,
+) -> tuple[Grid, torch.Tensor]:
+    """Integrate a single LiDAR / point-cloud sweep into a Bayesian
+    log-odds occupancy volume.
+
+    Sister primitive to :func:`integrate_tsdf_from_points_single`:
+    same shell allocator, same HDDA ray-walk, but writes log-odds
+    increments (``+log_odds_hit`` for near-endpoint voxels,
+    ``log_odds_miss`` for sensor-side voxels in the walk band) and
+    clamps the accumulated value to ``[log_odds_min, log_odds_max]``.
+
+    The stored sidecar IS the log-odds. To recover probability on
+    the host: ``p = torch.sigmoid(log_odds)``.
+
+    Defaults match nvblox's `ProjectiveIntegratorType.OCCUPANCY`
+    defaults (hit +0.85, miss -0.40, clamp [-4, +4]).
+
+    Args:
+        grid: Input grid (topology grows via the point-shell union).
+        truncation_distance: Width of the hit band around each point
+            endpoint, and the shell-allocator dilation distance.
+        points: ``[N, 3]`` world-frame point cloud.
+        sensor_origin: ``[3]`` or ``[1, 3]`` world-frame sensor origin.
+        log_odds: ``[num_voxels]`` current log-odds sidecar.
+        log_odds_hit: Increment per hit observation.
+        log_odds_miss: Increment per miss observation (negative).
+        log_odds_min: Lower clamp bound.
+        log_odds_max: Upper clamp bound.
+
+    Returns:
+        updated_grid: Union of ``grid`` and the new point shell.
+        updated_log_odds: Log-odds sidecar on the updated grid.
+    """
+    from ..grid import Grid as G
+
+    grid_data = grid.data
+    points_jt = JaggedTensor(points)
+    log_odds_jt = JaggedTensor(log_odds)
+    rg, rlo = _fvdb_cpp.integrate_occupancy_from_points(
+        grid_data,
+        float(truncation_distance),
+        points_jt._impl,
+        sensor_origin.unsqueeze(0) if sensor_origin.dim() == 1 else sensor_origin,
+        log_odds_jt._impl,
+        float(log_odds_hit),
+        float(log_odds_miss),
+        float(log_odds_min),
+        float(log_odds_max),
+    )
+    return G(data=rg), rlo.jdata
+
+
+def integrate_occupancy_from_points_frames_single(
+    grid: Grid,
+    truncation_distance: float,
+    points_per_frame: list[torch.Tensor],
+    sensor_origins: torch.Tensor,
+    log_odds: torch.Tensor,
+    log_odds_hit: float = 0.85,
+    log_odds_miss: float = -0.40,
+    log_odds_min: float = -4.0,
+    log_odds_max: float = 4.0,
+) -> tuple[Grid, torch.Tensor]:
+    """Integrate N LiDAR sweeps into a persistent log-odds occupancy
+    volume in one C++ call.
+
+    Semantically equivalent to calling
+    :func:`integrate_occupancy_from_points_single` N times in
+    sequence, but amortises the per-frame Python <-> C++ dispatch
+    overhead. Mirrors the `integrate_tsdf_from_points_frames`
+    batched API one-for-one.
+
+    See :func:`integrate_occupancy_from_points_single` for argument
+    semantics and default values.
+    """
+    from ..grid import Grid as G
+
+    grid_data = grid.data
+    log_odds_jt = JaggedTensor(log_odds)
+    rg, rlo = _fvdb_cpp.integrate_occupancy_from_points_frames(
+        grid_data,
+        float(truncation_distance),
+        list(points_per_frame),
+        sensor_origins,
+        log_odds_jt._impl,
+        float(log_odds_hit),
+        float(log_odds_miss),
+        float(log_odds_min),
+        float(log_odds_max),
+    )
+    return G(data=rg), rlo.jdata
+
+
+def compute_esdf_single(
+    grid: Grid,
+    tsdf: torch.Tensor,
+    weights: torch.Tensor,
+    truncation_distance: float,
+    max_distance: float,
+    weight_threshold: float = 1.0e-6,
+    prune_unreached: bool = False,
+    use_vbm: bool = True,
+) -> tuple[Grid, torch.Tensor]:
+    """Compute a Euclidean Signed Distance Field (ESDF) from an integrated TSDF.
+
+    Extends the narrow-band signed distances stored in ``tsdf`` outward
+    (and inward) across a wider support band, producing per-voxel world-
+    unit signed distances with ``|d| <= max_distance``. The returned
+    :class:`Grid` is the input topology dilated by
+    ``ceil(max_distance / voxel_size) + 1`` voxels (unless
+    ``prune_unreached=True``, in which case the unreached frontier is
+    dropped).
+
+    This is the **second application** of the nanoVDB topology-op
+    vocabulary in this campaign (the first being depth/LiDAR TSDF). The
+    algorithm composes three primitives:
+
+    * :meth:`Grid.dilated_grid` — allocates the ESDF support band.
+    * A custom VBM-stencil kernel (26-neighbour monotone min) — does
+      the wavefront propagation.
+    * :meth:`Grid.pruned_grid` — optional, drops unreached voxels.
+
+    Scope: float32 CUDA + single grid only.
+
+    TSDF convention: the ``tsdf`` tensor is assumed to follow fvdb's
+    ``integrate_tsdf`` convention of ``tsdf = clip(d_world / T, -1, +1)``
+    where ``T = truncation_distance``. The returned ESDF is in world
+    units (i.e., the same units as ``truncation_distance`` and
+    ``max_distance``).
+
+    Args:
+        grid: Input TSDF grid topology.
+        tsdf: ``[num_voxels]`` fp32 normalized TSDF in ``[-1, +1]``.
+        weights: ``[num_voxels]`` fp32 integration weights.
+        truncation_distance: TSDF truncation margin in world units.
+        max_distance: ESDF support radius in world units.
+        weight_threshold: Voxels with ``weights <= threshold`` are not
+            used as wavefront sources. Default ``1e-6``.
+        prune_unreached: If ``True``, drop voxels the wavefront never
+            reached (still at distance ``max_distance`` sentinel).
+            Default ``False``: return the full dilated support with
+            unreached voxels clamped to ``max_distance``.
+        use_vbm: Use :class:`VoxelBlockManager`-based sweep kernel (the
+            default) versus per-leaf-slot iteration (ablation). Output
+            is bit-identical.
+
+    Returns:
+        esdf_grid: New :class:`Grid` for the ESDF support band.
+        esdf: ``[esdf_grid.num_voxels]`` fp32 world-unit signed distance.
+    """
+    from ..grid import Grid as G
+
+    grid_data = grid.data
+    out_grid, out_esdf = _fvdb_cpp.compute_esdf(
+        grid_data,
+        tsdf,
+        weights,
+        float(truncation_distance),
+        float(max_distance),
+        float(weight_threshold),
+        bool(prune_unreached),
+        bool(use_vbm),
+    )
+    return G(data=out_grid), out_esdf
+
+
+def compute_esdf_incremental_single(
+    grid: Grid,
+    tsdf: torch.Tensor,
+    weights: torch.Tensor,
+    prev_esdf_grid: Grid,
+    prev_esdf: torch.Tensor,
+    truncation_distance: float,
+    max_distance: float,
+    weight_threshold: float = 1.0e-6,
+    prune_unreached: bool = False,
+    use_vbm: bool = True,
+    dirty_mask: torch.Tensor | None = None,
+) -> tuple[Grid, torch.Tensor]:
+    """Monotone-incremental ESDF: warm-start from a previous ESDF.
+
+    Same algorithm as :func:`compute_esdf_single` but takes a
+    ``(prev_esdf_grid, prev_esdf)`` pair that was returned from a
+    previous call (either this function or :func:`compute_esdf_single`).
+    The resulting grid is the merge of ``dilate(grid, K) ∪ prev_esdf_grid``,
+    so voxels that were in the previous support band but not in the
+    current support band are preserved. Previous ESDF values are
+    injected into the new sidecar before the wavefront sweep, giving
+    the monotone-min kernel a warm start.
+
+    **Monotone-only assumption**: this function is correct when distances
+    can only decrease between frames (new surfaces added; existing
+    surfaces refined but not removed). For scenes with dynamic objects
+    or noise-resolved phantom surfaces, call :func:`compute_esdf_single`
+    periodically as a global correction pass.
+
+    When ``prev_esdf_grid`` is empty (e.g. first frame of a session),
+    this falls through to :func:`compute_esdf_single` semantics.
+
+    Args:
+        grid: Current TSDF grid.
+        tsdf: ``[num_voxels]`` fp32 normalized TSDF in ``[-1, +1]``.
+        weights: ``[num_voxels]`` fp32 integration weights.
+        prev_esdf_grid: Previous frame's ESDF :class:`Grid`.
+        prev_esdf: Previous frame's ``[prev_esdf_grid.num_voxels]`` fp32
+            signed distance sidecar.
+        truncation_distance: TSDF truncation margin (world units).
+        max_distance: ESDF support radius (world units).
+        weight_threshold: Voxels with ``weights <= weight_threshold``
+            are not used as wavefront sources.
+        prune_unreached: If ``True``, drop voxels the wavefront never
+            reached.
+        use_vbm: Use :class:`VoxelBlockManager`-based sweep kernel.
+
+    Args (continued):
+        dirty_mask (torch.Tensor | None): Optional ``[grid.num_voxels]``
+            bool tensor marking which voxels' TSDF changed this frame.
+            When provided, only dirty voxels seed the ESDF wavefront;
+            the rest inherit the previous frame's values unchanged.
+            This is the mechanism that makes ``compute_esdf_incremental``
+            scale with the dirty-region size rather than with the full
+            grid (matching nvblox's block-dirty-tracking behaviour).
+            When ``dirty_mask.any() == False`` AND ``prev_esdf_grid``
+            is non-empty, the call short-circuits in Python and
+            returns ``(prev_esdf_grid, prev_esdf)`` directly without
+            entering C++ -- this is the "static TSDF cache hit" path
+            that matches nvblox's ~50 us warm-reuse cost.
+            Produce the mask via
+            :func:`fvdb.functional.dirty_mask_from_sidecars_single`
+            (``(new_grid, new_weights, old_grid, old_weights)``) or
+            with any user-authored predicate. Default ``None`` =
+            full-recompute (original semantics).
+
+    Returns:
+        esdf_grid: New :class:`Grid` (merge of dilated support +
+            previous ESDF support).
+        esdf: ``[esdf_grid.num_voxels]`` fp32 signed distance.
+    """
+    from ..grid import Grid as G
+
+    # Python-level short-circuit: if the caller provided a dirty mask
+    # that is entirely false AND we have a previous ESDF state, we
+    # know the monotone-min result is unchanged and return immediately.
+    # Costs one host-side `.any().item()` sync (~30 us) and never
+    # enters C++. This is the "cache hit" equivalent of nvblox's
+    # dirty-block short-circuit -- but expressed at the Python layer
+    # against a user-held tensor, not hidden allocator state.
+    if dirty_mask is not None and prev_esdf_grid.num_voxels > 0:
+        if not dirty_mask.any().item():
+            return prev_esdf_grid, prev_esdf
+
+    grid_data = grid.data
+    prev_grid_data = prev_esdf_grid.data
+    # C++ accepts `dirty_mask` as a possibly-undefined tensor; pass an
+    # empty tensor to signal "no dirty mask" (pybind then sees an
+    # undefined Tensor which the C++ side interprets via `.defined()`).
+    if dirty_mask is None:
+        dm_arg = torch.empty(0, device=tsdf.device, dtype=torch.bool)
+    else:
+        dm_arg = dirty_mask
+    out_grid, out_esdf = _fvdb_cpp.compute_esdf_incremental(
+        grid_data,
+        tsdf,
+        weights,
+        prev_grid_data,
+        prev_esdf,
+        float(truncation_distance),
+        float(max_distance),
+        float(weight_threshold),
+        bool(prune_unreached),
+        bool(use_vbm),
+        dm_arg,
+    )
+    return G(data=out_grid), out_esdf
+
+
+def integrate_tsdf_from_points_with_features_single(
+    grid: Grid,
+    truncation_distance: float,
+    points: torch.Tensor,
+    sensor_origin: torch.Tensor,
+    tsdf: torch.Tensor,
+    features: torch.Tensor,
+    weights: torch.Tensor,
+    point_features: torch.Tensor,
+    carve_free_space: bool = True,
+) -> tuple[Grid, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Integrate a single point cloud with per-point features into a TSDF volume.
+
+    .. seealso:: :func:`integrate_tsdf_from_points_with_features_batch`
+    """
+    from ..grid import Grid as G
+
+    grid_data = grid.data
+    points_jt = JaggedTensor(points)
+    tsdf_jt = JaggedTensor(tsdf)
+    features_jt = JaggedTensor(features)
+    weights_jt = JaggedTensor(weights)
+    point_features_jt = JaggedTensor(point_features)
+    rg, rt, rw, rf = _fvdb_cpp.integrate_tsdf_from_points_with_features(
+        grid_data,
+        truncation_distance,
+        points_jt._impl,
+        sensor_origin.unsqueeze(0) if sensor_origin.dim() == 1 else sensor_origin,
+        tsdf_jt._impl,
+        features_jt._impl,
+        weights_jt._impl,
+        point_features_jt._impl,
+        carve_free_space,
+    )
+    return G(data=rg), rt.jdata, rw.jdata, rf.jdata

--- a/fvdb/functional/_topology.py
+++ b/fvdb/functional/_topology.py
@@ -29,6 +29,63 @@ def _wrap_single_grid(cpp_impl):
     return Grid(data=cpp_impl)
 
 
+def dirty_mask_from_sidecars_single(
+    new_grid: "Grid",
+    new_sidecar: torch.Tensor,
+    old_grid: "Grid",
+    old_sidecar: torch.Tensor,
+) -> torch.Tensor:
+    """Compute a ``[new_grid.num_voxels]`` bool "dirty" mask flagging
+    voxels whose sidecar value on ``new_grid`` differs from the
+    corresponding voxel on ``old_grid`` (or is absent from it).
+
+    Intended as the backbone of dirty-region ESDF / occupancy updates:
+    pass the result as the optional ``dirty_mask`` argument to
+    :meth:`Grid.compute_esdf_incremental` (or any other downstream
+    op that gates on a dirty set). Built entirely on top of the
+    existing ``inject`` primitive — no new CUDA kernels.
+
+    Semantics per output voxel ``v`` in ``new_grid``:
+
+    - If ``v.ijk`` is **not** in ``old_grid``: marked dirty (the
+      voxel is new).
+    - If ``v.ijk`` IS in ``old_grid`` at some ``w`` and
+      ``new_sidecar[v] == old_sidecar[w]`` (elementwise equality
+      across all channels for multi-channel sidecars): **not** dirty.
+    - Otherwise: dirty.
+
+    Multi-channel sidecars (``[num_voxels, C]``) reduce via "any
+    channel differs" to per-voxel bool.
+
+    **Paper-framing**: fvdb exposes dirty-region information as a
+    user-visible torch tensor (the result of this function) rather
+    than as library-internal allocator state (nvblox's
+    ``BlockManager``-resident dirty-block set). The user can
+    inspect it, combine it with other predicates
+    (``mask & (weights > threshold)``), pass it to multiple
+    consumers, or drop it to reclaim memory. All composable,
+    nothing hidden.
+
+    Args:
+        new_grid (Grid): Grid whose voxel set we compute the mask on.
+        new_sidecar (torch.Tensor): ``[new_grid.num_voxels]`` or
+            ``[new_grid.num_voxels, C]`` sidecar on ``new_grid``.
+            Must be floating-point (uses NaN sentinels to detect
+            voxels absent from ``old_grid``).
+        old_grid (Grid): Baseline grid for comparison.
+        old_sidecar (torch.Tensor): Sidecar on ``old_grid`` with the
+            same per-voxel shape and dtype as ``new_sidecar``.
+
+    Returns:
+        dirty (torch.Tensor): ``[new_grid.num_voxels]`` bool tensor
+        on the same device as ``new_sidecar``.
+    """
+    return _fvdb_cpp.dirty_mask_from_sidecars(
+        new_grid.data, new_sidecar,
+        old_grid.data, old_sidecar,
+    )
+
+
 # ---------------------------------------------------------------------------
 #  Grid structure derivation
 # ---------------------------------------------------------------------------

--- a/fvdb/functional/_topology.py
+++ b/fvdb/functional/_topology.py
@@ -8,13 +8,19 @@ from typing import TYPE_CHECKING
 
 import torch
 
-from ..jagged_tensor import JaggedTensor
 from .. import _fvdb_cpp
-from ..types import NumericMaxRank1, NumericMaxRank2, ValueConstraint, to_Vec3i, to_Vec3iBatchBroadcastable
+from ..jagged_tensor import JaggedTensor
+from ..types import (
+    NumericMaxRank1,
+    NumericMaxRank2,
+    ValueConstraint,
+    to_Vec3i,
+    to_Vec3iBatchBroadcastable,
+)
 
 if TYPE_CHECKING:
-    from ..grid_batch import GridBatch
     from ..grid import Grid
+    from ..grid_batch import GridBatch
 
 
 def _wrap_grid(cpp_impl):
@@ -81,8 +87,10 @@ def dirty_mask_from_sidecars_single(
         on the same device as ``new_sidecar``.
     """
     return _fvdb_cpp.dirty_mask_from_sidecars(
-        new_grid.data, new_sidecar,
-        old_grid.data, old_sidecar,
+        new_grid.data,
+        new_sidecar,
+        old_grid.data,
+        old_sidecar,
     )
 
 

--- a/fvdb/grid.py
+++ b/fvdb/grid.py
@@ -25,15 +25,19 @@ Class-methods for creating Grid objects from various sources:
 
 from __future__ import annotations
 
-import pathlib
 from typing import TYPE_CHECKING, Any, overload
+
+import pathlib
 
 import torch
 
 from ._fvdb_cpp import GridBatchData
 from .enums import SmoothingMode
 from .jagged_tensor import JaggedTensor
-from .types import DeviceIdentifier, NumericMaxRank1
+from .types import (
+    DeviceIdentifier,
+    NumericMaxRank1,
+)
 
 if TYPE_CHECKING:
     from .grid_batch import GridBatch
@@ -778,6 +782,106 @@ class Grid:
 
         return functional.merged_grid_single(self, other)
 
+    def decay_and_prune(
+        self,
+        sidecar: torch.Tensor,
+        decay_factor: float,
+        prune_threshold: float = 0.0,
+        extra_sidecars: "list[torch.Tensor] | tuple[torch.Tensor, ...]" = (),
+    ) -> "tuple[Grid, torch.Tensor, list[torch.Tensor]]":
+        """Multiplicatively decay a per-voxel sidecar and (optionally)
+        prune voxels whose decayed magnitude falls below a threshold.
+
+        Dynamic-scene support pattern mirroring nvblox's
+        ``Mapper.decay()`` + block-level deallocation, but expressed
+        entirely in terms of fvdb primitives:
+
+        1. ``sidecar_new = sidecar * decay_factor``  (pure torch op)
+        2. ``keep = |sidecar_new| > prune_threshold``  (pure torch op)
+        3. ``new_grid = self.pruned_grid(keep)``  (existing fvdb primitive)
+        4. ``sidecar_out = sidecar_new[keep]``; similar for extras.
+
+        **Paper-framing: this method demonstrates that per-field
+        decay is "free" under fvdb's sidecar-as-tensor architecture.**
+        Because each sidecar (``tsdf``, ``weights``, ``features``,
+        ``log_odds``, ...) is stored as a separate torch tensor
+        aligned to the sparse grid, selective decay is just a tensor
+        op on the field the user cares about -- there's no library
+        machinery needed to "know which layer to decay" (contrast
+        nvblox's block-packed ``{sdf, weight, color}`` tuples, which
+        need integrator-aware ``decay_tsdf`` / ``decay_color``
+        methods to reach individual fields within a block).
+
+        Common use cases (all 1-3 lines of Python):
+
+        .. code-block:: python
+
+            # Decay TSDF weights only, leaving tsdf + features alone.
+            # (Color / features decay independently by multiplying them.)
+            g2, w2, [tsdf2, feat2] = grid.decay_and_prune(
+                weights, decay_factor=0.95, prune_threshold=0.01,
+                extra_sidecars=[tsdf, features],
+            )
+
+            # Decay occupancy log-odds toward unknown (p=0.5).
+            g2, lo2, _ = grid.decay_and_prune(
+                log_odds, decay_factor=0.9, prune_threshold=0.1,
+            )
+
+            # Decay without prune (no topology change).
+            # Just use: weights *= decay_factor -- this helper is
+            # unnecessary for that case.
+
+        Args:
+            sidecar (torch.Tensor): ``[num_voxels]`` or
+                ``[num_voxels, C]`` per-voxel sidecar tensor to
+                decay. The decayed magnitude drives the prune mask.
+                For multi-channel sidecars, the per-voxel magnitude
+                is the L2 norm across channels.
+            decay_factor (float): Multiplicative scaling applied to
+                ``sidecar``. Typical: ``0.95`` (gentle decay) to
+                ``0.5`` (aggressive). ``1.0`` is no-op.
+            prune_threshold (float): Voxels whose decayed magnitude
+                is ``<= prune_threshold`` are dropped from the grid.
+                Default ``0.0`` means "never prune" (no topology
+                change; returns ``self`` as ``new_grid``).
+            extra_sidecars (list[torch.Tensor]): Additional per-
+                voxel sidecars to prune in-sync with the grid's
+                topology change. Each must have ``shape[0] ==
+                num_voxels``.
+
+        Returns:
+            new_grid (Grid): Pruned grid (equals ``self`` if
+                no voxels were pruned).
+            new_sidecar (torch.Tensor): Decayed + pruned sidecar.
+            new_extras (list[torch.Tensor]): Each ``extra_sidecars[i]``
+                pruned with the same mask.
+        """
+        decayed = sidecar * decay_factor
+
+        # Magnitude for pruning: L2 norm across channels for multi-
+        # channel sidecars, elementwise abs for 1-D.
+        if decayed.dim() == 1:
+            magnitude = decayed.abs()
+        else:
+            magnitude = decayed.norm(dim=1) if decayed.shape[1] > 0 \
+                else decayed.abs().sum(dim=tuple(range(1, decayed.dim())))
+
+        if prune_threshold <= 0.0:
+            return self, decayed, list(extra_sidecars)
+
+        keep_mask = magnitude > prune_threshold
+
+        if keep_mask.all().item():
+            # Nothing to prune — return topology unchanged, saving a
+            # pruneGrid call and the associated inject.
+            return self, decayed, list(extra_sidecars)
+
+        new_grid = self.pruned_grid(keep_mask)
+        new_sidecar = decayed[keep_mask]
+        new_extras = [t[keep_mask] for t in extra_sidecars]
+        return new_grid, new_sidecar, new_extras
+
     def pruned_grid(self, mask: torch.Tensor) -> Grid:
         """Return a pruned :class:`Grid` keeping only voxels where ``mask`` is ``True``.
 
@@ -1462,6 +1566,136 @@ class Grid:
     #                    Meshing / TSDF
     # ============================================================
 
+    def compute_esdf(
+        self,
+        tsdf: torch.Tensor,
+        weights: torch.Tensor,
+        truncation_distance: float,
+        max_distance: float,
+        weight_threshold: float = 1.0e-6,
+        prune_unreached: bool = False,
+        use_vbm: bool = True,
+    ) -> tuple["Grid", torch.Tensor]:
+        """Compute a Euclidean Signed Distance Field (ESDF) from an integrated TSDF.
+
+        The ESDF extends the TSDF's narrow-band signed distances outward
+        (and inward) across a wider band, producing per-voxel world-unit
+        signed distances with ``|d| <= max_distance``. Composes three
+        nanoVDB topology ops (``dilateGrid``, a VBM-stencil sweep kernel,
+        and optionally ``pruneGrid``) on the same sparse-grid substrate
+        used by ``integrate_tsdf``.
+
+        Args:
+            tsdf (torch.Tensor): ``[num_voxels]`` fp32 normalized TSDF
+                values in ``[-1, +1]`` (fvdb's ``integrate_tsdf``
+                convention: ``tsdf = clip(d_world / T, -1, +1)``).
+            weights (torch.Tensor): ``[num_voxels]`` fp32 integration
+                weights.
+            truncation_distance (float): TSDF truncation margin in
+                world units (the ``T`` of the normalization above).
+            max_distance (float): ESDF support radius in world units.
+            weight_threshold (float): Voxels with
+                ``weights <= weight_threshold`` are not used as
+                wavefront sources. Default ``1e-6``.
+            prune_unreached (bool): If ``True``, drop voxels the
+                wavefront never reached (distance clamped to
+                ``max_distance``). Default ``False``.
+            use_vbm (bool): Use :class:`VoxelBlockManager`-based sweep
+                kernel (default) vs per-leaf-slot iteration (ablation).
+
+        Returns:
+            esdf_grid (Grid): New :class:`Grid` for the ESDF support band.
+            esdf (torch.Tensor): ``[esdf_grid.num_voxels]`` fp32 world-unit
+                signed distance.
+        """
+        from . import functional
+
+        return functional.compute_esdf_single(
+            self,
+            tsdf,
+            weights,
+            truncation_distance,
+            max_distance,
+            weight_threshold,
+            prune_unreached,
+            use_vbm,
+        )
+
+    def compute_esdf_incremental(
+        self,
+        tsdf: torch.Tensor,
+        weights: torch.Tensor,
+        prev_esdf_grid: "Grid",
+        prev_esdf: torch.Tensor,
+        truncation_distance: float,
+        max_distance: float,
+        weight_threshold: float = 1.0e-6,
+        prune_unreached: bool = False,
+        use_vbm: bool = True,
+        dirty_mask: torch.Tensor | None = None,
+    ) -> tuple["Grid", torch.Tensor]:
+        """Incremental (warm-started) ESDF: reuse a previous ESDF as
+        the wavefront's initial state.
+
+        Same algorithm as :meth:`compute_esdf` but takes a previous
+        ``(esdf_grid, esdf)`` pair and merges / injects it into the
+        new support before running the sweep kernel. Correct under the
+        monotone-scene assumption (surfaces added or refined, but not
+        removed). When ``prev_esdf_grid`` is empty, falls through to
+        :meth:`compute_esdf` semantics.
+
+        When the optional ``dirty_mask`` is provided:
+
+        - If it is entirely ``False`` AND ``prev_esdf_grid`` is
+          non-empty, the call short-circuits in Python and returns
+          ``(prev_esdf_grid, prev_esdf)`` directly without entering
+          C++. This matches nvblox's ~50 μs "no dirty blocks" cache
+          hit but via a user-held tensor instead of hidden library
+          state.
+        - Otherwise, only dirty voxels seed the wavefront. Cost
+          scales with the dirty-region size rather than the full
+          grid — matches nvblox's block-dirty-tracking behaviour.
+
+        Build the mask with
+        :func:`fvdb.functional.dirty_mask_from_sidecars_single`
+        (pass ``(new_grid, new_weights, old_grid, old_weights)``) or
+        author any user-level predicate — it's just a bool tensor.
+
+        Args:
+            tsdf (torch.Tensor): ``[num_voxels]`` current TSDF values.
+            weights (torch.Tensor): ``[num_voxels]`` current weights.
+            prev_esdf_grid (Grid): Previous frame's ESDF grid.
+            prev_esdf (torch.Tensor): Previous frame's ``[prev_esdf_grid.num_voxels]``
+                fp32 signed-distance sidecar.
+            truncation_distance (float): TSDF truncation (world units).
+            max_distance (float): ESDF support radius (world units).
+            weight_threshold (float): Seeding threshold (default 1e-6).
+            prune_unreached (bool): Drop unreached voxels (default False).
+            use_vbm (bool): Use VBM sweep kernel (default True).
+            dirty_mask (torch.Tensor | None): Optional
+                ``[num_voxels]`` bool tensor marking voxels that
+                changed this frame. Default ``None`` = full recompute.
+
+        Returns:
+            esdf_grid (Grid): Merged ESDF support grid.
+            esdf (torch.Tensor): ``[esdf_grid.num_voxels]`` signed distance.
+        """
+        from . import functional
+
+        return functional.compute_esdf_incremental_single(
+            self,
+            tsdf,
+            weights,
+            prev_esdf_grid,
+            prev_esdf,
+            truncation_distance,
+            max_distance,
+            weight_threshold,
+            prune_unreached,
+            use_vbm,
+            dirty_mask,
+        )
+
     def marching_cubes(
         self, field: torch.Tensor, level: float = 0.0
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
@@ -1658,6 +1892,294 @@ class Grid:
             depth_images,
             feature_images,
             weight_images,
+        )
+
+    def integrate_tsdf_frames(
+        self,
+        truncation_distance: float,
+        projection_matrices: torch.Tensor,
+        cam_to_world_matrices: torch.Tensor,
+        tsdf: torch.Tensor,
+        weights: torch.Tensor,
+        depth_images: torch.Tensor,
+        weight_images: torch.Tensor | None = None,
+        features: torch.Tensor | None = None,
+        feature_images: torch.Tensor | None = None,
+    ):
+        """Integrate N depth frames with one-shot topology build.
+
+        Like :meth:`integrate_tsdf` but runs N frames in one call. The
+        union topology over all frames is built once up-front; each
+        frame's TSDF / weight update runs against that fixed topology.
+        Semantically identical to calling :meth:`integrate_tsdf` N
+        times in sequence but typically 3-5x faster for bulk /
+        offline RGB-D reconstruction, since the per-frame
+        ``buildPointTruncationShell + mergeGrids`` cost is amortized.
+
+        All per-frame tensors share the leading N dimension:
+        ``projection_matrices[N, 3, 3]``,
+        ``cam_to_world_matrices[N, 4, 4]``,
+        ``depth_images[N, H, W]`` (or ``[N, H, W, 1]``),
+        ``weight_images[N, H, W]`` (optional),
+        ``feature_images[N, H, W, D]`` (optional).
+
+        Args:
+            truncation_distance (float): TSDF truncation distance.
+            projection_matrices (torch.Tensor): ``[N, 3, 3]``.
+            cam_to_world_matrices (torch.Tensor): ``[N, 4, 4]``.
+            tsdf (torch.Tensor): Current TSDF values on this :class:`Grid`.
+            weights (torch.Tensor): Current integration weights on this :class:`Grid`.
+            depth_images (torch.Tensor): ``[N, H, W]`` or ``[N, H, W, 1]``.
+            weight_images (torch.Tensor | None): Optional per-pixel weights.
+            features (torch.Tensor | None): Optional ``[num_voxels, D]`` per-voxel features
+                on this :class:`Grid`. Dtype must match ``tsdf.dtype`` or be ``uint8``.
+                If provided, ``feature_images`` must also be provided.
+            feature_images (torch.Tensor | None): ``[N, H, W, D]`` per-pixel feature images.
+
+        Returns:
+            When no features are provided:
+                ``(updated_grid, updated_tsdf, updated_weights)``.
+            When features are provided:
+                ``(updated_grid, updated_tsdf, updated_weights, updated_features)``.
+        """
+        from . import functional
+
+        if features is not None or feature_images is not None:
+            if features is None or feature_images is None:
+                raise ValueError(
+                    "features and feature_images must be provided together"
+                )
+            return functional.integrate_tsdf_frames_with_features_single(
+                self,
+                truncation_distance,
+                projection_matrices,
+                cam_to_world_matrices,
+                tsdf,
+                features,
+                weights,
+                depth_images,
+                feature_images,
+                weight_images,
+            )
+        return functional.integrate_tsdf_frames_single(
+            self,
+            truncation_distance,
+            projection_matrices,
+            cam_to_world_matrices,
+            tsdf,
+            weights,
+            depth_images,
+            weight_images,
+        )
+
+    def integrate_tsdf_from_points(
+        self,
+        truncation_distance: float,
+        points: torch.Tensor,
+        sensor_origin: torch.Tensor,
+        tsdf: torch.Tensor,
+        weights: torch.Tensor,
+        point_features: torch.Tensor | None = None,
+        features: torch.Tensor | None = None,
+        carve_free_space: bool = True,
+    ):
+        """Integrate a LiDAR / point-cloud sweep into a TSDF volume via per-point ray-walking.
+
+        Unlike :meth:`integrate_tsdf` (which takes depth images and unprojects
+        them internally), this method ingests a point cloud directly and walks
+        rays from ``sensor_origin`` to each point endpoint through the sparse
+        grid using HDDA. This matches the VDBFusion / nvblox LiDAR integration
+        surface with no range-image projection proxy.
+
+        Args:
+            truncation_distance (float): TSDF truncation distance.
+            points (torch.Tensor): ``[N, 3]`` world-space point cloud.
+            sensor_origin (torch.Tensor): ``[3]`` world-space sensor origin
+                (per-frame; per-ray sensor origins are a future extension).
+            tsdf (torch.Tensor): Current TSDF values.
+            weights (torch.Tensor): Current integration weights.
+            point_features (torch.Tensor | None): Optional ``[N, D]`` per-
+                point feature vector (e.g. RGB colour). If provided,
+                ``features`` must also be supplied.
+            features (torch.Tensor | None): Optional ``[num_voxels, D]``
+                per-voxel feature vector. Dtype must match ``tsdf.dtype`` or
+                be ``uint8``.
+            carve_free_space (bool): If ``True``, voxels observed to be in
+                front of the endpoint (outside the truncation band) are
+                written ``tsdf = +1, weight = 1``. Matches VDBFusion /
+                nvblox default behaviour.
+
+        Returns:
+            When no features are provided:
+                ``(updated_grid: Grid, updated_tsdf: torch.Tensor,
+                updated_weights: torch.Tensor)``.
+            When features are provided:
+                ``(updated_grid: Grid, updated_tsdf: torch.Tensor,
+                updated_weights: torch.Tensor, updated_features: torch.Tensor)``.
+        """
+        from . import functional
+
+        if point_features is not None or features is not None:
+            if point_features is None or features is None:
+                raise ValueError(
+                    "point_features and features must be provided together"
+                )
+            return functional.integrate_tsdf_from_points_with_features_single(
+                self,
+                truncation_distance,
+                points,
+                sensor_origin,
+                tsdf,
+                features,
+                weights,
+                point_features,
+                carve_free_space,
+            )
+        return functional.integrate_tsdf_from_points_single(
+            self,
+            truncation_distance,
+            points,
+            sensor_origin,
+            tsdf,
+            weights,
+            carve_free_space,
+        )
+
+    def integrate_tsdf_from_points_frames(
+        self,
+        truncation_distance: float,
+        points_per_frame: list[torch.Tensor],
+        sensor_origins: torch.Tensor,
+        tsdf: torch.Tensor,
+        weights: torch.Tensor,
+        carve_free_space: bool = True,
+    ):
+        """Integrate N LiDAR sweeps into a persistent TSDF volume in one call.
+
+        Semantically equivalent to looping :meth:`integrate_tsdf_from_points`
+        N times in sequence (bit-identical output, pinned by
+        ``test_integrate_tsdf_from_points_frames_matches_sequential``),
+        but keeps the whole loop inside C++ so the per-frame
+        JaggedTensor + Python <-> C++ dispatch overhead is amortized.
+        Measured 2-3x speedup on Mai City seq00 (700 frames @ 20 cm
+        voxels, ~130 K pts/sweep) vs a Python ``for`` loop over
+        :meth:`integrate_tsdf_from_points`.
+
+        Args:
+            truncation_distance (float): TSDF truncation distance.
+            points_per_frame (list[torch.Tensor]): Length-N list;
+                each entry is ``[N_i, 3]`` world-frame points. Each
+                frame may have a different point count.
+            sensor_origins (torch.Tensor): ``[N, 3]`` per-frame sensor
+                origins in world frame.
+            tsdf (torch.Tensor): ``[num_voxels]`` current TSDF values.
+            weights (torch.Tensor): ``[num_voxels]`` current weights.
+            carve_free_space (bool): Same as single-frame integrate.
+
+        Returns:
+            ``(updated_grid: Grid, updated_tsdf: torch.Tensor,
+            updated_weights: torch.Tensor)``.
+
+        .. seealso:: :meth:`integrate_tsdf_from_points`
+        """
+        from . import functional
+
+        return functional.integrate_tsdf_from_points_frames_single(
+            self,
+            truncation_distance,
+            points_per_frame,
+            sensor_origins,
+            tsdf,
+            weights,
+            carve_free_space,
+        )
+
+    def integrate_occupancy_from_points(
+        self,
+        truncation_distance: float,
+        points: torch.Tensor,
+        sensor_origin: torch.Tensor,
+        log_odds: torch.Tensor,
+        log_odds_hit: float = 0.85,
+        log_odds_miss: float = -0.40,
+        log_odds_min: float = -4.0,
+        log_odds_max: float = 4.0,
+    ) -> tuple["Grid", torch.Tensor]:
+        """Integrate a single LiDAR / point-cloud sweep into a Bayesian
+        log-odds occupancy volume.
+
+        Sister primitive to :meth:`integrate_tsdf_from_points`: same
+        shell allocator, same HDDA ray-walk, but with log-odds
+        updates instead of running-weighted-avg signed distance.
+        Defaults match nvblox's ``ProjectiveIntegratorType.OCCUPANCY``
+        defaults (hit +0.85, miss -0.40, clamp [-4, +4]). The stored
+        sidecar IS the log-odds; to recover probability on the host:
+        ``p = torch.sigmoid(log_odds)``.
+
+        Args:
+            truncation_distance (float): Width of the hit band around
+                each point endpoint, and the shell-allocator dilation.
+            points (torch.Tensor): ``[N, 3]`` world-frame point cloud.
+            sensor_origin (torch.Tensor): ``[3]`` or ``[1, 3]``
+                world-frame sensor origin.
+            log_odds (torch.Tensor): ``[num_voxels]`` current
+                log-odds sidecar.
+            log_odds_hit (float): Increment per hit observation.
+            log_odds_miss (float): Increment per miss observation
+                (negative).
+            log_odds_min (float): Lower clamp bound.
+            log_odds_max (float): Upper clamp bound.
+
+        Returns:
+            updated_grid (Grid): Union of this grid and the new point
+                shell.
+            updated_log_odds (torch.Tensor): ``[updated_grid.num_voxels]``
+                log-odds sidecar.
+        """
+        from . import functional
+
+        return functional.integrate_occupancy_from_points_single(
+            self,
+            truncation_distance,
+            points,
+            sensor_origin,
+            log_odds,
+            log_odds_hit,
+            log_odds_miss,
+            log_odds_min,
+            log_odds_max,
+        )
+
+    def integrate_occupancy_from_points_frames(
+        self,
+        truncation_distance: float,
+        points_per_frame: list[torch.Tensor],
+        sensor_origins: torch.Tensor,
+        log_odds: torch.Tensor,
+        log_odds_hit: float = 0.85,
+        log_odds_miss: float = -0.40,
+        log_odds_min: float = -4.0,
+        log_odds_max: float = 4.0,
+    ) -> tuple["Grid", torch.Tensor]:
+        """Integrate N LiDAR sweeps into a persistent log-odds
+        occupancy volume in one C++ call.
+
+        Batched counterpart to :meth:`integrate_occupancy_from_points`,
+        matching the N-frame API of
+        :meth:`integrate_tsdf_from_points_frames`.
+        """
+        from . import functional
+
+        return functional.integrate_occupancy_from_points_frames_single(
+            self,
+            truncation_distance,
+            points_per_frame,
+            sensor_origins,
+            log_odds,
+            log_odds_hit,
+            log_odds_miss,
+            log_odds_min,
+            log_odds_max,
         )
 
     # ============================================================

--- a/fvdb/grid.py
+++ b/fvdb/grid.py
@@ -25,19 +25,15 @@ Class-methods for creating Grid objects from various sources:
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, overload
-
 import pathlib
+from typing import TYPE_CHECKING, Any, overload
 
 import torch
 
 from ._fvdb_cpp import GridBatchData
 from .enums import SmoothingMode
 from .jagged_tensor import JaggedTensor
-from .types import (
-    DeviceIdentifier,
-    NumericMaxRank1,
-)
+from .types import DeviceIdentifier, NumericMaxRank1
 
 if TYPE_CHECKING:
     from .grid_batch import GridBatch
@@ -864,8 +860,9 @@ class Grid:
         if decayed.dim() == 1:
             magnitude = decayed.abs()
         else:
-            magnitude = decayed.norm(dim=1) if decayed.shape[1] > 0 \
-                else decayed.abs().sum(dim=tuple(range(1, decayed.dim())))
+            magnitude = (
+                decayed.norm(dim=1) if decayed.shape[1] > 0 else decayed.abs().sum(dim=tuple(range(1, decayed.dim())))
+            )
 
         if prune_threshold <= 0.0:
             return self, decayed, list(extra_sidecars)
@@ -1946,9 +1943,7 @@ class Grid:
 
         if features is not None or feature_images is not None:
             if features is None or feature_images is None:
-                raise ValueError(
-                    "features and feature_images must be provided together"
-                )
+                raise ValueError("features and feature_images must be provided together")
             return functional.integrate_tsdf_frames_with_features_single(
                 self,
                 truncation_distance,
@@ -2021,9 +2016,7 @@ class Grid:
 
         if point_features is not None or features is not None:
             if point_features is None or features is None:
-                raise ValueError(
-                    "point_features and features must be provided together"
-                )
+                raise ValueError("point_features and features must be provided together")
             return functional.integrate_tsdf_from_points_with_features_single(
                 self,
                 truncation_distance,

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -116,6 +116,12 @@ set(FVDB_CU_FILES
     fvdb/detail/ops/IjkToInvIndex.cu
     fvdb/detail/ops/Inject.cu
     fvdb/detail/ops/IntegrateTSDF.cu
+    fvdb/detail/ops/IntegrateTSDFFromPoints.cu
+    fvdb/detail/ops/IntegrateOccupancyFromPoints.cu
+    fvdb/detail/ops/BuildPointTruncationShell.cu
+    fvdb/detail/ops/PersistentTSDFState.cu
+    fvdb/detail/ops/ComputeESDF.cu
+    fvdb/detail/ops/DirtyMaskFromSidecars.cu
     fvdb/detail/ops/jagged/JaggedSort.cu
     fvdb/detail/ops/JaggedTensorIndex.cu
     fvdb/detail/ops/JCat0.cu
@@ -123,6 +129,7 @@ set(FVDB_CU_FILES
     fvdb/detail/ops/JIdxForJOffsets.cu
     fvdb/detail/ops/JOffsetsFromJIdx.cu
     fvdb/detail/ops/MarchingCubes.cu
+    fvdb/detail/ops/MarchingCubesFast.cu
     fvdb/detail/ops/MortonHilbertFromIjk.cu
     fvdb/detail/ops/PointsInGrid.cu
     fvdb/detail/ops/PopulateGridMetadata.cu

--- a/src/cmake/get_nanovdb.cmake
+++ b/src/cmake/get_nanovdb.cmake
@@ -1,10 +1,16 @@
 # Copyright Contributors to the OpenVDB Project
 # SPDX-License-Identifier: Apache-2.0
 
+# TEMPORARY: pinned to the merged nanovdb injectable-memory-resource stack
+# (AcademySoftwareFoundation/openvdb PRs #2268, #2269, #2270, #2272, #2273 on
+# top of upstream master d980ad92; tracking issue #2232). fvdb relies on the
+# ResourceT seams these PRs add to route builder scratch through PyTorch's
+# caching allocator (see src/fvdb/TorchResource.h). Repoint at
+# AcademySoftwareFoundation/openvdb once the stack merges upstream.
 CPMAddPackage(
     NAME nanovdb
-    GITHUB_REPOSITORY AcademySoftwareFoundation/openvdb
-    GIT_TAG f9754140ba6031813b37d8e1b239ed0253ebd96d
+    GITHUB_REPOSITORY swahtz/openvdb
+    GIT_TAG 558bfb2ead7c993f980ba18e89fee4b69991fb39
     SOURCE_SUBDIR nanovdb/nanovdb
     DOWNLOAD_ONLY YES
 )

--- a/src/fvdb/TorchResource.h
+++ b/src/fvdb/TorchResource.h
@@ -51,10 +51,13 @@ struct TorchResource : nanovdb::cuda::SyncFromAsync<TorchResource> {
     void *
     allocate_async(size_t bytes, size_t /*alignment*/, cudaStream_t stream) {
         if (const char *env = std::getenv("FVDB_NANOVDB_TRACE_ALLOCS")) {
-            const size_t cutoff = (env[0] == '2') ? 0 : (1ull << 18); // '2' = trace all, else >= 256 KiB
+            const size_t cutoff =
+                (env[0] == '2') ? 0 : (1ull << 18); // '2' = trace all, else >= 256 KiB
             if (bytes >= cutoff) {
-                std::fprintf(stderr, "[fvdb/nanovdb] TorchResource alloc %12zu bytes (%.3f MB)\n",
-                             bytes, double(bytes) / 1e6);
+                std::fprintf(stderr,
+                             "[fvdb/nanovdb] TorchResource alloc %12zu bytes (%.3f MB)\n",
+                             bytes,
+                             double(bytes) / 1e6);
             }
         }
         void *p = c10::cuda::CUDACachingAllocator::raw_alloc_with_stream(bytes, stream);

--- a/src/fvdb/TorchResource.h
+++ b/src/fvdb/TorchResource.h
@@ -1,0 +1,86 @@
+// Copyright Contributors to the OpenVDB Project
+// SPDX-License-Identifier: Apache-2.0
+//
+#ifndef FVDB_TORCHRESOURCE_H
+#define FVDB_TORCHRESOURCE_H
+
+#include <nanovdb/cuda/DeviceResource.h>
+
+#include <c10/cuda/CUDACachingAllocator.h>
+
+#include <cstdio>
+#include <cstdlib>
+#include <stdexcept>
+
+namespace fvdb {
+
+/// @brief NanoVDB stream-ordered memory resource backed by PyTorch's CUDA caching
+///        allocator (c10::cuda::CUDACachingAllocator).
+///
+///        Passed as the ResourceT template parameter of NanoVDB's CUDA builders
+///        (PointsToGrid / DilateGrid / MergeGrids / PruneGrid / RefineGrid /
+///        CoarsenGrid), it routes their internal device scratch — O(N-points) sort
+///        keys, CUB temp storage, topology mask buffers — through the same pool
+///        that fvdb / PyTorch tensors use. Without this, nanoVDB's default
+///        DeviceResource allocates from a second cudaMallocAsync pool that
+///        partitions VRAM against torch's pool, and large workloads (e.g.
+///        multi-frame TSDF integration) OOM even when the GPU has free memory in
+///        aggregate.
+///
+///        The resource is stateless, so builders can bind the shared instance
+///        returned by nanovdb::cuda::default_resource<TorchResource>() — naming
+///        the template parameter at a call site is sufficient, no instance needs
+///        to be threaded through.
+///
+///        Set FVDB_NANOVDB_TRACE_ALLOCS=1 in the environment to trace allocations
+///        of 256 KiB and larger to stderr (a value starting with '2' traces every
+///        allocation). Useful for diagnosing topology-op memory blowup on large
+///        scenes.
+struct TorchResource : nanovdb::cuda::SyncFromAsync<TorchResource> {
+    /// Alignment guaranteed by every allocation. The caching allocator returns
+    /// blocks aligned to at least 512 bytes, so advertising nanoVDB's
+    /// conventional 256 (matching cuda::DeviceResource) is always satisfied and
+    /// the alignment parameter below can be ignored.
+    static constexpr size_t DEFAULT_ALIGNMENT = 256;
+
+    /// @brief Stream-ordered allocation from torch's caching allocator.
+    /// @note raw_alloc_with_stream records @p stream against the block so torch
+    ///       defers reuse until work on it completes, matching the stream-ordered
+    ///       semantics of the cudaMallocAsync call it replaces. Allocation
+    ///       happens on the current device, like cudaMallocAsync.
+    void *
+    allocate_async(size_t bytes, size_t /*alignment*/, cudaStream_t stream) {
+        if (const char *env = std::getenv("FVDB_NANOVDB_TRACE_ALLOCS")) {
+            const size_t cutoff = (env[0] == '2') ? 0 : (1ull << 18); // '2' = trace all, else >= 256 KiB
+            if (bytes >= cutoff) {
+                std::fprintf(stderr, "[fvdb/nanovdb] TorchResource alloc %12zu bytes (%.3f MB)\n",
+                             bytes, double(bytes) / 1e6);
+            }
+        }
+        void *p = c10::cuda::CUDACachingAllocator::raw_alloc_with_stream(bytes, stream);
+        if (!p) {
+            throw std::runtime_error("fvdb: TorchResource::allocate_async failed");
+        }
+        return p;
+    }
+
+    /// @brief Free through torch's caching allocator.
+    /// @note The stream argument is deliberately ignored: raw_delete relies on
+    ///       the stream recorded at allocation time plus torch's per-stream event
+    ///       tracking, so the free is safe without ordering on the caller's
+    ///       stream.
+    void
+    deallocate_async(void *p, size_t /*bytes*/, size_t /*alignment*/, cudaStream_t /*stream*/) {
+        if (p == nullptr) {
+            return;
+        }
+        c10::cuda::CUDACachingAllocator::raw_delete(p);
+    }
+};
+
+static_assert(nanovdb::cuda::is_async_resource<TorchResource>::value,
+              "TorchResource must model nanoVDB's stream-ordered AsyncResource concept");
+
+} // namespace fvdb
+
+#endif // FVDB_TORCHRESOURCE_H

--- a/src/fvdb/detail/ops/BuildCoarseGridFromFine.cu
+++ b/src/fvdb/detail/ops/BuildCoarseGridFromFine.cu
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 #include <fvdb/GridBatchData.h>
+#include <fvdb/TorchResource.h>
 #include <fvdb/detail/GridBatchDataFactory.h>
 #include <fvdb/detail/ops/BuildCoarseGridFromFine.h>
 #include <fvdb/detail/ops/BuildGridFromIjk.h>
@@ -84,7 +85,8 @@ coarseGridHandleFromFineCUDA(const GridBatchData &fineGridBatch,
         TORCH_CHECK(grid, "Grid is null");
         nanovdb::GridHandle<TorchDeviceBuffer> handle;
         for (int p = 0; p < nPasses; p += 1) {
-            nanovdb::tools::cuda::CoarsenGrid<nanovdb::ValueOnIndex> op(grid, stream.stream());
+            nanovdb::tools::cuda::CoarsenGrid<nanovdb::ValueOnIndex, TorchResource> op(
+                grid, stream.stream());
             op.setChecksum(nanovdb::CheckMode::Default);
             op.setVerbose(0);
             handle = op.getHandle(guide);

--- a/src/fvdb/detail/ops/BuildDenseGrid.cu
+++ b/src/fvdb/detail/ops/BuildDenseGrid.cu
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 #include <fvdb/GridBatchData.h>
+#include <fvdb/TorchResource.h>
 #include <fvdb/detail/GridBatchDataFactory.h>
 #include <fvdb/detail/ops/BuildDenseGrid.h>
 #include <fvdb/detail/utils/AccessorHelpers.cuh>
@@ -143,8 +144,9 @@ dispatchCreateNanoGridFromDense<torch::kCUDA>(int64_t batchSize,
             handles.push_back(createEmptyGridHandle(guide.device()));
         } else if (i == 0) {
             handles.push_back(
-                nanovdb::tools::cuda::voxelsToGrid<GridT, nanovdb::Coord *, TorchDeviceBuffer>(
-                    (nanovdb::Coord *)ijkData.data_ptr(), nVoxels, 1.0, guide));
+                nanovdb::tools::cuda::
+                    voxelsToGrid<GridT, nanovdb::Coord *, TorchDeviceBuffer, TorchResource>(
+                        (nanovdb::Coord *)ijkData.data_ptr(), nVoxels, 1.0, guide));
             C10_CUDA_KERNEL_LAUNCH_CHECK();
         } else {
             handles.push_back(handles[0].copy(guide));

--- a/src/fvdb/detail/ops/BuildDilatedGrid.cu
+++ b/src/fvdb/detail/ops/BuildDilatedGrid.cu
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 #include <fvdb/TorchDeviceBuffer.h>
+#include <fvdb/TorchResource.h>
 #include <fvdb/detail/GridBatchDataFactory.h>
 #include <fvdb/detail/ops/BuildDilatedGrid.h>
 #include <fvdb/detail/ops/CloneGrid.h>
@@ -54,7 +55,8 @@ dispatchDilateGrid<torch::kCUDA>(const GridBatchData &gridBatch,
             TORCH_CHECK(grid, "Grid is null");
 
             for (auto j = 0; j < dilationAmount[i]; j += 1) {
-                nanovdb::tools::cuda::DilateGrid<nanovdb::ValueOnIndex> dilateOp(grid, stream);
+                nanovdb::tools::cuda::DilateGrid<nanovdb::ValueOnIndex, TorchResource> dilateOp(
+                    grid, stream);
                 dilateOp.setOperation(nanovdb::tools::morphology::NN_FACE_EDGE_VERTEX);
                 dilateOp.setChecksum(nanovdb::CheckMode::Default);
                 dilateOp.setVerbose(0);

--- a/src/fvdb/detail/ops/BuildFineGridFromCoarse.cu
+++ b/src/fvdb/detail/ops/BuildFineGridFromCoarse.cu
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 #include <fvdb/GridBatchData.h>
+#include <fvdb/TorchResource.h>
 #include <fvdb/detail/GridBatchDataFactory.h>
 #include <fvdb/detail/ops/BuildFineGridFromCoarse.h>
 #include <fvdb/detail/ops/BuildGridFromIjk.h>
@@ -424,7 +425,8 @@ fineGridHandleFromCoarseCUDA(const GridBatchData &coarseBatchHdl,
         TORCH_CHECK(grid, "Grid is null");
         nanovdb::GridHandle<TorchDeviceBuffer> handle;
         for (int p = 0; p < nPasses; p += 1) {
-            nanovdb::tools::cuda::RefineGrid<nanovdb::ValueOnIndex> op(grid, stream.stream());
+            nanovdb::tools::cuda::RefineGrid<nanovdb::ValueOnIndex, TorchResource> op(
+                grid, stream.stream());
             op.setChecksum(nanovdb::CheckMode::Default);
             op.setVerbose(0);
             handle = op.getHandle(guide);

--- a/src/fvdb/detail/ops/BuildGridForConv.cu
+++ b/src/fvdb/detail/ops/BuildGridForConv.cu
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 #include <fvdb/GridBatchData.h>
+#include <fvdb/TorchResource.h>
 #include <fvdb/detail/GridBatchDataFactory.h>
 #include <fvdb/detail/ops/BuildCoarseGridFromFine.h>
 #include <fvdb/detail/ops/BuildGridForConv.h>
@@ -225,8 +226,8 @@ dispatchBuildGridForConv<torch::kCUDA>(const GridBatchData &baseGridHdl,
             nanovdb::GridHandle<TorchDeviceBuffer> handle;
             if (k % 2 == 1) {
                 for (int p = 0; p < (k - 1) / 2; p += 1) {
-                    nanovdb::tools::cuda::DilateGrid<nanovdb::ValueOnIndex> op(grid,
-                                                                               stream.stream());
+                    nanovdb::tools::cuda::DilateGrid<nanovdb::ValueOnIndex, TorchResource> op(
+                        grid, stream.stream());
                     op.setOperation(nanovdb::tools::morphology::NN_FACE_EDGE_VERTEX);
                     op.setChecksum(nanovdb::CheckMode::Default);
                     op.setVerbose(0);

--- a/src/fvdb/detail/ops/BuildGridForConvTranspose.cu
+++ b/src/fvdb/detail/ops/BuildGridForConvTranspose.cu
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 #include <fvdb/GridBatchData.h>
+#include <fvdb/TorchResource.h>
 #include <fvdb/detail/GridBatchDataFactory.h>
 #include <fvdb/detail/ops/BuildFineGridFromCoarse.h>
 #include <fvdb/detail/ops/BuildGridForConvTranspose.h>
@@ -232,8 +233,8 @@ dispatchBuildGridForConvTranspose<torch::kCUDA>(const GridBatchData &baseGridHdl
             nanovdb::GridHandle<TorchDeviceBuffer> handle;
             if (k % 2 == 1) {
                 for (int p = 0; p < (k - 1) / 2; p += 1) {
-                    nanovdb::tools::cuda::DilateGrid<nanovdb::ValueOnIndex> op(grid,
-                                                                               stream.stream());
+                    nanovdb::tools::cuda::DilateGrid<nanovdb::ValueOnIndex, TorchResource> op(
+                        grid, stream.stream());
                     op.setOperation(nanovdb::tools::morphology::NN_FACE_EDGE_VERTEX);
                     op.setChecksum(nanovdb::CheckMode::Default);
                     op.setVerbose(0);
@@ -260,7 +261,8 @@ dispatchBuildGridForConvTranspose<torch::kCUDA>(const GridBatchData &baseGridHdl
     // 2S (+) {0,1}^3, and one negative pad pass adds (+) {-1,0}^3, composing to (+) [-1,1]^3.
     if (stride == nanovdb::Coord(2) && uniformKernel && kernelSize[0] == 3) {
         return perItemGridHandle(baseGridHdl, guide, [&](nanovdb::OnIndexGrid *grid) {
-            nanovdb::tools::cuda::RefineGrid<nanovdb::ValueOnIndex> refineOp(grid, stream.stream());
+            nanovdb::tools::cuda::RefineGrid<nanovdb::ValueOnIndex, TorchResource> refineOp(
+                grid, stream.stream());
             refineOp.setChecksum(nanovdb::CheckMode::Default);
             refineOp.setVerbose(0);
             nanovdb::GridHandle<TorchDeviceBuffer> refined = refineOp.getHandle(guide);

--- a/src/fvdb/detail/ops/BuildGridFromIjk.cu
+++ b/src/fvdb/detail/ops/BuildGridFromIjk.cu
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 #include <fvdb/GridBatchData.h>
+#include <fvdb/TorchResource.h>
 #include <fvdb/detail/GridBatchDataFactory.h>
 #include <fvdb/detail/ops/BuildGridFromIjk.h>
 #include <fvdb/detail/utils/AccessorHelpers.cuh>
@@ -93,8 +94,9 @@ dispatchCreateNanoGridFromIJK<torch::kCUDA>(const JaggedTensor &ijk) {
         handles.push_back(
             nVoxels == 0
                 ? createEmptyGridHandle(guide.device())
-                : nanovdb::tools::cuda::voxelsToGrid<GridT, nanovdb::Coord *, TorchDeviceBuffer>(
-                      (nanovdb::Coord *)dataPtr, nVoxels, 1.0, guide));
+                : nanovdb::tools::cuda::
+                      voxelsToGrid<GridT, nanovdb::Coord *, TorchDeviceBuffer, TorchResource>(
+                          (nanovdb::Coord *)dataPtr, nVoxels, 1.0, guide));
         C10_CUDA_KERNEL_LAUNCH_CHECK();
     }
 

--- a/src/fvdb/detail/ops/BuildGridFromPoints.cu
+++ b/src/fvdb/detail/ops/BuildGridFromPoints.cu
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 #include <fvdb/GridBatchData.h>
+#include <fvdb/TorchResource.h>
 #include <fvdb/detail/GridBatchDataFactory.h>
 #include <fvdb/detail/ops/BuildGridFromIjk.h>
 #include <fvdb/detail/ops/BuildGridFromPoints.h>
@@ -196,17 +197,19 @@ dispatchBuildGridFromPoints<torch::kCUDA>(const JaggedTensor &points,
                 } else if (pointsAreContiguous) {
                     using PointPtrT = TransformedPointPtr<scalar_t, true>;
                     handles.push_back(
-                        nanovdb::tools::cuda::voxelsToGrid<GridT, PointPtrT, TorchDeviceBuffer>(
-                            PointPtrT(pointsPtr + 3 * startIdx, txs[i]), nPoints, 1.0, guide));
+                        nanovdb::tools::cuda::
+                            voxelsToGrid<GridT, PointPtrT, TorchDeviceBuffer, TorchResource>(
+                                PointPtrT(pointsPtr + 3 * startIdx, txs[i]), nPoints, 1.0, guide));
                 } else {
                     using PointPtrT = TransformedPointPtr<scalar_t, false>;
                     handles.push_back(
-                        nanovdb::tools::cuda::voxelsToGrid<GridT, PointPtrT, TorchDeviceBuffer>(
-                            PointPtrT(
-                                pointsPtr + startIdx * rowStride, txs[i], rowStride, colStride),
-                            nPoints,
-                            1.0,
-                            guide));
+                        nanovdb::tools::cuda::
+                            voxelsToGrid<GridT, PointPtrT, TorchDeviceBuffer, TorchResource>(
+                                PointPtrT(
+                                    pointsPtr + startIdx * rowStride, txs[i], rowStride, colStride),
+                                nPoints,
+                                1.0,
+                                guide));
                 }
                 C10_CUDA_KERNEL_LAUNCH_CHECK();
             }

--- a/src/fvdb/detail/ops/BuildMergedGrids.cu
+++ b/src/fvdb/detail/ops/BuildMergedGrids.cu
@@ -41,9 +41,9 @@ dispatchMergeGrids<torch::kCUDA>(const GridBatchData &gridBatch1, const GridBatc
     // Create a grid for each batch item and store the handles
     std::vector<nanovdb::GridHandle<TorchDeviceBuffer>> handles;
     for (int i = 0; i < gridBatch1.batchSize(); i += 1) {
-        nanovdb::OnIndexGrid *grid1 = gridBatch1.mGridHdl->deviceGrid<nanovdb::ValueOnIndex>(i);
+        nanovdb::OnIndexGrid *grid1 = gridBatch1.deviceGridPtrAt(i);
         TORCH_CHECK(grid1, "First Grid is null");
-        nanovdb::OnIndexGrid *grid2 = gridBatch2.mGridHdl->deviceGrid<nanovdb::ValueOnIndex>(i);
+        nanovdb::OnIndexGrid *grid2 = gridBatch2.deviceGridPtrAt(i);
         TORCH_CHECK(grid2, "Second Grid is null");
 
         nanovdb::tools::cuda::MergeGrids<nanovdb::ValueOnIndex, TorchResource> mergeOp(
@@ -77,14 +77,11 @@ dispatchMergeGrids<torch::kCPU>(const GridBatchData &gridBatch1, const GridBatch
     TORCH_CHECK_VALUE(gridBatch1.batchSize() == gridBatch2.batchSize(),
                       "GridBatches to merge should have the same batch size");
 
-    const nanovdb::GridHandle<TorchDeviceBuffer> &gridHdl1 = gridBatch1.nanoGridHandle();
-    const nanovdb::GridHandle<TorchDeviceBuffer> &gridHdl2 = gridBatch2.nanoGridHandle();
-
     std::vector<nanovdb::GridHandle<TorchDeviceBuffer>> gridHandles;
-    gridHandles.reserve(gridHdl1.gridCount());
-    for (uint32_t bidx = 0; bidx < gridHdl1.gridCount(); bidx += 1) {
-        const nanovdb::OnIndexGrid *grid1 = gridHdl1.template grid<GridT>(bidx);
-        const nanovdb::OnIndexGrid *grid2 = gridHdl2.template grid<GridT>(bidx);
+    gridHandles.reserve(gridBatch1.batchSize());
+    for (int64_t bidx = 0; bidx < gridBatch1.batchSize(); bidx += 1) {
+        const nanovdb::OnIndexGrid *grid1 = gridBatch1.hostGridPtrAt(bidx);
+        const nanovdb::OnIndexGrid *grid2 = gridBatch2.hostGridPtrAt(bidx);
         TORCH_CHECK(grid1, "Failed to get pointer to nanovdb index grid (first argument to merge)");
         TORCH_CHECK(grid2,
                     "Failed to get pointer to nanovdb index grid (second argument to merge)");

--- a/src/fvdb/detail/ops/BuildMergedGrids.cu
+++ b/src/fvdb/detail/ops/BuildMergedGrids.cu
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 #include <fvdb/TorchDeviceBuffer.h>
+#include <fvdb/TorchResource.h>
 #include <fvdb/detail/GridBatchDataFactory.h>
 #include <fvdb/detail/ops/BuildMergedGrids.h>
 #include <fvdb/detail/utils/Utils.h>
@@ -45,7 +46,8 @@ dispatchMergeGrids<torch::kCUDA>(const GridBatchData &gridBatch1, const GridBatc
         nanovdb::OnIndexGrid *grid2 = gridBatch2.mGridHdl->deviceGrid<nanovdb::ValueOnIndex>(i);
         TORCH_CHECK(grid2, "Second Grid is null");
 
-        nanovdb::tools::cuda::MergeGrids<nanovdb::ValueOnIndex> mergeOp(grid1, grid2, stream);
+        nanovdb::tools::cuda::MergeGrids<nanovdb::ValueOnIndex, TorchResource> mergeOp(
+            grid1, grid2, stream);
         mergeOp.setChecksum(nanovdb::CheckMode::Default);
         mergeOp.setVerbose(0);
 

--- a/src/fvdb/detail/ops/BuildPaddedGrid.cu
+++ b/src/fvdb/detail/ops/BuildPaddedGrid.cu
@@ -3,6 +3,7 @@
 //
 #include <fvdb/GridBatchData.h>
 #include <fvdb/TorchDeviceBuffer.h>
+#include <fvdb/TorchResource.h>
 #include <fvdb/detail/GridBatchDataFactory.h>
 #include <fvdb/detail/ops/BuildGridFromIjk.h>
 #include <fvdb/detail/ops/BuildPaddedGrid.h>
@@ -301,7 +302,8 @@ erodeOncePass(nanovdb::OnIndexGrid *grid,
         return createEmptyGridHandle(device);
     }
 
-    nanovdb::tools::cuda::PruneGrid<nanovdb::ValueOnIndex> pruneOp(grid, keepMasks, stream);
+    nanovdb::tools::cuda::PruneGrid<nanovdb::ValueOnIndex, TorchResource> pruneOp(
+        grid, keepMasks, stream);
     pruneOp.setChecksum(nanovdb::CheckMode::Default);
     pruneOp.setVerbose(0);
     auto handle = pruneOp.getHandle(guide);

--- a/src/fvdb/detail/ops/BuildPointTruncationShell.cu
+++ b/src/fvdb/detail/ops/BuildPointTruncationShell.cu
@@ -1,0 +1,723 @@
+// Copyright Contributors to the OpenVDB Project
+// SPDX-License-Identifier: Apache-2.0
+//
+#include <fvdb/detail/GridBatchDataFactory.h>
+#include <fvdb/detail/ops/ActiveGridCoords.h>
+#include <fvdb/detail/ops/BuildDilatedGrid.h>
+#include <fvdb/detail/ops/BuildGridFromIjk.h>
+#include <fvdb/detail/ops/BuildGridFromPoints.h>
+#include <fvdb/detail/ops/BuildPointTruncationShell.h>
+
+#include <c10/util/Exception.h>
+#include <torch/types.h>
+
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <limits>
+#include <vector>
+
+namespace fvdb {
+namespace detail {
+namespace ops {
+
+namespace {
+
+// Generate a dense (2*numPad+1)^3 x 3 int32 tensor of integer lattice offsets in
+// [-numPad, numPad]^3. Applied as a broadcast add on top of a base-voxel list
+// this is equivalent to `numPad` successive NN_FACE_EDGE_VERTEX dilations,
+// which is the stencil fvdb uses for truncation-band topology.
+// Currently unused because the voxel-path shell build separates the 3-D
+// stencil into three 1-D axis expansions; kept for the leaf-shell and
+// potential CPU fallback paths.
+[[maybe_unused]] torch::Tensor
+makeStencilOffsets(int64_t numPad, torch::Device device) {
+    const torch::TensorOptions optI32 =
+        torch::TensorOptions().dtype(torch::kInt32).device(device);
+    const torch::Tensor axis = torch::arange(-numPad, numPad + 1, optI32);
+    const auto grid          = at::meshgrid({axis, axis, axis}, "ij");
+    return torch::stack(
+               {grid[0].flatten(), grid[1].flatten(), grid[2].flatten()}, 1)
+        .contiguous(); // [(2k+1)^3, 3]
+}
+
+// Dedupe an [N, 3] int32 ijk tensor via lexicographic unique on dim 0.
+torch::Tensor
+uniqueIjk(const torch::Tensor &ijk) {
+    TORCH_CHECK(ijk.dim() == 2 && ijk.size(1) == 3, "uniqueIjk expects [N, 3]");
+    const auto uniq = at::unique_dim(ijk, /*dim=*/0, /*sorted=*/false,
+                                     /*return_inverse=*/false,
+                                     /*return_counts=*/false);
+    return std::get<0>(uniq).contiguous();
+}
+
+// Tree-merge a list of [N_i, 3] int32 unique-voxel tensors into a single
+// deduped unique-voxel tensor. Pairwise-merges the list in log2 rounds,
+// which bounds peak transient memory to ~2x the largest partial instead
+// of (sum of partials) + scratch that a single final-cat-plus-unique
+// would need. Unused since the voxel-granularity path switched to
+// packed-key int64 tree-merging (kept for parity with CPU path if it
+// is ever restored).
+[[maybe_unused]] torch::Tensor
+treeMergeUniqueIjk(std::vector<torch::Tensor> shards) {
+    while (shards.size() > 1) {
+        std::vector<torch::Tensor> next;
+        next.reserve((shards.size() + 1) / 2);
+        for (size_t i = 0; i + 1 < shards.size(); i += 2) {
+            next.push_back(uniqueIjk(
+                torch::cat({shards[i], shards[i + 1]}, /*dim=*/0)));
+            // Eagerly release input tensors now that they've been merged
+            // so torch's caching allocator can reuse their blocks for the
+            // next round. Without this the allocator holds the shard
+            // memory live until the enclosing vector dies, which roughly
+            // doubles peak usage at large N.
+            shards[i]     = torch::Tensor();
+            shards[i + 1] = torch::Tensor();
+        }
+        if (shards.size() % 2 == 1) {
+            next.push_back(std::move(shards.back()));
+        }
+        shards = std::move(next);
+    }
+    return shards.empty() ? torch::Tensor() : std::move(shards[0]);
+}
+
+// World-space point filter with scene-adaptive clamp.
+//
+// Motivation: `unprojectDepthmapKernel` emits a non-trivial fraction
+// (~1% for Replica room0) of "garbage" unprojected coordinates — finite
+// values ranging from tens of metres to millions of metres — for pixels
+// where the float32 inv-projection + cam-to-world matmul chain loses
+// precision. Reproducing the exact same depth + pose + intrinsics in fp32
+// torch on the same inputs produces 0% garbage, so the issue is specific
+// to the CUDA kernel (likely an FMA-accuracy / denormal interaction we
+// haven't yet tracked down; see research journal).
+//
+// A *static* clamp is brittle across workloads: ±10 m is fine for Replica
+// but will reject valid LiDAR at ±80 m; ±1024 m keeps the KITTI case but
+// readmits enough Replica garbage to blow up the downstream shell by 5x.
+//
+// Strategy: compute the p99 of `max|coord|` over the finite points, use
+// `k_sigma * p99` as the upper bound, and reject everything beyond. p99
+// adapts to scene scale (Replica ~5 m, KITTI ~60 m, autonomous-car LiDAR
+// ~100 m), and the 4x headroom keeps every realistic "last 1%" point
+// inside while still aggressively cutting the far-field garbage tail.
+// NaN / Inf are rejected first so the percentile only sees finite values.
+//
+// `kAdaptiveClampHeadroom` and the hard ceiling are chosen empirically:
+//   - On Replica room0, p99 is already polluted by the garbage tail
+//     (p99 ~= 50 m even though the real scene is only 4 m wide); using
+//     p50 (median) ~= 1.5 m is much more robust. `headroom=8x` over
+//     median gives a 12 m clamp for Replica, plenty for any room-scale
+//     scene while still rejecting garbage at 50+ m.
+//   - The hard ceiling (300 m) protects against workloads where even
+//     the median drifts high (e.g. if a whole frame's pixels are
+//     garbage); 300 m is larger than any real indoor/outdoor TSDF
+//     workload but small enough that the resulting voxel set is still
+//     tractable.
+//   - The hard floor (4 m) handles tiny scenes / initialisation edge
+//     cases so we never clamp below the plausible scene extent.
+constexpr double kAdaptiveClampHeadroom = 8.0;
+constexpr double kMinAdaptiveClamp      = 4.0;       // never clamp below 4 m
+// Raised from the room-scale default (300 m) so outdoor LiDAR
+// datasets (Mai City, KITTI, etc.) with trajectories that wander
+// far from the world origin don't get their entire per-frame point
+// cloud rejected. The filter's primary purpose is to drop the
+// fp32-precision garbage tail from `unprojectDepthmapKernel` (10^4-
+// 10^38 m coordinates); 100 km is generous for any realistic TSDF
+// workload while still well below the fp32 overflow regime. LiDAR
+// callers never hit this filter's garbage-rejection branch in
+// practice (their inputs are raw Velodyne-style fp32 readings, not
+// unprojected from fp32 matrix math), so the cap only matters to
+// prevent accidental rejection of legitimate far-from-origin points.
+constexpr double kMaxAdaptiveClamp      = 100000.0;
+
+torch::Tensor
+filterValidPoints(const torch::Tensor &points) {
+    // Runs in fp32 (whatever dtype the caller passed). Keeps peak memory
+    // to points.size(0) * sizeof(scalar_t) * 3 bytes rather than the 2x
+    // that an intermediate fp64 copy would need.
+    //
+    // Stage A: reject non-finite (NaN / Inf) so the quantile stage
+    // only looks at real-valued finite coordinates.
+    const torch::Tensor finite_mask =
+        at::isfinite(points).all(/*dim=*/1);
+    const torch::Tensor finite_pts = points.index({finite_mask});
+    if (finite_pts.size(0) == 0) {
+        return points.new_empty({0, 3});
+    }
+
+    // Stage B: scene-adaptive clamp. Robust statistic = median of
+    // max|coord| across the surviving finite points. The garbage tail
+    // that `unprojectDepthmapKernel` emits is a small fraction of the
+    // total (~1%) so the median is dominated by genuine scene content
+    // -- unlike p99 which gets dragged up by the garbage.
+    //
+    // `at::quantile` has a ~2^24-row internal sort limit, so we stride-
+    // subsample large inputs. 1 M samples pins the median to within a
+    // centimetre for any realistic point distribution, for ~20 ms of
+    // extra work.
+    const torch::Tensor max_abs =
+        std::get<0>(finite_pts.abs().max(/*dim=*/1)); // [N_fin]
+    constexpr int64_t kPctSampleCap = 1 << 20; // 1 M
+    torch::Tensor max_abs_for_quantile;
+    if (max_abs.size(0) > kPctSampleCap) {
+        const int64_t stride = (max_abs.size(0) + kPctSampleCap - 1) /
+                               kPctSampleCap;
+        max_abs_for_quantile =
+            max_abs.index({torch::indexing::Slice(0, torch::indexing::None,
+                                                   stride)})
+                .contiguous();
+    } else {
+        max_abs_for_quantile = max_abs;
+    }
+    // `at::quantile` does not support fp16 inputs as of PyTorch 2.x
+    // (it requires float or double). Promote to fp32 for the single
+    // median call -- this is a ~1 M-element tensor at most so the
+    // promotion cost is trivial.
+    const torch::Tensor max_abs_f32 =
+        max_abs_for_quantile.scalar_type() == torch::kHalf
+            ? max_abs_for_quantile.to(torch::kFloat32)
+            : max_abs_for_quantile;
+    const double median =
+        at::quantile(max_abs_f32, 0.50).item<double>();
+    const double clamp = std::min(
+        kMaxAdaptiveClamp,
+        std::max(kMinAdaptiveClamp, kAdaptiveClampHeadroom * median));
+    const torch::Tensor bounded_mask =
+        (finite_pts.abs() < clamp).all(/*dim=*/1);
+
+    if (std::getenv("FVDB_NANOVDB_TRACE_ALLOCS")) {
+        std::fprintf(
+            stderr,
+            "[fvdb] filterValidPoints median=%.3f m -> clamp=%.3f m (finite=%lld -> bounded=%lld)\n",
+            median, clamp, (long long)finite_pts.size(0),
+            (long long)bounded_mask.sum().item<int64_t>());
+    }
+
+    return finite_pts.index({bounded_mask}).contiguous();
+}
+
+// Quantise world-space points into integer voxel ijk using the same
+// transform (xyz - origin) / voxelSize + round() that fvdb's primal
+// `VoxelCoordTransform` applies. Uses the input dtype for the
+// `(xyz - origin) / voxelSize` math to avoid a 2x-memory fp32→fp64
+// upcast; for typical TSDF settings (2 cm voxels, ~10 m scenes) the
+// worst-case rounding error is well under a single voxel, so fp32 is
+// sufficient for correctness.
+torch::Tensor
+pointsToIjk(const torch::Tensor &points,
+            const nanovdb::Vec3d &voxelSize,
+            const nanovdb::Vec3d &origin) {
+    const torch::TensorOptions optSame =
+        torch::TensorOptions().dtype(points.scalar_type()).device(points.device());
+    const torch::Tensor vs =
+        torch::tensor({voxelSize[0], voxelSize[1], voxelSize[2]}, optSame);
+    const torch::Tensor og =
+        torch::tensor({origin[0], origin[1], origin[2]}, optSame);
+    const torch::Tensor ijk_same = ((points - og) / vs).round();
+    return ijk_same.to(torch::kInt32).contiguous(); // [N, 3]
+}
+
+// Leaf-granularity shell builder (FVDB_LEAF_SHELL=1 fast path).
+//
+// Compared to the default voxel-granularity build:
+//   - Map each unique voxel ijk to its LEAF key: `ijk >> 3` per axis
+//     (each nanoVDB leaf is 8^3 voxels).
+//   - Dilate at LEAF granularity. A voxel-level dilation radius of
+//     `numPad` voxels translates to a leaf-level dilation of
+//     `ceil((numPad + 7) / 8)` leaves per axis (worst case when a
+//     voxel sits at the far edge of its leaf). So for the typical
+//     numPad = 3 case (6 cm truncation at 2 cm voxels), the leaf
+//     stencil is just 3^3 = 27 vs the voxel stencil's 7^3 = 343 --
+//     a 13x reduction in dilate-and-dedupe work.
+//   - Dedupe to unique leaves.
+//   - Expand each unique leaf to its 512 voxel ijks (a fixed cartesian
+//     `[0, 8)^3` offset, then broadcast-add to the leaf origin).
+//   - Hand the 512-voxels-per-leaf ijk set to `_createNanoGridFromIJK`.
+//
+// The resulting grid is a strict SUPERSET of what the voxel-granularity
+// path produces: every voxel within `numPad` of any input point is
+// active, AND so are all other voxels in those voxels' leaves. Extra
+// voxels cost a little memory (roughly `512 / voxels_per_leaf_hit`)
+// but they're a no-op for the downstream TSDF integrate kernel -- they
+// stay at weight = 0 and do nothing. In exchange we avoid ~50 dedupe
+// passes on multi-million-row tensors, which was the ~60 ms/frame
+// bottleneck on Replica (see research journal
+// `2026-04-22_topology_ops_feasibility.md`).
+//
+// Returns `[U_leaves * 512, 3]` int32 voxel ijk tensor ready to hand
+// to `_createNanoGridFromIJK`.
+torch::Tensor
+leafGranularityShell(const torch::Tensor &ijk,
+                     int64_t numPad) {
+    TORCH_CHECK(ijk.dim() == 2 && ijk.size(1) == 3,
+                "leafGranularityShell expects ijk [N, 3]");
+    const torch::Device device = ijk.device();
+    const torch::TensorOptions optI32 =
+        torch::TensorOptions().dtype(torch::kInt32).device(device);
+
+    // Step 1: map each ijk to its LEAF key (ijk >> 3 in floor-arithmetic),
+    // then dedupe to UNIQUE LEAVES.
+    //
+    // This is the crucial ordering: we dedupe BEFORE dilating. For a
+    // Replica-scale depth frame, the 816 K quantised ijks collapse down
+    // to ~1-2 K unique 8-voxel leaves (a 500x collapse), so the
+    // downstream dilate-and-dedupe pass works on a tiny set. The
+    // ~2-3 ms dedupe dominates; everything after it is sub-ms.
+    const torch::Tensor leaf_key =
+        at::div(ijk, 8, /*rounding_mode=*/"floor");
+    torch::Tensor unique_leaves_raw = uniqueIjk(leaf_key);
+    if (unique_leaves_raw.size(0) == 0) {
+        return at::empty({0, 3}, optI32);
+    }
+
+    // Step 2: dilate at leaf granularity. Leaf-level dilation
+    // half-radius for a voxel-level radius of `numPad`: a voxel anywhere
+    // within an 8-wide leaf can reach up to `ceil((numPad + 7) / 8)`
+    // leaves away, so the leaf stencil is `(2 * half + 1)^3`. For the
+    // typical numPad = 3 case that is 3^3 = 27 (vs the voxel path's
+    // 7^3 = 343).
+    const int64_t leaf_half = (numPad + 7 + 7) / 8; // ceil((numPad+7)/8)
+    const torch::Tensor leaf_axis =
+        torch::arange(-leaf_half, leaf_half + 1, optI32);
+    const auto leaf_grid =
+        at::meshgrid({leaf_axis, leaf_axis, leaf_axis}, "ij");
+    const torch::Tensor leaf_stencil =
+        torch::stack({leaf_grid[0].flatten(),
+                      leaf_grid[1].flatten(),
+                      leaf_grid[2].flatten()},
+                     1)
+            .contiguous();
+
+    // [U_raw, 1, 3] + [1, S_leaf, 3] -> [U_raw * S_leaf, 3]. At typical
+    // Replica scale U_raw ~ 1-2 K and S_leaf = 27 so this is ~30-50 K
+    // rows, trivial to dedupe.
+    const torch::Tensor leaf_expanded =
+        (unique_leaves_raw.unsqueeze(1) + leaf_stencil.unsqueeze(0))
+            .reshape({-1, 3})
+            .contiguous();
+    unique_leaves_raw = torch::Tensor(); // free
+    const torch::Tensor unique_leaves = uniqueIjk(leaf_expanded);
+    if (unique_leaves.size(0) == 0) {
+        return at::empty({0, 3}, optI32);
+    }
+
+    // Emit all 512 voxels per leaf: leaf origin = leaf_key * 8, and each
+    // voxel in the leaf is leaf_origin + (i, j, k) for (i,j,k) in
+    // [0, 8)^3.
+    const torch::Tensor local_axis = torch::arange(0, 8, optI32);
+    const auto local_grid = at::meshgrid({local_axis, local_axis, local_axis}, "ij");
+    const torch::Tensor local_offsets =
+        torch::stack({local_grid[0].flatten(),
+                      local_grid[1].flatten(),
+                      local_grid[2].flatten()},
+                     1)
+            .contiguous();  // [512, 3]
+
+    const torch::Tensor leaf_origins = unique_leaves * 8;  // [U_leaves, 3]
+    // [U, 1, 3] + [1, 512, 3] -> [U, 512, 3] -> [U*512, 3]
+    const torch::Tensor shell =
+        (leaf_origins.unsqueeze(1) + local_offsets.unsqueeze(0))
+            .reshape({-1, 3})
+            .contiguous();
+
+    if (std::getenv("FVDB_NANOVDB_TRACE_ALLOCS")) {
+        std::fprintf(
+            stderr,
+            "[fvdb] leafGranularityShell input_ijks=%lld leaves=%lld shell_voxels=%lld\n",
+            (long long)ijk.size(0),
+            (long long)unique_leaves.size(0),
+            (long long)shell.size(0));
+    }
+    return shell;
+}
+
+// Build the single-batch truncation-shell grid directly from a list of
+// world-space points. Entirely in torch ops (no `buildGridFromPoints` /
+// `dilateGrid` call), deduping at two levels and tree-merging the
+// per-stencil-chunk partials so that peak transient memory stays at
+// `O(U_unique_base_voxels * stencil_chunk * 12 B)` rather than
+// `O(N_points)` or `O(pointGrid_tile_count * 16 MB)`.
+//
+// Env override `FVDB_LEAF_SHELL=1` switches to the leaf-granularity
+// fast path (see `leafGranularityShell` above). The leaf path
+// over-covers at the sub-leaf scale but avoids the ~50 dedupe-pass
+// accumulation that dominates the voxel-granularity path on room-
+// scale scenes. Targeted for the phase-1b per-frame fusion pipeline;
+// see research journal `2026-04-22_topology_ops_feasibility.md`.
+nanovdb::GridHandle<TorchDeviceBuffer>
+buildSingleBatchShell(const torch::Tensor &points_b,
+                      const nanovdb::Vec3d &voxelSize,
+                      const nanovdb::Vec3d &origin,
+                      int64_t numPad) {
+    TORCH_CHECK(points_b.dim() == 2 && points_b.size(1) == 3,
+                "points must be [N, 3]");
+    TORCH_CHECK(points_b.device().is_cuda(),
+                "fast shell builder is CUDA-only");
+
+    const torch::Device device = points_b.device();
+
+    // `FVDB_SHELL_PHASE_PROFILE=1` decomposes the voxel-shell build into
+    // its four sub-steps (filter+quantise, base-dedupe, stencil
+    // expand+merge, createGrid). Use to identify which stage to attack
+    // next in the shell-build speedup track. One line per frame to
+    // stderr.
+    const bool phaseProfile =
+        std::getenv("FVDB_SHELL_PHASE_PROFILE") != nullptr;
+    cudaEvent_t evA{}, evB{}, evC{}, evD{}, evE{};
+    auto phaseMark = [&](cudaEvent_t &ev) {
+        if (phaseProfile) {
+            cudaEventCreate(&ev);
+            cudaEventRecord(ev);
+        }
+    };
+    phaseMark(evA);
+
+    // Stage 1: point-level filter + quantise.
+    //
+    // Work in the caller's dtype (typically fp32) throughout. Converting
+    // to fp64 for "precision" doubles peak memory for no benefit in this
+    // workload -- the subsequent `.round()` step is trivially exact in
+    // fp32 for any realistic voxel size / scene extent combination.
+    //
+    // Eagerly drop `valid_points` as soon as `ijk_i32` exists, so the
+    // [N_valid, 3] fp32 tensor (~1 GB at N=200 frames @ 1200x680) is
+    // reclaimed before the dedupe / stencil stages ask for scratch.
+    torch::Tensor ijk_i32;
+    {
+        torch::Tensor valid_points = filterValidPoints(points_b);
+        if (valid_points.size(0) == 0) {
+            TorchDeviceBuffer emptyBuf(0, device);
+            return nanovdb::GridHandle<TorchDeviceBuffer>(std::move(emptyBuf));
+        }
+        ijk_i32 = pointsToIjk(valid_points, voxelSize, origin);
+    } // valid_points drops here
+    phaseMark(evB);
+
+    // --- Voxel-granularity shell (default CUDA fast path) ----------
+    //
+    // The voxel-granularity path uses separable-axis dilation on
+    // packed int64 ijk keys followed by `voxelsToGrid`: quantise ->
+    // base dedupe -> dilate-X + dedupe -> dilate-Y + dedupe ->
+    // dilate-Z + dedupe -> unpack -> voxelsToGrid. Total dedupe work
+    // is O(N * 3 * (2r+1)) with each intermediate compressing by
+    // 2-3x before the next axis expansion, replacing the ~90
+    // `_unique` launches of the old 3D-stencil-chunked tree-merge
+    // with 3 launches on progressively larger but still bounded
+    // tensors.
+    //
+    // In our experiments this runs measurably faster and with
+    // substantially lower peak memory than the previous chunked-3D-
+    // stencil path, especially at fine voxel sizes where the 3D
+    // stencil's intermediate buffer is the bottleneck.
+    //
+    // Opt-in: `FVDB_LEAF_SHELL=1` reverts to the leaf-granularity
+    // builder further down. The leaf path over-covers at the
+    // sub-leaf scale (allocates all 512 voxels in every touched
+    // leaf, mostly weight-zero no-ops) but retains a potential
+    // edge for workloads where the scene is so dense that every
+    // 8^3 voxel neighborhood is in the truncation band anyway;
+    // kept as an ablation knob.
+    const bool force_leaf_shell = [&]() {
+        const char *env = std::getenv("FVDB_LEAF_SHELL");
+        return env != nullptr && env[0] == '1';
+    }();
+
+    if (force_leaf_shell) {
+        const torch::Tensor leaf_shell =
+            leafGranularityShell(ijk_i32, numPad);
+        ijk_i32 = torch::Tensor();
+        if (leaf_shell.size(0) == 0) {
+            TorchDeviceBuffer emptyBuf(0, device);
+            return nanovdb::GridHandle<TorchDeviceBuffer>(std::move(emptyBuf));
+        }
+        if (std::getenv("FVDB_NANOVDB_TRACE_ALLOCS")) {
+            std::fprintf(
+                stderr,
+                "[fvdb] buildSingleBatchShell (leaf path, FVDB_LEAF_SHELL opt-in) shell=%lld\n",
+                (long long)leaf_shell.size(0));
+        }
+        const JaggedTensor shellJT(leaf_shell);
+        return _createNanoGridFromIJK(shellJT);
+    }
+
+    // Stage 2: separable box dilation in packed int64 keys.
+    //
+    // The voxel-shell's [-r, r]^3 box dilation is a morphological
+    // open-ball operation in the Chebyshev metric; such dilations are
+    // separable across axes: dilate_3D(A, r) ==
+    // dilate_Z(dilate_Y(dilate_X(A, r), r), r). Doing it separably
+    // reduces work from O(N * (2r+1)^3) to O(N * 3 * (2r+1)) with
+    // dedup between each axis, which shrinks each stage's working set
+    // by ~2-3x before the next axis expands it. At Replica scale
+    // (N=800 K, r=3) the total dedup work drops from ~440 M to ~60 M
+    // rows, and we replace ~90 `_unique` kernel launches with exactly
+    // three.
+    //
+    // Keys are packed into int64 (21 bits per axis, 20-bit bias) so
+    // `_unique` runs on a 1-D tensor rather than row-wise on
+    // int32[N, 3]. Stencil offsets are pre-packed the same way so the
+    // per-axis expand is a single `[U, 1] + [1, 2r+1]` broadcast add.
+    // Final unpack hands int32[F, 3] to `voxelsToGrid` which builds
+    // topology in one more sort+RLE pass.
+    //
+    // `voxelsToGrid` itself will dedupe any input, but feeding it the
+    // raw undeduped ~400-600 M voxels directly (we tested) takes ~300
+    // ms at 5 mm because CUB radix-sort cost scales near-linearly with
+    // input size. The three pre-sorts here are cheap (each works on a
+    // progressively larger but still much smaller tensor than the full
+    // N * S expansion) and reduce the final voxelsToGrid input to
+    // ~10 M unique voxels, which is ~10 ms to turn into a grid.
+    constexpr int64_t kPackBias = 1ll << 20;
+    constexpr int64_t kPackMask = (1ll << 21) - 1;
+    auto packIjk = [&](const torch::Tensor &ijk_i32) -> torch::Tensor {
+        const torch::Tensor ijk_i64 = ijk_i32.to(torch::kInt64);
+        const torch::Tensor i =
+            ijk_i64.select(1, 0).add(kPackBias);
+        const torch::Tensor j =
+            ijk_i64.select(1, 1).add(kPackBias);
+        const torch::Tensor k =
+            ijk_i64.select(1, 2).add(kPackBias);
+        return (i.bitwise_left_shift(42))
+            .bitwise_or(j.bitwise_left_shift(21))
+            .bitwise_or(k);
+    };
+    auto unpackKeys = [&](const torch::Tensor &keys) -> torch::Tensor {
+        const torch::Tensor i =
+            keys.bitwise_right_shift(42).bitwise_and(kPackMask)
+                .sub(kPackBias);
+        const torch::Tensor j =
+            keys.bitwise_right_shift(21).bitwise_and(kPackMask)
+                .sub(kPackBias);
+        const torch::Tensor k =
+            keys.bitwise_and(kPackMask).sub(kPackBias);
+        return torch::stack({i, j, k}, /*dim=*/1)
+            .to(torch::kInt32).contiguous();
+    };
+
+    // Pack and dedup the base ijks once. Raw N includes substantial
+    // aliasing (multiple depth pixels quantising to the same voxel),
+    // and deduping here saves work at every subsequent axis-expand.
+    //
+    // We use `at::_unique` rather than a direct CUB radix-sort + select-
+    // unique because `_unique` already calls into CUB under the hood
+    // and the per-call allocation overhead is absorbed by torch's
+    // caching allocator.
+    torch::Tensor keys = std::get<0>(
+        at::_unique(packIjk(ijk_i32), /*sorted=*/false,
+                    /*return_inverse=*/false));
+    ijk_i32 = torch::Tensor();
+    phaseMark(evC);
+
+    // Per-axis 1-D stencils of length `2r+1`, pre-packed as int64 so
+    // broadcast-add composes directly with the packed base keys. Shift
+    // factors (42, 21, 0) mirror the axis-to-bit assignment above.
+    const torch::TensorOptions optI64 =
+        torch::TensorOptions().dtype(torch::kInt64).device(device);
+    const torch::Tensor axisOffsets =
+        torch::arange(-numPad, numPad + 1, optI64); // [2r+1] signed
+    const torch::Tensor stencil_x =
+        axisOffsets.bitwise_left_shift(42);
+    const torch::Tensor stencil_y =
+        axisOffsets.bitwise_left_shift(21);
+    const torch::Tensor stencil_z = axisOffsets;
+
+    auto applyAxis = [&](torch::Tensor keys_in,
+                         const torch::Tensor &axisStencil) {
+        // [U, 1] + [1, 2r+1] -> [U * (2r+1)] -> unique.
+        torch::Tensor expanded =
+            (keys_in.unsqueeze(1) + axisStencil.unsqueeze(0))
+                .flatten().contiguous();
+        keys_in = torch::Tensor();
+        return std::get<0>(
+            at::_unique(expanded, /*sorted=*/false,
+                        /*return_inverse=*/false));
+    };
+
+    keys = applyAxis(std::move(keys), stencil_x);
+    keys = applyAxis(std::move(keys), stencil_y);
+    keys = applyAxis(std::move(keys), stencil_z);
+    const int64_t F = keys.size(0);
+    if (F == 0) {
+        TorchDeviceBuffer emptyBuf(0, device);
+        return nanovdb::GridHandle<TorchDeviceBuffer>(std::move(emptyBuf));
+    }
+    const torch::Tensor shell = unpackKeys(keys);
+    keys = torch::Tensor();
+    phaseMark(evD);
+
+    if (std::getenv("FVDB_NANOVDB_TRACE_ALLOCS")) {
+        std::fprintf(
+            stderr,
+            "[fvdb] buildSingleBatchShell (voxel path, separable) "
+            "numPad=%lld shell=%lld\n",
+            (long long)numPad, (long long)F);
+    }
+
+    const JaggedTensor shellJT(shell);
+    auto gridHandle = _createNanoGridFromIJK(shellJT);
+    phaseMark(evE);
+
+    if (phaseProfile) {
+        cudaEventSynchronize(evE);
+        float t_filter = 0, t_base = 0, t_sep = 0, t_grid = 0;
+        cudaEventElapsedTime(&t_filter, evA, evB);
+        cudaEventElapsedTime(&t_base, evB, evC);
+        cudaEventElapsedTime(&t_sep, evC, evD);
+        cudaEventElapsedTime(&t_grid, evD, evE);
+        std::fprintf(
+            stderr,
+            "[fvdb/shell_phase] filter+ijk=%.2f ms  base_dedup=%.2f ms "
+            " separable_xyz=%.2f ms  createGrid=%.2f ms  total=%.2f "
+            "ms  numPad=%lld shell=%lld\n",
+            t_filter, t_base, t_sep, t_grid,
+            t_filter + t_base + t_sep + t_grid,
+            (long long)numPad, (long long)F);
+        cudaEventDestroy(evA);
+        cudaEventDestroy(evB);
+        cudaEventDestroy(evC);
+        cudaEventDestroy(evD);
+        cudaEventDestroy(evE);
+    }
+    return gridHandle;
+}
+
+} // namespace
+
+c10::intrusive_ptr<GridBatchData>
+buildPointTruncationShell(const JaggedTensor &points,
+                          const GridBatchData &grid,
+                          double truncationMargin) {
+    TORCH_CHECK_VALUE(truncationMargin > 0.0,
+                      "truncationMargin must be > 0, got ",
+                      truncationMargin);
+    TORCH_CHECK_VALUE(points.num_outer_lists() == grid.batchSize(),
+                      "points batch size (", points.num_outer_lists(),
+                      ") must equal grid batch size (", grid.batchSize(), ")");
+
+    // Per-batch voxel sizes and origins define the world-to-index
+    // transform for the new grid.
+    std::vector<nanovdb::Vec3d> voxelSizes;
+    std::vector<nanovdb::Vec3d> origins;
+    grid.gridVoxelSizesAndOrigins(voxelSizes, origins);
+
+    // Per-batch truncation-band radius (in voxels). `ceil(trunc/voxel)`
+    // guarantees every voxel within `truncationMargin` of any point is
+    // covered; we use the minimum per-batch voxel length so anisotropic
+    // grids dilate enough on the shortest axis.
+    constexpr int64_t MAX_PAD_VOXELS = 16;
+    std::vector<int64_t> numPadVoxels;
+    numPadVoxels.reserve(grid.batchSize());
+    for (int64_t i = 0; i < grid.batchSize(); ++i) {
+        const double minVoxLengthI = grid.voxelSizeAt(i).min();
+        // `std::ceil(trunc / voxel)` snaps to the next integer even when
+        // the ratio is mathematically exact -- e.g. a user-requested
+        // `trunc=0.015`, `voxel=0.005` (ratio 3 exactly) comes out as
+        // ~3.000000067 because `Grid.from_dense` internally rounds
+        // `voxel_size` to fp32 along the way (observed stored value:
+        // `0.00499999988...`). The naive ceil then yields numPad=4
+        // where the intended value is 3, inflating the separable-axis
+        // stencil from 7 to 9 per axis and wasting 28% of dedup work
+        // on expanded voxels nobody asked for.
+        //
+        // Snap to the lower integer when the fractional part is within
+        // an fp32-epsilon-scale tolerance. We use ~4 * float32_eps so
+        // the check is scale-invariant (works for both 0.015/0.005 and
+        // 15.0/5.0) and accepts both the fp32 rounding artifact above
+        // and the much smaller fp64 round-off from the `trunc / voxel`
+        // division itself. A genuine input like `trunc=0.0151` (which
+        // the user really meant to be ceiled to 4) has a fractional
+        // part of ~0.02 in ratio space -- 0.02 >> 5e-7 so the legit
+        // ceil case is untouched.
+        const double ratio        = truncationMargin / minVoxLengthI;
+        const double ratioRounded = std::round(ratio);
+        const double tol = 4.0 * static_cast<double>(
+            std::numeric_limits<float>::epsilon()) * std::max(1.0, ratio);
+        const double ceilRatio = (std::abs(ratio - ratioRounded) <= tol)
+                                     ? ratioRounded
+                                     : std::ceil(ratio);
+        const auto numPadVoxelsI = static_cast<int32_t>(ceilRatio);
+        TORCH_CHECK_VALUE(numPadVoxelsI > 0,
+                          "Number of padding voxels must be positive, got ",
+                          numPadVoxelsI,
+                          " (truncationMargin=", truncationMargin,
+                          ", voxelSize=", minVoxLengthI, ")");
+        TORCH_CHECK_VALUE(numPadVoxelsI < MAX_PAD_VOXELS,
+                          "Truncation margin (", truncationMargin,
+                          ") is too large for grid with voxel size ",
+                          minVoxLengthI,
+                          ", resulting in too many padding voxels (",
+                          numPadVoxelsI, ") which cannot exceed ",
+                          MAX_PAD_VOXELS,
+                          ". Use a larger voxel size or a smaller truncation margin.");
+        numPadVoxels.push_back(numPadVoxelsI);
+    }
+
+    // CPU and opt-out paths: run the original `buildGridFromPoints +
+    // dilateGrid(numPad)` pipeline verbatim. The CUDA fast path below
+    // sidesteps it because `dilateGrid` scratch blows up on
+    // room-scale scenes.
+    const bool isCuda = points.device().is_cuda();
+    if (!isCuda ||
+        (std::getenv("FVDB_NANOVDB_LEGACY_SHELL") != nullptr &&
+         std::getenv("FVDB_NANOVDB_LEGACY_SHELL")[0] == '1')) {
+        auto pointGrid = buildGridFromPoints(points, voxelSizes, origins);
+        return dilateGrid(*pointGrid, numPadVoxels);
+    }
+
+    // --- Fast path (CUDA, N-way union via voxel-level dilation) ---------
+    //
+    // For each batch item we:
+    //
+    //   1. Filter out NaN / Inf / far-field garbage at the point level
+    //      (`unprojectDepthmapKernel` has a precision quirk that emits
+    //      ~1% of its pixels at 10-10^6 m from the scene -- see the
+    //      research journal entry for details).
+    //   2. Quantise surviving points to integer voxel ijk.
+    //   3. Dedupe to unique-base voxels.
+    //   4. Stencil-dilate by `[-numPad, numPad]^3`, chunked + tree-merged.
+    //   5. Call `voxelsToGrid` once on the final shell voxel set.
+    //
+    // Per-batch grids are concatenated via `nanovdb::cuda::mergeGridHandles`
+    // which is a pure-buffer memcpy (no topology work, no speculative root
+    // blow-up).
+    std::vector<nanovdb::GridHandle<TorchDeviceBuffer>> handles;
+    handles.reserve(points.num_outer_lists());
+
+    const torch::Tensor offsetsCpu = points.joffsets().cpu();
+    const auto offsets             = offsetsCpu.accessor<JOffsetsType, 1>();
+    TORCH_CHECK(offsets.size(0) == grid.batchSize() + 1,
+                "joffsets length mismatch: expected ",
+                grid.batchSize() + 1, " got ", offsets.size(0));
+
+    const torch::Tensor data = points.jdata();
+    for (int64_t i = 0; i < grid.batchSize(); ++i) {
+        const int64_t start = offsets[i];
+        const int64_t count = offsets[i + 1] - start;
+        if (count == 0) {
+            TorchDeviceBuffer emptyBuf(0, points.device());
+            handles.emplace_back(
+                nanovdb::GridHandle<TorchDeviceBuffer>(std::move(emptyBuf)));
+            continue;
+        }
+
+        const torch::Tensor points_i =
+            data.narrow(0, start, count).contiguous();
+        handles.push_back(buildSingleBatchShell(
+            points_i, voxelSizes[i], origins[i], numPadVoxels[i]));
+    }
+
+    nanovdb::GridHandle<TorchDeviceBuffer> mergedHandle;
+    if (handles.size() == 1) {
+        mergedHandle = std::move(handles[0]);
+    } else {
+        TorchDeviceBuffer guide(0, points.device());
+        mergedHandle = nanovdb::cuda::mergeGridHandles(handles, &guide);
+    }
+    return makeGridBatchData(std::move(mergedHandle), voxelSizes, origins);
+}
+
+} // namespace ops
+} // namespace detail
+} // namespace fvdb

--- a/src/fvdb/detail/ops/BuildPointTruncationShell.cu
+++ b/src/fvdb/detail/ops/BuildPointTruncationShell.cu
@@ -32,12 +32,10 @@ namespace {
 // potential CPU fallback paths.
 [[maybe_unused]] torch::Tensor
 makeStencilOffsets(int64_t numPad, torch::Device device) {
-    const torch::TensorOptions optI32 =
-        torch::TensorOptions().dtype(torch::kInt32).device(device);
-    const torch::Tensor axis = torch::arange(-numPad, numPad + 1, optI32);
-    const auto grid          = at::meshgrid({axis, axis, axis}, "ij");
-    return torch::stack(
-               {grid[0].flatten(), grid[1].flatten(), grid[2].flatten()}, 1)
+    const torch::TensorOptions optI32 = torch::TensorOptions().dtype(torch::kInt32).device(device);
+    const torch::Tensor axis          = torch::arange(-numPad, numPad + 1, optI32);
+    const auto grid                   = at::meshgrid({axis, axis, axis}, "ij");
+    return torch::stack({grid[0].flatten(), grid[1].flatten(), grid[2].flatten()}, 1)
         .contiguous(); // [(2k+1)^3, 3]
 }
 
@@ -45,7 +43,9 @@ makeStencilOffsets(int64_t numPad, torch::Device device) {
 torch::Tensor
 uniqueIjk(const torch::Tensor &ijk) {
     TORCH_CHECK(ijk.dim() == 2 && ijk.size(1) == 3, "uniqueIjk expects [N, 3]");
-    const auto uniq = at::unique_dim(ijk, /*dim=*/0, /*sorted=*/false,
+    const auto uniq = at::unique_dim(ijk,
+                                     /*dim=*/0,
+                                     /*sorted=*/false,
                                      /*return_inverse=*/false,
                                      /*return_counts=*/false);
     return std::get<0>(uniq).contiguous();
@@ -64,8 +64,7 @@ treeMergeUniqueIjk(std::vector<torch::Tensor> shards) {
         std::vector<torch::Tensor> next;
         next.reserve((shards.size() + 1) / 2);
         for (size_t i = 0; i + 1 < shards.size(); i += 2) {
-            next.push_back(uniqueIjk(
-                torch::cat({shards[i], shards[i + 1]}, /*dim=*/0)));
+            next.push_back(uniqueIjk(torch::cat({shards[i], shards[i + 1]}, /*dim=*/0)));
             // Eagerly release input tensors now that they've been merged
             // so torch's caching allocator can reuse their blocks for the
             // next round. Without this the allocator holds the shard
@@ -118,7 +117,7 @@ treeMergeUniqueIjk(std::vector<torch::Tensor> shards) {
 //   - The hard floor (4 m) handles tiny scenes / initialisation edge
 //     cases so we never clamp below the plausible scene extent.
 constexpr double kAdaptiveClampHeadroom = 8.0;
-constexpr double kMinAdaptiveClamp      = 4.0;       // never clamp below 4 m
+constexpr double kMinAdaptiveClamp      = 4.0; // never clamp below 4 m
 // Raised from the room-scale default (300 m) so outdoor LiDAR
 // datasets (Mai City, KITTI, etc.) with trajectories that wander
 // far from the world origin don't get their entire per-frame point
@@ -130,7 +129,7 @@ constexpr double kMinAdaptiveClamp      = 4.0;       // never clamp below 4 m
 // practice (their inputs are raw Velodyne-style fp32 readings, not
 // unprojected from fp32 matrix math), so the cap only matters to
 // prevent accidental rejection of legitimate far-from-origin points.
-constexpr double kMaxAdaptiveClamp      = 100000.0;
+constexpr double kMaxAdaptiveClamp = 100000.0;
 
 torch::Tensor
 filterValidPoints(const torch::Tensor &points) {
@@ -140,9 +139,8 @@ filterValidPoints(const torch::Tensor &points) {
     //
     // Stage A: reject non-finite (NaN / Inf) so the quantile stage
     // only looks at real-valued finite coordinates.
-    const torch::Tensor finite_mask =
-        at::isfinite(points).all(/*dim=*/1);
-    const torch::Tensor finite_pts = points.index({finite_mask});
+    const torch::Tensor finite_mask = at::isfinite(points).all(/*dim=*/1);
+    const torch::Tensor finite_pts  = points.index({finite_mask});
     if (finite_pts.size(0) == 0) {
         return points.new_empty({0, 3});
     }
@@ -157,17 +155,13 @@ filterValidPoints(const torch::Tensor &points) {
     // subsample large inputs. 1 M samples pins the median to within a
     // centimetre for any realistic point distribution, for ~20 ms of
     // extra work.
-    const torch::Tensor max_abs =
-        std::get<0>(finite_pts.abs().max(/*dim=*/1)); // [N_fin]
-    constexpr int64_t kPctSampleCap = 1 << 20; // 1 M
+    const torch::Tensor max_abs     = std::get<0>(finite_pts.abs().max(/*dim=*/1)); // [N_fin]
+    constexpr int64_t kPctSampleCap = 1 << 20;                                      // 1 M
     torch::Tensor max_abs_for_quantile;
     if (max_abs.size(0) > kPctSampleCap) {
-        const int64_t stride = (max_abs.size(0) + kPctSampleCap - 1) /
-                               kPctSampleCap;
+        const int64_t stride = (max_abs.size(0) + kPctSampleCap - 1) / kPctSampleCap;
         max_abs_for_quantile =
-            max_abs.index({torch::indexing::Slice(0, torch::indexing::None,
-                                                   stride)})
-                .contiguous();
+            max_abs.index({torch::indexing::Slice(0, torch::indexing::None, stride)}).contiguous();
     } else {
         max_abs_for_quantile = max_abs;
     }
@@ -175,23 +169,21 @@ filterValidPoints(const torch::Tensor &points) {
     // (it requires float or double). Promote to fp32 for the single
     // median call -- this is a ~1 M-element tensor at most so the
     // promotion cost is trivial.
-    const torch::Tensor max_abs_f32 =
-        max_abs_for_quantile.scalar_type() == torch::kHalf
-            ? max_abs_for_quantile.to(torch::kFloat32)
-            : max_abs_for_quantile;
-    const double median =
-        at::quantile(max_abs_f32, 0.50).item<double>();
-    const double clamp = std::min(
-        kMaxAdaptiveClamp,
-        std::max(kMinAdaptiveClamp, kAdaptiveClampHeadroom * median));
-    const torch::Tensor bounded_mask =
-        (finite_pts.abs() < clamp).all(/*dim=*/1);
+    const torch::Tensor max_abs_f32 = max_abs_for_quantile.scalar_type() == torch::kHalf
+                                          ? max_abs_for_quantile.to(torch::kFloat32)
+                                          : max_abs_for_quantile;
+    const double median             = at::quantile(max_abs_f32, 0.50).item<double>();
+    const double clamp =
+        std::min(kMaxAdaptiveClamp, std::max(kMinAdaptiveClamp, kAdaptiveClampHeadroom * median));
+    const torch::Tensor bounded_mask = (finite_pts.abs() < clamp).all(/*dim=*/1);
 
     if (std::getenv("FVDB_NANOVDB_TRACE_ALLOCS")) {
         std::fprintf(
             stderr,
             "[fvdb] filterValidPoints median=%.3f m -> clamp=%.3f m (finite=%lld -> bounded=%lld)\n",
-            median, clamp, (long long)finite_pts.size(0),
+            median,
+            clamp,
+            (long long)finite_pts.size(0),
             (long long)bounded_mask.sum().item<int64_t>());
     }
 
@@ -211,10 +203,8 @@ pointsToIjk(const torch::Tensor &points,
             const nanovdb::Vec3d &origin) {
     const torch::TensorOptions optSame =
         torch::TensorOptions().dtype(points.scalar_type()).device(points.device());
-    const torch::Tensor vs =
-        torch::tensor({voxelSize[0], voxelSize[1], voxelSize[2]}, optSame);
-    const torch::Tensor og =
-        torch::tensor({origin[0], origin[1], origin[2]}, optSame);
+    const torch::Tensor vs = torch::tensor({voxelSize[0], voxelSize[1], voxelSize[2]}, optSame);
+    const torch::Tensor og = torch::tensor({origin[0], origin[1], origin[2]}, optSame);
     const torch::Tensor ijk_same = ((points - og) / vs).round();
     return ijk_same.to(torch::kInt32).contiguous(); // [N, 3]
 }
@@ -249,13 +239,10 @@ pointsToIjk(const torch::Tensor &points,
 // Returns `[U_leaves * 512, 3]` int32 voxel ijk tensor ready to hand
 // to `_createNanoGridFromIJK`.
 torch::Tensor
-leafGranularityShell(const torch::Tensor &ijk,
-                     int64_t numPad) {
-    TORCH_CHECK(ijk.dim() == 2 && ijk.size(1) == 3,
-                "leafGranularityShell expects ijk [N, 3]");
-    const torch::Device device = ijk.device();
-    const torch::TensorOptions optI32 =
-        torch::TensorOptions().dtype(torch::kInt32).device(device);
+leafGranularityShell(const torch::Tensor &ijk, int64_t numPad) {
+    TORCH_CHECK(ijk.dim() == 2 && ijk.size(1) == 3, "leafGranularityShell expects ijk [N, 3]");
+    const torch::Device device        = ijk.device();
+    const torch::TensorOptions optI32 = torch::TensorOptions().dtype(torch::kInt32).device(device);
 
     // Step 1: map each ijk to its LEAF key (ijk >> 3 in floor-arithmetic),
     // then dedupe to UNIQUE LEAVES.
@@ -265,8 +252,7 @@ leafGranularityShell(const torch::Tensor &ijk,
     // to ~1-2 K unique 8-voxel leaves (a 500x collapse), so the
     // downstream dilate-and-dedupe pass works on a tiny set. The
     // ~2-3 ms dedupe dominates; everything after it is sub-ms.
-    const torch::Tensor leaf_key =
-        at::div(ijk, 8, /*rounding_mode=*/"floor");
+    const torch::Tensor leaf_key    = at::div(ijk, 8, /*rounding_mode=*/"floor");
     torch::Tensor unique_leaves_raw = uniqueIjk(leaf_key);
     if (unique_leaves_raw.size(0) == 0) {
         return at::empty({0, 3}, optI32);
@@ -278,26 +264,19 @@ leafGranularityShell(const torch::Tensor &ijk,
     // leaves away, so the leaf stencil is `(2 * half + 1)^3`. For the
     // typical numPad = 3 case that is 3^3 = 27 (vs the voxel path's
     // 7^3 = 343).
-    const int64_t leaf_half = (numPad + 7 + 7) / 8; // ceil((numPad+7)/8)
-    const torch::Tensor leaf_axis =
-        torch::arange(-leaf_half, leaf_half + 1, optI32);
-    const auto leaf_grid =
-        at::meshgrid({leaf_axis, leaf_axis, leaf_axis}, "ij");
+    const int64_t leaf_half       = (numPad + 7 + 7) / 8; // ceil((numPad+7)/8)
+    const torch::Tensor leaf_axis = torch::arange(-leaf_half, leaf_half + 1, optI32);
+    const auto leaf_grid          = at::meshgrid({leaf_axis, leaf_axis, leaf_axis}, "ij");
     const torch::Tensor leaf_stencil =
-        torch::stack({leaf_grid[0].flatten(),
-                      leaf_grid[1].flatten(),
-                      leaf_grid[2].flatten()},
-                     1)
+        torch::stack({leaf_grid[0].flatten(), leaf_grid[1].flatten(), leaf_grid[2].flatten()}, 1)
             .contiguous();
 
     // [U_raw, 1, 3] + [1, S_leaf, 3] -> [U_raw * S_leaf, 3]. At typical
     // Replica scale U_raw ~ 1-2 K and S_leaf = 27 so this is ~30-50 K
     // rows, trivial to dedupe.
     const torch::Tensor leaf_expanded =
-        (unique_leaves_raw.unsqueeze(1) + leaf_stencil.unsqueeze(0))
-            .reshape({-1, 3})
-            .contiguous();
-    unique_leaves_raw = torch::Tensor(); // free
+        (unique_leaves_raw.unsqueeze(1) + leaf_stencil.unsqueeze(0)).reshape({-1, 3}).contiguous();
+    unique_leaves_raw                 = torch::Tensor(); // free
     const torch::Tensor unique_leaves = uniqueIjk(leaf_expanded);
     if (unique_leaves.size(0) == 0) {
         return at::empty({0, 3}, optI32);
@@ -307,28 +286,23 @@ leafGranularityShell(const torch::Tensor &ijk,
     // voxel in the leaf is leaf_origin + (i, j, k) for (i,j,k) in
     // [0, 8)^3.
     const torch::Tensor local_axis = torch::arange(0, 8, optI32);
-    const auto local_grid = at::meshgrid({local_axis, local_axis, local_axis}, "ij");
+    const auto local_grid          = at::meshgrid({local_axis, local_axis, local_axis}, "ij");
     const torch::Tensor local_offsets =
-        torch::stack({local_grid[0].flatten(),
-                      local_grid[1].flatten(),
-                      local_grid[2].flatten()},
+        torch::stack({local_grid[0].flatten(), local_grid[1].flatten(), local_grid[2].flatten()},
                      1)
-            .contiguous();  // [512, 3]
+            .contiguous();                                // [512, 3]
 
-    const torch::Tensor leaf_origins = unique_leaves * 8;  // [U_leaves, 3]
+    const torch::Tensor leaf_origins = unique_leaves * 8; // [U_leaves, 3]
     // [U, 1, 3] + [1, 512, 3] -> [U, 512, 3] -> [U*512, 3]
     const torch::Tensor shell =
-        (leaf_origins.unsqueeze(1) + local_offsets.unsqueeze(0))
-            .reshape({-1, 3})
-            .contiguous();
+        (leaf_origins.unsqueeze(1) + local_offsets.unsqueeze(0)).reshape({-1, 3}).contiguous();
 
     if (std::getenv("FVDB_NANOVDB_TRACE_ALLOCS")) {
-        std::fprintf(
-            stderr,
-            "[fvdb] leafGranularityShell input_ijks=%lld leaves=%lld shell_voxels=%lld\n",
-            (long long)ijk.size(0),
-            (long long)unique_leaves.size(0),
-            (long long)shell.size(0));
+        std::fprintf(stderr,
+                     "[fvdb] leafGranularityShell input_ijks=%lld leaves=%lld shell_voxels=%lld\n",
+                     (long long)ijk.size(0),
+                     (long long)unique_leaves.size(0),
+                     (long long)shell.size(0));
     }
     return shell;
 }
@@ -351,10 +325,8 @@ buildSingleBatchShell(const torch::Tensor &points_b,
                       const nanovdb::Vec3d &voxelSize,
                       const nanovdb::Vec3d &origin,
                       int64_t numPad) {
-    TORCH_CHECK(points_b.dim() == 2 && points_b.size(1) == 3,
-                "points must be [N, 3]");
-    TORCH_CHECK(points_b.device().is_cuda(),
-                "fast shell builder is CUDA-only");
+    TORCH_CHECK(points_b.dim() == 2 && points_b.size(1) == 3, "points must be [N, 3]");
+    TORCH_CHECK(points_b.device().is_cuda(), "fast shell builder is CUDA-only");
 
     const torch::Device device = points_b.device();
 
@@ -363,8 +335,7 @@ buildSingleBatchShell(const torch::Tensor &points_b,
     // expand+merge, createGrid). Use to identify which stage to attack
     // next in the shell-build speedup track. One line per frame to
     // stderr.
-    const bool phaseProfile =
-        std::getenv("FVDB_SHELL_PHASE_PROFILE") != nullptr;
+    const bool phaseProfile = std::getenv("FVDB_SHELL_PHASE_PROFILE") != nullptr;
     cudaEvent_t evA{}, evB{}, evC{}, evD{}, evE{};
     auto phaseMark = [&](cudaEvent_t &ev) {
         if (phaseProfile) {
@@ -425,9 +396,8 @@ buildSingleBatchShell(const torch::Tensor &points_b,
     }();
 
     if (force_leaf_shell) {
-        const torch::Tensor leaf_shell =
-            leafGranularityShell(ijk_i32, numPad);
-        ijk_i32 = torch::Tensor();
+        const torch::Tensor leaf_shell = leafGranularityShell(ijk_i32, numPad);
+        ijk_i32                        = torch::Tensor();
         if (leaf_shell.size(0) == 0) {
             TorchDeviceBuffer emptyBuf(0, device);
             return nanovdb::GridHandle<TorchDeviceBuffer>(std::move(emptyBuf));
@@ -471,29 +441,18 @@ buildSingleBatchShell(const torch::Tensor &points_b,
     // ~10 M unique voxels, which is ~10 ms to turn into a grid.
     constexpr int64_t kPackBias = 1ll << 20;
     constexpr int64_t kPackMask = (1ll << 21) - 1;
-    auto packIjk = [&](const torch::Tensor &ijk_i32) -> torch::Tensor {
+    auto packIjk                = [&](const torch::Tensor &ijk_i32) -> torch::Tensor {
         const torch::Tensor ijk_i64 = ijk_i32.to(torch::kInt64);
-        const torch::Tensor i =
-            ijk_i64.select(1, 0).add(kPackBias);
-        const torch::Tensor j =
-            ijk_i64.select(1, 1).add(kPackBias);
-        const torch::Tensor k =
-            ijk_i64.select(1, 2).add(kPackBias);
-        return (i.bitwise_left_shift(42))
-            .bitwise_or(j.bitwise_left_shift(21))
-            .bitwise_or(k);
+        const torch::Tensor i       = ijk_i64.select(1, 0).add(kPackBias);
+        const torch::Tensor j       = ijk_i64.select(1, 1).add(kPackBias);
+        const torch::Tensor k       = ijk_i64.select(1, 2).add(kPackBias);
+        return (i.bitwise_left_shift(42)).bitwise_or(j.bitwise_left_shift(21)).bitwise_or(k);
     };
     auto unpackKeys = [&](const torch::Tensor &keys) -> torch::Tensor {
-        const torch::Tensor i =
-            keys.bitwise_right_shift(42).bitwise_and(kPackMask)
-                .sub(kPackBias);
-        const torch::Tensor j =
-            keys.bitwise_right_shift(21).bitwise_and(kPackMask)
-                .sub(kPackBias);
-        const torch::Tensor k =
-            keys.bitwise_and(kPackMask).sub(kPackBias);
-        return torch::stack({i, j, k}, /*dim=*/1)
-            .to(torch::kInt32).contiguous();
+        const torch::Tensor i = keys.bitwise_right_shift(42).bitwise_and(kPackMask).sub(kPackBias);
+        const torch::Tensor j = keys.bitwise_right_shift(21).bitwise_and(kPackMask).sub(kPackBias);
+        const torch::Tensor k = keys.bitwise_and(kPackMask).sub(kPackBias);
+        return torch::stack({i, j, k}, /*dim=*/1).to(torch::kInt32).contiguous();
     };
 
     // Pack and dedup the base ijks once. Raw N includes substantial
@@ -504,55 +463,49 @@ buildSingleBatchShell(const torch::Tensor &points_b,
     // unique because `_unique` already calls into CUB under the hood
     // and the per-call allocation overhead is absorbed by torch's
     // caching allocator.
-    torch::Tensor keys = std::get<0>(
-        at::_unique(packIjk(ijk_i32), /*sorted=*/false,
-                    /*return_inverse=*/false));
-    ijk_i32 = torch::Tensor();
+    torch::Tensor keys = std::get<0>(at::_unique(packIjk(ijk_i32),
+                                                 /*sorted=*/false,
+                                                 /*return_inverse=*/false));
+    ijk_i32            = torch::Tensor();
     phaseMark(evC);
 
     // Per-axis 1-D stencils of length `2r+1`, pre-packed as int64 so
     // broadcast-add composes directly with the packed base keys. Shift
     // factors (42, 21, 0) mirror the axis-to-bit assignment above.
-    const torch::TensorOptions optI64 =
-        torch::TensorOptions().dtype(torch::kInt64).device(device);
-    const torch::Tensor axisOffsets =
-        torch::arange(-numPad, numPad + 1, optI64); // [2r+1] signed
-    const torch::Tensor stencil_x =
-        axisOffsets.bitwise_left_shift(42);
-    const torch::Tensor stencil_y =
-        axisOffsets.bitwise_left_shift(21);
-    const torch::Tensor stencil_z = axisOffsets;
+    const torch::TensorOptions optI64 = torch::TensorOptions().dtype(torch::kInt64).device(device);
+    const torch::Tensor axisOffsets   = torch::arange(-numPad, numPad + 1, optI64); // [2r+1] signed
+    const torch::Tensor stencil_x     = axisOffsets.bitwise_left_shift(42);
+    const torch::Tensor stencil_y     = axisOffsets.bitwise_left_shift(21);
+    const torch::Tensor stencil_z     = axisOffsets;
 
-    auto applyAxis = [&](torch::Tensor keys_in,
-                         const torch::Tensor &axisStencil) {
+    auto applyAxis = [&](torch::Tensor keys_in, const torch::Tensor &axisStencil) {
         // [U, 1] + [1, 2r+1] -> [U * (2r+1)] -> unique.
         torch::Tensor expanded =
-            (keys_in.unsqueeze(1) + axisStencil.unsqueeze(0))
-                .flatten().contiguous();
+            (keys_in.unsqueeze(1) + axisStencil.unsqueeze(0)).flatten().contiguous();
         keys_in = torch::Tensor();
-        return std::get<0>(
-            at::_unique(expanded, /*sorted=*/false,
-                        /*return_inverse=*/false));
+        return std::get<0>(at::_unique(expanded,
+                                       /*sorted=*/false,
+                                       /*return_inverse=*/false));
     };
 
-    keys = applyAxis(std::move(keys), stencil_x);
-    keys = applyAxis(std::move(keys), stencil_y);
-    keys = applyAxis(std::move(keys), stencil_z);
+    keys            = applyAxis(std::move(keys), stencil_x);
+    keys            = applyAxis(std::move(keys), stencil_y);
+    keys            = applyAxis(std::move(keys), stencil_z);
     const int64_t F = keys.size(0);
     if (F == 0) {
         TorchDeviceBuffer emptyBuf(0, device);
         return nanovdb::GridHandle<TorchDeviceBuffer>(std::move(emptyBuf));
     }
     const torch::Tensor shell = unpackKeys(keys);
-    keys = torch::Tensor();
+    keys                      = torch::Tensor();
     phaseMark(evD);
 
     if (std::getenv("FVDB_NANOVDB_TRACE_ALLOCS")) {
-        std::fprintf(
-            stderr,
-            "[fvdb] buildSingleBatchShell (voxel path, separable) "
-            "numPad=%lld shell=%lld\n",
-            (long long)numPad, (long long)F);
+        std::fprintf(stderr,
+                     "[fvdb] buildSingleBatchShell (voxel path, separable) "
+                     "numPad=%lld shell=%lld\n",
+                     (long long)numPad,
+                     (long long)F);
     }
 
     const JaggedTensor shellJT(shell);
@@ -566,14 +519,17 @@ buildSingleBatchShell(const torch::Tensor &points_b,
         cudaEventElapsedTime(&t_base, evB, evC);
         cudaEventElapsedTime(&t_sep, evC, evD);
         cudaEventElapsedTime(&t_grid, evD, evE);
-        std::fprintf(
-            stderr,
-            "[fvdb/shell_phase] filter+ijk=%.2f ms  base_dedup=%.2f ms "
-            " separable_xyz=%.2f ms  createGrid=%.2f ms  total=%.2f "
-            "ms  numPad=%lld shell=%lld\n",
-            t_filter, t_base, t_sep, t_grid,
-            t_filter + t_base + t_sep + t_grid,
-            (long long)numPad, (long long)F);
+        std::fprintf(stderr,
+                     "[fvdb/shell_phase] filter+ijk=%.2f ms  base_dedup=%.2f ms "
+                     " separable_xyz=%.2f ms  createGrid=%.2f ms  total=%.2f "
+                     "ms  numPad=%lld shell=%lld\n",
+                     t_filter,
+                     t_base,
+                     t_sep,
+                     t_grid,
+                     t_filter + t_base + t_sep + t_grid,
+                     (long long)numPad,
+                     (long long)F);
         cudaEventDestroy(evA);
         cudaEventDestroy(evB);
         cudaEventDestroy(evC);
@@ -589,12 +545,14 @@ c10::intrusive_ptr<GridBatchData>
 buildPointTruncationShell(const JaggedTensor &points,
                           const GridBatchData &grid,
                           double truncationMargin) {
-    TORCH_CHECK_VALUE(truncationMargin > 0.0,
-                      "truncationMargin must be > 0, got ",
-                      truncationMargin);
+    TORCH_CHECK_VALUE(
+        truncationMargin > 0.0, "truncationMargin must be > 0, got ", truncationMargin);
     TORCH_CHECK_VALUE(points.num_outer_lists() == grid.batchSize(),
-                      "points batch size (", points.num_outer_lists(),
-                      ") must equal grid batch size (", grid.batchSize(), ")");
+                      "points batch size (",
+                      points.num_outer_lists(),
+                      ") must equal grid batch size (",
+                      grid.batchSize(),
+                      ")");
 
     // Per-batch voxel sizes and origins define the world-to-index
     // transform for the new grid.
@@ -632,23 +590,27 @@ buildPointTruncationShell(const JaggedTensor &points,
         // ceil case is untouched.
         const double ratio        = truncationMargin / minVoxLengthI;
         const double ratioRounded = std::round(ratio);
-        const double tol = 4.0 * static_cast<double>(
-            std::numeric_limits<float>::epsilon()) * std::max(1.0, ratio);
-        const double ceilRatio = (std::abs(ratio - ratioRounded) <= tol)
-                                     ? ratioRounded
-                                     : std::ceil(ratio);
+        const double tol =
+            4.0 * static_cast<double>(std::numeric_limits<float>::epsilon()) * std::max(1.0, ratio);
+        const double ceilRatio =
+            (std::abs(ratio - ratioRounded) <= tol) ? ratioRounded : std::ceil(ratio);
         const auto numPadVoxelsI = static_cast<int32_t>(ceilRatio);
         TORCH_CHECK_VALUE(numPadVoxelsI > 0,
                           "Number of padding voxels must be positive, got ",
                           numPadVoxelsI,
-                          " (truncationMargin=", truncationMargin,
-                          ", voxelSize=", minVoxLengthI, ")");
+                          " (truncationMargin=",
+                          truncationMargin,
+                          ", voxelSize=",
+                          minVoxLengthI,
+                          ")");
         TORCH_CHECK_VALUE(numPadVoxelsI < MAX_PAD_VOXELS,
-                          "Truncation margin (", truncationMargin,
+                          "Truncation margin (",
+                          truncationMargin,
                           ") is too large for grid with voxel size ",
                           minVoxLengthI,
                           ", resulting in too many padding voxels (",
-                          numPadVoxelsI, ") which cannot exceed ",
+                          numPadVoxelsI,
+                          ") which cannot exceed ",
                           MAX_PAD_VOXELS,
                           ". Use a larger voxel size or a smaller truncation margin.");
         numPadVoxels.push_back(numPadVoxelsI);
@@ -659,9 +621,8 @@ buildPointTruncationShell(const JaggedTensor &points,
     // sidesteps it because `dilateGrid` scratch blows up on
     // room-scale scenes.
     const bool isCuda = points.device().is_cuda();
-    if (!isCuda ||
-        (std::getenv("FVDB_NANOVDB_LEGACY_SHELL") != nullptr &&
-         std::getenv("FVDB_NANOVDB_LEGACY_SHELL")[0] == '1')) {
+    if (!isCuda || (std::getenv("FVDB_NANOVDB_LEGACY_SHELL") != nullptr &&
+                    std::getenv("FVDB_NANOVDB_LEGACY_SHELL")[0] == '1')) {
         auto pointGrid = buildGridFromPoints(points, voxelSizes, origins);
         return dilateGrid(*pointGrid, numPadVoxels);
     }
@@ -689,7 +650,9 @@ buildPointTruncationShell(const JaggedTensor &points,
     const auto offsets             = offsetsCpu.accessor<JOffsetsType, 1>();
     TORCH_CHECK(offsets.size(0) == grid.batchSize() + 1,
                 "joffsets length mismatch: expected ",
-                grid.batchSize() + 1, " got ", offsets.size(0));
+                grid.batchSize() + 1,
+                " got ",
+                offsets.size(0));
 
     const torch::Tensor data = points.jdata();
     for (int64_t i = 0; i < grid.batchSize(); ++i) {
@@ -697,15 +660,13 @@ buildPointTruncationShell(const JaggedTensor &points,
         const int64_t count = offsets[i + 1] - start;
         if (count == 0) {
             TorchDeviceBuffer emptyBuf(0, points.device());
-            handles.emplace_back(
-                nanovdb::GridHandle<TorchDeviceBuffer>(std::move(emptyBuf)));
+            handles.emplace_back(nanovdb::GridHandle<TorchDeviceBuffer>(std::move(emptyBuf)));
             continue;
         }
 
-        const torch::Tensor points_i =
-            data.narrow(0, start, count).contiguous();
-        handles.push_back(buildSingleBatchShell(
-            points_i, voxelSizes[i], origins[i], numPadVoxels[i]));
+        const torch::Tensor points_i = data.narrow(0, start, count).contiguous();
+        handles.push_back(
+            buildSingleBatchShell(points_i, voxelSizes[i], origins[i], numPadVoxels[i]));
     }
 
     nanovdb::GridHandle<TorchDeviceBuffer> mergedHandle;

--- a/src/fvdb/detail/ops/BuildPointTruncationShell.h
+++ b/src/fvdb/detail/ops/BuildPointTruncationShell.h
@@ -1,0 +1,52 @@
+// Copyright Contributors to the OpenVDB Project
+// SPDX-License-Identifier: Apache-2.0
+//
+#ifndef FVDB_DETAIL_OPS_BUILDPOINTTRUNCATIONSHELL_H
+#define FVDB_DETAIL_OPS_BUILDPOINTTRUNCATIONSHELL_H
+
+#include <fvdb/GridBatchData.h>
+#include <fvdb/JaggedTensor.h>
+
+#include <c10/util/intrusive_ptr.h>
+
+namespace fvdb {
+namespace detail {
+namespace ops {
+
+/// @brief Build a sparse grid covering the truncation shell of a
+///        point cloud.
+///
+/// Composition of two topology primitives that together define the
+/// minimal set of voxels a TSDF-fusion pass must touch:
+///
+///   1. `buildGridFromPoints(points, voxelSize, origin)` — one active
+///      voxel per occupied cell in world space.
+///   2. `dilateGrid(numPadVoxels)` where
+///      `numPadVoxels = ceil(truncationMargin / voxelSize)` — expand
+///      by the truncation-band radius so every voxel within
+///      `truncationMargin` of any point is active.
+///
+/// Shared between the depth-image and LiDAR-point TSDF integrators so
+/// both paths hit the same paper-relevant topology primitive. This
+/// matters for the paper's "topology ops compose as a reusable
+/// primitive" claim (both integrators call this function literally).
+///
+/// `points` is a JaggedTensor `[B, N_i, 3]` — each batch item may
+/// have a different number of input points. `grid` is used only for
+/// its per-batch voxel sizes + origins (the truncation-shell output
+/// has a different active-voxel set).
+///
+/// `truncationMargin` is the world-space truncation distance. Caller
+/// is responsible for ensuring it's positive and fits within the
+/// `MAX_PAD_VOXELS = 16` dilation cap; both are enforced via
+/// TORCH_CHECK inside.
+c10::intrusive_ptr<GridBatchData>
+buildPointTruncationShell(const JaggedTensor &points,
+                          const GridBatchData &grid,
+                          double truncationMargin);
+
+} // namespace ops
+} // namespace detail
+} // namespace fvdb
+
+#endif // FVDB_DETAIL_OPS_BUILDPOINTTRUNCATIONSHELL_H

--- a/src/fvdb/detail/ops/BuildPointTruncationShell.h
+++ b/src/fvdb/detail/ops/BuildPointTruncationShell.h
@@ -40,10 +40,9 @@ namespace ops {
 /// is responsible for ensuring it's positive and fits within the
 /// `MAX_PAD_VOXELS = 16` dilation cap; both are enforced via
 /// TORCH_CHECK inside.
-c10::intrusive_ptr<GridBatchData>
-buildPointTruncationShell(const JaggedTensor &points,
-                          const GridBatchData &grid,
-                          double truncationMargin);
+c10::intrusive_ptr<GridBatchData> buildPointTruncationShell(const JaggedTensor &points,
+                                                            const GridBatchData &grid,
+                                                            double truncationMargin);
 
 } // namespace ops
 } // namespace detail

--- a/src/fvdb/detail/ops/BuildPrunedGrid.cu
+++ b/src/fvdb/detail/ops/BuildPrunedGrid.cu
@@ -4,6 +4,7 @@
 #include <fvdb/GridBatchData.h>
 #include <fvdb/JaggedTensor.h>
 #include <fvdb/TorchDeviceBuffer.h>
+#include <fvdb/TorchResource.h>
 #include <fvdb/detail/GridBatchDataFactory.h>
 #include <fvdb/detail/ops/BuildPrunedGrid.h>
 #include <fvdb/detail/utils/Utils.h>
@@ -73,7 +74,8 @@ dispatchPruneGrid<torch::kCUDA>(const GridBatchData &gridBatch, const JaggedTens
                 maskI.data_ptr<bool>(),
                 reinterpret_cast<nanovdb::Mask<3> *>(maskBuffer.deviceData()));
         C10_CUDA_KERNEL_LAUNCH_CHECK();
-        nanovdb::tools::cuda::PruneGrid<nanovdb::ValueOnIndex> pruneOp(grid, leafMask);
+        nanovdb::tools::cuda::PruneGrid<nanovdb::ValueOnIndex, TorchResource> pruneOp(grid,
+                                                                                      leafMask);
         pruneOp.setChecksum(nanovdb::CheckMode::Default);
         pruneOp.setVerbose(0);
 

--- a/src/fvdb/detail/ops/ComputeESDF.cu
+++ b/src/fvdb/detail/ops/ComputeESDF.cu
@@ -1,0 +1,847 @@
+// Copyright Contributors to the OpenVDB Project
+// SPDX-License-Identifier: Apache-2.0
+//
+// One-shot Euclidean Signed Distance Field (ESDF) computation over an
+// integrated narrow-band TSDF.
+//
+// Composition pattern:
+//
+//    esdfGrid = dilateGrid(tsdfGrid, ceil(R / vs) + 1)         // topology
+//    esdf    = torch.full(|esdfGrid|, +R + sentinel)           // sidecar
+//    esdfSeed(tsdfGrid, tsdf, weights, truncDist, esdfGrid, esdf)
+//    for sweep in range(N):                                    // 26-N stencil
+//        esdfSweep(esdfGrid, esdf_in, esdf_out, voxelSize)
+//        swap(esdf_in, esdf_out)
+//    if prune_unreached: esdfGrid, esdf = pruneGrid(...)
+//
+// Algorithm notes:
+//
+// Chamfer vs true Euclidean. Monotone 26-neighbour min-propagation
+// produces a "chamfer" distance approximation that is bounded a few
+// percent above true Euclidean at worst (this matches nvblox's default
+// ESDF and FIESTA). True-Euclidean (Felzenszwalb-style separable O(N)
+// SDT) is possible but doesn't compose on sparse grids without a
+// dense-back-conversion pass that defeats the point.
+//
+// Sweep count. With 26-connectivity a wavefront propagates by at least
+// one axis-aligned step per sweep, so `N = ceil(R / vs) + 2` sweeps are
+// sufficient even accounting for non-convex seed topology (e.g.
+// wavefronts meeting behind an obstacle). Additional sweeps past
+// convergence are free (monotone min is idempotent at fixed point).
+//
+// Double-buffering. We ping-pong between two contiguous fp32 sidecar
+// tensors rather than trying to do in-place updates with atomicMin. A
+// single in-place pass using atomicCAS on packed bits would work but
+// the two-buffer approach is simpler, deterministic, and the kernel is
+// memory-bound so the extra bandwidth cost is hidden.
+//
+// Scope. float32 CUDA + batchSize == 1 only. Multi-batch and fp64 are
+// future-work lifts.
+
+#include <fvdb/GridBatchData.h>
+#include <fvdb/detail/GridBatchDataFactory.h>
+#include <fvdb/detail/ops/BuildDilatedGrid.h>
+#include <fvdb/detail/ops/BuildMergedGrids.h>
+#include <fvdb/detail/ops/BuildPrunedGrid.h>
+#include <fvdb/detail/ops/ComputeESDF.h>
+#include <fvdb/detail/ops/Inject.h>
+
+#include <c10/cuda/CUDAException.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <c10/cuda/CUDAStream.h>
+
+#include <nanovdb/NanoVDB.h>
+#include <nanovdb/tools/cuda/VoxelBlockManager.cuh>
+#include <nanovdb/util/cuda/DeviceGridTraits.cuh>
+
+#include <cuda_runtime.h>
+#include <torch/types.h>
+
+#include <cmath>
+
+namespace fvdb {
+namespace detail {
+namespace ops {
+
+namespace {
+
+// -----------------------------------------------------------------------
+// Kernel tuning: 128-voxel VBM blocks with a 2-u64 jump map.
+// -----------------------------------------------------------------------
+
+constexpr int ESDF_BLOCK_WIDTH_LOG2 = 7;
+constexpr int ESDF_BLOCK_WIDTH      = 1 << ESDF_BLOCK_WIDTH_LOG2;  // 128
+constexpr int ESDF_JUMP_MAP_LENGTH  = ESDF_BLOCK_WIDTH / 64;       // 2
+constexpr int ESDF_PERLEAF_THREADS  = 128;                         // per-leaf ablation
+
+// Sentinel used for "never-reached" voxels. Must be LARGE ENOUGH that
+// it is unambiguously identifiable after propagation: the wavefront
+// intentionally doesn't cap at `max_distance` (doing so loses sign
+// information on voxels beyond the cap — see journal entry for this
+// session). With a 1e30 sentinel, any finite propagated distance (even
+// well beyond `max_distance`) is clearly distinguishable, and the
+// final post-loop `clamp(-max, +max)` yields the correct signed result.
+constexpr float kEsdfSentinel = 1.0e30f;
+// Threshold used to detect "still at sentinel" inside the kernel. Any
+// real propagated distance is astronomically smaller than this.
+constexpr float kEsdfSentinelCheck = 0.5e30f;
+
+// -----------------------------------------------------------------------
+// Offset table for 26-neighbour stencil. Ordered so small-step offsets
+// come first; not semantically meaningful (our min-propagation is
+// order-invariant within a single sweep), but improves L1 hit rate on
+// the self-voxel lookup since `acc.isActive(c)` touches the same leaf
+// node for small offsets. 26 entries: 6 face + 12 edge + 8 corner.
+// -----------------------------------------------------------------------
+
+struct EsdfOffset {
+    int dx, dy, dz;
+    float weight;  // ||offset||, in units of voxel_size
+};
+
+__device__ __constant__ EsdfOffset kEsdfOffsets[26] = {
+    // 6 face neighbours (axis-aligned, weight = 1)
+    {-1,  0,  0, 1.0f}, { 1,  0,  0, 1.0f},
+    { 0, -1,  0, 1.0f}, { 0,  1,  0, 1.0f},
+    { 0,  0, -1, 1.0f}, { 0,  0,  1, 1.0f},
+    // 12 edge neighbours (face-diagonal, weight = sqrt(2) ~ 1.41421356)
+    {-1, -1,  0, 1.41421356f}, { 1, -1,  0, 1.41421356f},
+    {-1,  1,  0, 1.41421356f}, { 1,  1,  0, 1.41421356f},
+    {-1,  0, -1, 1.41421356f}, { 1,  0, -1, 1.41421356f},
+    {-1,  0,  1, 1.41421356f}, { 1,  0,  1, 1.41421356f},
+    { 0, -1, -1, 1.41421356f}, { 0,  1, -1, 1.41421356f},
+    { 0, -1,  1, 1.41421356f}, { 0,  1,  1, 1.41421356f},
+    // 8 corner neighbours (vertex-diagonal, weight = sqrt(3) ~ 1.73205081)
+    {-1, -1, -1, 1.73205081f}, { 1, -1, -1, 1.73205081f},
+    {-1,  1, -1, 1.73205081f}, { 1,  1, -1, 1.73205081f},
+    {-1, -1,  1, 1.73205081f}, { 1, -1,  1, 1.73205081f},
+    {-1,  1,  1, 1.73205081f}, { 1,  1,  1, 1.73205081f},
+};
+
+// -----------------------------------------------------------------------
+// Core stencil body: given self-distance `dSelf` and a neighbour query
+// callable `readNeighbour(ijk+o)`, return the monotone-min of dSelf and
+// all 26 valid neighbour propagations. Sign-preserving: the candidate
+// is `sign(d_n) * (|d_n| + ||offset|| * vs)`, which expands the
+// neighbour's signed distance outward by the geometric step. A zero
+// d_n stays zero (zero-crossing propagation).
+// -----------------------------------------------------------------------
+
+template <typename ReadNeighbourFn>
+__device__ __forceinline__ float
+esdfSweepBody(float dSelf, float voxelSize, float maxDistance,
+              ReadNeighbourFn readNeighbour) {
+    float d = dSelf;
+#pragma unroll
+    for (int i = 0; i < 26; ++i) {
+        const EsdfOffset off = kEsdfOffsets[i];
+        float dN;
+        bool active;
+        readNeighbour(off.dx, off.dy, off.dz, dN, active);
+        if (!active) continue;
+        const float dNAbs = fabsf(dN);
+        if (dNAbs >= kEsdfSentinelCheck) continue;  // neighbour not yet reached
+        const float step    = off.weight * voxelSize;
+        const float candAbs = dNAbs + step;
+        // Cap propagation at `maxDistance` so wavefronts can't smear
+        // chamfer-overshoot past the user's ESDF support radius. In
+        // particular this is load-bearing for the incremental path:
+        // without the cap, surviving-from-prev-frame negative-sign
+        // voxels (with |d| < max_distance) could propagate their sign
+        // arbitrarily far via the cascading sweep, smearing
+        // -maxDistance into voxels that one-shot would have left at
+        // sentinel. With the cap, voxels more than `maxDistance` from
+        // ANY seed stay at sentinel -> clamped to +maxDistance at the
+        // end (the "unknown, free space" convention). This matches
+        // nvblox / FIESTA defaults.
+        if (candAbs >= maxDistance) continue;
+        if (candAbs < fabsf(d)) {
+            // Preserve the sign of the witness neighbour.
+            d = (dN < 0.0f) ? -candAbs : candAbs;
+        }
+    }
+    return d;
+}
+
+// -----------------------------------------------------------------------
+// Seed kernel. Iterates *input* grid voxels (one thread per active voxel
+// via a simple per-leaf-slot launch — the input grid is typically
+// small and the seed runs once, so VBM overhead here is not worth
+// introducing). For each input voxel with weights > threshold and
+// |tsdf| < 1 - eps, writes `tsdf * truncation_distance` into the
+// corresponding slot in the ESDF sidecar.
+//
+// We use per-leaf-slot iteration here (not VBM) for two reasons:
+//   1. This kernel runs once; VBM's amortization story doesn't apply.
+//   2. Per-leaf iteration gives us the leaf directly, which lets us
+//      compute the input sidecar offset without a second grid lookup.
+// -----------------------------------------------------------------------
+
+__global__ void
+esdfSeedKernel(
+    const nanovdb::NanoGrid<nanovdb::ValueOnIndex> *__restrict__ inputGrid,
+    const nanovdb::NanoGrid<nanovdb::ValueOnIndex> *__restrict__ esdfGrid,
+    const float *__restrict__ tsdf,       // [inputGrid->totalActiveVoxels]
+    const float *__restrict__ weights,    // [inputGrid->totalActiveVoxels]
+    const bool *__restrict__ dirtyMask,   // nullable; when non-null,
+                                          // only dirty voxels seed
+    float *__restrict__ esdf,             // [esdfGrid->totalActiveVoxels]
+    float truncationDistance,
+    float weightThreshold,
+    float saturationEps) {
+    constexpr uint64_t VPL =
+        nanovdb::OnIndexTree::LeafNodeType::NUM_VALUES;
+
+    const int64_t leafIdx = blockIdx.x;
+    const int64_t voxOff  = threadIdx.x;
+    if (voxOff >= static_cast<int64_t>(VPL)) return;
+
+    const auto &leaf = inputGrid->tree().template getFirstNode<0>()[leafIdx];
+    if (!leaf.isActive(voxOff)) return;
+
+    // 1-indexed pid; subtract one for torch tensor offset.
+    const int64_t inputPid = static_cast<int64_t>(leaf.getValue(voxOff)) - 1;
+
+    // Dirty-mask gate: when provided, skip non-dirty voxels so the
+    // wavefront only re-propagates from what actually changed this
+    // frame. This is the mechanism that gives fvdb's
+    // `compute_esdf_incremental` nvblox-style dirty-region update
+    // scaling. When `dirtyMask == nullptr` (the default), behaves
+    // as before -- seed from every near-surface voxel.
+    if (dirtyMask != nullptr && !dirtyMask[inputPid]) return;
+
+    const float w  = weights[inputPid];
+    if (!(w > weightThreshold)) return;
+
+    const float t = tsdf[inputPid];
+    if (!(fabsf(t) < 1.0f - saturationEps)) return;
+
+    const nanovdb::Coord ijk = leaf.offsetToGlobalCoord(voxOff);
+    auto esdfAcc             = esdfGrid->getAccessor();
+    // By construction (dilateGrid superset), ijk is always active in
+    // esdfGrid; assert defensively in debug builds.
+    const uint64_t esdfRaw = esdfAcc.getValue(ijk);
+    if (esdfRaw == 0) return;
+    const int64_t esdfPid = static_cast<int64_t>(esdfRaw) - 1;
+
+    esdf[esdfPid] = t * truncationDistance;
+}
+
+// -----------------------------------------------------------------------
+// Sweep kernel (VBM path). One CUDA block iterates ESDF_BLOCK_WIDTH
+// contiguous active voxels via `decodeInverseMaps`. Each thread reads
+// its own self-distance and 26 neighbours, writes the monotone min to
+// `esdfOut`. Reads from `esdfIn` only — safe double-buffered Jacobi.
+// -----------------------------------------------------------------------
+
+__global__ void
+esdfSweepVBMKernel(
+    nanovdb::NanoGrid<nanovdb::ValueOnIndex> *__restrict__ esdfGrid,
+    const uint32_t *__restrict__ firstLeafID,
+    const uint64_t *__restrict__ jumpMap,
+    const float *__restrict__ esdfIn,
+    float *__restrict__ esdfOut,
+    float voxelSize,
+    float maxDistance,
+    int *__restrict__ dChanged) {
+    constexpr int BW       = ESDF_BLOCK_WIDTH;
+    constexpr int JML      = ESDF_JUMP_MAP_LENGTH;
+    constexpr uint64_t VPL =
+        nanovdb::OnIndexTree::LeafNodeType::NUM_VALUES;
+
+    __shared__ uint32_t smem_leafIndex[BW];
+    __shared__ uint16_t smem_voxelOffset[BW];
+
+    const uint64_t blockFirstOffset =
+        static_cast<uint64_t>(blockIdx.x) * BW + 1;
+
+    nanovdb::tools::cuda::VoxelBlockManager<BW>::template decodeInverseMaps<
+        nanovdb::ValueOnIndex>(
+        esdfGrid,
+        firstLeafID[blockIdx.x],
+        jumpMap + static_cast<uint64_t>(blockIdx.x) * JML,
+        blockFirstOffset,
+        smem_leafIndex,
+        smem_voxelOffset);
+    // __syncthreads() is issued inside decodeInverseMaps.
+
+    const uint32_t leafID = smem_leafIndex[threadIdx.x];
+    if (leafID ==
+        nanovdb::tools::cuda::VoxelBlockManager<BW>::UnusedLeafIndex) {
+        return;
+    }
+    const uint16_t voxOff = smem_voxelOffset[threadIdx.x];
+
+    const auto &leaf         = esdfGrid->tree().template getFirstNode<0>()[leafID];
+    const nanovdb::Coord ijk = leaf.offsetToGlobalCoord(voxOff);
+    auto acc                 = esdfGrid->getAccessor();
+    const int64_t selfPid    =
+        static_cast<int64_t>(leaf.getValue(voxOff)) - 1;
+
+    const float dSelf = esdfIn[selfPid];
+
+    const float dNew = esdfSweepBody(
+        dSelf, voxelSize, maxDistance,
+        [&](int dx, int dy, int dz, float &dOut, bool &activeOut) {
+            const nanovdb::Coord c = ijk + nanovdb::Coord(dx, dy, dz);
+            if (!acc.isActive(c)) {
+                activeOut = false;
+                return;
+            }
+            const int64_t pid = static_cast<int64_t>(acc.getValue(c)) - 1;
+            dOut      = esdfIn[pid];
+            activeOut = true;
+        });
+
+    esdfOut[selfPid] = dNew;
+    // Signal fixed-point detection: if this voxel's value changed,
+    // the host-side loop will run another sweep. Race-free: all
+    // threads write the same value (1) and we only read *dChanged
+    // after the kernel completes. The comparison is exact because
+    // `esdfSweepBody` only writes a new `d` via assignment and
+    // starts at `d = dSelf`; if no neighbour won the min, `dNew`
+    // equals `dSelf` bit-for-bit.
+    if (dNew != dSelf) {
+        dChanged[0] = 1;
+    }
+    (void)VPL;
+}
+
+// -----------------------------------------------------------------------
+// Sweep kernel (per-leaf-slot ablation path). One CUDA block per leaf;
+// 512 threads iterate every slot in that leaf, skipping inactive ones.
+// Same inner body as the VBM kernel. Purpose: measure the cost model
+// delta of VBM iteration vs V4-style per-leaf iteration on this
+// specific stencil shape, for the paper's VBM ablation figure.
+// -----------------------------------------------------------------------
+
+__global__ void
+esdfSweepPerLeafKernel(
+    nanovdb::NanoGrid<nanovdb::ValueOnIndex> *__restrict__ esdfGrid,
+    const float *__restrict__ esdfIn,
+    float *__restrict__ esdfOut,
+    float voxelSize,
+    float maxDistance,
+    int *__restrict__ dChanged) {
+    constexpr uint64_t VPL =
+        nanovdb::OnIndexTree::LeafNodeType::NUM_VALUES;
+
+    const int64_t leafIdx = blockIdx.x;
+    // Each thread handles VPL / blockDim.x slots if VPL > blockDim.x.
+    // For VPL = 512 and ESDF_PERLEAF_THREADS = 128, that's 4 slots/thread.
+    for (int64_t voxOff = threadIdx.x; voxOff < static_cast<int64_t>(VPL);
+         voxOff += blockDim.x) {
+        const auto &leaf =
+            esdfGrid->tree().template getFirstNode<0>()[leafIdx];
+        if (!leaf.isActive(voxOff)) continue;
+
+        const int64_t selfPid =
+            static_cast<int64_t>(leaf.getValue(voxOff)) - 1;
+        const nanovdb::Coord ijk = leaf.offsetToGlobalCoord(voxOff);
+        auto acc                 = esdfGrid->getAccessor();
+
+        const float dSelf = esdfIn[selfPid];
+        const float dNew  = esdfSweepBody(
+             dSelf, voxelSize, maxDistance,
+             [&](int dx, int dy, int dz, float &dOut, bool &activeOut) {
+                 const nanovdb::Coord c = ijk + nanovdb::Coord(dx, dy, dz);
+                 if (!acc.isActive(c)) {
+                     activeOut = false;
+                     return;
+                 }
+                 const int64_t pid = static_cast<int64_t>(acc.getValue(c)) - 1;
+                 dOut      = esdfIn[pid];
+                 activeOut = true;
+             });
+        esdfOut[selfPid] = dNew;
+        if (dNew != dSelf) {
+            dChanged[0] = 1;
+        }
+    }
+}
+
+// -----------------------------------------------------------------------
+// Shared sweep-and-finalize helper. Runs N = 2*dilateAmount + 4 sweeps
+// of the chosen iteration kernel (VBM or per-leaf-slot), then clamps
+// magnitudes to [-maxDist, +maxDist], then optionally prunes voxels
+// still saturated at the cap.
+//
+// Takes a pre-allocated `esdfInit` sidecar that is assumed to already
+// hold the correct initial values for this run:
+//   - one-shot: sentinel + seeded from TSDF
+//   - incremental: sentinel + injected prev_esdf + seeded from TSDF
+//
+// The returned grid is either `esdfGrid` itself or the pruned subset.
+// The returned tensor has `(*returned_grid).totalVoxels` entries.
+// -----------------------------------------------------------------------
+
+std::tuple<c10::intrusive_ptr<GridBatchData>, torch::Tensor>
+runEsdfSweepsAndFinalize(
+    const c10::intrusive_ptr<GridBatchData> &esdfGrid,
+    torch::Tensor esdfInit,
+    float voxelSizeF,
+    int64_t dilateAmount,
+    float maxDistF,
+    bool prune_unreached,
+    bool use_vbm,
+    at::cuda::CUDAStream stream) {
+    const int64_t esdfVoxels = esdfGrid->totalVoxels();
+    auto u32Opts =
+        torch::TensorOptions().dtype(torch::kInt32).device(esdfInit.device());
+    auto u64Opts =
+        torch::TensorOptions().dtype(torch::kInt64).device(esdfInit.device());
+    auto i32Opts =
+        torch::TensorOptions().dtype(torch::kInt32).device(esdfInit.device());
+
+    auto *esdfDeviceGrid =
+        esdfGrid->mGridHdl->deviceGrid<nanovdb::ValueOnIndex>(0);
+    TORCH_CHECK(esdfDeviceGrid != nullptr, "computeESDF: null esdf grid");
+
+    // Double-buffered Jacobi. `esdfInit` is the first read; `esdfB`
+    // receives the first write; they swap each sweep.
+    torch::Tensor esdfB = esdfInit.clone();  // same content so reads are safe
+    torch::Tensor *esdfIn  = &esdfInit;
+    torch::Tensor *esdfOut = &esdfB;
+
+    // Fixed-point early termination: each sweep, the kernel sets
+    // `*dChanged = 1` whenever any voxel's value updates. After the
+    // kernel completes we sync-read the flag; if zero, the wavefront
+    // has converged and we break. This is load-bearing for the
+    // warm-reuse case (incremental on unchanged TSDF should exit
+    // after 1 sweep with ~3 ms cost, not run all 2K+4 sweeps). It
+    // also reduces cold cost on typical workloads where convergence
+    // happens in ~K sweeps rather than 2K+4.
+    torch::Tensor changedFlag = torch::zeros({1}, i32Opts);
+
+    // Hard upper bound on sweeps: 2K+4 covers worst-case opposite-
+    // corner propagation. The early-exit loop will usually terminate
+    // far before reaching this cap on warm-reuse and at ~K on cold
+    // builds where the wavefront is compact.
+    const int numSweepsMax = static_cast<int>(dilateAmount) * 2 + 4;
+
+    if (use_vbm) {
+        const auto treeData =
+            nanovdb::util::cuda::DeviceGridTraits<nanovdb::ValueOnIndex>::
+                getTreeData(esdfDeviceGrid);
+        const int lowerCount = static_cast<int>(treeData.mNodeCount[1]);
+
+        const int nBlocks = static_cast<int>(
+            (esdfVoxels + ESDF_BLOCK_WIDTH - 1) / ESDF_BLOCK_WIDTH);
+
+        torch::Tensor firstLeafID = torch::zeros({nBlocks}, u32Opts);
+        torch::Tensor jumpMap     =
+            torch::zeros({nBlocks * ESDF_JUMP_MAP_LENGTH}, u64Opts);
+
+        nanovdb::tools::cuda::buildVoxelBlockManager<
+            ESDF_BLOCK_WIDTH_LOG2, 128>(
+            /*firstOffset=*/1,
+            /*lastOffset=*/static_cast<uint64_t>(esdfVoxels),
+            /*nBlocks=*/nBlocks,
+            /*lowerCount=*/lowerCount,
+            /*grid=*/esdfDeviceGrid,
+            /*firstLeafID=*/
+            reinterpret_cast<uint32_t *>(firstLeafID.data_ptr<int32_t>()),
+            /*jumpMap=*/
+            reinterpret_cast<uint64_t *>(jumpMap.data_ptr<int64_t>()),
+            /*stream=*/stream.stream());
+        C10_CUDA_KERNEL_LAUNCH_CHECK();
+
+        for (int sweep = 0; sweep < numSweepsMax; ++sweep) {
+            changedFlag.zero_();
+            esdfSweepVBMKernel<<<static_cast<unsigned int>(nBlocks),
+                                 static_cast<unsigned int>(ESDF_BLOCK_WIDTH),
+                                 0, stream.stream()>>>(
+                esdfDeviceGrid,
+                reinterpret_cast<uint32_t *>(firstLeafID.data_ptr<int32_t>()),
+                reinterpret_cast<uint64_t *>(jumpMap.data_ptr<int64_t>()),
+                esdfIn->data_ptr<float>(),
+                esdfOut->data_ptr<float>(),
+                voxelSizeF, maxDistF,
+                changedFlag.data_ptr<int32_t>());
+            C10_CUDA_KERNEL_LAUNCH_CHECK();
+            std::swap(esdfIn, esdfOut);
+            // .item() is a sync + host-device copy (~30 us). Each
+            // sweep is ~3-10 ms at our scales, so the overhead is
+            // ~1%. Break early when the wavefront has converged.
+            if (changedFlag.item<int32_t>() == 0) {
+                break;
+            }
+        }
+    } else {
+        const int64_t esdfLeaves = esdfGrid->totalLeaves();
+        for (int sweep = 0; sweep < numSweepsMax; ++sweep) {
+            changedFlag.zero_();
+            esdfSweepPerLeafKernel<<<
+                static_cast<unsigned int>(esdfLeaves),
+                static_cast<unsigned int>(ESDF_PERLEAF_THREADS),
+                0, stream.stream()>>>(
+                esdfDeviceGrid,
+                esdfIn->data_ptr<float>(),
+                esdfOut->data_ptr<float>(),
+                voxelSizeF, maxDistF,
+                changedFlag.data_ptr<int32_t>());
+            C10_CUDA_KERNEL_LAUNCH_CHECK();
+            std::swap(esdfIn, esdfOut);
+            if (changedFlag.item<int32_t>() == 0) {
+                break;
+            }
+        }
+    }
+
+    torch::Tensor esdfFinal =
+        esdfIn->clamp(-maxDistF, maxDistF).contiguous();
+
+    if (!prune_unreached) {
+        return {esdfGrid, esdfFinal};
+    }
+
+    torch::Tensor keepMask = esdfFinal.abs() < maxDistF;
+    auto idxOpts = torch::TensorOptions()
+                       .dtype(fvdb::JIdxScalarType)
+                       .device(esdfInit.device());
+    auto jidx  = torch::zeros({keepMask.size(0)}, idxOpts);
+    auto jlidx = torch::empty({0, 1}, idxOpts);
+    auto keepMaskJagged = JaggedTensor::from_data_indices_and_list_ids(
+        keepMask, jidx, jlidx, /*num_tensors=*/1);
+    auto prunedGrid = pruneGrid(*esdfGrid, keepMaskJagged);
+    torch::Tensor prunedEsdf = esdfFinal.masked_select(keepMask);
+    return {prunedGrid, prunedEsdf};
+}
+
+} // anonymous namespace
+
+// -----------------------------------------------------------------------
+// Public entry point: one-shot.
+// -----------------------------------------------------------------------
+
+std::tuple<c10::intrusive_ptr<GridBatchData>, torch::Tensor>
+computeESDF(const GridBatchData &gridBatch,
+            const torch::Tensor &tsdf,
+            const torch::Tensor &weights,
+            double truncation_distance,
+            double max_distance,
+            double weight_threshold,
+            bool prune_unreached,
+            bool use_vbm) {
+    // ------------------ Shape / dtype / scope checks ------------------
+
+    TORCH_CHECK_VALUE(gridBatch.batchSize() == 1,
+                      "computeESDF: batchSize must be 1 in M5, got ",
+                      gridBatch.batchSize());
+    TORCH_CHECK(tsdf.is_cuda() && weights.is_cuda(),
+                "computeESDF: tsdf and weights must be CUDA tensors");
+    gridBatch.checkDevice(tsdf);
+    gridBatch.checkDevice(weights);
+
+    TORCH_CHECK_VALUE(tsdf.dim() == 1 && weights.dim() == 1,
+                      "computeESDF: tsdf and weights must be 1-D, got dims (",
+                      tsdf.dim(), ",", weights.dim(), ")");
+    TORCH_CHECK_VALUE(tsdf.size(0) == gridBatch.totalVoxels() &&
+                      weights.size(0) == gridBatch.totalVoxels(),
+                      "computeESDF: tsdf/weights size must match totalVoxels (",
+                      gridBatch.totalVoxels(), "), got tsdf=", tsdf.size(0),
+                      " weights=", weights.size(0));
+
+    TORCH_CHECK_TYPE(tsdf.scalar_type() == torch::kFloat32,
+                     "computeESDF: only float32 tsdf is supported in M5");
+    TORCH_CHECK_TYPE(weights.scalar_type() == torch::kFloat32,
+                     "computeESDF: only float32 weights is supported in M5");
+
+    TORCH_CHECK_VALUE(truncation_distance > 0.0,
+                      "computeESDF: truncation_distance must be > 0, got ",
+                      truncation_distance);
+    TORCH_CHECK_VALUE(max_distance > 0.0,
+                      "computeESDF: max_distance must be > 0, got ",
+                      max_distance);
+
+    c10::cuda::CUDAGuard guard(tsdf.device());
+    at::cuda::CUDAStream stream =
+        at::cuda::getCurrentCUDAStream(tsdf.device().index());
+
+    // Cast configuration to fp32 for kernel use.
+    const float truncF    = static_cast<float>(truncation_distance);
+    const float maxDistF  = static_cast<float>(max_distance);
+    const float threshF   = static_cast<float>(weight_threshold);
+    const float saturEps  = 1.0e-5f;  // "|tsdf| < 1" margin for float stability
+
+    // Voxel size: single-batch, isotropic expected. Use the minimum axis
+    // to drive chamfer step length; TSDF convention assumes isotropic.
+    std::vector<nanovdb::Vec3d> voxSizes, origins;
+    gridBatch.gridVoxelSizesAndOrigins(voxSizes, origins);
+    TORCH_CHECK_VALUE(voxSizes.size() == 1,
+                      "computeESDF: expected single-batch voxel size");
+    const double vsX = voxSizes[0][0];
+    const double vsY = voxSizes[0][1];
+    const double vsZ = voxSizes[0][2];
+    TORCH_CHECK_VALUE(std::fabs(vsX - vsY) < 1e-9 &&
+                      std::fabs(vsX - vsZ) < 1e-9,
+                      "computeESDF: anisotropic voxels not supported in M5 (",
+                      vsX, ", ", vsY, ", ", vsZ, ")");
+    const float voxelSizeF = static_cast<float>(vsX);
+
+    auto floatOpts =
+        torch::TensorOptions().dtype(torch::kFloat32).device(tsdf.device());
+
+    // ------------------ Step 1: build ESDF support topology ------------------
+
+    const int64_t dilateAmount =
+        static_cast<int64_t>(std::ceil(max_distance / vsX)) + 1;
+    auto esdfGrid = dilateGrid(gridBatch,
+                               std::vector<int64_t>{dilateAmount});
+    const int64_t esdfVoxels = esdfGrid->totalVoxels();
+
+    if (esdfVoxels == 0) {
+        // Input grid was empty; return empty ESDF.
+        torch::Tensor emptyEsdf = torch::empty({0}, floatOpts);
+        return {esdfGrid, emptyEsdf};
+    }
+
+    // ------------------ Step 2: allocate + fill-sentinel ESDF ----------------
+
+    torch::Tensor esdfA = torch::full({esdfVoxels}, kEsdfSentinel, floatOpts);
+
+    // ------------------ Step 3: seed from input TSDF ------------------------
+
+    auto *inputDeviceGrid =
+        gridBatch.mGridHdl->deviceGrid<nanovdb::ValueOnIndex>(0);
+    auto *esdfDeviceGrid =
+        esdfGrid->mGridHdl->deviceGrid<nanovdb::ValueOnIndex>(0);
+    TORCH_CHECK(inputDeviceGrid != nullptr, "computeESDF: null input grid");
+    TORCH_CHECK(esdfDeviceGrid != nullptr, "computeESDF: null esdf grid");
+
+    {
+        const int64_t inputLeaves = gridBatch.totalLeaves();
+        if (inputLeaves > 0) {
+            // One-shot compute has no dirty-mask concept (it seeds
+            // from every near-surface voxel unconditionally). Pass
+            // nullptr.
+            esdfSeedKernel<<<static_cast<unsigned int>(inputLeaves),
+                             static_cast<unsigned int>(
+                                 nanovdb::OnIndexTree::LeafNodeType::NUM_VALUES),
+                             0, stream.stream()>>>(
+                inputDeviceGrid, esdfDeviceGrid,
+                tsdf.data_ptr<float>(), weights.data_ptr<float>(),
+                /*dirtyMask=*/nullptr,
+                esdfA.data_ptr<float>(),
+                truncF, threshF, saturEps);
+            C10_CUDA_KERNEL_LAUNCH_CHECK();
+        }
+    }
+
+    // ------------------ Step 4-5: sweeps + clamp + prune ---------------------
+
+    return runEsdfSweepsAndFinalize(
+        esdfGrid, esdfA, voxelSizeF, dilateAmount, maxDistF,
+        prune_unreached, use_vbm, stream);
+}
+
+// -----------------------------------------------------------------------
+// Public entry point: incremental.
+// -----------------------------------------------------------------------
+
+std::tuple<c10::intrusive_ptr<GridBatchData>, torch::Tensor>
+computeESDFIncremental(const GridBatchData &gridBatch,
+                       const torch::Tensor &tsdf,
+                       const torch::Tensor &weights,
+                       const GridBatchData &prevEsdfGrid,
+                       const torch::Tensor &prevEsdf,
+                       double truncation_distance,
+                       double max_distance,
+                       double weight_threshold,
+                       bool prune_unreached,
+                       bool use_vbm,
+                       const torch::Tensor &dirtyMask) {
+    // ------------------ Shape / dtype / scope checks ------------------
+
+    TORCH_CHECK_VALUE(gridBatch.batchSize() == 1 &&
+                          prevEsdfGrid.batchSize() <= 1,
+                      "computeESDFIncremental: batchSize must be 1 in M5");
+    TORCH_CHECK(tsdf.is_cuda() && weights.is_cuda() && prevEsdf.is_cuda(),
+                "computeESDFIncremental: all tensors must be CUDA");
+    gridBatch.checkDevice(tsdf);
+    gridBatch.checkDevice(weights);
+    TORCH_CHECK_VALUE(tsdf.dim() == 1 && weights.dim() == 1 && prevEsdf.dim() == 1,
+                      "computeESDFIncremental: tsdf/weights/prevEsdf must be 1-D");
+    TORCH_CHECK_VALUE(tsdf.size(0) == gridBatch.totalVoxels() &&
+                          weights.size(0) == gridBatch.totalVoxels(),
+                      "computeESDFIncremental: tsdf/weights size must match "
+                      "current grid.totalVoxels (",
+                      gridBatch.totalVoxels(), ")");
+    TORCH_CHECK_VALUE(prevEsdf.size(0) == prevEsdfGrid.totalVoxels(),
+                      "computeESDFIncremental: prevEsdf size (",
+                      prevEsdf.size(0),
+                      ") must match prevEsdfGrid.totalVoxels (",
+                      prevEsdfGrid.totalVoxels(), ")");
+    TORCH_CHECK_TYPE(tsdf.scalar_type() == torch::kFloat32 &&
+                         weights.scalar_type() == torch::kFloat32 &&
+                         prevEsdf.scalar_type() == torch::kFloat32,
+                     "computeESDFIncremental: only float32 is supported in M5");
+    TORCH_CHECK_VALUE(truncation_distance > 0.0,
+                      "computeESDFIncremental: truncation_distance must be > 0");
+    TORCH_CHECK_VALUE(max_distance > 0.0,
+                      "computeESDFIncremental: max_distance must be > 0");
+
+    const bool hasDirtyMask = dirtyMask.defined() && dirtyMask.numel() > 0;
+    if (hasDirtyMask) {
+        TORCH_CHECK_VALUE(dirtyMask.scalar_type() == torch::kBool,
+                          "computeESDFIncremental: dirty_mask must be bool");
+        TORCH_CHECK_VALUE(dirtyMask.size(0) == gridBatch.totalVoxels(),
+                          "computeESDFIncremental: dirty_mask size (",
+                          dirtyMask.size(0),
+                          ") must equal gridBatch.totalVoxels (",
+                          gridBatch.totalVoxels(), ")");
+        TORCH_CHECK(dirtyMask.device() == tsdf.device(),
+                    "computeESDFIncremental: dirty_mask must be on same "
+                    "device as tsdf");
+    }
+    // Python wrapper handles the "dirtyMask.any() == False"
+    // short-circuit (returns prev state directly, never entering
+    // C++). By the time we get here, the dirty mask has at least
+    // one true entry, so we do the full incremental work but with
+    // the seed kernel gated on the mask.
+
+    // Fall through to one-shot when there's no previous state. Keeps
+    // the first-frame-of-a-session code path trivial.
+    if (prevEsdfGrid.totalVoxels() == 0) {
+        return computeESDF(gridBatch, tsdf, weights,
+                           truncation_distance, max_distance,
+                           weight_threshold, prune_unreached, use_vbm);
+    }
+
+    c10::cuda::CUDAGuard guard(tsdf.device());
+    at::cuda::CUDAStream stream =
+        at::cuda::getCurrentCUDAStream(tsdf.device().index());
+
+    const float truncF   = static_cast<float>(truncation_distance);
+    const float maxDistF = static_cast<float>(max_distance);
+    const float threshF  = static_cast<float>(weight_threshold);
+    const float saturEps = 1.0e-5f;
+
+    std::vector<nanovdb::Vec3d> voxSizes, origins;
+    gridBatch.gridVoxelSizesAndOrigins(voxSizes, origins);
+    TORCH_CHECK_VALUE(voxSizes.size() == 1,
+                      "computeESDFIncremental: expected single-batch voxel size");
+    const double vsX = voxSizes[0][0];
+    TORCH_CHECK_VALUE(std::fabs(vsX - voxSizes[0][1]) < 1e-9 &&
+                          std::fabs(vsX - voxSizes[0][2]) < 1e-9,
+                      "computeESDFIncremental: anisotropic voxels not supported");
+    // Require matching voxel size between previous and current grids.
+    // Changing voxel sizes across frames would break the sign-propagation
+    // witness semantics; users in that case should reset to one-shot.
+    std::vector<nanovdb::Vec3d> prevVoxSizes, prevOrigins;
+    prevEsdfGrid.gridVoxelSizesAndOrigins(prevVoxSizes, prevOrigins);
+    TORCH_CHECK_VALUE(!prevVoxSizes.empty() &&
+                          std::fabs(prevVoxSizes[0][0] - vsX) < 1e-9,
+                      "computeESDFIncremental: prevEsdfGrid voxel_size (",
+                      prevVoxSizes.empty() ? 0.0 : prevVoxSizes[0][0],
+                      ") must match current grid voxel_size (", vsX, ")");
+    const float voxelSizeF = static_cast<float>(vsX);
+
+    auto floatOpts =
+        torch::TensorOptions().dtype(torch::kFloat32).device(tsdf.device());
+
+    // ------------------ Step 1: build union ESDF support topology ------------
+
+    const int64_t dilateAmount =
+        static_cast<int64_t>(std::ceil(max_distance / vsX)) + 1;
+    auto dilated = dilateGrid(gridBatch,
+                              std::vector<int64_t>{dilateAmount});
+    // Merge with the previous ESDF grid so voxels that were in the
+    // previous support but fall outside the current TSDF's dilation
+    // are still carried over (monotone scene assumption: previously-
+    // known ESDF values shouldn't disappear just because the TSDF
+    // shell shifted in this frame).
+    auto esdfGrid = mergeGrids(*dilated, prevEsdfGrid);
+    const int64_t esdfVoxels = esdfGrid->totalVoxels();
+
+    if (esdfVoxels == 0) {
+        return {esdfGrid, torch::empty({0}, floatOpts)};
+    }
+
+    // ------------------ Step 2: sentinel-fill + inject prev_esdf -------------
+
+    torch::Tensor esdfInit = torch::full({esdfVoxels}, kEsdfSentinel, floatOpts);
+    {
+        // Inject previous ESDF values into their (possibly-shifted)
+        // slot positions in the merged grid. `ops::inject` copies only
+        // the ijk-overlapping voxels and leaves the rest (sentinel)
+        // untouched.
+        JaggedTensor dstJt = esdfGrid->jaggedTensor(esdfInit);
+        JaggedTensor srcJt = prevEsdfGrid.jaggedTensor(prevEsdf);
+        ops::inject(*esdfGrid, prevEsdfGrid, dstJt, srcJt);
+        esdfInit = dstJt.jdata();
+    }
+
+    // Reset voxels saturated at the previous frame's max_distance cap
+    // back to sentinel. Two reasons:
+    //
+    // (1) The clamped output from a previous `compute_esdf` call loses
+    //     the distinction between "reached at exactly max_distance" and
+    //     "unreached (sentinel)" voxels -- both appear as
+    //     `±max_distance` in the prev tensor. Without this reset, the
+    //     injected `+max_distance` values would be treated as "reached
+    //     witnesses" by this frame's wavefront. Converting them back
+    //     to sentinel lets the current-frame sweep correctly
+    //     re-propagate into previously-unreached regions.
+    //
+    // (2) A surviving prev value at e.g. `-max_distance + epsilon`
+    //     (|d| < max_distance so it survives this reset) would,
+    //     without the propagation cap in `esdfSweepBody`, cascade its
+    //     negative sign arbitrarily far via the 18-sweep chain. The
+    //     `candAbs >= maxDistance` guard in the sweep kernel now
+    //     prevents this; here we just normalize the "exactly-at-cap"
+    //     boundary values to sentinel so they don't act as phantom
+    //     witnesses.
+    //
+    // Edge case: voxels that genuinely were at exactly `max_distance`
+    // get converted too, but they'll be re-derived correctly by the
+    // wavefront from neighbouring seeded voxels with the same accuracy
+    // as a one-shot call.
+    {
+        auto resetMask = esdfInit.abs().ge(maxDistF);
+        esdfInit.masked_fill_(resetMask, kEsdfSentinel);
+    }
+
+    // ------------------ Step 3: seed from current TSDF ----------------------
+
+    auto *inputDeviceGrid =
+        gridBatch.mGridHdl->deviceGrid<nanovdb::ValueOnIndex>(0);
+    auto *esdfDeviceGrid =
+        esdfGrid->mGridHdl->deviceGrid<nanovdb::ValueOnIndex>(0);
+    TORCH_CHECK(inputDeviceGrid != nullptr && esdfDeviceGrid != nullptr,
+                "computeESDFIncremental: null device grid");
+
+    const int64_t inputLeaves = gridBatch.totalLeaves();
+    if (inputLeaves > 0) {
+        // Current-frame seed writes unconditionally (at the voxels it
+        // visits), which is correct: seeds are by definition exact
+        // signed distances. The dirty-mask gate (when provided) limits
+        // which voxels are visited at all — non-dirty voxels inherit
+        // whatever they had in `prevEsdf` (via the inject+restore
+        // above). Monotone-min correctness is preserved under the
+        // existing "distances can decrease but not grow" assumption.
+        const bool *dirtyMaskPtr = hasDirtyMask
+            ? dirtyMask.data_ptr<bool>()
+            : nullptr;
+        esdfSeedKernel<<<static_cast<unsigned int>(inputLeaves),
+                         static_cast<unsigned int>(
+                             nanovdb::OnIndexTree::LeafNodeType::NUM_VALUES),
+                         0, stream.stream()>>>(
+            inputDeviceGrid, esdfDeviceGrid,
+            tsdf.data_ptr<float>(), weights.data_ptr<float>(),
+            dirtyMaskPtr,
+            esdfInit.data_ptr<float>(),
+            truncF, threshF, saturEps);
+        C10_CUDA_KERNEL_LAUNCH_CHECK();
+    }
+
+    // ------------------ Step 4-5: sweeps + clamp + prune --------------------
+
+    return runEsdfSweepsAndFinalize(
+        esdfGrid, esdfInit, voxelSizeF, dilateAmount, maxDistF,
+        prune_unreached, use_vbm, stream);
+}
+
+} // namespace ops
+} // namespace detail
+} // namespace fvdb

--- a/src/fvdb/detail/ops/ComputeESDF.cu
+++ b/src/fvdb/detail/ops/ComputeESDF.cu
@@ -398,12 +398,15 @@ runEsdfSweepsAndFinalize(const c10::intrusive_ptr<GridBatchData> &esdfGrid,
     const int64_t esdfVoxels = esdfGrid->totalVoxels();
     auto i32Opts = torch::TensorOptions().dtype(torch::kInt32).device(esdfInit.device());
 
-    auto *esdfDeviceGrid = esdfGrid->mGridHdl->deviceGrid<nanovdb::ValueOnIndex>(0);
+    auto *esdfDeviceGrid = esdfGrid->deviceGridPtrAt(0);
     TORCH_CHECK(esdfDeviceGrid != nullptr, "computeESDF: null esdf grid");
 
     // Double-buffered Jacobi. `esdfInit` is the first read; `esdfB`
-    // receives the first write; they swap each sweep.
-    torch::Tensor esdfB    = esdfInit.clone(); // same content so reads are safe
+    // receives the first write; they swap each sweep. `esdfB` can be
+    // uninitialized: every sweep writes `esdfOut[selfPid]` for every
+    // active voxel before the buffers swap, so no sweep ever reads a
+    // slot the previous sweep didn't write.
+    torch::Tensor esdfB    = torch::empty_like(esdfInit);
     torch::Tensor *esdfIn  = &esdfInit;
     torch::Tensor *esdfOut = &esdfB;
 
@@ -504,7 +507,11 @@ runEsdfSweepsAndFinalize(const c10::intrusive_ptr<GridBatchData> &esdfGrid,
         }
     }
 
-    torch::Tensor esdfFinal = esdfIn->clamp(-maxDistF, maxDistF).contiguous();
+    // In-place clamp: allocating a third sidecar here (while both
+    // ping-pong buffers are still alive) was the ESDF-phase memory
+    // peak. `esdfIn` is one of the two function-local buffers, so
+    // clamping in place is safe; both were born contiguous.
+    torch::Tensor esdfFinal = esdfIn->clamp_(-maxDistF, maxDistF);
 
     if (!prune_unreached) {
         return {esdfGrid, esdfFinal};
@@ -512,7 +519,7 @@ runEsdfSweepsAndFinalize(const c10::intrusive_ptr<GridBatchData> &esdfGrid,
 
     torch::Tensor keepMask = esdfFinal.abs() < maxDistF;
     auto idxOpts = torch::TensorOptions().dtype(fvdb::JIdxScalarType).device(esdfInit.device());
-    auto jidx    = torch::zeros({keepMask.size(0)}, idxOpts);
+    auto jidx    = torch::empty({0}, idxOpts);
     auto jlidx   = torch::empty({0, 1}, idxOpts);
     auto keepMaskJagged =
         JaggedTensor::from_data_indices_and_list_ids(keepMask, jidx, jlidx, /*num_tensors=*/1);
@@ -619,8 +626,8 @@ computeESDF(const GridBatchData &gridBatch,
 
     // ------------------ Step 3: seed from input TSDF ------------------------
 
-    auto *inputDeviceGrid = gridBatch.mGridHdl->deviceGrid<nanovdb::ValueOnIndex>(0);
-    auto *esdfDeviceGrid  = esdfGrid->mGridHdl->deviceGrid<nanovdb::ValueOnIndex>(0);
+    auto *inputDeviceGrid = gridBatch.deviceGridPtrAt(0);
+    auto *esdfDeviceGrid  = esdfGrid->deviceGridPtrAt(0);
     TORCH_CHECK(inputDeviceGrid != nullptr, "computeESDF: null input grid");
     TORCH_CHECK(esdfDeviceGrid != nullptr, "computeESDF: null esdf grid");
 
@@ -772,7 +779,11 @@ computeESDFIncremental(const GridBatchData &gridBatch,
     // are still carried over (monotone scene assumption: previously-
     // known ESDF values shouldn't disappear just because the TSDF
     // shell shifted in this frame).
-    auto esdfGrid            = mergeGrids(*dilated, prevEsdfGrid);
+    auto esdfGrid = mergeGrids(*dilated, prevEsdfGrid);
+    // The dilated grid is only an input to the merge; release it now
+    // so it doesn't coexist with the merged grid and both fp32
+    // sidecars for the whole sweep phase.
+    dilated.reset();
     const int64_t esdfVoxels = esdfGrid->totalVoxels();
 
     if (esdfVoxels == 0) {
@@ -819,14 +830,20 @@ computeESDFIncremental(const GridBatchData &gridBatch,
     // wavefront from neighbouring seeded voxels with the same accuracy
     // as a one-shot call.
     {
-        auto resetMask = esdfInit.abs().ge(maxDistF);
-        esdfInit.masked_fill_(resetMask, kEsdfSentinel);
+        // Two sign-aware comparisons instead of `abs().ge(...)`: the
+        // abs() would materialize a full fp32 temp over the merged
+        // support band; each comparison only allocates a 1-byte bool
+        // mask (sequentially, so they don't stack). The sentinel
+        // itself is >= maxDistF, so already-sentinel voxels are a
+        // harmless self-assignment.
+        esdfInit.masked_fill_(esdfInit.ge(maxDistF), kEsdfSentinel);
+        esdfInit.masked_fill_(esdfInit.le(-maxDistF), kEsdfSentinel);
     }
 
     // ------------------ Step 3: seed from current TSDF ----------------------
 
-    auto *inputDeviceGrid = gridBatch.mGridHdl->deviceGrid<nanovdb::ValueOnIndex>(0);
-    auto *esdfDeviceGrid  = esdfGrid->mGridHdl->deviceGrid<nanovdb::ValueOnIndex>(0);
+    auto *inputDeviceGrid = gridBatch.deviceGridPtrAt(0);
+    auto *esdfDeviceGrid  = esdfGrid->deviceGridPtrAt(0);
     TORCH_CHECK(inputDeviceGrid != nullptr && esdfDeviceGrid != nullptr,
                 "computeESDFIncremental: null device grid");
 

--- a/src/fvdb/detail/ops/ComputeESDF.cu
+++ b/src/fvdb/detail/ops/ComputeESDF.cu
@@ -46,16 +46,16 @@
 #include <fvdb/detail/ops/ComputeESDF.h>
 #include <fvdb/detail/ops/Inject.h>
 
-#include <c10/cuda/CUDAException.h>
-#include <c10/cuda/CUDAGuard.h>
-#include <c10/cuda/CUDAStream.h>
-
 #include <nanovdb/NanoVDB.h>
 #include <nanovdb/tools/cuda/VoxelBlockManager.cuh>
 #include <nanovdb/util/cuda/DeviceGridTraits.cuh>
 
-#include <cuda_runtime.h>
+#include <c10/cuda/CUDAException.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <c10/cuda/CUDAStream.h>
 #include <torch/types.h>
+
+#include <cuda_runtime.h>
 
 #include <cmath>
 
@@ -70,9 +70,9 @@ namespace {
 // -----------------------------------------------------------------------
 
 constexpr int ESDF_BLOCK_WIDTH_LOG2 = 7;
-constexpr int ESDF_BLOCK_WIDTH      = 1 << ESDF_BLOCK_WIDTH_LOG2;  // 128
-constexpr int ESDF_JUMP_MAP_LENGTH  = ESDF_BLOCK_WIDTH / 64;       // 2
-constexpr int ESDF_PERLEAF_THREADS  = 128;                         // per-leaf ablation
+constexpr int ESDF_BLOCK_WIDTH      = 1 << ESDF_BLOCK_WIDTH_LOG2; // 128
+constexpr int ESDF_JUMP_MAP_LENGTH  = ESDF_BLOCK_WIDTH / 64;      // 2
+constexpr int ESDF_PERLEAF_THREADS  = 128;                        // per-leaf ablation
 
 // Sentinel used for "never-reached" voxels. Must be LARGE ENOUGH that
 // it is unambiguously identifiable after propagation: the wavefront
@@ -96,26 +96,39 @@ constexpr float kEsdfSentinelCheck = 0.5e30f;
 
 struct EsdfOffset {
     int dx, dy, dz;
-    float weight;  // ||offset||, in units of voxel_size
+    float weight; // ||offset||, in units of voxel_size
 };
 
 __device__ __constant__ EsdfOffset kEsdfOffsets[26] = {
     // 6 face neighbours (axis-aligned, weight = 1)
-    {-1,  0,  0, 1.0f}, { 1,  0,  0, 1.0f},
-    { 0, -1,  0, 1.0f}, { 0,  1,  0, 1.0f},
-    { 0,  0, -1, 1.0f}, { 0,  0,  1, 1.0f},
+    {-1, 0, 0, 1.0f},
+    {1, 0, 0, 1.0f},
+    {0, -1, 0, 1.0f},
+    {0, 1, 0, 1.0f},
+    {0, 0, -1, 1.0f},
+    {0, 0, 1, 1.0f},
     // 12 edge neighbours (face-diagonal, weight = sqrt(2) ~ 1.41421356)
-    {-1, -1,  0, 1.41421356f}, { 1, -1,  0, 1.41421356f},
-    {-1,  1,  0, 1.41421356f}, { 1,  1,  0, 1.41421356f},
-    {-1,  0, -1, 1.41421356f}, { 1,  0, -1, 1.41421356f},
-    {-1,  0,  1, 1.41421356f}, { 1,  0,  1, 1.41421356f},
-    { 0, -1, -1, 1.41421356f}, { 0,  1, -1, 1.41421356f},
-    { 0, -1,  1, 1.41421356f}, { 0,  1,  1, 1.41421356f},
+    {-1, -1, 0, 1.41421356f},
+    {1, -1, 0, 1.41421356f},
+    {-1, 1, 0, 1.41421356f},
+    {1, 1, 0, 1.41421356f},
+    {-1, 0, -1, 1.41421356f},
+    {1, 0, -1, 1.41421356f},
+    {-1, 0, 1, 1.41421356f},
+    {1, 0, 1, 1.41421356f},
+    {0, -1, -1, 1.41421356f},
+    {0, 1, -1, 1.41421356f},
+    {0, -1, 1, 1.41421356f},
+    {0, 1, 1, 1.41421356f},
     // 8 corner neighbours (vertex-diagonal, weight = sqrt(3) ~ 1.73205081)
-    {-1, -1, -1, 1.73205081f}, { 1, -1, -1, 1.73205081f},
-    {-1,  1, -1, 1.73205081f}, { 1,  1, -1, 1.73205081f},
-    {-1, -1,  1, 1.73205081f}, { 1, -1,  1, 1.73205081f},
-    {-1,  1,  1, 1.73205081f}, { 1,  1,  1, 1.73205081f},
+    {-1, -1, -1, 1.73205081f},
+    {1, -1, -1, 1.73205081f},
+    {-1, 1, -1, 1.73205081f},
+    {1, 1, -1, 1.73205081f},
+    {-1, -1, 1, 1.73205081f},
+    {1, -1, 1, 1.73205081f},
+    {-1, 1, 1, 1.73205081f},
+    {1, 1, 1, 1.73205081f},
 };
 
 // -----------------------------------------------------------------------
@@ -129,8 +142,7 @@ __device__ __constant__ EsdfOffset kEsdfOffsets[26] = {
 
 template <typename ReadNeighbourFn>
 __device__ __forceinline__ float
-esdfSweepBody(float dSelf, float voxelSize, float maxDistance,
-              ReadNeighbourFn readNeighbour) {
+esdfSweepBody(float dSelf, float voxelSize, float maxDistance, ReadNeighbourFn readNeighbour) {
     float d = dSelf;
 #pragma unroll
     for (int i = 0; i < 26; ++i) {
@@ -138,9 +150,11 @@ esdfSweepBody(float dSelf, float voxelSize, float maxDistance,
         float dN;
         bool active;
         readNeighbour(off.dx, off.dy, off.dz, dN, active);
-        if (!active) continue;
+        if (!active)
+            continue;
         const float dNAbs = fabsf(dN);
-        if (dNAbs >= kEsdfSentinelCheck) continue;  // neighbour not yet reached
+        if (dNAbs >= kEsdfSentinelCheck)
+            continue; // neighbour not yet reached
         const float step    = off.weight * voxelSize;
         const float candAbs = dNAbs + step;
         // Cap propagation at `maxDistance` so wavefronts can't smear
@@ -154,7 +168,8 @@ esdfSweepBody(float dSelf, float voxelSize, float maxDistance,
         // ANY seed stay at sentinel -> clamped to +maxDistance at the
         // end (the "unknown, free space" convention). This matches
         // nvblox / FIESTA defaults.
-        if (candAbs >= maxDistance) continue;
+        if (candAbs >= maxDistance)
+            continue;
         if (candAbs < fabsf(d)) {
             // Preserve the sign of the witness neighbour.
             d = (dN < 0.0f) ? -candAbs : candAbs;
@@ -178,26 +193,26 @@ esdfSweepBody(float dSelf, float voxelSize, float maxDistance,
 // -----------------------------------------------------------------------
 
 __global__ void
-esdfSeedKernel(
-    const nanovdb::NanoGrid<nanovdb::ValueOnIndex> *__restrict__ inputGrid,
-    const nanovdb::NanoGrid<nanovdb::ValueOnIndex> *__restrict__ esdfGrid,
-    const float *__restrict__ tsdf,       // [inputGrid->totalActiveVoxels]
-    const float *__restrict__ weights,    // [inputGrid->totalActiveVoxels]
-    const bool *__restrict__ dirtyMask,   // nullable; when non-null,
-                                          // only dirty voxels seed
-    float *__restrict__ esdf,             // [esdfGrid->totalActiveVoxels]
-    float truncationDistance,
-    float weightThreshold,
-    float saturationEps) {
-    constexpr uint64_t VPL =
-        nanovdb::OnIndexTree::LeafNodeType::NUM_VALUES;
+esdfSeedKernel(const nanovdb::NanoGrid<nanovdb::ValueOnIndex> *__restrict__ inputGrid,
+               const nanovdb::NanoGrid<nanovdb::ValueOnIndex> *__restrict__ esdfGrid,
+               const float *__restrict__ tsdf,     // [inputGrid->totalActiveVoxels]
+               const float *__restrict__ weights,  // [inputGrid->totalActiveVoxels]
+               const bool *__restrict__ dirtyMask, // nullable; when non-null,
+                                                   // only dirty voxels seed
+               float *__restrict__ esdf,           // [esdfGrid->totalActiveVoxels]
+               float truncationDistance,
+               float weightThreshold,
+               float saturationEps) {
+    constexpr uint64_t VPL = nanovdb::OnIndexTree::LeafNodeType::NUM_VALUES;
 
     const int64_t leafIdx = blockIdx.x;
     const int64_t voxOff  = threadIdx.x;
-    if (voxOff >= static_cast<int64_t>(VPL)) return;
+    if (voxOff >= static_cast<int64_t>(VPL))
+        return;
 
     const auto &leaf = inputGrid->tree().template getFirstNode<0>()[leafIdx];
-    if (!leaf.isActive(voxOff)) return;
+    if (!leaf.isActive(voxOff))
+        return;
 
     // 1-indexed pid; subtract one for torch tensor offset.
     const int64_t inputPid = static_cast<int64_t>(leaf.getValue(voxOff)) - 1;
@@ -208,20 +223,24 @@ esdfSeedKernel(
     // `compute_esdf_incremental` nvblox-style dirty-region update
     // scaling. When `dirtyMask == nullptr` (the default), behaves
     // as before -- seed from every near-surface voxel.
-    if (dirtyMask != nullptr && !dirtyMask[inputPid]) return;
+    if (dirtyMask != nullptr && !dirtyMask[inputPid])
+        return;
 
-    const float w  = weights[inputPid];
-    if (!(w > weightThreshold)) return;
+    const float w = weights[inputPid];
+    if (!(w > weightThreshold))
+        return;
 
     const float t = tsdf[inputPid];
-    if (!(fabsf(t) < 1.0f - saturationEps)) return;
+    if (!(fabsf(t) < 1.0f - saturationEps))
+        return;
 
     const nanovdb::Coord ijk = leaf.offsetToGlobalCoord(voxOff);
     auto esdfAcc             = esdfGrid->getAccessor();
     // By construction (dilateGrid superset), ijk is always active in
     // esdfGrid; assert defensively in debug builds.
     const uint64_t esdfRaw = esdfAcc.getValue(ijk);
-    if (esdfRaw == 0) return;
+    if (esdfRaw == 0)
+        return;
     const int64_t esdfPid = static_cast<int64_t>(esdfRaw) - 1;
 
     esdf[esdfPid] = t * truncationDistance;
@@ -235,28 +254,24 @@ esdfSeedKernel(
 // -----------------------------------------------------------------------
 
 __global__ void
-esdfSweepVBMKernel(
-    nanovdb::NanoGrid<nanovdb::ValueOnIndex> *__restrict__ esdfGrid,
-    const uint32_t *__restrict__ firstLeafID,
-    const uint64_t *__restrict__ jumpMap,
-    const float *__restrict__ esdfIn,
-    float *__restrict__ esdfOut,
-    float voxelSize,
-    float maxDistance,
-    int *__restrict__ dChanged) {
+esdfSweepVBMKernel(nanovdb::NanoGrid<nanovdb::ValueOnIndex> *__restrict__ esdfGrid,
+                   const uint32_t *__restrict__ firstLeafID,
+                   const uint64_t *__restrict__ jumpMap,
+                   const float *__restrict__ esdfIn,
+                   float *__restrict__ esdfOut,
+                   float voxelSize,
+                   float maxDistance,
+                   int *__restrict__ dChanged) {
     constexpr int BW       = ESDF_BLOCK_WIDTH;
     constexpr int JML      = ESDF_JUMP_MAP_LENGTH;
-    constexpr uint64_t VPL =
-        nanovdb::OnIndexTree::LeafNodeType::NUM_VALUES;
+    constexpr uint64_t VPL = nanovdb::OnIndexTree::LeafNodeType::NUM_VALUES;
 
     __shared__ uint32_t smem_leafIndex[BW];
     __shared__ uint16_t smem_voxelOffset[BW];
 
-    const uint64_t blockFirstOffset =
-        static_cast<uint64_t>(blockIdx.x) * BW + 1;
+    const uint64_t blockFirstOffset = static_cast<uint64_t>(blockIdx.x) * BW + 1;
 
-    nanovdb::tools::cuda::VoxelBlockManager<BW>::template decodeInverseMaps<
-        nanovdb::ValueOnIndex>(
+    nanovdb::tools::cuda::VoxelBlockManager<BW>::template decodeInverseMaps<nanovdb::ValueOnIndex>(
         esdfGrid,
         firstLeafID[blockIdx.x],
         jumpMap + static_cast<uint64_t>(blockIdx.x) * JML,
@@ -266,8 +281,7 @@ esdfSweepVBMKernel(
     // __syncthreads() is issued inside decodeInverseMaps.
 
     const uint32_t leafID = smem_leafIndex[threadIdx.x];
-    if (leafID ==
-        nanovdb::tools::cuda::VoxelBlockManager<BW>::UnusedLeafIndex) {
+    if (leafID == nanovdb::tools::cuda::VoxelBlockManager<BW>::UnusedLeafIndex) {
         return;
     }
     const uint16_t voxOff = smem_voxelOffset[threadIdx.x];
@@ -275,22 +289,20 @@ esdfSweepVBMKernel(
     const auto &leaf         = esdfGrid->tree().template getFirstNode<0>()[leafID];
     const nanovdb::Coord ijk = leaf.offsetToGlobalCoord(voxOff);
     auto acc                 = esdfGrid->getAccessor();
-    const int64_t selfPid    =
-        static_cast<int64_t>(leaf.getValue(voxOff)) - 1;
+    const int64_t selfPid    = static_cast<int64_t>(leaf.getValue(voxOff)) - 1;
 
     const float dSelf = esdfIn[selfPid];
 
     const float dNew = esdfSweepBody(
-        dSelf, voxelSize, maxDistance,
-        [&](int dx, int dy, int dz, float &dOut, bool &activeOut) {
+        dSelf, voxelSize, maxDistance, [&](int dx, int dy, int dz, float &dOut, bool &activeOut) {
             const nanovdb::Coord c = ijk + nanovdb::Coord(dx, dy, dz);
             if (!acc.isActive(c)) {
                 activeOut = false;
                 return;
             }
             const int64_t pid = static_cast<int64_t>(acc.getValue(c)) - 1;
-            dOut      = esdfIn[pid];
-            activeOut = true;
+            dOut              = esdfIn[pid];
+            activeOut         = true;
         });
 
     esdfOut[selfPid] = dNew;
@@ -316,43 +328,41 @@ esdfSweepVBMKernel(
 // -----------------------------------------------------------------------
 
 __global__ void
-esdfSweepPerLeafKernel(
-    nanovdb::NanoGrid<nanovdb::ValueOnIndex> *__restrict__ esdfGrid,
-    const float *__restrict__ esdfIn,
-    float *__restrict__ esdfOut,
-    float voxelSize,
-    float maxDistance,
-    int *__restrict__ dChanged) {
-    constexpr uint64_t VPL =
-        nanovdb::OnIndexTree::LeafNodeType::NUM_VALUES;
+esdfSweepPerLeafKernel(nanovdb::NanoGrid<nanovdb::ValueOnIndex> *__restrict__ esdfGrid,
+                       const float *__restrict__ esdfIn,
+                       float *__restrict__ esdfOut,
+                       float voxelSize,
+                       float maxDistance,
+                       int *__restrict__ dChanged) {
+    constexpr uint64_t VPL = nanovdb::OnIndexTree::LeafNodeType::NUM_VALUES;
 
     const int64_t leafIdx = blockIdx.x;
     // Each thread handles VPL / blockDim.x slots if VPL > blockDim.x.
     // For VPL = 512 and ESDF_PERLEAF_THREADS = 128, that's 4 slots/thread.
-    for (int64_t voxOff = threadIdx.x; voxOff < static_cast<int64_t>(VPL);
-         voxOff += blockDim.x) {
-        const auto &leaf =
-            esdfGrid->tree().template getFirstNode<0>()[leafIdx];
-        if (!leaf.isActive(voxOff)) continue;
+    for (int64_t voxOff = threadIdx.x; voxOff < static_cast<int64_t>(VPL); voxOff += blockDim.x) {
+        const auto &leaf = esdfGrid->tree().template getFirstNode<0>()[leafIdx];
+        if (!leaf.isActive(voxOff))
+            continue;
 
-        const int64_t selfPid =
-            static_cast<int64_t>(leaf.getValue(voxOff)) - 1;
+        const int64_t selfPid    = static_cast<int64_t>(leaf.getValue(voxOff)) - 1;
         const nanovdb::Coord ijk = leaf.offsetToGlobalCoord(voxOff);
         auto acc                 = esdfGrid->getAccessor();
 
         const float dSelf = esdfIn[selfPid];
-        const float dNew  = esdfSweepBody(
-             dSelf, voxelSize, maxDistance,
-             [&](int dx, int dy, int dz, float &dOut, bool &activeOut) {
-                 const nanovdb::Coord c = ijk + nanovdb::Coord(dx, dy, dz);
-                 if (!acc.isActive(c)) {
-                     activeOut = false;
-                     return;
-                 }
-                 const int64_t pid = static_cast<int64_t>(acc.getValue(c)) - 1;
-                 dOut      = esdfIn[pid];
-                 activeOut = true;
-             });
+        const float dNew =
+            esdfSweepBody(dSelf,
+                          voxelSize,
+                          maxDistance,
+                          [&](int dx, int dy, int dz, float &dOut, bool &activeOut) {
+                              const nanovdb::Coord c = ijk + nanovdb::Coord(dx, dy, dz);
+                              if (!acc.isActive(c)) {
+                                  activeOut = false;
+                                  return;
+                              }
+                              const int64_t pid = static_cast<int64_t>(acc.getValue(c)) - 1;
+                              dOut              = esdfIn[pid];
+                              activeOut         = true;
+                          });
         esdfOut[selfPid] = dNew;
         if (dNew != dSelf) {
             dChanged[0] = 1;
@@ -376,30 +386,25 @@ esdfSweepPerLeafKernel(
 // -----------------------------------------------------------------------
 
 std::tuple<c10::intrusive_ptr<GridBatchData>, torch::Tensor>
-runEsdfSweepsAndFinalize(
-    const c10::intrusive_ptr<GridBatchData> &esdfGrid,
-    torch::Tensor esdfInit,
-    float voxelSizeF,
-    int64_t dilateAmount,
-    float maxDistF,
-    bool prune_unreached,
-    bool use_vbm,
-    at::cuda::CUDAStream stream) {
+runEsdfSweepsAndFinalize(const c10::intrusive_ptr<GridBatchData> &esdfGrid,
+                         torch::Tensor esdfInit,
+                         float voxelSizeF,
+                         int64_t dilateAmount,
+                         float maxDistF,
+                         bool prune_unreached,
+                         bool use_vbm,
+                         at::cuda::CUDAStream stream) {
     const int64_t esdfVoxels = esdfGrid->totalVoxels();
-    auto u32Opts =
-        torch::TensorOptions().dtype(torch::kInt32).device(esdfInit.device());
-    auto u64Opts =
-        torch::TensorOptions().dtype(torch::kInt64).device(esdfInit.device());
-    auto i32Opts =
-        torch::TensorOptions().dtype(torch::kInt32).device(esdfInit.device());
+    auto u32Opts = torch::TensorOptions().dtype(torch::kInt32).device(esdfInit.device());
+    auto u64Opts = torch::TensorOptions().dtype(torch::kInt64).device(esdfInit.device());
+    auto i32Opts = torch::TensorOptions().dtype(torch::kInt32).device(esdfInit.device());
 
-    auto *esdfDeviceGrid =
-        esdfGrid->mGridHdl->deviceGrid<nanovdb::ValueOnIndex>(0);
+    auto *esdfDeviceGrid = esdfGrid->mGridHdl->deviceGrid<nanovdb::ValueOnIndex>(0);
     TORCH_CHECK(esdfDeviceGrid != nullptr, "computeESDF: null esdf grid");
 
     // Double-buffered Jacobi. `esdfInit` is the first read; `esdfB`
     // receives the first write; they swap each sweep.
-    torch::Tensor esdfB = esdfInit.clone();  // same content so reads are safe
+    torch::Tensor esdfB    = esdfInit.clone(); // same content so reads are safe
     torch::Tensor *esdfIn  = &esdfInit;
     torch::Tensor *esdfOut = &esdfB;
 
@@ -421,19 +426,17 @@ runEsdfSweepsAndFinalize(
 
     if (use_vbm) {
         const auto treeData =
-            nanovdb::util::cuda::DeviceGridTraits<nanovdb::ValueOnIndex>::
-                getTreeData(esdfDeviceGrid);
+            nanovdb::util::cuda::DeviceGridTraits<nanovdb::ValueOnIndex>::getTreeData(
+                esdfDeviceGrid);
         const int lowerCount = static_cast<int>(treeData.mNodeCount[1]);
 
-        const int nBlocks = static_cast<int>(
-            (esdfVoxels + ESDF_BLOCK_WIDTH - 1) / ESDF_BLOCK_WIDTH);
+        const int nBlocks =
+            static_cast<int>((esdfVoxels + ESDF_BLOCK_WIDTH - 1) / ESDF_BLOCK_WIDTH);
 
         torch::Tensor firstLeafID = torch::zeros({nBlocks}, u32Opts);
-        torch::Tensor jumpMap     =
-            torch::zeros({nBlocks * ESDF_JUMP_MAP_LENGTH}, u64Opts);
+        torch::Tensor jumpMap     = torch::zeros({nBlocks * ESDF_JUMP_MAP_LENGTH}, u64Opts);
 
-        nanovdb::tools::cuda::buildVoxelBlockManager<
-            ESDF_BLOCK_WIDTH_LOG2, 128>(
+        nanovdb::tools::cuda::buildVoxelBlockManager<ESDF_BLOCK_WIDTH_LOG2, 128>(
             /*firstOffset=*/1,
             /*lastOffset=*/static_cast<uint64_t>(esdfVoxels),
             /*nBlocks=*/nBlocks,
@@ -450,13 +453,15 @@ runEsdfSweepsAndFinalize(
             changedFlag.zero_();
             esdfSweepVBMKernel<<<static_cast<unsigned int>(nBlocks),
                                  static_cast<unsigned int>(ESDF_BLOCK_WIDTH),
-                                 0, stream.stream()>>>(
+                                 0,
+                                 stream.stream()>>>(
                 esdfDeviceGrid,
                 reinterpret_cast<uint32_t *>(firstLeafID.data_ptr<int32_t>()),
                 reinterpret_cast<uint64_t *>(jumpMap.data_ptr<int64_t>()),
                 esdfIn->data_ptr<float>(),
                 esdfOut->data_ptr<float>(),
-                voxelSizeF, maxDistF,
+                voxelSizeF,
+                maxDistF,
                 changedFlag.data_ptr<int32_t>());
             C10_CUDA_KERNEL_LAUNCH_CHECK();
             std::swap(esdfIn, esdfOut);
@@ -471,15 +476,15 @@ runEsdfSweepsAndFinalize(
         const int64_t esdfLeaves = esdfGrid->totalLeaves();
         for (int sweep = 0; sweep < numSweepsMax; ++sweep) {
             changedFlag.zero_();
-            esdfSweepPerLeafKernel<<<
-                static_cast<unsigned int>(esdfLeaves),
-                static_cast<unsigned int>(ESDF_PERLEAF_THREADS),
-                0, stream.stream()>>>(
-                esdfDeviceGrid,
-                esdfIn->data_ptr<float>(),
-                esdfOut->data_ptr<float>(),
-                voxelSizeF, maxDistF,
-                changedFlag.data_ptr<int32_t>());
+            esdfSweepPerLeafKernel<<<static_cast<unsigned int>(esdfLeaves),
+                                     static_cast<unsigned int>(ESDF_PERLEAF_THREADS),
+                                     0,
+                                     stream.stream()>>>(esdfDeviceGrid,
+                                                        esdfIn->data_ptr<float>(),
+                                                        esdfOut->data_ptr<float>(),
+                                                        voxelSizeF,
+                                                        maxDistF,
+                                                        changedFlag.data_ptr<int32_t>());
             C10_CUDA_KERNEL_LAUNCH_CHECK();
             std::swap(esdfIn, esdfOut);
             if (changedFlag.item<int32_t>() == 0) {
@@ -488,22 +493,19 @@ runEsdfSweepsAndFinalize(
         }
     }
 
-    torch::Tensor esdfFinal =
-        esdfIn->clamp(-maxDistF, maxDistF).contiguous();
+    torch::Tensor esdfFinal = esdfIn->clamp(-maxDistF, maxDistF).contiguous();
 
     if (!prune_unreached) {
         return {esdfGrid, esdfFinal};
     }
 
     torch::Tensor keepMask = esdfFinal.abs() < maxDistF;
-    auto idxOpts = torch::TensorOptions()
-                       .dtype(fvdb::JIdxScalarType)
-                       .device(esdfInit.device());
-    auto jidx  = torch::zeros({keepMask.size(0)}, idxOpts);
-    auto jlidx = torch::empty({0, 1}, idxOpts);
-    auto keepMaskJagged = JaggedTensor::from_data_indices_and_list_ids(
-        keepMask, jidx, jlidx, /*num_tensors=*/1);
-    auto prunedGrid = pruneGrid(*esdfGrid, keepMaskJagged);
+    auto idxOpts = torch::TensorOptions().dtype(fvdb::JIdxScalarType).device(esdfInit.device());
+    auto jidx    = torch::zeros({keepMask.size(0)}, idxOpts);
+    auto jlidx   = torch::empty({0, 1}, idxOpts);
+    auto keepMaskJagged =
+        JaggedTensor::from_data_indices_and_list_ids(keepMask, jidx, jlidx, /*num_tensors=*/1);
+    auto prunedGrid          = pruneGrid(*esdfGrid, keepMaskJagged);
     torch::Tensor prunedEsdf = esdfFinal.masked_select(keepMask);
     return {prunedGrid, prunedEsdf};
 }
@@ -535,12 +537,18 @@ computeESDF(const GridBatchData &gridBatch,
 
     TORCH_CHECK_VALUE(tsdf.dim() == 1 && weights.dim() == 1,
                       "computeESDF: tsdf and weights must be 1-D, got dims (",
-                      tsdf.dim(), ",", weights.dim(), ")");
+                      tsdf.dim(),
+                      ",",
+                      weights.dim(),
+                      ")");
     TORCH_CHECK_VALUE(tsdf.size(0) == gridBatch.totalVoxels() &&
-                      weights.size(0) == gridBatch.totalVoxels(),
+                          weights.size(0) == gridBatch.totalVoxels(),
                       "computeESDF: tsdf/weights size must match totalVoxels (",
-                      gridBatch.totalVoxels(), "), got tsdf=", tsdf.size(0),
-                      " weights=", weights.size(0));
+                      gridBatch.totalVoxels(),
+                      "), got tsdf=",
+                      tsdf.size(0),
+                      " weights=",
+                      weights.size(0));
 
     TORCH_CHECK_TYPE(tsdf.scalar_type() == torch::kFloat32,
                      "computeESDF: only float32 tsdf is supported in M5");
@@ -550,45 +558,43 @@ computeESDF(const GridBatchData &gridBatch,
     TORCH_CHECK_VALUE(truncation_distance > 0.0,
                       "computeESDF: truncation_distance must be > 0, got ",
                       truncation_distance);
-    TORCH_CHECK_VALUE(max_distance > 0.0,
-                      "computeESDF: max_distance must be > 0, got ",
-                      max_distance);
+    TORCH_CHECK_VALUE(
+        max_distance > 0.0, "computeESDF: max_distance must be > 0, got ", max_distance);
 
     c10::cuda::CUDAGuard guard(tsdf.device());
-    at::cuda::CUDAStream stream =
-        at::cuda::getCurrentCUDAStream(tsdf.device().index());
+    at::cuda::CUDAStream stream = at::cuda::getCurrentCUDAStream(tsdf.device().index());
 
     // Cast configuration to fp32 for kernel use.
-    const float truncF    = static_cast<float>(truncation_distance);
-    const float maxDistF  = static_cast<float>(max_distance);
-    const float threshF   = static_cast<float>(weight_threshold);
-    const float saturEps  = 1.0e-5f;  // "|tsdf| < 1" margin for float stability
+    const float truncF   = static_cast<float>(truncation_distance);
+    const float maxDistF = static_cast<float>(max_distance);
+    const float threshF  = static_cast<float>(weight_threshold);
+    const float saturEps = 1.0e-5f; // "|tsdf| < 1" margin for float stability
 
     // Voxel size: single-batch, isotropic expected. Use the minimum axis
     // to drive chamfer step length; TSDF convention assumes isotropic.
     std::vector<nanovdb::Vec3d> voxSizes, origins;
     gridBatch.gridVoxelSizesAndOrigins(voxSizes, origins);
-    TORCH_CHECK_VALUE(voxSizes.size() == 1,
-                      "computeESDF: expected single-batch voxel size");
+    TORCH_CHECK_VALUE(voxSizes.size() == 1, "computeESDF: expected single-batch voxel size");
     const double vsX = voxSizes[0][0];
     const double vsY = voxSizes[0][1];
     const double vsZ = voxSizes[0][2];
-    TORCH_CHECK_VALUE(std::fabs(vsX - vsY) < 1e-9 &&
-                      std::fabs(vsX - vsZ) < 1e-9,
+    TORCH_CHECK_VALUE(std::fabs(vsX - vsY) < 1e-9 && std::fabs(vsX - vsZ) < 1e-9,
                       "computeESDF: anisotropic voxels not supported in M5 (",
-                      vsX, ", ", vsY, ", ", vsZ, ")");
+                      vsX,
+                      ", ",
+                      vsY,
+                      ", ",
+                      vsZ,
+                      ")");
     const float voxelSizeF = static_cast<float>(vsX);
 
-    auto floatOpts =
-        torch::TensorOptions().dtype(torch::kFloat32).device(tsdf.device());
+    auto floatOpts = torch::TensorOptions().dtype(torch::kFloat32).device(tsdf.device());
 
     // ------------------ Step 1: build ESDF support topology ------------------
 
-    const int64_t dilateAmount =
-        static_cast<int64_t>(std::ceil(max_distance / vsX)) + 1;
-    auto esdfGrid = dilateGrid(gridBatch,
-                               std::vector<int64_t>{dilateAmount});
-    const int64_t esdfVoxels = esdfGrid->totalVoxels();
+    const int64_t dilateAmount = static_cast<int64_t>(std::ceil(max_distance / vsX)) + 1;
+    auto esdfGrid              = dilateGrid(gridBatch, std::vector<int64_t>{dilateAmount});
+    const int64_t esdfVoxels   = esdfGrid->totalVoxels();
 
     if (esdfVoxels == 0) {
         // Input grid was empty; return empty ESDF.
@@ -602,10 +608,8 @@ computeESDF(const GridBatchData &gridBatch,
 
     // ------------------ Step 3: seed from input TSDF ------------------------
 
-    auto *inputDeviceGrid =
-        gridBatch.mGridHdl->deviceGrid<nanovdb::ValueOnIndex>(0);
-    auto *esdfDeviceGrid =
-        esdfGrid->mGridHdl->deviceGrid<nanovdb::ValueOnIndex>(0);
+    auto *inputDeviceGrid = gridBatch.mGridHdl->deviceGrid<nanovdb::ValueOnIndex>(0);
+    auto *esdfDeviceGrid  = esdfGrid->mGridHdl->deviceGrid<nanovdb::ValueOnIndex>(0);
     TORCH_CHECK(inputDeviceGrid != nullptr, "computeESDF: null input grid");
     TORCH_CHECK(esdfDeviceGrid != nullptr, "computeESDF: null esdf grid");
 
@@ -618,12 +622,16 @@ computeESDF(const GridBatchData &gridBatch,
             esdfSeedKernel<<<static_cast<unsigned int>(inputLeaves),
                              static_cast<unsigned int>(
                                  nanovdb::OnIndexTree::LeafNodeType::NUM_VALUES),
-                             0, stream.stream()>>>(
-                inputDeviceGrid, esdfDeviceGrid,
-                tsdf.data_ptr<float>(), weights.data_ptr<float>(),
-                /*dirtyMask=*/nullptr,
-                esdfA.data_ptr<float>(),
-                truncF, threshF, saturEps);
+                             0,
+                             stream.stream()>>>(inputDeviceGrid,
+                                                esdfDeviceGrid,
+                                                tsdf.data_ptr<float>(),
+                                                weights.data_ptr<float>(),
+                                                /*dirtyMask=*/nullptr,
+                                                esdfA.data_ptr<float>(),
+                                                truncF,
+                                                threshF,
+                                                saturEps);
             C10_CUDA_KERNEL_LAUNCH_CHECK();
         }
     }
@@ -631,8 +639,7 @@ computeESDF(const GridBatchData &gridBatch,
     // ------------------ Step 4-5: sweeps + clamp + prune ---------------------
 
     return runEsdfSweepsAndFinalize(
-        esdfGrid, esdfA, voxelSizeF, dilateAmount, maxDistF,
-        prune_unreached, use_vbm, stream);
+        esdfGrid, esdfA, voxelSizeF, dilateAmount, maxDistF, prune_unreached, use_vbm, stream);
 }
 
 // -----------------------------------------------------------------------
@@ -653,8 +660,7 @@ computeESDFIncremental(const GridBatchData &gridBatch,
                        const torch::Tensor &dirtyMask) {
     // ------------------ Shape / dtype / scope checks ------------------
 
-    TORCH_CHECK_VALUE(gridBatch.batchSize() == 1 &&
-                          prevEsdfGrid.batchSize() <= 1,
+    TORCH_CHECK_VALUE(gridBatch.batchSize() == 1 && prevEsdfGrid.batchSize() <= 1,
                       "computeESDFIncremental: batchSize must be 1 in M5");
     TORCH_CHECK(tsdf.is_cuda() && weights.is_cuda() && prevEsdf.is_cuda(),
                 "computeESDFIncremental: all tensors must be CUDA");
@@ -666,20 +672,21 @@ computeESDFIncremental(const GridBatchData &gridBatch,
                           weights.size(0) == gridBatch.totalVoxels(),
                       "computeESDFIncremental: tsdf/weights size must match "
                       "current grid.totalVoxels (",
-                      gridBatch.totalVoxels(), ")");
+                      gridBatch.totalVoxels(),
+                      ")");
     TORCH_CHECK_VALUE(prevEsdf.size(0) == prevEsdfGrid.totalVoxels(),
                       "computeESDFIncremental: prevEsdf size (",
                       prevEsdf.size(0),
                       ") must match prevEsdfGrid.totalVoxels (",
-                      prevEsdfGrid.totalVoxels(), ")");
+                      prevEsdfGrid.totalVoxels(),
+                      ")");
     TORCH_CHECK_TYPE(tsdf.scalar_type() == torch::kFloat32 &&
                          weights.scalar_type() == torch::kFloat32 &&
                          prevEsdf.scalar_type() == torch::kFloat32,
                      "computeESDFIncremental: only float32 is supported in M5");
     TORCH_CHECK_VALUE(truncation_distance > 0.0,
                       "computeESDFIncremental: truncation_distance must be > 0");
-    TORCH_CHECK_VALUE(max_distance > 0.0,
-                      "computeESDFIncremental: max_distance must be > 0");
+    TORCH_CHECK_VALUE(max_distance > 0.0, "computeESDFIncremental: max_distance must be > 0");
 
     const bool hasDirtyMask = dirtyMask.defined() && dirtyMask.numel() > 0;
     if (hasDirtyMask) {
@@ -689,7 +696,8 @@ computeESDFIncremental(const GridBatchData &gridBatch,
                           "computeESDFIncremental: dirty_mask size (",
                           dirtyMask.size(0),
                           ") must equal gridBatch.totalVoxels (",
-                          gridBatch.totalVoxels(), ")");
+                          gridBatch.totalVoxels(),
+                          ")");
         TORCH_CHECK(dirtyMask.device() == tsdf.device(),
                     "computeESDFIncremental: dirty_mask must be on same "
                     "device as tsdf");
@@ -703,14 +711,18 @@ computeESDFIncremental(const GridBatchData &gridBatch,
     // Fall through to one-shot when there's no previous state. Keeps
     // the first-frame-of-a-session code path trivial.
     if (prevEsdfGrid.totalVoxels() == 0) {
-        return computeESDF(gridBatch, tsdf, weights,
-                           truncation_distance, max_distance,
-                           weight_threshold, prune_unreached, use_vbm);
+        return computeESDF(gridBatch,
+                           tsdf,
+                           weights,
+                           truncation_distance,
+                           max_distance,
+                           weight_threshold,
+                           prune_unreached,
+                           use_vbm);
     }
 
     c10::cuda::CUDAGuard guard(tsdf.device());
-    at::cuda::CUDAStream stream =
-        at::cuda::getCurrentCUDAStream(tsdf.device().index());
+    at::cuda::CUDAStream stream = at::cuda::getCurrentCUDAStream(tsdf.device().index());
 
     const float truncF   = static_cast<float>(truncation_distance);
     const float maxDistF = static_cast<float>(max_distance);
@@ -730,28 +742,26 @@ computeESDFIncremental(const GridBatchData &gridBatch,
     // witness semantics; users in that case should reset to one-shot.
     std::vector<nanovdb::Vec3d> prevVoxSizes, prevOrigins;
     prevEsdfGrid.gridVoxelSizesAndOrigins(prevVoxSizes, prevOrigins);
-    TORCH_CHECK_VALUE(!prevVoxSizes.empty() &&
-                          std::fabs(prevVoxSizes[0][0] - vsX) < 1e-9,
+    TORCH_CHECK_VALUE(!prevVoxSizes.empty() && std::fabs(prevVoxSizes[0][0] - vsX) < 1e-9,
                       "computeESDFIncremental: prevEsdfGrid voxel_size (",
                       prevVoxSizes.empty() ? 0.0 : prevVoxSizes[0][0],
-                      ") must match current grid voxel_size (", vsX, ")");
+                      ") must match current grid voxel_size (",
+                      vsX,
+                      ")");
     const float voxelSizeF = static_cast<float>(vsX);
 
-    auto floatOpts =
-        torch::TensorOptions().dtype(torch::kFloat32).device(tsdf.device());
+    auto floatOpts = torch::TensorOptions().dtype(torch::kFloat32).device(tsdf.device());
 
     // ------------------ Step 1: build union ESDF support topology ------------
 
-    const int64_t dilateAmount =
-        static_cast<int64_t>(std::ceil(max_distance / vsX)) + 1;
-    auto dilated = dilateGrid(gridBatch,
-                              std::vector<int64_t>{dilateAmount});
+    const int64_t dilateAmount = static_cast<int64_t>(std::ceil(max_distance / vsX)) + 1;
+    auto dilated               = dilateGrid(gridBatch, std::vector<int64_t>{dilateAmount});
     // Merge with the previous ESDF grid so voxels that were in the
     // previous support but fall outside the current TSDF's dilation
     // are still carried over (monotone scene assumption: previously-
     // known ESDF values shouldn't disappear just because the TSDF
     // shell shifted in this frame).
-    auto esdfGrid = mergeGrids(*dilated, prevEsdfGrid);
+    auto esdfGrid            = mergeGrids(*dilated, prevEsdfGrid);
     const int64_t esdfVoxels = esdfGrid->totalVoxels();
 
     if (esdfVoxels == 0) {
@@ -804,10 +814,8 @@ computeESDFIncremental(const GridBatchData &gridBatch,
 
     // ------------------ Step 3: seed from current TSDF ----------------------
 
-    auto *inputDeviceGrid =
-        gridBatch.mGridHdl->deviceGrid<nanovdb::ValueOnIndex>(0);
-    auto *esdfDeviceGrid =
-        esdfGrid->mGridHdl->deviceGrid<nanovdb::ValueOnIndex>(0);
+    auto *inputDeviceGrid = gridBatch.mGridHdl->deviceGrid<nanovdb::ValueOnIndex>(0);
+    auto *esdfDeviceGrid  = esdfGrid->mGridHdl->deviceGrid<nanovdb::ValueOnIndex>(0);
     TORCH_CHECK(inputDeviceGrid != nullptr && esdfDeviceGrid != nullptr,
                 "computeESDFIncremental: null device grid");
 
@@ -820,26 +828,26 @@ computeESDFIncremental(const GridBatchData &gridBatch,
         // whatever they had in `prevEsdf` (via the inject+restore
         // above). Monotone-min correctness is preserved under the
         // existing "distances can decrease but not grow" assumption.
-        const bool *dirtyMaskPtr = hasDirtyMask
-            ? dirtyMask.data_ptr<bool>()
-            : nullptr;
+        const bool *dirtyMaskPtr = hasDirtyMask ? dirtyMask.data_ptr<bool>() : nullptr;
         esdfSeedKernel<<<static_cast<unsigned int>(inputLeaves),
-                         static_cast<unsigned int>(
-                             nanovdb::OnIndexTree::LeafNodeType::NUM_VALUES),
-                         0, stream.stream()>>>(
-            inputDeviceGrid, esdfDeviceGrid,
-            tsdf.data_ptr<float>(), weights.data_ptr<float>(),
-            dirtyMaskPtr,
-            esdfInit.data_ptr<float>(),
-            truncF, threshF, saturEps);
+                         static_cast<unsigned int>(nanovdb::OnIndexTree::LeafNodeType::NUM_VALUES),
+                         0,
+                         stream.stream()>>>(inputDeviceGrid,
+                                            esdfDeviceGrid,
+                                            tsdf.data_ptr<float>(),
+                                            weights.data_ptr<float>(),
+                                            dirtyMaskPtr,
+                                            esdfInit.data_ptr<float>(),
+                                            truncF,
+                                            threshF,
+                                            saturEps);
         C10_CUDA_KERNEL_LAUNCH_CHECK();
     }
 
     // ------------------ Step 4-5: sweeps + clamp + prune --------------------
 
     return runEsdfSweepsAndFinalize(
-        esdfGrid, esdfInit, voxelSizeF, dilateAmount, maxDistF,
-        prune_unreached, use_vbm, stream);
+        esdfGrid, esdfInit, voxelSizeF, dilateAmount, maxDistF, prune_unreached, use_vbm, stream);
 }
 
 } // namespace ops

--- a/src/fvdb/detail/ops/ComputeESDF.cu
+++ b/src/fvdb/detail/ops/ComputeESDF.cu
@@ -49,6 +49,7 @@
 #include <nanovdb/NanoVDB.h>
 #include <nanovdb/tools/cuda/VoxelBlockManager.cuh>
 #include <nanovdb/util/cuda/DeviceGridTraits.cuh>
+#include <nanovdb/util/cuda/Util.h>
 
 #include <c10/cuda/CUDAException.h>
 #include <c10/cuda/CUDAGuard.h>
@@ -271,17 +272,17 @@ esdfSweepVBMKernel(nanovdb::NanoGrid<nanovdb::ValueOnIndex> *__restrict__ esdfGr
 
     const uint64_t blockFirstOffset = static_cast<uint64_t>(blockIdx.x) * BW + 1;
 
-    nanovdb::tools::cuda::VoxelBlockManager<BW>::template decodeInverseMaps<nanovdb::ValueOnIndex>(
-        esdfGrid,
-        firstLeafID[blockIdx.x],
-        jumpMap + static_cast<uint64_t>(blockIdx.x) * JML,
-        blockFirstOffset,
-        smem_leafIndex,
-        smem_voxelOffset);
+    nanovdb::tools::cuda::VoxelBlockManager<ESDF_BLOCK_WIDTH_LOG2>::template decodeInverseMaps<
+        nanovdb::ValueOnIndex>(esdfGrid,
+                               firstLeafID[blockIdx.x],
+                               jumpMap + static_cast<uint64_t>(blockIdx.x) * JML,
+                               blockFirstOffset,
+                               smem_leafIndex,
+                               smem_voxelOffset);
     // __syncthreads() is issued inside decodeInverseMaps.
 
     const uint32_t leafID = smem_leafIndex[threadIdx.x];
-    if (leafID == nanovdb::tools::cuda::VoxelBlockManager<BW>::UnusedLeafIndex) {
+    if (leafID == nanovdb::tools::cuda::VoxelBlockManager<ESDF_BLOCK_WIDTH_LOG2>::UnusedLeafIndex) {
         return;
     }
     const uint16_t voxOff = smem_voxelOffset[threadIdx.x];
@@ -395,8 +396,6 @@ runEsdfSweepsAndFinalize(const c10::intrusive_ptr<GridBatchData> &esdfGrid,
                          bool use_vbm,
                          at::cuda::CUDAStream stream) {
     const int64_t esdfVoxels = esdfGrid->totalVoxels();
-    auto u32Opts = torch::TensorOptions().dtype(torch::kInt32).device(esdfInit.device());
-    auto u64Opts = torch::TensorOptions().dtype(torch::kInt64).device(esdfInit.device());
     auto i32Opts = torch::TensorOptions().dtype(torch::kInt32).device(esdfInit.device());
 
     auto *esdfDeviceGrid = esdfGrid->mGridHdl->deviceGrid<nanovdb::ValueOnIndex>(0);
@@ -433,20 +432,33 @@ runEsdfSweepsAndFinalize(const c10::intrusive_ptr<GridBatchData> &esdfGrid,
         const int nBlocks =
             static_cast<int>((esdfVoxels + ESDF_BLOCK_WIDTH - 1) / ESDF_BLOCK_WIDTH);
 
+        // firstLeafID / jumpMap live in torch tensors so they come from the
+        // same caching-allocator pool as every other fvdb allocation.
+        // nanovdb's VoxelBlockManagerHandle can't own them (its accessors
+        // static_cast from deviceData(), which TorchDeviceBuffer types as
+        // uint8_t*), so launch the public build functor directly — the same
+        // launch buildVoxelBlockManager performs on a handle it owns. The
+        // functor expects a zeroed jumpMap, which torch::zeros provides.
+        auto u32Opts = torch::TensorOptions().dtype(torch::kInt32).device(esdfInit.device());
+        auto u64Opts = torch::TensorOptions().dtype(torch::kInt64).device(esdfInit.device());
         torch::Tensor firstLeafID = torch::zeros({nBlocks}, u32Opts);
         torch::Tensor jumpMap     = torch::zeros({nBlocks * ESDF_JUMP_MAP_LENGTH}, u64Opts);
+        uint32_t *vbmFirstLeafID  = reinterpret_cast<uint32_t *>(firstLeafID.data_ptr<int32_t>());
+        uint64_t *vbmJumpMap      = reinterpret_cast<uint64_t *>(jumpMap.data_ptr<int64_t>());
 
-        nanovdb::tools::cuda::buildVoxelBlockManager<ESDF_BLOCK_WIDTH_LOG2, 128>(
-            /*firstOffset=*/1,
-            /*lastOffset=*/static_cast<uint64_t>(esdfVoxels),
-            /*nBlocks=*/nBlocks,
-            /*lowerCount=*/lowerCount,
-            /*grid=*/esdfDeviceGrid,
-            /*firstLeafID=*/
-            reinterpret_cast<uint32_t *>(firstLeafID.data_ptr<int32_t>()),
-            /*jumpMap=*/
-            reinterpret_cast<uint64_t *>(jumpMap.data_ptr<int64_t>()),
-            /*stream=*/stream.stream());
+        using VbmBuildOp =
+            nanovdb::tools::cuda::BuildVoxelBlockManagerFunctor<ESDF_BLOCK_WIDTH_LOG2>;
+        nanovdb::util::cuda::operatorKernel<VbmBuildOp>
+            <<<dim3(lowerCount, VbmBuildOp::SlicesPerLowerNode, 1),
+               VbmBuildOp::MaxThreadsPerBlock,
+               0,
+               stream.stream()>>>(
+                /*firstOffset=*/static_cast<uint64_t>(1),
+                /*lastOffset=*/static_cast<uint64_t>(esdfVoxels),
+                /*nBlocks=*/nBlocks,
+                esdfDeviceGrid,
+                vbmFirstLeafID,
+                vbmJumpMap);
         C10_CUDA_KERNEL_LAUNCH_CHECK();
 
         for (int sweep = 0; sweep < numSweepsMax; ++sweep) {
@@ -454,15 +466,14 @@ runEsdfSweepsAndFinalize(const c10::intrusive_ptr<GridBatchData> &esdfGrid,
             esdfSweepVBMKernel<<<static_cast<unsigned int>(nBlocks),
                                  static_cast<unsigned int>(ESDF_BLOCK_WIDTH),
                                  0,
-                                 stream.stream()>>>(
-                esdfDeviceGrid,
-                reinterpret_cast<uint32_t *>(firstLeafID.data_ptr<int32_t>()),
-                reinterpret_cast<uint64_t *>(jumpMap.data_ptr<int64_t>()),
-                esdfIn->data_ptr<float>(),
-                esdfOut->data_ptr<float>(),
-                voxelSizeF,
-                maxDistF,
-                changedFlag.data_ptr<int32_t>());
+                                 stream.stream()>>>(esdfDeviceGrid,
+                                                    vbmFirstLeafID,
+                                                    vbmJumpMap,
+                                                    esdfIn->data_ptr<float>(),
+                                                    esdfOut->data_ptr<float>(),
+                                                    voxelSizeF,
+                                                    maxDistF,
+                                                    changedFlag.data_ptr<int32_t>());
             C10_CUDA_KERNEL_LAUNCH_CHECK();
             std::swap(esdfIn, esdfOut);
             // .item() is a sync + host-device copy (~30 us). Each

--- a/src/fvdb/detail/ops/ComputeESDF.h
+++ b/src/fvdb/detail/ops/ComputeESDF.h
@@ -1,0 +1,156 @@
+// Copyright Contributors to the OpenVDB Project
+// SPDX-License-Identifier: Apache-2.0
+//
+#ifndef FVDB_DETAIL_OPS_COMPUTEESDF_H
+#define FVDB_DETAIL_OPS_COMPUTEESDF_H
+
+#include <fvdb/GridBatchData.h>
+
+#include <torch/types.h>
+
+#include <cstdint>
+#include <tuple>
+
+namespace fvdb {
+namespace detail {
+namespace ops {
+
+/// @brief Compute a Euclidean Signed Distance Field (ESDF) from an
+///        integrated narrow-band TSDF.
+///
+/// The ESDF extends the TSDF's narrow-band signed distances outward (and
+/// inward) across a wider band via monotone 26-neighbour min-propagation,
+/// producing per-voxel world-unit signed distances `d` with
+/// `|d| <= max_distance`. This is the paper's **second application** of
+/// the nanoVDB topology-op vocabulary (the first being depth/LiDAR TSDF):
+///
+///   - `dilateGrid`  (once, by `ceil(max_distance / voxel_size) + 1`) to
+///     allocate the ESDF support band around the TSDF zero-crossing shell.
+///   - A custom VBM-stencil kernel, launched N times, that reads each
+///     voxel's 26-neighbourhood and computes
+///     `d' = sign(d_n) * (|d_n| + ||offset|| * voxel_size)`
+///     against the current value. N = `ceil(max_distance / voxel_size) + 2`
+///     is sufficient for 26-connectivity convergence; more-than-needed
+///     sweeps are cheap (each voxel's min is monotone, so extra sweeps
+///     are no-ops).
+///   - `pruneGrid` (once, optional) to drop voxels the wavefront never
+///     reached (still at sentinel value). Off by default so the returned
+///     grid matches the dilated support and the caller decides whether
+///     to prune.
+///
+/// Seeding: voxels with `weights[v] > weight_threshold` AND
+/// `|tsdf[v]| < 1 - eps` (i.e., the TSDF is not saturated at the
+/// truncation boundary) are used as wavefront sources with initial
+/// distance `tsdf[v] * truncation_distance` (world units). Saturated
+/// voxels (|tsdf|==1 after clamping) carry no useful distance
+/// information and are filled by the wavefront; unobserved voxels
+/// (|weights|==0) likewise.
+///
+/// Ablation knob: `use_vbm == false` replaces the VBM per-active-voxel
+/// iteration with a per-leaf-slot iteration so the two cost models can
+/// be compared directly on the same workload. Output is bit-identical
+/// (both code paths execute the same
+/// `min(d, d_n + ||offset|| * voxel_size)` formula in the same order
+/// per voxel).
+///
+/// @param gridBatch               Input TSDF grid topology (single batch).
+/// @param tsdf                    `[totalVoxels]` fp32 normalized TSDF
+///                                in `[-1, +1]` (fvdb's `integrate_tsdf*`
+///                                convention). Other scalar types fall
+///                                back to float by internal cast in M5.
+/// @param weights                 `[totalVoxels]` fp32 integration weights.
+/// @param truncation_distance     Truncation margin in world units (the
+///                                `T` of `tsdf = clip(d_world / T, -1, 1)`).
+/// @param max_distance            ESDF support radius in world units.
+/// @param weight_threshold        Voxels with `weights <= threshold` are
+///                                not used as wavefront sources.
+/// @param prune_unreached         If true, drop voxels the wavefront
+///                                never reached (still at sentinel).
+/// @param use_vbm                 Iteration-pattern ablation knob.
+///
+/// @return `(esdf_grid, esdf_values)` where `esdf_values` is
+///         `[esdf_grid.totalVoxels]` fp32 world-unit signed distances,
+///         with `|esdf[i]| <= max_distance + voxel_size` at wavefront
+///         terminations.
+std::tuple<c10::intrusive_ptr<GridBatchData>, torch::Tensor>
+computeESDF(const GridBatchData &gridBatch,
+            const torch::Tensor &tsdf,
+            const torch::Tensor &weights,
+            double truncation_distance,
+            double max_distance,
+            double weight_threshold,
+            bool prune_unreached,
+            bool use_vbm);
+
+/// @brief Monotone-incremental ESDF: extend a previous ESDF to cover
+///        the current TSDF grid without paying the full-from-scratch
+///        wavefront cost on every frame.
+///
+/// Pattern (the paper's "same primitives, different composition"
+/// argument): instead of restarting from a sentinel-filled buffer, we
+/// reuse the previous frame's ESDF values as a warm-start for the
+/// wavefront. Because the 26-neighbour min-propagation is monotone, a
+/// warm-started sweep converges in fewer effective iterations than a
+/// cold start -- and even better, previously-converged values in
+/// regions the current frame didn't touch are preserved byte-for-byte.
+///
+/// Composition (exclusively topology-op primitives + the same two
+/// kernels as one-shot):
+///
+///   1. `dilateGrid(gridBatch, K)`  to size the minimum new support.
+///   2. `mergeGrids(dilated_support, prevEsdfGrid)` so the output
+///      covers BOTH the new support AND the previous ESDF's
+///      support (handles the monotonically-growing-scene case
+///      cleanly without dropping previously-computed data).
+///   3. Allocate `esdf_new[|merged|]` initialized to sentinel.
+///   4. `inject(esdfGrid, prevEsdfGrid, esdf_new, prevEsdf)` to copy
+///      previous values into their (possibly shifted) positions in
+///      the merged grid.
+///   5. Seed from current TSDF (same `esdfSeedKernel` as one-shot;
+///      overwrites previous value at seed voxels with the current-
+///      frame's signed distance, which is correct since seeds are by
+///      definition exact).
+///   6. Same sweep loop as one-shot (same VBM / per-leaf kernels).
+///   7. Same clamp + optional prune.
+///
+/// **Correctness assumption (monotone only)**: we assume distances
+/// decrease monotonically between frames -- i.e. surfaces are added
+/// or refined but never removed. This matches standard TSDF-fusion
+/// workflows where the sensor adds observations over time. If surfaces
+/// disappear (dynamic objects, noise-resolved phantom surfaces), the
+/// incremental ESDF can lock in stale-lower distances. For those
+/// cases, call `computeESDF` one-shot on a fresh schedule (e.g. every
+/// M frames) as a correction pass. See
+/// `sessions/2026-04-23_esdf_one_shot.md` section on "the one subtle
+/// correctness trap" for the FIESTA-style parent-witness alternative
+/// we explicitly chose NOT to implement here.
+///
+/// When `prevEsdfGrid.totalVoxels() == 0`, falls through to one-shot
+/// semantics (useful for the first frame of an incremental session).
+///
+/// When `dirtyMask.defined()` (non-trivial bool tensor of shape
+/// `[gridBatch.totalVoxels()]`): only voxels with
+/// `dirtyMask[v] == true` seed the wavefront. This exposes nvblox-
+/// style "dirty-region update" cost scaling (proportional to the
+/// number of changed voxels, not the full grid) without any
+/// library-internal block-dirty state. Combine with
+/// `ops::dirtyMaskFromSidecars(newGrid, newWeights, oldGrid,
+/// oldWeights)` to derive the mask from a TSDF integration pair.
+std::tuple<c10::intrusive_ptr<GridBatchData>, torch::Tensor>
+computeESDFIncremental(const GridBatchData &gridBatch,
+                       const torch::Tensor &tsdf,
+                       const torch::Tensor &weights,
+                       const GridBatchData &prevEsdfGrid,
+                       const torch::Tensor &prevEsdf,
+                       double truncation_distance,
+                       double max_distance,
+                       double weight_threshold,
+                       bool prune_unreached,
+                       bool use_vbm,
+                       const torch::Tensor &dirtyMask);
+
+} // namespace ops
+} // namespace detail
+} // namespace fvdb
+
+#endif // FVDB_DETAIL_OPS_COMPUTEESDF_H

--- a/src/fvdb/detail/ops/DirtyMaskFromSidecars.cu
+++ b/src/fvdb/detail/ops/DirtyMaskFromSidecars.cu
@@ -1,0 +1,112 @@
+// Copyright Contributors to the OpenVDB Project
+// SPDX-License-Identifier: Apache-2.0
+//
+// DirtyMaskFromSidecars.cu
+//
+// Standalone utility that computes a per-voxel "dirty" bool mask on
+// newGrid from two (grid, sidecar) pairs. Built entirely on top of
+// `ops::inject` — no new CUDA kernels, just one inject + one tensor
+// comparison.
+//
+// Paper-framing: this is a 40-LoC C++ helper that the paper cites as
+// the backbone of fvdb's dirty-region ESDF update. Contrast nvblox's
+// dirty-block tracking, which lives inside the block-hash allocator
+// and isn't user-visible. Ours is a torch tensor the user can pass
+// to `compute_esdf_incremental` (new `dirty_mask` arg) or compose
+// with their own predicates.
+
+#include <fvdb/GridBatchData.h>
+#include <fvdb/JaggedTensor.h>
+#include <fvdb/detail/ops/DirtyMaskFromSidecars.h>
+#include <fvdb/detail/ops/Inject.h>
+
+#include <ATen/TensorOperators.h>
+#include <c10/cuda/CUDAGuard.h>
+
+#include <cmath>
+#include <torch/types.h>
+
+namespace fvdb::detail::ops {
+
+torch::Tensor
+dirtyMaskFromSidecars(const GridBatchData &newGrid,
+                      const torch::Tensor &newSidecar,
+                      const GridBatchData &oldGrid,
+                      const torch::Tensor &oldSidecar) {
+    TORCH_CHECK_VALUE(newSidecar.is_floating_point(),
+                      "dirtyMaskFromSidecars: newSidecar must be "
+                      "floating-point (NaN-sentinel trick requires it)");
+    TORCH_CHECK_VALUE(oldSidecar.scalar_type() == newSidecar.scalar_type(),
+                      "dirtyMaskFromSidecars: newSidecar and oldSidecar "
+                      "must share dtype; got ", newSidecar.scalar_type(),
+                      " and ", oldSidecar.scalar_type());
+    TORCH_CHECK_VALUE(newGrid.device() == oldGrid.device(),
+                      "dirtyMaskFromSidecars: newGrid and oldGrid must "
+                      "be on the same device");
+    TORCH_CHECK_VALUE(newSidecar.device() == newGrid.device(),
+                      "dirtyMaskFromSidecars: newSidecar must be on the "
+                      "same device as newGrid");
+    TORCH_CHECK_VALUE(oldSidecar.device() == oldGrid.device(),
+                      "dirtyMaskFromSidecars: oldSidecar must be on the "
+                      "same device as oldGrid");
+    TORCH_CHECK_VALUE(newSidecar.size(0) == newGrid.totalVoxels(),
+                      "dirtyMaskFromSidecars: newSidecar size(0) (",
+                      newSidecar.size(0),
+                      ") must match newGrid totalVoxels (",
+                      newGrid.totalVoxels(), ")");
+    TORCH_CHECK_VALUE(oldSidecar.size(0) == oldGrid.totalVoxels(),
+                      "dirtyMaskFromSidecars: oldSidecar size(0) (",
+                      oldSidecar.size(0),
+                      ") must match oldGrid totalVoxels (",
+                      oldGrid.totalVoxels(), ")");
+    TORCH_CHECK_VALUE(newSidecar.dim() == oldSidecar.dim(),
+                      "dirtyMaskFromSidecars: newSidecar and oldSidecar "
+                      "must have the same number of dimensions");
+    if (newSidecar.dim() > 1) {
+        TORCH_CHECK_VALUE(newSidecar.sizes().slice(1) ==
+                              oldSidecar.sizes().slice(1),
+                          "dirtyMaskFromSidecars: feature dims must match");
+    }
+
+    const c10::cuda::CUDAGuard deviceGuard(newSidecar.device());
+
+    // Fast-path: oldGrid is empty. Every voxel in newGrid is "new" →
+    // entirely dirty. Avoids calling inject with a zero-voxel source.
+    if (oldGrid.totalVoxels() == 0) {
+        return torch::ones({newGrid.totalVoxels()},
+                           torch::TensorOptions()
+                               .dtype(torch::kBool)
+                               .device(newSidecar.device()));
+    }
+
+    // NaN-init the projection target. `ops::inject` writes only
+    // ijk-overlap slots, so non-overlap slots keep their NaN — and
+    // NaN comparison with anything returns True, giving us "not in
+    // old grid" ⇒ dirty automatically.
+    torch::Tensor projected = torch::full(
+        newSidecar.sizes(),
+        std::nan(""),
+        newSidecar.options());
+
+    JaggedTensor projectedJt = newGrid.jaggedTensor(projected);
+    JaggedTensor oldJt       = oldGrid.jaggedTensor(oldSidecar);
+    ops::inject(newGrid, oldGrid, projectedJt, oldJt);
+    // `ops::inject` may swap the underlying tensor reference inside
+    // the dst JaggedTensor (see PersistentTSDFState.cu:59-61). Pull
+    // the possibly-new tensor back out.
+    projected = projectedJt.jdata();
+
+    // Per-voxel, per-channel bool: True if new differs from projected.
+    // NaN != anything (even NaN) is True, so non-overlap voxels
+    // automatically flag as dirty.
+    torch::Tensor diff = projected.ne(newSidecar);
+
+    // Multi-channel: reduce via "any channel differs".
+    while (diff.dim() > 1) {
+        diff = diff.any(/*dim=*/-1);
+    }
+
+    return diff;
+}
+
+} // namespace fvdb::detail::ops

--- a/src/fvdb/detail/ops/DirtyMaskFromSidecars.cu
+++ b/src/fvdb/detail/ops/DirtyMaskFromSidecars.cu
@@ -22,9 +22,9 @@
 
 #include <ATen/TensorOperators.h>
 #include <c10/cuda/CUDAGuard.h>
+#include <torch/types.h>
 
 #include <cmath>
-#include <torch/types.h>
 
 namespace fvdb::detail::ops {
 
@@ -38,8 +38,10 @@ dirtyMaskFromSidecars(const GridBatchData &newGrid,
                       "floating-point (NaN-sentinel trick requires it)");
     TORCH_CHECK_VALUE(oldSidecar.scalar_type() == newSidecar.scalar_type(),
                       "dirtyMaskFromSidecars: newSidecar and oldSidecar "
-                      "must share dtype; got ", newSidecar.scalar_type(),
-                      " and ", oldSidecar.scalar_type());
+                      "must share dtype; got ",
+                      newSidecar.scalar_type(),
+                      " and ",
+                      oldSidecar.scalar_type());
     TORCH_CHECK_VALUE(newGrid.device() == oldGrid.device(),
                       "dirtyMaskFromSidecars: newGrid and oldGrid must "
                       "be on the same device");
@@ -53,18 +55,19 @@ dirtyMaskFromSidecars(const GridBatchData &newGrid,
                       "dirtyMaskFromSidecars: newSidecar size(0) (",
                       newSidecar.size(0),
                       ") must match newGrid totalVoxels (",
-                      newGrid.totalVoxels(), ")");
+                      newGrid.totalVoxels(),
+                      ")");
     TORCH_CHECK_VALUE(oldSidecar.size(0) == oldGrid.totalVoxels(),
                       "dirtyMaskFromSidecars: oldSidecar size(0) (",
                       oldSidecar.size(0),
                       ") must match oldGrid totalVoxels (",
-                      oldGrid.totalVoxels(), ")");
+                      oldGrid.totalVoxels(),
+                      ")");
     TORCH_CHECK_VALUE(newSidecar.dim() == oldSidecar.dim(),
                       "dirtyMaskFromSidecars: newSidecar and oldSidecar "
                       "must have the same number of dimensions");
     if (newSidecar.dim() > 1) {
-        TORCH_CHECK_VALUE(newSidecar.sizes().slice(1) ==
-                              oldSidecar.sizes().slice(1),
+        TORCH_CHECK_VALUE(newSidecar.sizes().slice(1) == oldSidecar.sizes().slice(1),
                           "dirtyMaskFromSidecars: feature dims must match");
     }
 
@@ -74,19 +77,14 @@ dirtyMaskFromSidecars(const GridBatchData &newGrid,
     // entirely dirty. Avoids calling inject with a zero-voxel source.
     if (oldGrid.totalVoxels() == 0) {
         return torch::ones({newGrid.totalVoxels()},
-                           torch::TensorOptions()
-                               .dtype(torch::kBool)
-                               .device(newSidecar.device()));
+                           torch::TensorOptions().dtype(torch::kBool).device(newSidecar.device()));
     }
 
     // NaN-init the projection target. `ops::inject` writes only
     // ijk-overlap slots, so non-overlap slots keep their NaN — and
     // NaN comparison with anything returns True, giving us "not in
     // old grid" ⇒ dirty automatically.
-    torch::Tensor projected = torch::full(
-        newSidecar.sizes(),
-        std::nan(""),
-        newSidecar.options());
+    torch::Tensor projected = torch::full(newSidecar.sizes(), std::nan(""), newSidecar.options());
 
     JaggedTensor projectedJt = newGrid.jaggedTensor(projected);
     JaggedTensor oldJt       = oldGrid.jaggedTensor(oldSidecar);

--- a/src/fvdb/detail/ops/DirtyMaskFromSidecars.h
+++ b/src/fvdb/detail/ops/DirtyMaskFromSidecars.h
@@ -1,0 +1,62 @@
+// Copyright Contributors to the OpenVDB Project
+// SPDX-License-Identifier: Apache-2.0
+//
+#ifndef FVDB_DETAIL_OPS_DIRTYMASKFROMSIDECARS_H
+#define FVDB_DETAIL_OPS_DIRTYMASKFROMSIDECARS_H
+
+#include <fvdb/GridBatchData.h>
+#include <fvdb/JaggedTensor.h>
+
+#include <torch/types.h>
+
+namespace fvdb {
+namespace detail {
+namespace ops {
+
+/// @brief Compute a "dirty" bool mask on `newGrid` flagging voxels
+///        whose sidecar value differs from the corresponding voxel in
+///        `oldGrid` (if present), or is absent from `oldGrid` entirely.
+///
+/// Primitive used by the paper's dirty-region ESDF update pattern
+/// (and composable into any user-level change-tracking workflow).
+/// Built from `ops::inject`, no new CUDA kernels.
+///
+/// Semantics per output voxel `v` in `newGrid`:
+///
+///   - If `v.ijk` is **not** in `oldGrid`: the voxel is new → marked
+///     dirty.
+///   - If `v.ijk` IS in `oldGrid` at some `w` and
+///     `newSidecar[v] == oldSidecar[w]` (elementwise equality across
+///     all channels for multi-channel sidecars): not dirty.
+///   - Otherwise: dirty.
+///
+/// Multi-channel sidecars (2-D `[num_voxels, C]`) reduce via
+/// "any channel differs" → per-voxel bool.
+///
+/// Both sidecars must have floating-point dtype in M5; we use the
+/// NaN != anything trick to flag "voxel not present in old grid"
+/// without needing a separate overlap mask pass (NaN-init the
+/// projection target, inject only writes ijk-overlap slots, then
+/// `new != projection` gives dirty — NaN comparison is always True
+/// so non-overlap slots automatically flag as dirty).
+///
+/// @param newGrid      Grid whose voxel set we compute the mask on.
+/// @param newSidecar   `[newGrid.totalVoxels]` or
+///                     `[newGrid.totalVoxels, C]` sidecar on newGrid.
+/// @param oldGrid      Baseline grid for comparison.
+/// @param oldSidecar   Sidecar on `oldGrid`, same feature-dim as
+///                     `newSidecar`.
+///
+/// @return Bool tensor of shape `[newGrid.totalVoxels]` on the same
+///         device as `newSidecar`.
+torch::Tensor
+dirtyMaskFromSidecars(const GridBatchData &newGrid,
+                      const torch::Tensor &newSidecar,
+                      const GridBatchData &oldGrid,
+                      const torch::Tensor &oldSidecar);
+
+} // namespace ops
+} // namespace detail
+} // namespace fvdb
+
+#endif // FVDB_DETAIL_OPS_DIRTYMASKFROMSIDECARS_H

--- a/src/fvdb/detail/ops/DirtyMaskFromSidecars.h
+++ b/src/fvdb/detail/ops/DirtyMaskFromSidecars.h
@@ -49,11 +49,10 @@ namespace ops {
 ///
 /// @return Bool tensor of shape `[newGrid.totalVoxels]` on the same
 ///         device as `newSidecar`.
-torch::Tensor
-dirtyMaskFromSidecars(const GridBatchData &newGrid,
-                      const torch::Tensor &newSidecar,
-                      const GridBatchData &oldGrid,
-                      const torch::Tensor &oldSidecar);
+torch::Tensor dirtyMaskFromSidecars(const GridBatchData &newGrid,
+                                    const torch::Tensor &newSidecar,
+                                    const GridBatchData &oldGrid,
+                                    const torch::Tensor &oldSidecar);
 
 } // namespace ops
 } // namespace detail

--- a/src/fvdb/detail/ops/Inject.cu
+++ b/src/fvdb/detail/ops/Inject.cu
@@ -232,10 +232,8 @@ dispatchInject<torch::kCUDA>(const GridBatchData &dstGridBatch,
 
     // Create a grid for each batch item and store the handles
     for (int i = 0; i < dstGridBatch.batchSize(); i += 1) {
-        const nanovdb::OnIndexGrid *dstGrid =
-            dstGridBatch.nanoGridHandle().deviceGrid<nanovdb::ValueOnIndex>(i);
-        const nanovdb::OnIndexGrid *srcGrid =
-            srcGridBatch.nanoGridHandle().deviceGrid<nanovdb::ValueOnIndex>(i);
+        const nanovdb::OnIndexGrid *dstGrid = dstGridBatch.deviceGridPtrAt(i);
+        const nanovdb::OnIndexGrid *srcGrid = srcGridBatch.deviceGridPtrAt(i);
         TORCH_CHECK(dstGrid, "Destination grid is null");
         TORCH_CHECK(srcGrid, "Source grid is null");
 
@@ -310,10 +308,8 @@ dispatchInject<torch::kPrivateUse1>(const GridBatchData &dstGridBatch,
 
     // Create a grid for each batch item and store the handles
     for (int i = 0; i < dstGridBatch.batchSize(); i += 1) {
-        const nanovdb::OnIndexGrid *dstGrid =
-            dstGridBatch.nanoGridHandle().deviceGrid<nanovdb::ValueOnIndex>(i);
-        const nanovdb::OnIndexGrid *srcGrid =
-            srcGridBatch.nanoGridHandle().deviceGrid<nanovdb::ValueOnIndex>(i);
+        const nanovdb::OnIndexGrid *dstGrid = dstGridBatch.deviceGridPtrAt(i);
+        const nanovdb::OnIndexGrid *srcGrid = srcGridBatch.deviceGridPtrAt(i);
         TORCH_CHECK(dstGrid, "Destination grid is null");
         TORCH_CHECK(srcGrid, "Source grid is null");
 
@@ -407,13 +403,11 @@ dispatchInject<torch::kCPU>(const GridBatchData &dstGridBatch,
                        auto dstJDataAccessor       = dstJData.accessor<scalar_t, 2>();
 
                        for (auto i = 0; i < srcGridBatch.batchSize(); i += 1) {
-                           const nanovdb::OnIndexGrid *grid =
-                               srcGridBatch.nanoGridHandle().grid<nanovdb::ValueOnIndex>(i);
-                           const nanovdb::OnIndexGrid *dstGrid =
-                               dstGridBatch.nanoGridHandle().grid<nanovdb::ValueOnIndex>(i);
-                           auto dstAccessor           = dstGrid->getAccessor();
-                           const int64_t baseSrcIndex = srcGridBatch.cumVoxelsAt(i);
-                           const int64_t baseDstIndex = dstGridBatch.cumVoxelsAt(i);
+                           const nanovdb::OnIndexGrid *grid    = srcGridBatch.hostGridPtrAt(i);
+                           const nanovdb::OnIndexGrid *dstGrid = dstGridBatch.hostGridPtrAt(i);
+                           auto dstAccessor                    = dstGrid->getAccessor();
+                           const int64_t baseSrcIndex          = srcGridBatch.cumVoxelsAt(i);
+                           const int64_t baseDstIndex          = dstGridBatch.cumVoxelsAt(i);
                            for (auto it = ActiveVoxelIterator<-1>(grid->tree()); it.isValid();
                                 ++it) {
                                const nanovdb::Coord ijk = it->first;

--- a/src/fvdb/detail/ops/IntegrateOccupancyFromPoints.cu
+++ b/src/fvdb/detail/ops/IntegrateOccupancyFromPoints.cu
@@ -1,0 +1,410 @@
+// Copyright Contributors to the OpenVDB Project
+// SPDX-License-Identifier: Apache-2.0
+//
+// IntegrateOccupancyFromPoints.cu
+//
+// Bayesian log-odds occupancy integrator for LiDAR / point-cloud
+// sweeps. Sister primitive to `IntegrateTSDFFromPoints`: same shell
+// allocator, same HDDA ray-walk; the only structural difference is
+// the per-voxel update rule (log-odds increment instead of running
+// weighted-average signed distance).
+//
+// Paper-framing: this is the paper's fifth application of the
+// nanoVDB topology-op vocabulary. Uses:
+//   - `voxelsToGrid` (via buildPointTruncationShell -> voxelsToGrid)
+//   - `mergeGrids`   (to preserve previous-frame topology)
+//   - `inject`       (to carry over previous log-odds values)
+//   - ONE custom CUDA kernel (the ray-walk log-odds update)
+//   - `torch.clamp` (for the [log_odds_min, log_odds_max] cap)
+//
+// No custom allocator, no custom hash table, no per-pixel projective
+// integrator. Just the same sparse-substrate primitives that power
+// TSDF.
+//
+// Pipeline:
+//   P0. Build topology: union of existing grid + truncation shell of
+//       new points (identical to TSDF).
+//   P1. Inject previous log-odds values into the new grid; new
+//       voxels default to 0 (log-odds = 0 => p = 0.5 = unknown).
+//   P2. Ray-walk kernel: one thread per input point. HDDA-walks
+//       active voxels along the ray; for each voxel, classifies as
+//       hit / miss / unknown and atomicAdd's the appropriate
+//       log-odds delta.
+//   P3. Clamp to [log_odds_min, log_odds_max].
+
+#include <fvdb/GridBatchData.h>
+#include <fvdb/JaggedTensor.h>
+#include <fvdb/VoxelCoordTransform.h>
+#include <fvdb/detail/ops/BuildMergedGrids.h>
+#include <fvdb/detail/ops/BuildPointTruncationShell.h>
+#include <fvdb/detail/ops/Inject.h>
+#include <fvdb/detail/ops/IntegrateOccupancyFromPoints.h>
+#include <fvdb/detail/utils/AccessorHelpers.cuh>
+#include <fvdb/detail/utils/Utils.h>
+#include <fvdb/detail/utils/cuda/Atomics.cuh>
+#include <fvdb/detail/utils/cuda/GridDim.h>
+#include <fvdb/detail/utils/nanovdb/HDDAIterators.h>
+
+#include <ATen/OpMathType.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/core/ScalarType.h>
+#include <c10/cuda/CUDAException.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <c10/cuda/CUDAStream.h>
+
+#include <nanovdb/NanoVDB.h>
+#include <nanovdb/math/Ray.h>
+
+#include <cmath>
+#include <cuda_runtime.h>
+#include <torch/types.h>
+
+namespace fvdb::detail::ops {
+
+namespace {
+
+using GridT = nanovdb::ValueOnIndex;
+
+// -------------------------------------------------------------------------
+// P2: ray-walk log-odds kernel.
+//
+// Mirrors `rayWalkIntegrateKernel` from IntegrateTSDFFromPoints.cu
+// — same HDDA-walk, same endpoint / free-band / unknown classification
+// via the `sdfWorld` (range-to-surface) test — but writes log-odds
+// deltas instead of accumulating weighted signed-distance sums.
+//
+// Per-ray update rule:
+//   - For each active voxel `v` along the ray within the walk window:
+//       sdfWorld = ||P - O|| - ||v - O||
+//       if sdfWorld > +truncationMargin (voxel behind endpoint, free):
+//           log_odds[v] += logOddsMiss   (negative -> more likely free)
+//       if sdfWorld in [-truncationMargin, +truncationMargin] (hit band):
+//           log_odds[v] += logOddsHit    (positive -> more likely occupied)
+//       else: unknown region behind the endpoint, skip.
+//
+// We DO NOT clamp in the kernel; the host-side `torch::clamp_` in the
+// orchestrator does the bounded update in one shot after all rays
+// have been integrated. This matches the additive-log-odds Bayesian
+// semantics and avoids per-write atomicMin/Max complexity.
+// -------------------------------------------------------------------------
+
+template <typename ScalarT>
+__global__ void
+rayWalkLogOddsKernel(
+    const fvdb::BatchGridAccessor unionGridAcc,
+    const fvdb::JaggedRAcc64<ScalarT, 2> pointsAcc,
+    const fvdb::TorchRAcc64<ScalarT, 2> sensorOriginsAcc,
+    const float truncationMargin,
+    const float logOddsHit,
+    const float logOddsMiss,
+    fvdb::TorchRAcc64<ScalarT, 1> outLogOddsAcc) {
+    using MathT = at::opmath_type<ScalarT>;
+    using Vec3T = nanovdb::math::Vec3<MathT>;
+    using RayT  = nanovdb::math::Ray<MathT>;
+
+    const int64_t totalPoints = pointsAcc.elementCount();
+    const int64_t pointIdx    = blockIdx.x * blockDim.x + threadIdx.x;
+    if (pointIdx >= totalPoints) return;
+
+    const fvdb::JIdxType batchIdx = pointsAcc.batchIdx(pointIdx);
+
+    const Vec3T originWorld(
+        static_cast<MathT>(sensorOriginsAcc[batchIdx][0]),
+        static_cast<MathT>(sensorOriginsAcc[batchIdx][1]),
+        static_cast<MathT>(sensorOriginsAcc[batchIdx][2]));
+    const Vec3T endpointWorld(
+        static_cast<MathT>(pointsAcc.data()[pointIdx][0]),
+        static_cast<MathT>(pointsAcc.data()[pointIdx][1]),
+        static_cast<MathT>(pointsAcc.data()[pointIdx][2]));
+    Vec3T dirWorld         = endpointWorld - originWorld;
+    const MathT rangeWorld = dirWorld.length();
+    if (rangeWorld < MathT(1e-8)) return;
+    dirWorld = dirWorld / rangeWorld;
+
+    // Walk from the sensor origin through the hit band. We always
+    // carve free space here — occupancy without free-space carving
+    // degenerates to a "hit-set" tracker, which isn't what the
+    // log-odds formulation needs.
+    const MathT tWalkStart = MathT(0);
+    const MathT tWalkEnd   = rangeWorld + MathT(truncationMargin);
+    if (tWalkEnd <= tWalkStart) return;
+
+    const RayT rayWorld(originWorld, dirWorld, tWalkStart, tWalkEnd);
+
+    const VoxelCoordTransform transform =
+        unionGridAcc.primalTransform(batchIdx);
+    const RayT rayVox = transform.applyToRay(rayWorld);
+
+    const nanovdb::NanoGrid<GridT> *grid = unionGridAcc.grid(batchIdx);
+    auto acc                             = grid->getAccessor();
+    const int64_t voxelOffsetBase = unionGridAcc.voxelOffset(batchIdx);
+
+    fvdb::HDDAVoxelIterator<decltype(acc), MathT> it(rayVox, acc);
+    while (it.isValid()) {
+        const nanovdb::Coord voxIjk = it->first;
+        ++it;
+
+        // World-space "signed distance along ray to endpoint":
+        // positive = voxel is on the sensor side of the endpoint
+        // (free space); negative = voxel is beyond the endpoint
+        // (unknown region behind the observed surface).
+        const Vec3T voxPosWorld = transform.applyInv<MathT>(
+            static_cast<MathT>(voxIjk[0]),
+            static_cast<MathT>(voxIjk[1]),
+            static_cast<MathT>(voxIjk[2]));
+        const Vec3T toVox       = voxPosWorld - originWorld;
+        const MathT rangeToVox  = toVox.length();
+        const MathT sdfWorld    = rangeWorld - rangeToVox;
+
+        // Classify + pick log-odds delta.
+        float logOddsDelta;
+        if (sdfWorld > MathT(truncationMargin)) {
+            // Free space (voxel is farther from the endpoint than the
+            // truncation band; sensor side).
+            logOddsDelta = logOddsMiss;
+        } else if (sdfWorld >= -MathT(truncationMargin)) {
+            // Hit band: within +/- truncationMargin of the endpoint.
+            logOddsDelta = logOddsHit;
+        } else {
+            // Behind the endpoint — unknown state, skip.
+            continue;
+        }
+
+        const int64_t writeOffset =
+            voxelOffsetBase + static_cast<int64_t>(acc.getValue(voxIjk)) - 1;
+        atomAdd(&outLogOddsAcc[writeOffset], static_cast<ScalarT>(logOddsDelta));
+    }
+}
+
+// -------------------------------------------------------------------------
+// Host orchestrator. Callable from both single-frame and batched paths.
+// -------------------------------------------------------------------------
+
+JaggedTensor
+doIntegrateOccupancyFromPoints(const float truncationMargin,
+                               const JaggedTensor &points,
+                               const torch::Tensor &sensorOrigins,
+                               const GridBatchData &unionGrid,
+                               const GridBatchData &baseGrid,
+                               const JaggedTensor &logOddsIn,
+                               const float logOddsHit,
+                               const float logOddsMiss,
+                               const float logOddsMin,
+                               const float logOddsMax) {
+    const c10::cuda::CUDAGuard device_guard(logOddsIn.device());
+
+    const int64_t totalOutVoxels = unionGrid.totalVoxels();
+
+    // P1: allocate new log-odds tensor + inject previous values onto
+    // the merged grid. New voxels default to zero (log-odds = 0 =>
+    // p = 0.5 = unknown), which is the standard Bayesian prior for
+    // an unobserved cell.
+    torch::Tensor outLogOdds =
+        torch::zeros({totalOutVoxels}, logOddsIn.jdata().options());
+    {
+        JaggedTensor dstJt = unionGrid.jaggedTensor(outLogOdds);
+        // inject(dstGrid, srcGrid, dst, src): copies ijk-overlapping
+        // voxels from src into dst; leaves non-overlapping slots
+        // untouched (i.e. at the zero-init value). This is the same
+        // state-carry-over pattern PersistentTSDFState uses.
+        ops::inject(unionGrid, baseGrid, dstJt, logOddsIn);
+        outLogOdds = dstJt.jdata();
+    }
+
+    // P2: ray-walk kernel.
+    AT_DISPATCH_V2(
+        logOddsIn.scalar_type(),
+        "integrateOccupancyFromPointsKernel",
+        AT_WRAP([&] {
+            const auto stream = at::cuda::getCurrentCUDAStream();
+            auto outLogOddsAcc =
+                outLogOdds.packed_accessor64<scalar_t, 1,
+                                             torch::RestrictPtrTraits>();
+            auto pointsAcc =
+                points.packed_accessor64<scalar_t, 2,
+                                         torch::RestrictPtrTraits>();
+            auto sensorAcc =
+                sensorOrigins.packed_accessor64<scalar_t, 2,
+                                                torch::RestrictPtrTraits>();
+            const int64_t totalPoints = points.jdata().size(0);
+            if (totalPoints > 0) {
+                const int64_t blocks =
+                    GET_BLOCKS(totalPoints, DEFAULT_BLOCK_DIM);
+                rayWalkLogOddsKernel<scalar_t>
+                    <<<blocks, DEFAULT_BLOCK_DIM, 0, stream.stream()>>>(
+                        unionGrid.deviceAccessor(),
+                        pointsAcc,
+                        sensorAcc,
+                        truncationMargin,
+                        logOddsHit,
+                        logOddsMiss,
+                        outLogOddsAcc);
+                C10_CUDA_KERNEL_LAUNCH_CHECK();
+            }
+        }),
+        AT_EXPAND(AT_FLOATING_TYPES),
+        c10::kHalf);
+
+    // P3: clamp. Single torch-level call, avoids a separate CUDA
+    // kernel. The clamp is applied AFTER all rays have accumulated
+    // so the Bayesian log-odds sum is respected even if individual
+    // ray contributions would overshoot the bounds momentarily.
+    outLogOdds.clamp_(logOddsMin, logOddsMax);
+
+    return unionGrid.jaggedTensor(outLogOdds);
+}
+
+c10::intrusive_ptr<GridBatchData>
+buildUnionGrid(const c10::intrusive_ptr<GridBatchData> &baseGrid,
+               const JaggedTensor &points,
+               double truncationMargin) {
+    auto pointShell = buildPointTruncationShell(points, *baseGrid, truncationMargin);
+    return mergeGrids(*baseGrid, *pointShell);
+}
+
+void
+checkCommonInputs(const c10::intrusive_ptr<GridBatchData> &grid,
+                  const JaggedTensor &points,
+                  const torch::Tensor &sensorOrigins,
+                  const JaggedTensor &logOdds,
+                  double logOddsMin,
+                  double logOddsMax) {
+    TORCH_CHECK_VALUE(grid != nullptr, "grid must be non-null");
+    TORCH_CHECK_VALUE(grid->device().is_cuda(),
+                      "integrateOccupancyFromPoints requires a CUDA grid");
+    TORCH_CHECK_VALUE(points.rdim() == 2 && points.rsize(-1) == 3,
+                      "points must have shape [B, N, 3]");
+    TORCH_CHECK_VALUE(sensorOrigins.dim() == 2 && sensorOrigins.size(1) == 3,
+                      "sensorOrigins must have shape [B, 3]");
+    TORCH_CHECK_VALUE(sensorOrigins.size(0) == grid->batchSize(),
+                      "sensorOrigins batch size (", sensorOrigins.size(0),
+                      ") must match grid batch size (", grid->batchSize(), ")");
+    TORCH_CHECK_VALUE(points.num_outer_lists() == grid->batchSize(),
+                      "points batch size mismatch");
+    TORCH_CHECK_VALUE(logOdds.num_outer_lists() == grid->batchSize(),
+                      "logOdds batch size mismatch");
+    TORCH_CHECK_TYPE(logOdds.is_floating_point(),
+                     "logOdds must be a floating-point dtype");
+    TORCH_CHECK_TYPE(points.scalar_type() == logOdds.scalar_type(),
+                     "points dtype must match logOdds dtype");
+    TORCH_CHECK_TYPE(sensorOrigins.scalar_type() == logOdds.scalar_type(),
+                     "sensorOrigins dtype must match logOdds dtype");
+    TORCH_CHECK_VALUE(logOdds.numel() == grid->totalVoxels(),
+                      "logOdds size (", logOdds.numel(),
+                      ") must equal grid totalVoxels (", grid->totalVoxels(), ")");
+    TORCH_CHECK_VALUE(logOddsMax > logOddsMin,
+                      "logOddsMax (", logOddsMax,
+                      ") must be strictly greater than logOddsMin (",
+                      logOddsMin, ")");
+}
+
+} // anonymous namespace
+
+// -------------------------------------------------------------------------
+// Public entry points.
+// -------------------------------------------------------------------------
+
+std::tuple<c10::intrusive_ptr<GridBatchData>, JaggedTensor>
+integrateOccupancyFromPoints(const c10::intrusive_ptr<GridBatchData> grid,
+                             const double truncationMargin,
+                             const JaggedTensor &points,
+                             const torch::Tensor &sensorOrigins,
+                             const JaggedTensor &logOdds,
+                             const double logOddsHit,
+                             const double logOddsMiss,
+                             const double logOddsMin,
+                             const double logOddsMax) {
+    checkCommonInputs(grid, points, sensorOrigins, logOdds, logOddsMin, logOddsMax);
+
+    // Empty point cloud: nothing to allocate, nothing to integrate.
+    // Return the grid + log-odds unchanged. `buildPointTruncationShell`
+    // doesn't handle a zero-point input cleanly (it tries to build an
+    // empty grid handle which triggers a batched-handle assert); this
+    // pre-check keeps the no-op case clean.
+    if (points.numel() == 0) {
+        return {grid, logOdds};
+    }
+
+    auto unionGrid = buildUnionGrid(grid, points, truncationMargin);
+    auto newLogOdds = doIntegrateOccupancyFromPoints(
+        static_cast<float>(truncationMargin),
+        points, sensorOrigins,
+        *unionGrid, *grid,
+        logOdds,
+        static_cast<float>(logOddsHit),
+        static_cast<float>(logOddsMiss),
+        static_cast<float>(logOddsMin),
+        static_cast<float>(logOddsMax));
+    return {unionGrid, newLogOdds};
+}
+
+std::tuple<c10::intrusive_ptr<GridBatchData>, JaggedTensor>
+integrateOccupancyFromPointsFrames(
+    const c10::intrusive_ptr<GridBatchData> grid,
+    const double truncationMargin,
+    const std::vector<torch::Tensor> &pointsPerFrame,
+    const torch::Tensor &sensorOrigins,
+    const JaggedTensor &logOdds,
+    const double logOddsHit,
+    const double logOddsMiss,
+    const double logOddsMin,
+    const double logOddsMax) {
+    const int64_t N = static_cast<int64_t>(pointsPerFrame.size());
+    TORCH_CHECK_VALUE(N > 0, "pointsPerFrame must have at least one frame");
+    TORCH_CHECK_VALUE(
+        sensorOrigins.dim() == 2 && sensorOrigins.size(0) == N &&
+            sensorOrigins.size(1) == 3,
+        "sensorOrigins must have shape [N=", N, ", 3]; got ",
+        sensorOrigins.sizes());
+    TORCH_CHECK_VALUE(grid->batchSize() == 1,
+                      "integrateOccupancyFromPointsFrames supports "
+                      "single-scene grids only (batchSize = 1); got ",
+                      grid->batchSize());
+    TORCH_CHECK_VALUE(grid->device().is_cuda(),
+                      "integrateOccupancyFromPointsFrames requires a CUDA grid");
+
+    const at::cuda::CUDAGuard device_guard(logOdds.device());
+
+    // Running accumulator (same pattern as the LiDAR TSDF batched
+    // path). Each frame builds a fresh shell, unions with accumGrid,
+    // injects previous log-odds, ray-walks, and clamps. Old refs
+    // drop out of scope each iteration; the caching allocator
+    // reclaims memory.
+    c10::intrusive_ptr<GridBatchData> accumGrid = grid;
+    JaggedTensor accumLogOdds = logOdds;
+
+    for (int64_t i = 0; i < N; ++i) {
+        const torch::Tensor &ptsTensor = pointsPerFrame[i];
+        TORCH_CHECK_VALUE(ptsTensor.dim() == 2 && ptsTensor.size(1) == 3,
+                          "pointsPerFrame[", i, "] must be [N_i, 3]");
+        TORCH_CHECK_VALUE(ptsTensor.device() == logOdds.device(),
+                          "pointsPerFrame[", i,
+                          "] must be on the same device as logOdds");
+        TORCH_CHECK_TYPE(ptsTensor.scalar_type() == logOdds.scalar_type(),
+                         "pointsPerFrame[", i,
+                         "] dtype must match logOdds dtype");
+
+        JaggedTensor ptsJagged =
+            JaggedTensor(std::vector<torch::Tensor>{ptsTensor});
+        torch::Tensor originI = sensorOrigins.narrow(0, i, 1).contiguous();
+
+        auto unionGrid =
+            buildUnionGrid(accumGrid, ptsJagged, truncationMargin);
+        auto newLogOdds = doIntegrateOccupancyFromPoints(
+            static_cast<float>(truncationMargin),
+            ptsJagged, originI,
+            *unionGrid, *accumGrid,
+            accumLogOdds,
+            static_cast<float>(logOddsHit),
+            static_cast<float>(logOddsMiss),
+            static_cast<float>(logOddsMin),
+            static_cast<float>(logOddsMax));
+
+        accumGrid     = unionGrid;
+        accumLogOdds  = newLogOdds;
+    }
+
+    return {accumGrid, accumLogOdds};
+}
+
+} // namespace fvdb::detail::ops

--- a/src/fvdb/detail/ops/IntegrateOccupancyFromPoints.cu
+++ b/src/fvdb/detail/ops/IntegrateOccupancyFromPoints.cu
@@ -139,7 +139,7 @@ rayWalkLogOddsKernel(const fvdb::BatchGridAccessor unionGridAcc,
     auto acc                             = grid->getAccessor();
     const int64_t voxelOffsetBase        = unionGridAcc.voxelOffset(batchIdx);
 
-    fvdb::HDDAVoxelIterator<decltype(acc), MathT> it(rayVox, acc);
+    fvdb::HDDALeafVoxelIterator<decltype(acc), MathT> it(rayVox, acc);
     while (it.isValid()) {
         const nanovdb::Coord voxIjk = it->first;
         ++it;

--- a/src/fvdb/detail/ops/IntegrateOccupancyFromPoints.cu
+++ b/src/fvdb/detail/ops/IntegrateOccupancyFromPoints.cu
@@ -45,19 +45,20 @@
 #include <fvdb/detail/utils/cuda/GridDim.h>
 #include <fvdb/detail/utils/nanovdb/HDDAIterators.h>
 
+#include <nanovdb/NanoVDB.h>
+#include <nanovdb/math/Ray.h>
+
 #include <ATen/OpMathType.h>
 #include <ATen/cuda/CUDAContext.h>
 #include <c10/core/ScalarType.h>
 #include <c10/cuda/CUDAException.h>
 #include <c10/cuda/CUDAGuard.h>
 #include <c10/cuda/CUDAStream.h>
+#include <torch/types.h>
 
-#include <nanovdb/NanoVDB.h>
-#include <nanovdb/math/Ray.h>
+#include <cuda_runtime.h>
 
 #include <cmath>
-#include <cuda_runtime.h>
-#include <torch/types.h>
 
 namespace fvdb::detail::ops {
 
@@ -90,35 +91,34 @@ using GridT = nanovdb::ValueOnIndex;
 
 template <typename ScalarT>
 __global__ void
-rayWalkLogOddsKernel(
-    const fvdb::BatchGridAccessor unionGridAcc,
-    const fvdb::JaggedRAcc64<ScalarT, 2> pointsAcc,
-    const fvdb::TorchRAcc64<ScalarT, 2> sensorOriginsAcc,
-    const float truncationMargin,
-    const float logOddsHit,
-    const float logOddsMiss,
-    fvdb::TorchRAcc64<ScalarT, 1> outLogOddsAcc) {
+rayWalkLogOddsKernel(const fvdb::BatchGridAccessor unionGridAcc,
+                     const fvdb::JaggedRAcc64<ScalarT, 2> pointsAcc,
+                     const fvdb::TorchRAcc64<ScalarT, 2> sensorOriginsAcc,
+                     const float truncationMargin,
+                     const float logOddsHit,
+                     const float logOddsMiss,
+                     fvdb::TorchRAcc64<ScalarT, 1> outLogOddsAcc) {
     using MathT = at::opmath_type<ScalarT>;
     using Vec3T = nanovdb::math::Vec3<MathT>;
     using RayT  = nanovdb::math::Ray<MathT>;
 
     const int64_t totalPoints = pointsAcc.elementCount();
     const int64_t pointIdx    = blockIdx.x * blockDim.x + threadIdx.x;
-    if (pointIdx >= totalPoints) return;
+    if (pointIdx >= totalPoints)
+        return;
 
     const fvdb::JIdxType batchIdx = pointsAcc.batchIdx(pointIdx);
 
-    const Vec3T originWorld(
-        static_cast<MathT>(sensorOriginsAcc[batchIdx][0]),
-        static_cast<MathT>(sensorOriginsAcc[batchIdx][1]),
-        static_cast<MathT>(sensorOriginsAcc[batchIdx][2]));
-    const Vec3T endpointWorld(
-        static_cast<MathT>(pointsAcc.data()[pointIdx][0]),
-        static_cast<MathT>(pointsAcc.data()[pointIdx][1]),
-        static_cast<MathT>(pointsAcc.data()[pointIdx][2]));
+    const Vec3T originWorld(static_cast<MathT>(sensorOriginsAcc[batchIdx][0]),
+                            static_cast<MathT>(sensorOriginsAcc[batchIdx][1]),
+                            static_cast<MathT>(sensorOriginsAcc[batchIdx][2]));
+    const Vec3T endpointWorld(static_cast<MathT>(pointsAcc.data()[pointIdx][0]),
+                              static_cast<MathT>(pointsAcc.data()[pointIdx][1]),
+                              static_cast<MathT>(pointsAcc.data()[pointIdx][2]));
     Vec3T dirWorld         = endpointWorld - originWorld;
     const MathT rangeWorld = dirWorld.length();
-    if (rangeWorld < MathT(1e-8)) return;
+    if (rangeWorld < MathT(1e-8))
+        return;
     dirWorld = dirWorld / rangeWorld;
 
     // Walk from the sensor origin through the hit band. We always
@@ -127,17 +127,17 @@ rayWalkLogOddsKernel(
     // log-odds formulation needs.
     const MathT tWalkStart = MathT(0);
     const MathT tWalkEnd   = rangeWorld + MathT(truncationMargin);
-    if (tWalkEnd <= tWalkStart) return;
+    if (tWalkEnd <= tWalkStart)
+        return;
 
     const RayT rayWorld(originWorld, dirWorld, tWalkStart, tWalkEnd);
 
-    const VoxelCoordTransform transform =
-        unionGridAcc.primalTransform(batchIdx);
-    const RayT rayVox = transform.applyToRay(rayWorld);
+    const VoxelCoordTransform transform = unionGridAcc.primalTransform(batchIdx);
+    const RayT rayVox                   = transform.applyToRay(rayWorld);
 
     const nanovdb::NanoGrid<GridT> *grid = unionGridAcc.grid(batchIdx);
     auto acc                             = grid->getAccessor();
-    const int64_t voxelOffsetBase = unionGridAcc.voxelOffset(batchIdx);
+    const int64_t voxelOffsetBase        = unionGridAcc.voxelOffset(batchIdx);
 
     fvdb::HDDAVoxelIterator<decltype(acc), MathT> it(rayVox, acc);
     while (it.isValid()) {
@@ -148,10 +148,9 @@ rayWalkLogOddsKernel(
         // positive = voxel is on the sensor side of the endpoint
         // (free space); negative = voxel is beyond the endpoint
         // (unknown region behind the observed surface).
-        const Vec3T voxPosWorld = transform.applyInv<MathT>(
-            static_cast<MathT>(voxIjk[0]),
-            static_cast<MathT>(voxIjk[1]),
-            static_cast<MathT>(voxIjk[2]));
+        const Vec3T voxPosWorld = transform.applyInv<MathT>(static_cast<MathT>(voxIjk[0]),
+                                                            static_cast<MathT>(voxIjk[1]),
+                                                            static_cast<MathT>(voxIjk[2]));
         const Vec3T toVox       = voxPosWorld - originWorld;
         const MathT rangeToVox  = toVox.length();
         const MathT sdfWorld    = rangeWorld - rangeToVox;
@@ -199,8 +198,7 @@ doIntegrateOccupancyFromPoints(const float truncationMargin,
     // the merged grid. New voxels default to zero (log-odds = 0 =>
     // p = 0.5 = unknown), which is the standard Bayesian prior for
     // an unobserved cell.
-    torch::Tensor outLogOdds =
-        torch::zeros({totalOutVoxels}, logOddsIn.jdata().options());
+    torch::Tensor outLogOdds = torch::zeros({totalOutVoxels}, logOddsIn.jdata().options());
     {
         JaggedTensor dstJt = unionGrid.jaggedTensor(outLogOdds);
         // inject(dstGrid, srcGrid, dst, src): copies ijk-overlapping
@@ -218,27 +216,21 @@ doIntegrateOccupancyFromPoints(const float truncationMargin,
         AT_WRAP([&] {
             const auto stream = at::cuda::getCurrentCUDAStream();
             auto outLogOddsAcc =
-                outLogOdds.packed_accessor64<scalar_t, 1,
-                                             torch::RestrictPtrTraits>();
-            auto pointsAcc =
-                points.packed_accessor64<scalar_t, 2,
-                                         torch::RestrictPtrTraits>();
+                outLogOdds.packed_accessor64<scalar_t, 1, torch::RestrictPtrTraits>();
+            auto pointsAcc = points.packed_accessor64<scalar_t, 2, torch::RestrictPtrTraits>();
             auto sensorAcc =
-                sensorOrigins.packed_accessor64<scalar_t, 2,
-                                                torch::RestrictPtrTraits>();
+                sensorOrigins.packed_accessor64<scalar_t, 2, torch::RestrictPtrTraits>();
             const int64_t totalPoints = points.jdata().size(0);
             if (totalPoints > 0) {
-                const int64_t blocks =
-                    GET_BLOCKS(totalPoints, DEFAULT_BLOCK_DIM);
+                const int64_t blocks = GET_BLOCKS(totalPoints, DEFAULT_BLOCK_DIM);
                 rayWalkLogOddsKernel<scalar_t>
-                    <<<blocks, DEFAULT_BLOCK_DIM, 0, stream.stream()>>>(
-                        unionGrid.deviceAccessor(),
-                        pointsAcc,
-                        sensorAcc,
-                        truncationMargin,
-                        logOddsHit,
-                        logOddsMiss,
-                        outLogOddsAcc);
+                    <<<blocks, DEFAULT_BLOCK_DIM, 0, stream.stream()>>>(unionGrid.deviceAccessor(),
+                                                                        pointsAcc,
+                                                                        sensorAcc,
+                                                                        truncationMargin,
+                                                                        logOddsHit,
+                                                                        logOddsMiss,
+                                                                        outLogOddsAcc);
                 C10_CUDA_KERNEL_LAUNCH_CHECK();
             }
         }),
@@ -277,25 +269,31 @@ checkCommonInputs(const c10::intrusive_ptr<GridBatchData> &grid,
     TORCH_CHECK_VALUE(sensorOrigins.dim() == 2 && sensorOrigins.size(1) == 3,
                       "sensorOrigins must have shape [B, 3]");
     TORCH_CHECK_VALUE(sensorOrigins.size(0) == grid->batchSize(),
-                      "sensorOrigins batch size (", sensorOrigins.size(0),
-                      ") must match grid batch size (", grid->batchSize(), ")");
-    TORCH_CHECK_VALUE(points.num_outer_lists() == grid->batchSize(),
-                      "points batch size mismatch");
+                      "sensorOrigins batch size (",
+                      sensorOrigins.size(0),
+                      ") must match grid batch size (",
+                      grid->batchSize(),
+                      ")");
+    TORCH_CHECK_VALUE(points.num_outer_lists() == grid->batchSize(), "points batch size mismatch");
     TORCH_CHECK_VALUE(logOdds.num_outer_lists() == grid->batchSize(),
                       "logOdds batch size mismatch");
-    TORCH_CHECK_TYPE(logOdds.is_floating_point(),
-                     "logOdds must be a floating-point dtype");
+    TORCH_CHECK_TYPE(logOdds.is_floating_point(), "logOdds must be a floating-point dtype");
     TORCH_CHECK_TYPE(points.scalar_type() == logOdds.scalar_type(),
                      "points dtype must match logOdds dtype");
     TORCH_CHECK_TYPE(sensorOrigins.scalar_type() == logOdds.scalar_type(),
                      "sensorOrigins dtype must match logOdds dtype");
     TORCH_CHECK_VALUE(logOdds.numel() == grid->totalVoxels(),
-                      "logOdds size (", logOdds.numel(),
-                      ") must equal grid totalVoxels (", grid->totalVoxels(), ")");
+                      "logOdds size (",
+                      logOdds.numel(),
+                      ") must equal grid totalVoxels (",
+                      grid->totalVoxels(),
+                      ")");
     TORCH_CHECK_VALUE(logOddsMax > logOddsMin,
-                      "logOddsMax (", logOddsMax,
+                      "logOddsMax (",
+                      logOddsMax,
                       ") must be strictly greater than logOddsMin (",
-                      logOddsMin, ")");
+                      logOddsMin,
+                      ")");
 }
 
 } // anonymous namespace
@@ -325,37 +323,38 @@ integrateOccupancyFromPoints(const c10::intrusive_ptr<GridBatchData> grid,
         return {grid, logOdds};
     }
 
-    auto unionGrid = buildUnionGrid(grid, points, truncationMargin);
-    auto newLogOdds = doIntegrateOccupancyFromPoints(
-        static_cast<float>(truncationMargin),
-        points, sensorOrigins,
-        *unionGrid, *grid,
-        logOdds,
-        static_cast<float>(logOddsHit),
-        static_cast<float>(logOddsMiss),
-        static_cast<float>(logOddsMin),
-        static_cast<float>(logOddsMax));
+    auto unionGrid  = buildUnionGrid(grid, points, truncationMargin);
+    auto newLogOdds = doIntegrateOccupancyFromPoints(static_cast<float>(truncationMargin),
+                                                     points,
+                                                     sensorOrigins,
+                                                     *unionGrid,
+                                                     *grid,
+                                                     logOdds,
+                                                     static_cast<float>(logOddsHit),
+                                                     static_cast<float>(logOddsMiss),
+                                                     static_cast<float>(logOddsMin),
+                                                     static_cast<float>(logOddsMax));
     return {unionGrid, newLogOdds};
 }
 
 std::tuple<c10::intrusive_ptr<GridBatchData>, JaggedTensor>
-integrateOccupancyFromPointsFrames(
-    const c10::intrusive_ptr<GridBatchData> grid,
-    const double truncationMargin,
-    const std::vector<torch::Tensor> &pointsPerFrame,
-    const torch::Tensor &sensorOrigins,
-    const JaggedTensor &logOdds,
-    const double logOddsHit,
-    const double logOddsMiss,
-    const double logOddsMin,
-    const double logOddsMax) {
+integrateOccupancyFromPointsFrames(const c10::intrusive_ptr<GridBatchData> grid,
+                                   const double truncationMargin,
+                                   const std::vector<torch::Tensor> &pointsPerFrame,
+                                   const torch::Tensor &sensorOrigins,
+                                   const JaggedTensor &logOdds,
+                                   const double logOddsHit,
+                                   const double logOddsMiss,
+                                   const double logOddsMin,
+                                   const double logOddsMax) {
     const int64_t N = static_cast<int64_t>(pointsPerFrame.size());
     TORCH_CHECK_VALUE(N > 0, "pointsPerFrame must have at least one frame");
-    TORCH_CHECK_VALUE(
-        sensorOrigins.dim() == 2 && sensorOrigins.size(0) == N &&
-            sensorOrigins.size(1) == 3,
-        "sensorOrigins must have shape [N=", N, ", 3]; got ",
-        sensorOrigins.sizes());
+    TORCH_CHECK_VALUE(sensorOrigins.dim() == 2 && sensorOrigins.size(0) == N &&
+                          sensorOrigins.size(1) == 3,
+                      "sensorOrigins must have shape [N=",
+                      N,
+                      ", 3]; got ",
+                      sensorOrigins.sizes());
     TORCH_CHECK_VALUE(grid->batchSize() == 1,
                       "integrateOccupancyFromPointsFrames supports "
                       "single-scene grids only (batchSize = 1); got ",
@@ -371,37 +370,40 @@ integrateOccupancyFromPointsFrames(
     // drop out of scope each iteration; the caching allocator
     // reclaims memory.
     c10::intrusive_ptr<GridBatchData> accumGrid = grid;
-    JaggedTensor accumLogOdds = logOdds;
+    JaggedTensor accumLogOdds                   = logOdds;
 
     for (int64_t i = 0; i < N; ++i) {
         const torch::Tensor &ptsTensor = pointsPerFrame[i];
         TORCH_CHECK_VALUE(ptsTensor.dim() == 2 && ptsTensor.size(1) == 3,
-                          "pointsPerFrame[", i, "] must be [N_i, 3]");
+                          "pointsPerFrame[",
+                          i,
+                          "] must be [N_i, 3]");
         TORCH_CHECK_VALUE(ptsTensor.device() == logOdds.device(),
-                          "pointsPerFrame[", i,
+                          "pointsPerFrame[",
+                          i,
                           "] must be on the same device as logOdds");
         TORCH_CHECK_TYPE(ptsTensor.scalar_type() == logOdds.scalar_type(),
-                         "pointsPerFrame[", i,
+                         "pointsPerFrame[",
+                         i,
                          "] dtype must match logOdds dtype");
 
-        JaggedTensor ptsJagged =
-            JaggedTensor(std::vector<torch::Tensor>{ptsTensor});
-        torch::Tensor originI = sensorOrigins.narrow(0, i, 1).contiguous();
+        JaggedTensor ptsJagged = JaggedTensor(std::vector<torch::Tensor>{ptsTensor});
+        torch::Tensor originI  = sensorOrigins.narrow(0, i, 1).contiguous();
 
-        auto unionGrid =
-            buildUnionGrid(accumGrid, ptsJagged, truncationMargin);
-        auto newLogOdds = doIntegrateOccupancyFromPoints(
-            static_cast<float>(truncationMargin),
-            ptsJagged, originI,
-            *unionGrid, *accumGrid,
-            accumLogOdds,
-            static_cast<float>(logOddsHit),
-            static_cast<float>(logOddsMiss),
-            static_cast<float>(logOddsMin),
-            static_cast<float>(logOddsMax));
+        auto unionGrid  = buildUnionGrid(accumGrid, ptsJagged, truncationMargin);
+        auto newLogOdds = doIntegrateOccupancyFromPoints(static_cast<float>(truncationMargin),
+                                                         ptsJagged,
+                                                         originI,
+                                                         *unionGrid,
+                                                         *accumGrid,
+                                                         accumLogOdds,
+                                                         static_cast<float>(logOddsHit),
+                                                         static_cast<float>(logOddsMiss),
+                                                         static_cast<float>(logOddsMin),
+                                                         static_cast<float>(logOddsMax));
 
-        accumGrid     = unionGrid;
-        accumLogOdds  = newLogOdds;
+        accumGrid    = unionGrid;
+        accumLogOdds = newLogOdds;
     }
 
     return {accumGrid, accumLogOdds};

--- a/src/fvdb/detail/ops/IntegrateOccupancyFromPoints.h
+++ b/src/fvdb/detail/ops/IntegrateOccupancyFromPoints.h
@@ -1,0 +1,114 @@
+// Copyright Contributors to the OpenVDB Project
+// SPDX-License-Identifier: Apache-2.0
+//
+#ifndef FVDB_DETAIL_OPS_INTEGRATEOCCUPANCYFROMPOINTS_H
+#define FVDB_DETAIL_OPS_INTEGRATEOCCUPANCYFROMPOINTS_H
+
+#include <fvdb/GridBatchData.h>
+#include <fvdb/JaggedTensor.h>
+
+#include <torch/types.h>
+
+#include <tuple>
+
+namespace fvdb {
+namespace detail {
+namespace ops {
+
+/// @brief Integrate a batch of LiDAR / range-sensor point clouds into
+///        a log-odds **occupancy** volume via per-point ray-walking.
+///
+/// Sister primitive to `integrateTSDFFromPoints`: same shell-allocator
+/// (buildPointTruncationShell -> mergeGrids) and same HDDA ray-walk
+/// pattern, but the per-voxel update is a Bayesian log-odds
+/// accumulation instead of the TSDF's running weighted-average.
+///
+/// For each ray origin -> endpoint:
+///   - Voxels within `truncationMargin` of the endpoint ("hit band")
+///     get `log_odds += logOddsHit` per ray that passes through them.
+///   - Voxels on the sensor-ray side of the endpoint ("free band")
+///     and within `truncationMargin` of the ray get
+///     `log_odds += logOddsMiss`.
+///   - Voxels beyond the endpoint by more than `truncationMargin`
+///     are "unknown" and left alone.
+///   - After all rays are processed, `log_odds` is clamped to
+///     `[logOddsMin, logOddsMax]`.
+///
+/// The stored value IS the log-odds. To get probability, apply a
+/// sigmoid host-side: `p = 1 / (1 + exp(-log_odds))`. Storing log-
+/// odds (rather than probabilities) is the standard choice because
+/// Bayesian updates compose as additions in log space and don't
+/// require per-update division.
+///
+/// Paper-framing: this is the paper's fifth application of the
+/// nanoVDB topology-op vocabulary (after depth TSDF, LiDAR TSDF, MC,
+/// ESDF). Same substrate (voxelsToGrid + mergeGrids + an HDDA ray-
+/// walk) with a different per-voxel update rule. Demonstrates the
+/// orthogonality claim: nvblox's `OCCUPANCY` vs `TSDF` integrator is
+/// a whole-different-allocator distinction; ours is a
+/// different-inner-loop distinction.
+///
+/// **Why ray-walking and not projective-per-pixel** (nvblox's default):
+/// nvblox's occupancy integrator projects voxels into the depth
+/// frame and updates based on (voxel_depth vs pixel_depth). We use
+/// the same ray-walk as our TSDF-from-points integrator instead, to
+/// keep the comparison with nvblox LiDAR honest (nvblox also walks
+/// rays for LiDAR input). The two yield equivalent probabilities
+/// modulo the LiDAR's discretisation-to-range-image step.
+///
+/// @param grid  The existing grid to integrate into. The output grid
+///              is the union of this and the truncation shell of the
+///              new points.
+/// @param truncationMargin  World-space distance defining the hit
+///                          band (voxels within this distance of the
+///                          endpoint are "hit"). Also drives the
+///                          shell allocator's dilation.
+/// @param points  JaggedTensor [B, N_i, 3] of world-space point
+///                positions.
+/// @param sensorOrigins  [B, 3] per-batch sensor origin in world
+///                       space.
+/// @param logOdds  JaggedTensor [totalVoxels, 1] — current log-odds
+///                 values on `grid`.
+/// @param logOddsHit  Increment per ray endpoint observation
+///                    (typical: +0.85).
+/// @param logOddsMiss  Increment per ray-pass-through observation
+///                     (typical: -0.40, negative).
+/// @param logOddsMin  Lower clamp bound (typical: -4.0).
+/// @param logOddsMax  Upper clamp bound (typical: +4.0).
+///
+/// @return (newGrid, newLogOdds) on the union grid.
+std::tuple<c10::intrusive_ptr<GridBatchData>, JaggedTensor>
+integrateOccupancyFromPoints(const c10::intrusive_ptr<GridBatchData> grid,
+                             const double truncationMargin,
+                             const JaggedTensor &points,
+                             const torch::Tensor &sensorOrigins,
+                             const JaggedTensor &logOdds,
+                             const double logOddsHit,
+                             const double logOddsMiss,
+                             const double logOddsMin,
+                             const double logOddsMax);
+
+/// @brief Batched version of `integrateOccupancyFromPoints`: integrate
+///        N LiDAR sweeps into a single persistent occupancy volume.
+///
+/// Mirrors `integrateTSDFFromPointsFrames` exactly but with log-odds
+/// updates instead of running-weighted-avg. The topology grows
+/// incrementally frame-by-frame; the final `(grid, logOdds)` is the
+/// union over all frames' truncation shells with the log-odds
+/// accumulated value.
+std::tuple<c10::intrusive_ptr<GridBatchData>, JaggedTensor>
+integrateOccupancyFromPointsFrames(const c10::intrusive_ptr<GridBatchData> grid,
+                                   const double truncationMargin,
+                                   const std::vector<torch::Tensor> &pointsPerFrame,
+                                   const torch::Tensor &sensorOrigins,
+                                   const JaggedTensor &logOdds,
+                                   const double logOddsHit,
+                                   const double logOddsMiss,
+                                   const double logOddsMin,
+                                   const double logOddsMax);
+
+} // namespace ops
+} // namespace detail
+} // namespace fvdb
+
+#endif // FVDB_DETAIL_OPS_INTEGRATEOCCUPANCYFROMPOINTS_H

--- a/src/fvdb/detail/ops/IntegrateTSDF.cu
+++ b/src/fvdb/detail/ops/IntegrateTSDF.cu
@@ -3,10 +3,10 @@
 //
 #include <fvdb/GridBatchData.h>
 #include <fvdb/JaggedTensor.h>
-#include <fvdb/detail/ops/BuildDilatedGrid.h>
-#include <fvdb/detail/ops/BuildGridFromPoints.h>
 #include <fvdb/detail/ops/BuildMergedGrids.h>
+#include <fvdb/detail/ops/BuildPointTruncationShell.h>
 #include <fvdb/detail/ops/IntegrateTSDF.h>
+#include <fvdb/detail/ops/PersistentTSDFState.h>
 #include <fvdb/detail/utils/AccessorHelpers.cuh>
 #include <fvdb/detail/utils/Utils.h>
 #include <fvdb/detail/utils/cuda/GridDim.h>
@@ -371,35 +371,19 @@ c10::intrusive_ptr<GridBatchData>
 buildPointGrid(const double truncationMargin,
                const torch::Tensor &unprojectedPoints,
                const GridBatchData &grid) {
-    std::vector<int64_t> numPadVoxels;
+    // Pack the [B, N, 3] contiguous-per-batch unprojected-points
+    // tensor into a JaggedTensor so we can hit the shared
+    // buildPointTruncationShell primitive that the LiDAR integrator
+    // also uses. Depth paths always produce equal-N per batch (N = H
+    // * W of the input depth image), so the packing is trivial.
     std::vector<torch::Tensor> jaggedPointsList;
-    for (auto i = 0; i < unprojectedPoints.size(0); ++i) {
+    jaggedPointsList.reserve(unprojectedPoints.size(0));
+    for (int64_t i = 0; i < unprojectedPoints.size(0); ++i) {
         jaggedPointsList.push_back(unprojectedPoints[i]);
-        const auto minVoxLengthI = grid.voxelSizeAt(i).min();
-        const auto numPadVoxelsI = static_cast<int32_t>(ceil(truncationMargin / minVoxLengthI));
-        TORCH_CHECK(numPadVoxelsI > 0,
-                    "Number of padding voxels must be non-negative, but got ",
-                    numPadVoxelsI);
-        constexpr int64_t MAX_PAD_VOXELS = 16;
-        TORCH_CHECK(numPadVoxelsI < MAX_PAD_VOXELS,
-                    "Truncation margin (",
-                    truncationMargin,
-                    ") is too large for grid with voxel size ",
-                    minVoxLengthI,
-                    ", resulting in too many padding voxels (",
-                    numPadVoxelsI,
-                    ") which cannot exceed ",
-                    MAX_PAD_VOXELS,
-                    ". Use a larger voxel size or a smaller truncation margin.");
-        numPadVoxels.push_back(numPadVoxelsI);
     }
     const JaggedTensor jaggedPoints(jaggedPointsList);
 
-    std::vector<nanovdb::Vec3d> voxelSizes;
-    std::vector<nanovdb::Vec3d> origins;
-    grid.gridVoxelSizesAndOrigins(voxelSizes, origins);
-    auto pointGrid = ops::buildGridFromPoints(jaggedPoints, voxelSizes, origins);
-    return ops::dilateGrid(*pointGrid, numPadVoxels);
+    return buildPointTruncationShell(jaggedPoints, grid, truncationMargin);
 }
 
 #define DISPATCH_FEATURE_TYPE(...)                                \
@@ -410,6 +394,283 @@ buildPointGrid(const double truncationMargin,
         using feature_t = scalar_t;                               \
         __VA_ARGS__();                                            \
     }
+
+// Shell-filtered integrate: two kernels that together do the same
+// work as `integrateTSDFKernel` but with a different decomposition.
+//
+//   1. `injectFromBaseKernel`: walks the BASE grid's leaves, looks each
+//      active voxel up in the union grid, and copies old tsdf /
+//      weight / features to its new position. Cheap per-thread work
+//      (no projection, no depth lookup), and the launch size is
+//      `baseGrid.totalLeaves() * 512` rather than `union.totalLeaves()
+//      * 512` -- so on late frames where union has accumulated
+//      carry-forward voxels that no longer correspond to any current
+//      observation, we only pay for the ones that actually need
+//      copying.
+//
+//   2. `integrateShellKernel`: walks the SHELL grid's leaves (i.e.
+//      the per-frame truncation-band voxels produced by
+//      `buildPointTruncationShell`), looks each active voxel up in
+//      the union grid, projects + frustum-checks + applies the TSDF
+//      blend. Reads the output buffer (already populated by inject
+//      for voxels that were in base) as the "old" value, so
+//      read-modify-write is stream-ordered correctly relative to
+//      inject.
+//
+// For a scene that's saturated the union grid, late-frame shell size
+// is much smaller than union size (typically ~25% at fine voxel sizes
+// on a real RGB-D capture after ~100 frames), so this is a real
+// asymptotic win over `integrateTSDFKernel`, which pays projection
+// and visibility-check cost on every union voxel every frame.
+//
+// The legacy single-kernel path (`integrateTSDFKernel`) is still
+// available as an ablation via `FVDB_FULL_UNION_INTEGRATE=1`.
+template <typename ScalarDataType, typename FeatureScalarDataType = ScalarDataType>
+__global__ __launch_bounds__(DEFAULT_BLOCK_DIM) void
+injectFromBaseKernel(
+    const bool hasFeatures,
+    const fvdb::BatchGridAccessor baseGridAcc,
+    const fvdb::BatchGridAccessor unionGridAcc,
+    const fvdb::JaggedRAcc64<ScalarDataType, 1> tsdfAcc,
+    const fvdb::JaggedRAcc64<ScalarDataType, 1> weightsAcc,
+    const fvdb::JaggedRAcc64<FeatureScalarDataType, 2> featuresAcc,
+    fvdb::TorchRAcc64<ScalarDataType, 1> outTsdfAcc,
+    fvdb::TorchRAcc64<ScalarDataType, 1> outWeightsAcc,
+    fvdb::TorchRAcc64<FeatureScalarDataType, 2> outFeaturesAcc) {
+    using GridT        = nanovdb::ValueOnIndex;
+    using LeafNodeType = nanovdb::NanoGrid<GridT>::LeafNodeType;
+    constexpr uint64_t VOXELS_PER_LEAF =
+        nanovdb::NanoTree<GridT>::LeafNodeType::NUM_VALUES;
+
+    const auto problemSize = baseGridAcc.totalLeaves() * VOXELS_PER_LEAF;
+    for (auto idx = blockIdx.x * blockDim.x + threadIdx.x;
+         idx < problemSize; idx += blockDim.x * gridDim.x) {
+        const int64_t cumBaseLeafIdx =
+            static_cast<int64_t>(idx / VOXELS_PER_LEAF);
+        const fvdb::JIdxType batchIdx =
+            baseGridAcc.leafBatchIndex(cumBaseLeafIdx);
+        const int64_t baseLeafIdx =
+            cumBaseLeafIdx - baseGridAcc.leafOffset(batchIdx);
+        const int64_t baseLeafVoxelIdx =
+            static_cast<int64_t>(idx - cumBaseLeafIdx * VOXELS_PER_LEAF);
+
+        const nanovdb::NanoGrid<GridT> *baseGrid =
+            baseGridAcc.grid(batchIdx);
+        const LeafNodeType &baseLeaf =
+            baseGrid->tree().template getFirstNode<0>()[baseLeafIdx];
+        const int64_t baseVoxelValue = static_cast<int64_t>(
+            baseLeaf.getValue(baseLeafVoxelIdx)) - 1;
+        if (baseVoxelValue < 0) continue;
+        const int64_t baseOffset = baseGridAcc.voxelOffset(batchIdx) +
+                                   baseVoxelValue;
+
+        // Look up this ijk in the union grid. Base is guaranteed to
+        // be a subset of union (union = merge(shell, base)), so the
+        // lookup always succeeds and yields an active voxel.
+        const nanovdb::Coord ijk =
+            baseLeaf.offsetToGlobalCoord(baseLeafVoxelIdx);
+        const nanovdb::NanoGrid<GridT> *unionGrid =
+            unionGridAcc.grid(batchIdx);
+        const auto unionAcc = unionGrid->getAccessor();
+        const int64_t unionOffset = unionGridAcc.voxelOffset(batchIdx) +
+            static_cast<int64_t>(unionAcc.getValue(ijk)) - 1;
+        if (unionOffset < 0) continue; // defensive; shouldn't happen
+
+        outTsdfAcc[unionOffset]    = tsdfAcc.data()[baseOffset];
+        outWeightsAcc[unionOffset] = weightsAcc.data()[baseOffset];
+        if (hasFeatures) {
+            for (int64_t i = 0; i < outFeaturesAcc.size(1); ++i) {
+                outFeaturesAcc[unionOffset][i] =
+                    featuresAcc.data()[baseOffset][i];
+            }
+        }
+    }
+}
+
+template <typename ScalarDataType, typename FeatureScalarDataType = ScalarDataType>
+__global__ __launch_bounds__(DEFAULT_BLOCK_DIM) void
+integrateShellKernel(
+    const ScalarDataType truncationMargin,
+    const int64_t imageWidth,
+    const int64_t imageHeight,
+    const bool hasFeatures,
+    const bool hasWeights,
+    const fvdb::TorchRAcc64<ScalarDataType, 3> projMats,
+    const fvdb::TorchRAcc64<ScalarDataType, 3> invProjMats,
+    const fvdb::TorchRAcc64<ScalarDataType, 3> worldToCamMats,
+    const fvdb::TorchRAcc64<ScalarDataType, 3> camToWorldMats,
+    const fvdb::TorchRAcc64<ScalarDataType, 3> depthImages,
+    const fvdb::TorchRAcc64<FeatureScalarDataType, 4> featureImages,
+    const fvdb::TorchRAcc64<ScalarDataType, 3> weightImages,
+    const fvdb::BatchGridAccessor shellGridAcc,
+    const fvdb::BatchGridAccessor unionGridAcc,
+    fvdb::TorchRAcc64<ScalarDataType, 1> outTsdfAcc,
+    fvdb::TorchRAcc64<ScalarDataType, 1> outWeightsAcc,
+    fvdb::TorchRAcc64<FeatureScalarDataType, 2> outFeaturesAcc) {
+    using ScalarType        = at::opmath_type<ScalarDataType>;
+    using FeatureScalarType = at::opmath_type<FeatureScalarDataType>;
+    using GridT        = nanovdb::ValueOnIndex;
+    using LeafNodeType = nanovdb::NanoGrid<GridT>::LeafNodeType;
+    using Vec3T        = nanovdb::math::Vec3<ScalarType>;
+    using Vec4T        = nanovdb::math::Vec4<ScalarType>;
+    using Mat3T        = nanovdb::math::Mat3<ScalarType>;
+    using Mat4T        = nanovdb::math::Mat4<ScalarType>;
+    constexpr uint64_t VOXELS_PER_LEAF =
+        nanovdb::NanoTree<GridT>::LeafNodeType::NUM_VALUES;
+
+    const auto batchSize = projMats.size(0);
+
+    // Identical shared-memory layout to `integrateTSDFKernel` so the
+    // host-side shared-size calculation can be shared.
+    extern __shared__ uint8_t sharedData[];
+    Mat3T *sharedProjMats       = reinterpret_cast<Mat3T *>(sharedData);
+    Mat4T *sharedWorldToCamMats = reinterpret_cast<Mat4T *>(
+        sharedData + batchSize * sizeof(Mat3T));
+    Mat3T *sharedInvProjMats =
+        reinterpret_cast<Mat3T *>(sharedData +
+                                  batchSize * (sizeof(Mat3T) + sizeof(Mat4T)));
+    Mat4T *sharedCamToWorldMats = reinterpret_cast<Mat4T *>(
+        sharedData + batchSize * (sizeof(Mat3T) + sizeof(Mat4T) +
+                                  sizeof(Mat3T)));
+
+    const auto sharedMat3x3NumElements = batchSize * 3 * 3;
+    const auto sharedMat4x4NumElements = batchSize * 4 * 4;
+    if (threadIdx.x < sharedMat3x3NumElements) {
+        const auto batchIdx = threadIdx.x / 9;
+        const auto rowIdx   = (threadIdx.x % 9) / 3;
+        const auto colIdx   = threadIdx.x % 3;
+        sharedProjMats[batchIdx][rowIdx][colIdx] =
+            ScalarType(projMats[batchIdx][rowIdx][colIdx]);
+    } else if (threadIdx.x < sharedMat3x3NumElements + sharedMat4x4NumElements) {
+        const auto baseIdx  = threadIdx.x - sharedMat3x3NumElements;
+        const auto batchIdx = baseIdx / 16;
+        const auto rowIdx   = (baseIdx % 16) / 4;
+        const auto colIdx   = baseIdx % 4;
+        sharedWorldToCamMats[batchIdx][rowIdx][colIdx] =
+            ScalarType(worldToCamMats[batchIdx][rowIdx][colIdx]);
+    } else if (threadIdx.x <
+               2 * sharedMat3x3NumElements + sharedMat4x4NumElements) {
+        const auto baseIdx  = threadIdx.x - sharedMat3x3NumElements -
+                              sharedMat4x4NumElements;
+        const auto batchIdx = baseIdx / 9;
+        const auto rowIdx   = (baseIdx % 9) / 3;
+        const auto colIdx   = baseIdx % 3;
+        sharedInvProjMats[batchIdx][rowIdx][colIdx] =
+            ScalarType(invProjMats[batchIdx][rowIdx][colIdx]);
+    }
+    __syncthreads();
+
+    // Parallelise over the SHELL's voxels (not the full union). The
+    // kernel loads matrices once per block and then only threads whose
+    // idx falls inside the shell's 512 * numLeaves range do real
+    // work; any thread whose idx is past the shell's total voxel
+    // count just exits.
+    const auto problemSize = shellGridAcc.totalLeaves() * VOXELS_PER_LEAF;
+    for (auto idx = blockIdx.x * blockDim.x + threadIdx.x;
+         idx < problemSize; idx += blockDim.x * gridDim.x) {
+        const int64_t cumShellLeafIdx =
+            static_cast<int64_t>(idx / VOXELS_PER_LEAF);
+        const fvdb::JIdxType batchIdx =
+            shellGridAcc.leafBatchIndex(cumShellLeafIdx);
+        const int64_t shellLeafIdx =
+            cumShellLeafIdx - shellGridAcc.leafOffset(batchIdx);
+        const int64_t shellLeafVoxelIdx = static_cast<int64_t>(
+            idx - cumShellLeafIdx * VOXELS_PER_LEAF);
+
+        const nanovdb::NanoGrid<GridT> *shellGrid =
+            shellGridAcc.grid(batchIdx);
+        const LeafNodeType &shellLeaf =
+            shellGrid->tree().template getFirstNode<0>()[shellLeafIdx];
+        // Shell leaves can have inactive slots (nanoVDB leaf nodes
+        // are fixed 8^3, but only some slots are active).
+        const int64_t shellVoxelValue = static_cast<int64_t>(
+            shellLeaf.getValue(shellLeafVoxelIdx)) - 1;
+        if (shellVoxelValue < 0) continue;
+
+        const nanovdb::Coord ijk =
+            shellLeaf.offsetToGlobalCoord(shellLeafVoxelIdx);
+        const nanovdb::NanoGrid<GridT> *unionGrid =
+            unionGridAcc.grid(batchIdx);
+        const auto unionAcc = unionGrid->getAccessor();
+        const int64_t unionOffset = unionGridAcc.voxelOffset(batchIdx) +
+            static_cast<int64_t>(unionAcc.getValue(ijk)) - 1;
+        if (unionOffset < 0) continue;
+
+        // Project voxel to screen, frustum-check, apply TSDF blend.
+        const Vec3T voxelWorldPos = unionGridAcc.primalTransform(batchIdx)
+            .applyInv<ScalarType>(
+                ScalarType(ijk[0]), ScalarType(ijk[1]), ScalarType(ijk[2]));
+        const Vec4T voxelWorldPosHomogeneous = {
+            voxelWorldPos[0], voxelWorldPos[1], voxelWorldPos[2],
+            ScalarType(1.0)};
+        const Vec4T voxelPosCamSpace =
+            sharedWorldToCamMats[batchIdx] * voxelWorldPosHomogeneous;
+        const Vec3T voxelPosCamSpace3d = {
+            voxelPosCamSpace[0] / voxelPosCamSpace[3],
+            voxelPosCamSpace[1] / voxelPosCamSpace[3],
+            voxelPosCamSpace[2] / voxelPosCamSpace[3]};
+        const Vec3T voxelPosProjSpace =
+            sharedProjMats[batchIdx] * voxelPosCamSpace3d;
+        const Vec3T voxelPosScreenSpace = {
+            voxelPosProjSpace[0] / voxelPosProjSpace[2],
+            voxelPosProjSpace[1] / voxelPosProjSpace[2],
+            ScalarType(1.0)};
+        const int64_t voxelPosScreenSpaceX =
+            int64_t(voxelPosScreenSpace[0]);
+        const int64_t voxelPosScreenSpaceY =
+            int64_t(voxelPosScreenSpace[1]);
+
+        const bool voxelIsVisible =
+            (voxelPosScreenSpaceX >= 0 && voxelPosScreenSpaceX < imageWidth &&
+             voxelPosScreenSpaceY >= 0 && voxelPosScreenSpaceY < imageHeight &&
+             voxelPosCamSpace3d[2] > 0.0f);
+        // Not visible -> the inject pass has already carried the old
+        // value forward (or left the slot at zero for shell-only
+        // voxels, which is the correct initial state).
+        if (!voxelIsVisible) continue;
+
+        const ScalarType pixelDepth = ScalarType(
+            depthImages[batchIdx][voxelPosScreenSpaceY][voxelPosScreenSpaceX]);
+        const ScalarType zDiff = pixelDepth - voxelPosCamSpace3d[2];
+        if (zDiff <= -ScalarType(truncationMargin)) continue;
+
+        const ScalarType pixelWeight = [&]() {
+            if (hasWeights) {
+                return ScalarType(weightImages[batchIdx][voxelPosScreenSpaceY]
+                                             [voxelPosScreenSpaceX]);
+            } else {
+                return ScalarType{1};
+            }
+        }();
+        if (pixelWeight <= ScalarType(0)) continue;
+
+        const ScalarType tsdf = nanovdb::math::Min(
+            ScalarType(1), zDiff / ScalarType(truncationMargin));
+        // Read-modify-write: the old value was either written by the
+        // inject pass (for voxels in base) or is zero (for shell-only
+        // voxels, torch::zeros initialisation). Stream ordering
+        // guarantees inject completes before this kernel launches.
+        const ScalarType oldWeight   = ScalarType(outWeightsAcc[unionOffset]);
+        const ScalarType oldTsdf     = ScalarType(outTsdfAcc[unionOffset]);
+        const ScalarType newWeight   = oldWeight + pixelWeight;
+        const ScalarType newTsdf     =
+            (oldWeight * oldTsdf + pixelWeight * tsdf) / newWeight;
+        outTsdfAcc[unionOffset]    = ScalarDataType(newTsdf);
+        outWeightsAcc[unionOffset] = ScalarDataType(newWeight);
+        if (hasFeatures) {
+            for (int64_t i = 0; i < outFeaturesAcc.size(1); ++i) {
+                const ScalarType pixelFeatureI = ScalarType(
+                    featureImages[batchIdx][voxelPosScreenSpaceY]
+                                [voxelPosScreenSpaceX][i]);
+                const ScalarType oldFeatureI =
+                    ScalarType(outFeaturesAcc[unionOffset][i]);
+                outFeaturesAcc[unionOffset][i] = FeatureScalarDataType(
+                    (oldWeight * oldFeatureI + pixelWeight * pixelFeatureI) /
+                    newWeight);
+            }
+        }
+    }
+}
 
 std::tuple<JaggedTensor, JaggedTensor, JaggedTensor>
 doIntegrate(const float truncationMargin,
@@ -422,6 +683,7 @@ doIntegrate(const float truncationMargin,
             const torch::Tensor &worldToCamMatrices,
             const GridBatchData &unionGrid,
             const GridBatchData &baseGrid,
+            const GridBatchData &shellGrid,
             const JaggedTensor &tsdf,
             const JaggedTensor &weights,
             const JaggedTensor &features) {
@@ -435,26 +697,105 @@ doIntegrate(const float truncationMargin,
     const bool hasFeatures       = featureDim > 0;
     const bool hasWeights        = weightImages.size(0) > 0;
 
-    torch::Tensor outWeights = torch::zeros({totalOutVoxels}, weights.jdata().options());
-    torch::Tensor outTsdf    = torch::zeros({totalOutVoxels}, tsdf.jdata().options());
+    // Output tensors are zero-initialised. The shell-filtered integrate
+    // kernel has three "continue" branches (voxel not visible, zDiff
+    // behind surface, pixelWeight == 0) where it silently leaves the
+    // output slot unwritten; for shell voxels NOT in the base grid we
+    // need that slot to read as 0 rather than as uninitialised memory,
+    // otherwise downstream consumers see |tsdf| > 1 garbage.
+    torch::Tensor outWeights =
+        torch::zeros({totalOutVoxels}, weights.jdata().options());
+    torch::Tensor outTsdf =
+        torch::zeros({totalOutVoxels}, tsdf.jdata().options());
     torch::Tensor outFeatures =
-        torch::empty({totalOutVoxels, featureDim}, features.jdata().options());
+        torch::zeros({totalOutVoxels, featureDim},
+                     features.jdata().options());
 
+    // `FVDB_FULL_UNION_INTEGRATE=1` opts into the legacy single-kernel
+    // path that walks every union voxel and does either copy-forward
+    // or integrate per-thread. Default is the two-pass
+    // inject + shell-filtered integrate path above.
+    const bool force_legacy_integrate = [&]() {
+        const char *env = std::getenv("FVDB_FULL_UNION_INTEGRATE");
+        return env != nullptr && env[0] == '1';
+    }();
+
+    if (force_legacy_integrate) {
+        AT_DISPATCH_V2(
+            tsdf.scalar_type(),
+            "integrateTSDFKernel",
+            AT_WRAP([&]() {
+                using shared_scalar_t              = at::opmath_type<scalar_t>;
+                using SharedMat3T                  = nanovdb::math::Mat3<shared_scalar_t>;
+                using SharedMat4T                  = nanovdb::math::Mat4<shared_scalar_t>;
+                constexpr uint64_t VOXELS_PER_LEAF = nanovdb::OnIndexTree::LeafNodeType::NUM_VALUES;
+                const auto numUnionLeaves          = unionGrid.totalLeaves();
+                const auto numSharedScalars        = 2 * batchSize * 3 * 3 + 2 * batchSize * 4 * 4;
+                const auto problemSize =
+                    std::max(numUnionLeaves * VOXELS_PER_LEAF, uint64_t(numSharedScalars));
+                const auto sharedMemSize =
+                    2 * batchSize * sizeof(SharedMat3T) + 2 * batchSize * sizeof(SharedMat4T);
+                const auto numBlocks = GET_BLOCKS(problemSize, DEFAULT_BLOCK_DIM);
+
+                const auto dtype                = tsdf.scalar_type();
+                const auto projMatsCasted       = projectionMatrices.to(dtype);
+                const auto invProjMatsCasted    = invProjectionMatrices.to(dtype);
+                const auto camToWorldMatsCasted = camToWorldMatrices.to(dtype);
+                const auto worldToCamMatsCasted = worldToCamMatrices.to(dtype);
+
+                at::cuda::CUDAStream stream = at::cuda::getCurrentCUDAStream(tsdf.device().index());
+
+                if (cudaFuncSetAttribute(integrateTSDFKernel<scalar_t>,
+                                         cudaFuncAttributeMaxDynamicSharedMemorySize,
+                                         sharedMemSize) != cudaSuccess) {
+                    AT_ERROR("Failed to set maximum shared memory size (requested ",
+                             sharedMemSize,
+                             " bytes), try lowering tile_size.");
+                }
+
+                DISPATCH_FEATURE_TYPE([&]() {
+                    integrateTSDFKernel<<<numBlocks, DEFAULT_BLOCK_DIM, sharedMemSize, stream>>>(
+                        scalar_t(truncationMargin),
+                        imageWidth,
+                        imageHeight,
+                        hasFeatures,
+                        hasWeights,
+                        projMatsCasted.packed_accessor64<scalar_t, 3, torch::RestrictPtrTraits>(),
+                        invProjMatsCasted.packed_accessor64<scalar_t, 3, torch::RestrictPtrTraits>(),
+                        worldToCamMatsCasted.packed_accessor64<scalar_t, 3, torch::RestrictPtrTraits>(),
+                        camToWorldMatsCasted.packed_accessor64<scalar_t, 3, torch::RestrictPtrTraits>(),
+                        depthImages.packed_accessor64<scalar_t, 3, torch::RestrictPtrTraits>(),
+                        featureImages.packed_accessor64<feature_t, 4, torch::RestrictPtrTraits>(),
+                        weightImages.packed_accessor64<scalar_t, 3, torch::RestrictPtrTraits>(),
+                        baseGrid.deviceAccessor(),
+                        unionGrid.deviceAccessor(),
+                        tsdf.packed_accessor64<scalar_t, 1, torch::RestrictPtrTraits>(),
+                        weights.packed_accessor64<scalar_t, 1, torch::RestrictPtrTraits>(),
+                        features.packed_accessor64<feature_t, 2, torch::RestrictPtrTraits>(),
+                        outTsdf.packed_accessor64<scalar_t, 1, torch::RestrictPtrTraits>(),
+                        outWeights.packed_accessor64<scalar_t, 1, torch::RestrictPtrTraits>(),
+                        outFeatures.packed_accessor64<feature_t, 2, torch::RestrictPtrTraits>());
+                });
+                C10_CUDA_KERNEL_LAUNCH_CHECK();
+            }),
+            AT_EXPAND(AT_FLOATING_TYPES),
+            c10::kHalf);
+        return {unionGrid.jaggedTensor(outTsdf),
+                unionGrid.jaggedTensor(outWeights),
+                unionGrid.jaggedTensor(outFeatures)};
+    }
+
+    // Default: two-pass shell-filtered integrate.
     AT_DISPATCH_V2(
         tsdf.scalar_type(),
-        "integrateTSDFKernel",
+        "integrateTSDFShellFiltered",
         AT_WRAP([&]() {
             using shared_scalar_t              = at::opmath_type<scalar_t>;
             using SharedMat3T                  = nanovdb::math::Mat3<shared_scalar_t>;
             using SharedMat4T                  = nanovdb::math::Mat4<shared_scalar_t>;
             constexpr uint64_t VOXELS_PER_LEAF = nanovdb::OnIndexTree::LeafNodeType::NUM_VALUES;
-            const auto numUnionLeaves          = unionGrid.totalLeaves();
-            const auto numSharedScalars        = 2 * batchSize * 3 * 3 + 2 * batchSize * 4 * 4;
-            const auto problemSize =
-                std::max(numUnionLeaves * VOXELS_PER_LEAF, uint64_t(numSharedScalars));
             const auto sharedMemSize =
                 2 * batchSize * sizeof(SharedMat3T) + 2 * batchSize * sizeof(SharedMat4T);
-            const auto numBlocks = GET_BLOCKS(problemSize, DEFAULT_BLOCK_DIM);
 
             const auto dtype                = tsdf.scalar_type();
             const auto projMatsCasted       = projectionMatrices.to(dtype);
@@ -462,21 +803,57 @@ doIntegrate(const float truncationMargin,
             const auto camToWorldMatsCasted = camToWorldMatrices.to(dtype);
             const auto worldToCamMatsCasted = worldToCamMatrices.to(dtype);
 
-            at::cuda::CUDAStream stream = at::cuda::getCurrentCUDAStream(tsdf.device().index());
+            at::cuda::CUDAStream stream =
+                at::cuda::getCurrentCUDAStream(tsdf.device().index());
 
-            if (cudaFuncSetAttribute(integrateTSDFKernel<scalar_t>,
-                                     cudaFuncAttributeMaxDynamicSharedMemorySize,
-                                     sharedMemSize) != cudaSuccess) {
-                AT_ERROR("Failed to set maximum shared memory size (requested ",
-                         sharedMemSize,
-                         " bytes), try lowering tile_size.");
-            }
-
-            // Special case for uint8 features
-            // We don't need to do anything special here, but we need to ensure that the
-            // kernel is called with the correct scalar type.
             DISPATCH_FEATURE_TYPE([&]() {
-                integrateTSDFKernel<<<numBlocks, DEFAULT_BLOCK_DIM, sharedMemSize, stream>>>(
+                // Pass 1: inject old tsdf / weight / features from base
+                // grid to their new positions in union. Skipped when
+                // baseGrid is empty (first frame) since there's nothing
+                // to carry forward.
+                const auto numBaseLeaves = baseGrid.totalLeaves();
+                if (numBaseLeaves > 0) {
+                    const auto injectProblemSize =
+                        numBaseLeaves * VOXELS_PER_LEAF;
+                    const auto injectBlocks =
+                        GET_BLOCKS(injectProblemSize, DEFAULT_BLOCK_DIM);
+                    injectFromBaseKernel<<<injectBlocks, DEFAULT_BLOCK_DIM,
+                                          0, stream>>>(
+                        hasFeatures,
+                        baseGrid.deviceAccessor(),
+                        unionGrid.deviceAccessor(),
+                        tsdf.packed_accessor64<scalar_t, 1, torch::RestrictPtrTraits>(),
+                        weights.packed_accessor64<scalar_t, 1, torch::RestrictPtrTraits>(),
+                        features.packed_accessor64<feature_t, 2, torch::RestrictPtrTraits>(),
+                        outTsdf.packed_accessor64<scalar_t, 1, torch::RestrictPtrTraits>(),
+                        outWeights.packed_accessor64<scalar_t, 1, torch::RestrictPtrTraits>(),
+                        outFeatures.packed_accessor64<feature_t, 2, torch::RestrictPtrTraits>());
+                    C10_CUDA_KERNEL_LAUNCH_CHECK();
+                }
+
+                // Pass 2: apply this frame's depth observations to the
+                // shell's voxels. Stream ordering guarantees the inject
+                // above has completed before we enter the read-modify-
+                // write below.
+                const auto numShellLeaves = shellGrid.totalLeaves();
+                const auto numSharedScalars =
+                    2 * batchSize * 3 * 3 + 2 * batchSize * 4 * 4;
+                const auto integrateProblemSize = std::max(
+                    numShellLeaves * VOXELS_PER_LEAF,
+                    uint64_t(numSharedScalars));
+                const auto integrateBlocks =
+                    GET_BLOCKS(integrateProblemSize, DEFAULT_BLOCK_DIM);
+
+                if (cudaFuncSetAttribute(
+                        integrateShellKernel<scalar_t, feature_t>,
+                        cudaFuncAttributeMaxDynamicSharedMemorySize,
+                        sharedMemSize) != cudaSuccess) {
+                    AT_ERROR("Failed to set maximum shared memory size (requested ",
+                             sharedMemSize, " bytes), try lowering tile_size.");
+                }
+
+                integrateShellKernel<<<integrateBlocks, DEFAULT_BLOCK_DIM,
+                                       sharedMemSize, stream>>>(
                     scalar_t(truncationMargin),
                     imageWidth,
                     imageHeight,
@@ -489,16 +866,13 @@ doIntegrate(const float truncationMargin,
                     depthImages.packed_accessor64<scalar_t, 3, torch::RestrictPtrTraits>(),
                     featureImages.packed_accessor64<feature_t, 4, torch::RestrictPtrTraits>(),
                     weightImages.packed_accessor64<scalar_t, 3, torch::RestrictPtrTraits>(),
-                    baseGrid.deviceAccessor(),
+                    shellGrid.deviceAccessor(),
                     unionGrid.deviceAccessor(),
-                    tsdf.packed_accessor64<scalar_t, 1, torch::RestrictPtrTraits>(),
-                    weights.packed_accessor64<scalar_t, 1, torch::RestrictPtrTraits>(),
-                    features.packed_accessor64<feature_t, 2, torch::RestrictPtrTraits>(),
                     outTsdf.packed_accessor64<scalar_t, 1, torch::RestrictPtrTraits>(),
                     outWeights.packed_accessor64<scalar_t, 1, torch::RestrictPtrTraits>(),
                     outFeatures.packed_accessor64<feature_t, 2, torch::RestrictPtrTraits>());
+                C10_CUDA_KERNEL_LAUNCH_CHECK();
             });
-            C10_CUDA_KERNEL_LAUNCH_CHECK();
         }),
         AT_EXPAND(AT_FLOATING_TYPES),
         c10::kHalf);
@@ -506,6 +880,118 @@ doIntegrate(const float truncationMargin,
     return {unionGrid.jaggedTensor(outTsdf),
             unionGrid.jaggedTensor(outWeights),
             unionGrid.jaggedTensor(outFeatures)};
+}
+
+/// @brief Run `integrateShellKernel` in place against caller-owned
+///        sidecar tensors (tsdf / weights / features) whose layout
+///        already matches `liveGrid`. This is the kernel-dispatch
+///        path used by `integrateTSDFBatchImpl`:
+///        `PersistentTSDFState::growFromGrid` has already reallocated
+///        + injected the sidecars (or no-op'd on overlap-only shell),
+///        so the kernel only needs to read-modify-write the shell's
+///        voxels. No alloc, no inject-pass.
+///
+/// Semantics: identical to `doIntegrate(..., unionGrid=liveGrid,
+/// baseGrid=<any-empty-grid>, shellGrid=shellGrid, ...)` except we
+/// skip the zero-init + injectFromBaseKernel path since those are
+/// no-ops when (a) the output tensors already hold the current
+/// accumulator values (post-grow), and (b) the kernel only writes
+/// to shell voxels. The legacy `FVDB_FULL_UNION_INTEGRATE=1`
+/// ablation is unreachable here -- that path is only exercised via
+/// `integrateTSDFImpl` single-frame.
+void
+doIntegrateShellInPlace(const float truncationMargin,
+                        const torch::Tensor &depthImages,
+                        const torch::Tensor &featureImages,
+                        const torch::Tensor &weightImages,
+                        const torch::Tensor &projectionMatrices,
+                        const torch::Tensor &invProjectionMatrices,
+                        const torch::Tensor &camToWorldMatrices,
+                        const torch::Tensor &worldToCamMatrices,
+                        const GridBatchData &liveGrid,
+                        const GridBatchData &shellGrid,
+                        torch::Tensor &tsdf,
+                        torch::Tensor &weights,
+                        torch::Tensor &features) {
+    const c10::cuda::CUDAGuard device_guard(tsdf.device());
+
+    const int64_t batchSize   = depthImages.size(0);
+    const int64_t imageHeight = depthImages.size(1);
+    const int64_t imageWidth  = depthImages.size(2);
+    const int64_t featureDim  = features.size(-1);
+    const bool hasFeatures    = featureDim > 0;
+    const bool hasWeights     = weightImages.size(0) > 0;
+
+    AT_DISPATCH_V2(
+        tsdf.scalar_type(),
+        "integrateTSDFShellInPlace",
+        AT_WRAP([&]() {
+            using shared_scalar_t              = at::opmath_type<scalar_t>;
+            using SharedMat3T                  = nanovdb::math::Mat3<shared_scalar_t>;
+            using SharedMat4T                  = nanovdb::math::Mat4<shared_scalar_t>;
+            constexpr uint64_t VOXELS_PER_LEAF = nanovdb::OnIndexTree::LeafNodeType::NUM_VALUES;
+            const auto sharedMemSize =
+                2 * batchSize * sizeof(SharedMat3T) + 2 * batchSize * sizeof(SharedMat4T);
+
+            const auto dtype                = tsdf.scalar_type();
+            const auto projMatsCasted       = projectionMatrices.to(dtype);
+            const auto invProjMatsCasted    = invProjectionMatrices.to(dtype);
+            const auto camToWorldMatsCasted = camToWorldMatrices.to(dtype);
+            const auto worldToCamMatsCasted = worldToCamMatrices.to(dtype);
+
+            at::cuda::CUDAStream stream =
+                at::cuda::getCurrentCUDAStream(tsdf.device().index());
+
+            DISPATCH_FEATURE_TYPE([&]() {
+                const auto numShellLeaves = shellGrid.totalLeaves();
+                const auto numSharedScalars =
+                    2 * batchSize * 3 * 3 + 2 * batchSize * 4 * 4;
+                const auto integrateProblemSize = std::max(
+                    numShellLeaves * VOXELS_PER_LEAF,
+                    uint64_t(numSharedScalars));
+                const auto integrateBlocks =
+                    GET_BLOCKS(integrateProblemSize, DEFAULT_BLOCK_DIM);
+
+                if (cudaFuncSetAttribute(
+                        integrateShellKernel<scalar_t, feature_t>,
+                        cudaFuncAttributeMaxDynamicSharedMemorySize,
+                        sharedMemSize) != cudaSuccess) {
+                    AT_ERROR("Failed to set maximum shared memory size (requested ",
+                             sharedMemSize, " bytes), try lowering tile_size.");
+                }
+
+                // `integrateShellKernel` reads-modifies-writes
+                // `outTsdf / outWeights / outFeatures`, and here we
+                // pass the state tensors as both input and output.
+                // That's correct: for each shell voxel the kernel
+                // reads the current (accumulated) (tsdf, weight)
+                // value, computes the new weighted average with this
+                // frame's depth observation, and writes the result
+                // back -- a classic in-place running-mean update.
+                integrateShellKernel<<<integrateBlocks, DEFAULT_BLOCK_DIM,
+                                       sharedMemSize, stream>>>(
+                    scalar_t(truncationMargin),
+                    imageWidth,
+                    imageHeight,
+                    hasFeatures,
+                    hasWeights,
+                    projMatsCasted.packed_accessor64<scalar_t, 3, torch::RestrictPtrTraits>(),
+                    invProjMatsCasted.packed_accessor64<scalar_t, 3, torch::RestrictPtrTraits>(),
+                    worldToCamMatsCasted.packed_accessor64<scalar_t, 3, torch::RestrictPtrTraits>(),
+                    camToWorldMatsCasted.packed_accessor64<scalar_t, 3, torch::RestrictPtrTraits>(),
+                    depthImages.packed_accessor64<scalar_t, 3, torch::RestrictPtrTraits>(),
+                    featureImages.packed_accessor64<feature_t, 4, torch::RestrictPtrTraits>(),
+                    weightImages.packed_accessor64<scalar_t, 3, torch::RestrictPtrTraits>(),
+                    shellGrid.deviceAccessor(),
+                    liveGrid.deviceAccessor(),
+                    tsdf.packed_accessor64<scalar_t, 1, torch::RestrictPtrTraits>(),
+                    weights.packed_accessor64<scalar_t, 1, torch::RestrictPtrTraits>(),
+                    features.packed_accessor64<feature_t, 2, torch::RestrictPtrTraits>());
+                C10_CUDA_KERNEL_LAUNCH_CHECK();
+            });
+        }),
+        AT_EXPAND(AT_FLOATING_TYPES),
+        c10::kHalf);
 }
 
 std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>
@@ -825,6 +1311,24 @@ integrateTSDFImpl(const c10::intrusive_ptr<GridBatchData> grid,
                     projectionMatrices,
                     camToWorldMatrices);
 
+    // `FVDB_TSDF_PHASE_PROFILE=1` enables per-step CUDA-event timing of
+    // the integrate pipeline. Rows are printed to stderr as a CSV so
+    // they can be aggregated across frames by a wrapping script:
+    //   [fvdb/tsdf_phase] unproject=X ms  shell=Y ms  merge=Z ms
+    //   integrate=W ms  total=T ms  old_voxels=K  new_voxels=M
+    // This is invaluable for decomposing the fvdb_leaf vs fvdb_voxel
+    // ~15x slowdown (see session journal entry on voxel-shell tuning).
+    const bool phaseProfile =
+        std::getenv("FVDB_TSDF_PHASE_PROFILE") != nullptr;
+    cudaEvent_t evA{}, evB{}, evC{}, evD{}, evE{};
+    auto phaseMark = [&](cudaEvent_t &ev) {
+        if (phaseProfile) {
+            cudaEventCreate(&ev);
+            cudaEventRecord(ev);
+        }
+    };
+    phaseMark(evA);
+
     // If you passed in depth images with a channel dimension, squeeze it out
     const torch::Tensor squeezedDepthImages =
         depthImages.dim() == 4 ? depthImages.squeeze(-1) : depthImages;
@@ -835,13 +1339,33 @@ integrateTSDFImpl(const c10::intrusive_ptr<GridBatchData> grid,
     const auto [projectionMats, invProjectionMats, camToWorldMats, worldToCamMats] =
         getCameraMatrices(projectionMatrices, camToWorldMatrices);
 
-    // Step 1: Unproject the depth maps to 3D pointsauto
-    const torch::Tensor unprojectedPoints = unprojectDepthMapToPoints(
+    // Step 1: Unproject the depth maps to 3D points.
+    //
+    // For fp16 inputs we promote the unprojected point cloud to fp32
+    // before handing it to `buildPointGrid` because `pointsToIjk`
+    // quantises in the caller's dtype -- and fp16 at room-scale
+    // magnitudes (5-15 m) has ~0.3-1 mm ULP, which at 5 mm voxels is a
+    // nontrivial fraction of a voxel. In practice this was producing
+    // 5-20% *more* active voxels for fp16 workloads than fp32
+    // (different boundary points rounded to different voxels),
+    // partially cancelling the fp16 sidecar memory win. Promoting the
+    // ~H*W points to fp32 for the one-shot quantisation adds a few MB
+    // of transient memory and no measurable wall time; keeping the
+    // sidecar tensors (tsdf / weight / features) in fp16 retains the
+    // ~2x GB savings that motivated the fp16 path in the first place.
+    const torch::Tensor unprojectedPointsNative = unprojectDepthMapToPoints(
         squeezedDepthImages, projectionMats, invProjectionMats, camToWorldMats);
+    const torch::Tensor unprojectedPoints =
+        unprojectedPointsNative.scalar_type() == torch::kHalf
+            ? unprojectedPointsNative.to(torch::kFloat32)
+            : unprojectedPointsNative;
+    phaseMark(evB);
 
     // Step 2: Build union grid grid from unprojected points and merge into with the old grid
     const auto pointGrid = buildPointGrid(truncationMargin, unprojectedPoints, *grid);
+    phaseMark(evC);
     const auto unionGrid = ops::mergeGrids(*pointGrid, *grid);
+    phaseMark(evD);
 
     // Features are optional. If you don't pass them in, we will use placeholder values which are
     // just empty tensors.
@@ -865,7 +1389,15 @@ integrateTSDFImpl(const c10::intrusive_ptr<GridBatchData> grid,
                                        : torch::empty({0, 0, 0}, squeezedDepthImages.options());
     const auto weightImagesSqueezed =
         weightImagesValue.dim() == 4 ? weightImagesValue.squeeze(-1) : weightImagesValue;
-    // Step 3: Integrate weights, tsdf values, and feautures into the output tensor
+    // Step 3: Integrate weights, tsdf values, and features into the
+    // output tensor. We pass three grids:
+    //   - unionGrid: where output sidecars are indexed (size = total
+    //     active voxels after this frame's shell has been merged in).
+    //   - grid (base): the old accumulated grid, used for
+    //     carrying-forward previously-integrated tsdf/weight.
+    //   - pointGrid (shell): this frame's truncation-band voxels, which
+    //     is the set the integrate kernel actually needs to update
+    //     (everything else just needs a copy-forward).
     const auto [outTsdf, outWeights, outFeatures] = doIntegrate(truncationMargin,
                                                                 squeezedDepthImages,
                                                                 featureImagesValue,
@@ -876,9 +1408,34 @@ integrateTSDFImpl(const c10::intrusive_ptr<GridBatchData> grid,
                                                                 worldToCamMats,
                                                                 *unionGrid,
                                                                 *grid,
+                                                                *pointGrid,
                                                                 tsdf,
                                                                 weights,
                                                                 featuresValue);
+    phaseMark(evE);
+    if (phaseProfile) {
+        cudaEventSynchronize(evE);
+        float t_unproj = 0.f, t_shell = 0.f, t_merge = 0.f, t_integ = 0.f;
+        cudaEventElapsedTime(&t_unproj, evA, evB);
+        cudaEventElapsedTime(&t_shell, evB, evC);
+        cudaEventElapsedTime(&t_merge, evC, evD);
+        cudaEventElapsedTime(&t_integ, evD, evE);
+        std::fprintf(
+            stderr,
+            "[fvdb/tsdf_phase] unproject=%.3f ms  shell=%.3f ms  "
+            "merge=%.3f ms  integrate=%.3f ms  total=%.3f ms  "
+            "old_vox=%lld  union_vox=%lld  point_vox=%lld\n",
+            t_unproj, t_shell, t_merge, t_integ,
+            t_unproj + t_shell + t_merge + t_integ,
+            (long long)grid->totalVoxels(),
+            (long long)unionGrid->totalVoxels(),
+            (long long)pointGrid->totalVoxels());
+        cudaEventDestroy(evA);
+        cudaEventDestroy(evB);
+        cudaEventDestroy(evC);
+        cudaEventDestroy(evD);
+        cudaEventDestroy(evE);
+    }
 
     return {unionGrid, outTsdf, outWeights, outFeatures};
 }
@@ -930,6 +1487,270 @@ integrateTSDFWithFeatures(const c10::intrusive_ptr<GridBatchData> grid,
                              depthImages,
                              featureImages,
                              weightImages);
+}
+
+// -------------------------------------------------------------------------
+// Batched depth-image TSDF integration.
+//
+// Builds the full union-grid topology ONCE over all N frames, then runs
+// N sequential calls to the existing `doIntegrate` kernel against that
+// fixed topology. Semantically equivalent to calling `integrateTSDF` N
+// times (verified bit-identically in the unit test).
+//
+// The per-frame path pays O(pixels + unionVoxels) of topology rebuild
+// every call; the batched path does one topology build over
+// N * pixels points, then N kernel launches — so the perf win is
+// (N - 1) * (topology_build_ms + merge_ms) per N-frame batch.
+// -------------------------------------------------------------------------
+
+namespace {
+
+// Implementation note: an alternative one-shot topology build was
+// considered for the batched path -- unproject ALL N frames at once
+// and build a single union grid -- but it allocates an
+// O(N * pixels) point buffer that is dominated by free-space rays
+// at typical fine voxel sizes and high frame counts, and pays a
+// union-grid-sized integrate loop on every frame. The incremental
+// per-frame loop used by `integrateTSDFBatchImpl` below has the
+// same final topology while keeping intermediate working-set size
+// bounded.
+
+std::tuple<c10::intrusive_ptr<GridBatchData>, JaggedTensor, JaggedTensor, JaggedTensor>
+integrateTSDFBatchImpl(const c10::intrusive_ptr<GridBatchData> grid,
+                      const double truncationMargin,
+                      const torch::Tensor &projectionMatrices,
+                      const torch::Tensor &camToWorldMatrices,
+                      const JaggedTensor &tsdf,
+                      const JaggedTensor &weights,
+                      const std::optional<JaggedTensor> &features,
+                      const torch::Tensor &depthImages,
+                      const std::optional<torch::Tensor> &featureImages,
+                      const std::optional<torch::Tensor> &weightImages) {
+    const at::cuda::OptionalCUDAGuard device_guard(device_of(tsdf.jdata()));
+
+    TORCH_CHECK_VALUE(grid->batchSize() == 1,
+                      "integrateTSDFBatch requires a single-scene grid "
+                      "(batchSize = 1); got batchSize = ",
+                      grid->batchSize(),
+                      ". The N dimension is carried on depthImages.size(0).");
+
+    // Squeeze the optional trailing channel dim on depth / weight images
+    // so downstream code sees a uniform [N, H, W] shape.
+    const torch::Tensor depthImagesSqueezed =
+        depthImages.dim() == 4 ? depthImages.squeeze(-1) : depthImages;
+    const int64_t N = depthImagesSqueezed.size(0);
+    TORCH_CHECK_VALUE(N > 0, "depthImages must have at least one frame");
+    TORCH_CHECK_VALUE(projectionMatrices.size(0) == N,
+                      "projectionMatrices frame count (",
+                      projectionMatrices.size(0),
+                      ") must equal depth-image frame count (", N, ")");
+    TORCH_CHECK_VALUE(camToWorldMatrices.size(0) == N,
+                      "camToWorldMatrices frame count (",
+                      camToWorldMatrices.size(0),
+                      ") must equal depth-image frame count (", N, ")");
+
+    // --- Incremental per-frame pipeline ------------------------------
+    //
+    // The batched path grows topology one frame at a time, looping the
+    // existing single-frame `integrateTSDFImpl`. This is asymptotically
+    // O(N * frustum_voxels_per_frame) rather than the O(N^2) cost of
+    // building a static union over all frames up-front (each iteration
+    // of the union-then-integrate variant runs the TSDF kernel over
+    // every voxel in the union, the vast majority of which are not
+    // in-view for any given frame).
+    //
+    // It also fixes a mesh under-coverage bug the union-then-integrate
+    // variant exhibited: voxels in the union that were never visible
+    // in any frame stayed at weight=0 and got pruned out by the mesh
+    // extractor. In the incremental path, a voxel only enters the
+    // grid once some frame's truncation shell has touched it, so by
+    // construction every active voxel has at least one real TSDF
+    // update.
+    const bool profile_batch =
+        std::getenv("FVDB_TSDF_BATCH_PROFILE") != nullptr;
+    cudaEvent_t evStart{}, evEnd{};
+    if (profile_batch) {
+        cudaEventCreate(&evStart);
+        cudaEventCreate(&evEnd);
+        cudaEventRecord(evStart);
+    }
+
+    // Feature / weight-image validation (same convention as
+    // `integrateTSDFImpl` so per-frame slices pass its checks).
+    const bool hasFeatureImages = features.has_value();
+    if (hasFeatureImages) {
+        TORCH_CHECK(featureImages.has_value(),
+                    "Feature images must be provided if features are provided.");
+        TORCH_CHECK_VALUE(featureImages.value().size(0) == N,
+                          "featureImages frame count (",
+                          featureImages.value().size(0),
+                          ") must equal depth-image frame count (", N, ")");
+    } else {
+        TORCH_CHECK(!featureImages.has_value(),
+                    "Feature images must not be provided if features are not provided.");
+    }
+    const bool hasPerFrameWeightImages =
+        weightImages.has_value() && weightImages.value().size(0) == N;
+    if (weightImages.has_value()) {
+        TORCH_CHECK_VALUE(hasPerFrameWeightImages,
+                          "weightImages frame count (",
+                          weightImages.value().size(0),
+                          ") must equal depth-image frame count (", N, ")");
+    }
+
+    // Own the accumulator as a `PersistentTSDFState` so the per-frame
+    // "grow topology + carry sidecar values forward" step becomes a
+    // single `growFromGrid` call that fast-paths to a no-op when the
+    // frame's truncation shell is a subset of the current live grid.
+    // On bounded-scene trajectories the shell stops introducing new
+    // voxels after some warm-up, so post-converge frames skip both
+    // the sidecar realloc and the inject-from-base pass entirely,
+    // leaving only the shell integrate kernel to run.
+    //
+    // Equivalence with the pre-refactor path:
+    //   - `integrateTSDFImpl` did `zeros(union) + injectFromBase +
+    //     integrateShellKernel` each frame. The first two steps are
+    //     exactly what `PersistentTSDFState::growFromGrid` performs
+    //     (fresh zeros sized to union, then `ops::inject` from live
+    //     grid's sidecars). Replacing them with one `growFromGrid`
+    //     call is semantically identical -- bit-identical mesh /
+    //     tsdf / weight outputs are pinned by
+    //     `test_integrate_tsdf_frames_matches_sequential`
+    //     (atol=rtol=0).
+    //   - The integrate kernel call then becomes
+    //     `doIntegrateShellInPlace` on the state's tensors (skips
+    //     the alloc + inject since growFromGrid already did it).
+    //   - `FVDB_FULL_UNION_INTEGRATE=1` is an opt-in legacy knob
+    //     only exercised by the single-frame `integrateTSDFImpl`
+    //     path; batched always uses shell-filtered integrate.
+    auto featuresStart = hasFeatureImages
+                             ? std::make_optional(features.value().jdata())
+                             : std::nullopt;
+    PersistentTSDFState state(
+        grid, tsdf.jdata(), weights.jdata(), featuresStart);
+
+    for (int64_t i = 0; i < N; ++i) {
+        const torch::Tensor depth_i =
+            depthImagesSqueezed.narrow(0, i, 1).contiguous();
+        const torch::Tensor proj_i =
+            projectionMatrices.narrow(0, i, 1).contiguous();
+        const torch::Tensor c2w_i =
+            camToWorldMatrices.narrow(0, i, 1).contiguous();
+        const torch::Tensor featImg_i =
+            hasFeatureImages
+                ? featureImages.value().narrow(0, i, 1).contiguous()
+                : torch::empty({0, 0, 0, 0}, depth_i.options());
+        const torch::Tensor wImg_i =
+            hasPerFrameWeightImages
+                ? weightImages.value().narrow(0, i, 1).contiguous()
+                : torch::empty({0, 0, 0}, depth_i.options());
+
+        // Rebuild camera matrices for this frame (same helper the
+        // single-frame impl uses).
+        const auto [projMats, invProjMats, c2wMats, w2cMats] =
+            getCameraMatrices(proj_i, c2w_i);
+
+        // Squeeze optional channel dim to keep the single-frame
+        // conventions uniform.
+        const torch::Tensor depth_i_sq =
+            depth_i.dim() == 4 ? depth_i.squeeze(-1) : depth_i;
+        const torch::Tensor wImg_i_sq =
+            wImg_i.dim() == 4 ? wImg_i.squeeze(-1) : wImg_i;
+
+        // Unproject + build this frame's shell (identical to the
+        // single-frame path; see `integrateTSDFImpl` for fp16
+        // promote-for-quantise note).
+        const torch::Tensor unprojectedNative = unprojectDepthMapToPoints(
+            depth_i_sq, projMats, invProjMats, c2wMats);
+        const torch::Tensor unprojected =
+            unprojectedNative.scalar_type() == torch::kHalf
+                ? unprojectedNative.to(torch::kFloat32)
+                : unprojectedNative;
+        const auto pointGrid = buildPointGrid(
+            truncationMargin, unprojected, state.grid());
+
+        // Grow the persistent state: maybe-alloc sidecars, maybe-
+        // inject from old layout to new, update grid pointer.
+        // No-op when `pointGrid` is a subset of `state.grid()`.
+        state.growFromGrid(*pointGrid);
+
+        // Placeholder features tensor when features are disabled --
+        // the integrate kernel still takes the argument via its
+        // `hasFeatures` flag. Keep the size-matching invariant.
+        torch::Tensor featuresRef = state.features();
+
+        doIntegrateShellInPlace(
+            truncationMargin,
+            depth_i_sq,
+            featImg_i,
+            wImg_i_sq,
+            projMats, invProjMats, c2wMats, w2cMats,
+            state.grid(),
+            *pointGrid,
+            state.tsdf(), state.weights(), featuresRef);
+    }
+
+    c10::intrusive_ptr<GridBatchData> accumGrid = state.gridPtr();
+    JaggedTensor accumTsdf     = state.tsdfJagged();
+    JaggedTensor accumWeights  = state.weightsJagged();
+    JaggedTensor accumFeatures = hasFeatureImages
+                                     ? state.featuresJagged()
+                                     : JaggedTensor();
+
+    if (profile_batch) {
+        cudaEventRecord(evEnd);
+        cudaEventSynchronize(evEnd);
+        float ms = 0.f;
+        cudaEventElapsedTime(&ms, evStart, evEnd);
+        std::fprintf(
+            stderr,
+            "[fvdb/tsdf_batch] N=%lld  incremental=%.2f ms  (%.2f ms/frame)  final_voxels=%lld  final_leaves=%lld\n",
+            (long long)N, ms, ms / static_cast<float>(N),
+            (long long)accumGrid->totalVoxels(),
+            (long long)accumGrid->totalLeaves());
+        cudaEventDestroy(evStart);
+        cudaEventDestroy(evEnd);
+    }
+
+    return {accumGrid, accumTsdf, accumWeights, accumFeatures};
+}
+
+} // anonymous namespace
+
+std::tuple<c10::intrusive_ptr<GridBatchData>, JaggedTensor, JaggedTensor>
+integrateTSDFBatch(const c10::intrusive_ptr<GridBatchData> grid,
+                   const double truncationMargin,
+                   const torch::Tensor &projectionMatrices,
+                   const torch::Tensor &camToWorldMatrices,
+                   const JaggedTensor &tsdf,
+                   const JaggedTensor &weights,
+                   const torch::Tensor &depthImages,
+                   const std::optional<torch::Tensor> &weightImages) {
+    TORCH_CHECK_NOT_IMPLEMENTED(grid->device().is_cuda(),
+                                "TSDF integration not implemented on the CPU.");
+    auto [unionGrid, outTsdf, outWeights, _unusedFeatures] = integrateTSDFBatchImpl(
+        grid, truncationMargin, projectionMatrices, camToWorldMatrices,
+        tsdf, weights, std::nullopt,
+        depthImages, std::nullopt, weightImages);
+    return {unionGrid, outTsdf, outWeights};
+}
+
+std::tuple<c10::intrusive_ptr<GridBatchData>, JaggedTensor, JaggedTensor, JaggedTensor>
+integrateTSDFBatchWithFeatures(const c10::intrusive_ptr<GridBatchData> grid,
+                               const double truncationMargin,
+                               const torch::Tensor &projectionMatrices,
+                               const torch::Tensor &camToWorldMatrices,
+                               const JaggedTensor &tsdf,
+                               const JaggedTensor &features,
+                               const JaggedTensor &weights,
+                               const torch::Tensor &depthImages,
+                               const torch::Tensor &featureImages,
+                               const std::optional<torch::Tensor> &weightImages) {
+    TORCH_CHECK_NOT_IMPLEMENTED(grid->device().is_cuda(),
+                                "TSDF integration not implemented on the CPU.");
+    return integrateTSDFBatchImpl(grid, truncationMargin, projectionMatrices,
+                                  camToWorldMatrices, tsdf, weights, features,
+                                  depthImages, featureImages, weightImages);
 }
 
 } // namespace fvdb::detail::ops

--- a/src/fvdb/detail/ops/IntegrateTSDF.cu
+++ b/src/fvdb/detail/ops/IntegrateTSDF.cu
@@ -427,61 +427,52 @@ buildPointGrid(const double truncationMargin,
 // available as an ablation via `FVDB_FULL_UNION_INTEGRATE=1`.
 template <typename ScalarDataType, typename FeatureScalarDataType = ScalarDataType>
 __global__ __launch_bounds__(DEFAULT_BLOCK_DIM) void
-injectFromBaseKernel(
-    const bool hasFeatures,
-    const fvdb::BatchGridAccessor baseGridAcc,
-    const fvdb::BatchGridAccessor unionGridAcc,
-    const fvdb::JaggedRAcc64<ScalarDataType, 1> tsdfAcc,
-    const fvdb::JaggedRAcc64<ScalarDataType, 1> weightsAcc,
-    const fvdb::JaggedRAcc64<FeatureScalarDataType, 2> featuresAcc,
-    fvdb::TorchRAcc64<ScalarDataType, 1> outTsdfAcc,
-    fvdb::TorchRAcc64<ScalarDataType, 1> outWeightsAcc,
-    fvdb::TorchRAcc64<FeatureScalarDataType, 2> outFeaturesAcc) {
-    using GridT        = nanovdb::ValueOnIndex;
-    using LeafNodeType = nanovdb::NanoGrid<GridT>::LeafNodeType;
-    constexpr uint64_t VOXELS_PER_LEAF =
-        nanovdb::NanoTree<GridT>::LeafNodeType::NUM_VALUES;
+injectFromBaseKernel(const bool hasFeatures,
+                     const fvdb::BatchGridAccessor baseGridAcc,
+                     const fvdb::BatchGridAccessor unionGridAcc,
+                     const fvdb::JaggedRAcc64<ScalarDataType, 1> tsdfAcc,
+                     const fvdb::JaggedRAcc64<ScalarDataType, 1> weightsAcc,
+                     const fvdb::JaggedRAcc64<FeatureScalarDataType, 2> featuresAcc,
+                     fvdb::TorchRAcc64<ScalarDataType, 1> outTsdfAcc,
+                     fvdb::TorchRAcc64<ScalarDataType, 1> outWeightsAcc,
+                     fvdb::TorchRAcc64<FeatureScalarDataType, 2> outFeaturesAcc) {
+    using GridT                        = nanovdb::ValueOnIndex;
+    using LeafNodeType                 = nanovdb::NanoGrid<GridT>::LeafNodeType;
+    constexpr uint64_t VOXELS_PER_LEAF = nanovdb::NanoTree<GridT>::LeafNodeType::NUM_VALUES;
 
     const auto problemSize = baseGridAcc.totalLeaves() * VOXELS_PER_LEAF;
-    for (auto idx = blockIdx.x * blockDim.x + threadIdx.x;
-         idx < problemSize; idx += blockDim.x * gridDim.x) {
-        const int64_t cumBaseLeafIdx =
-            static_cast<int64_t>(idx / VOXELS_PER_LEAF);
-        const fvdb::JIdxType batchIdx =
-            baseGridAcc.leafBatchIndex(cumBaseLeafIdx);
-        const int64_t baseLeafIdx =
-            cumBaseLeafIdx - baseGridAcc.leafOffset(batchIdx);
+    for (auto idx = blockIdx.x * blockDim.x + threadIdx.x; idx < problemSize;
+         idx += blockDim.x * gridDim.x) {
+        const int64_t cumBaseLeafIdx  = static_cast<int64_t>(idx / VOXELS_PER_LEAF);
+        const fvdb::JIdxType batchIdx = baseGridAcc.leafBatchIndex(cumBaseLeafIdx);
+        const int64_t baseLeafIdx     = cumBaseLeafIdx - baseGridAcc.leafOffset(batchIdx);
         const int64_t baseLeafVoxelIdx =
             static_cast<int64_t>(idx - cumBaseLeafIdx * VOXELS_PER_LEAF);
 
-        const nanovdb::NanoGrid<GridT> *baseGrid =
-            baseGridAcc.grid(batchIdx);
-        const LeafNodeType &baseLeaf =
-            baseGrid->tree().template getFirstNode<0>()[baseLeafIdx];
-        const int64_t baseVoxelValue = static_cast<int64_t>(
-            baseLeaf.getValue(baseLeafVoxelIdx)) - 1;
-        if (baseVoxelValue < 0) continue;
-        const int64_t baseOffset = baseGridAcc.voxelOffset(batchIdx) +
-                                   baseVoxelValue;
+        const nanovdb::NanoGrid<GridT> *baseGrid = baseGridAcc.grid(batchIdx);
+        const LeafNodeType &baseLeaf = baseGrid->tree().template getFirstNode<0>()[baseLeafIdx];
+        const int64_t baseVoxelValue =
+            static_cast<int64_t>(baseLeaf.getValue(baseLeafVoxelIdx)) - 1;
+        if (baseVoxelValue < 0)
+            continue;
+        const int64_t baseOffset = baseGridAcc.voxelOffset(batchIdx) + baseVoxelValue;
 
         // Look up this ijk in the union grid. Base is guaranteed to
         // be a subset of union (union = merge(shell, base)), so the
         // lookup always succeeds and yields an active voxel.
-        const nanovdb::Coord ijk =
-            baseLeaf.offsetToGlobalCoord(baseLeafVoxelIdx);
-        const nanovdb::NanoGrid<GridT> *unionGrid =
-            unionGridAcc.grid(batchIdx);
-        const auto unionAcc = unionGrid->getAccessor();
-        const int64_t unionOffset = unionGridAcc.voxelOffset(batchIdx) +
-            static_cast<int64_t>(unionAcc.getValue(ijk)) - 1;
-        if (unionOffset < 0) continue; // defensive; shouldn't happen
+        const nanovdb::Coord ijk                  = baseLeaf.offsetToGlobalCoord(baseLeafVoxelIdx);
+        const nanovdb::NanoGrid<GridT> *unionGrid = unionGridAcc.grid(batchIdx);
+        const auto unionAcc                       = unionGrid->getAccessor();
+        const int64_t unionOffset =
+            unionGridAcc.voxelOffset(batchIdx) + static_cast<int64_t>(unionAcc.getValue(ijk)) - 1;
+        if (unionOffset < 0)
+            continue; // defensive; shouldn't happen
 
         outTsdfAcc[unionOffset]    = tsdfAcc.data()[baseOffset];
         outWeightsAcc[unionOffset] = weightsAcc.data()[baseOffset];
         if (hasFeatures) {
             for (int64_t i = 0; i < outFeaturesAcc.size(1); ++i) {
-                outFeaturesAcc[unionOffset][i] =
-                    featuresAcc.data()[baseOffset][i];
+                outFeaturesAcc[unionOffset][i] = featuresAcc.data()[baseOffset][i];
             }
         }
     }
@@ -489,34 +480,32 @@ injectFromBaseKernel(
 
 template <typename ScalarDataType, typename FeatureScalarDataType = ScalarDataType>
 __global__ __launch_bounds__(DEFAULT_BLOCK_DIM) void
-integrateShellKernel(
-    const ScalarDataType truncationMargin,
-    const int64_t imageWidth,
-    const int64_t imageHeight,
-    const bool hasFeatures,
-    const bool hasWeights,
-    const fvdb::TorchRAcc64<ScalarDataType, 3> projMats,
-    const fvdb::TorchRAcc64<ScalarDataType, 3> invProjMats,
-    const fvdb::TorchRAcc64<ScalarDataType, 3> worldToCamMats,
-    const fvdb::TorchRAcc64<ScalarDataType, 3> camToWorldMats,
-    const fvdb::TorchRAcc64<ScalarDataType, 3> depthImages,
-    const fvdb::TorchRAcc64<FeatureScalarDataType, 4> featureImages,
-    const fvdb::TorchRAcc64<ScalarDataType, 3> weightImages,
-    const fvdb::BatchGridAccessor shellGridAcc,
-    const fvdb::BatchGridAccessor unionGridAcc,
-    fvdb::TorchRAcc64<ScalarDataType, 1> outTsdfAcc,
-    fvdb::TorchRAcc64<ScalarDataType, 1> outWeightsAcc,
-    fvdb::TorchRAcc64<FeatureScalarDataType, 2> outFeaturesAcc) {
-    using ScalarType        = at::opmath_type<ScalarDataType>;
-    using FeatureScalarType = at::opmath_type<FeatureScalarDataType>;
-    using GridT        = nanovdb::ValueOnIndex;
-    using LeafNodeType = nanovdb::NanoGrid<GridT>::LeafNodeType;
-    using Vec3T        = nanovdb::math::Vec3<ScalarType>;
-    using Vec4T        = nanovdb::math::Vec4<ScalarType>;
-    using Mat3T        = nanovdb::math::Mat3<ScalarType>;
-    using Mat4T        = nanovdb::math::Mat4<ScalarType>;
-    constexpr uint64_t VOXELS_PER_LEAF =
-        nanovdb::NanoTree<GridT>::LeafNodeType::NUM_VALUES;
+integrateShellKernel(const ScalarDataType truncationMargin,
+                     const int64_t imageWidth,
+                     const int64_t imageHeight,
+                     const bool hasFeatures,
+                     const bool hasWeights,
+                     const fvdb::TorchRAcc64<ScalarDataType, 3> projMats,
+                     const fvdb::TorchRAcc64<ScalarDataType, 3> invProjMats,
+                     const fvdb::TorchRAcc64<ScalarDataType, 3> worldToCamMats,
+                     const fvdb::TorchRAcc64<ScalarDataType, 3> camToWorldMats,
+                     const fvdb::TorchRAcc64<ScalarDataType, 3> depthImages,
+                     const fvdb::TorchRAcc64<FeatureScalarDataType, 4> featureImages,
+                     const fvdb::TorchRAcc64<ScalarDataType, 3> weightImages,
+                     const fvdb::BatchGridAccessor shellGridAcc,
+                     const fvdb::BatchGridAccessor unionGridAcc,
+                     fvdb::TorchRAcc64<ScalarDataType, 1> outTsdfAcc,
+                     fvdb::TorchRAcc64<ScalarDataType, 1> outWeightsAcc,
+                     fvdb::TorchRAcc64<FeatureScalarDataType, 2> outFeaturesAcc) {
+    using ScalarType                   = at::opmath_type<ScalarDataType>;
+    using FeatureScalarType            = at::opmath_type<FeatureScalarDataType>;
+    using GridT                        = nanovdb::ValueOnIndex;
+    using LeafNodeType                 = nanovdb::NanoGrid<GridT>::LeafNodeType;
+    using Vec3T                        = nanovdb::math::Vec3<ScalarType>;
+    using Vec4T                        = nanovdb::math::Vec4<ScalarType>;
+    using Mat3T                        = nanovdb::math::Mat3<ScalarType>;
+    using Mat4T                        = nanovdb::math::Mat4<ScalarType>;
+    constexpr uint64_t VOXELS_PER_LEAF = nanovdb::NanoTree<GridT>::LeafNodeType::NUM_VALUES;
 
     const auto batchSize = projMats.size(0);
 
@@ -524,23 +513,19 @@ integrateShellKernel(
     // host-side shared-size calculation can be shared.
     extern __shared__ uint8_t sharedData[];
     Mat3T *sharedProjMats       = reinterpret_cast<Mat3T *>(sharedData);
-    Mat4T *sharedWorldToCamMats = reinterpret_cast<Mat4T *>(
-        sharedData + batchSize * sizeof(Mat3T));
+    Mat4T *sharedWorldToCamMats = reinterpret_cast<Mat4T *>(sharedData + batchSize * sizeof(Mat3T));
     Mat3T *sharedInvProjMats =
-        reinterpret_cast<Mat3T *>(sharedData +
-                                  batchSize * (sizeof(Mat3T) + sizeof(Mat4T)));
+        reinterpret_cast<Mat3T *>(sharedData + batchSize * (sizeof(Mat3T) + sizeof(Mat4T)));
     Mat4T *sharedCamToWorldMats = reinterpret_cast<Mat4T *>(
-        sharedData + batchSize * (sizeof(Mat3T) + sizeof(Mat4T) +
-                                  sizeof(Mat3T)));
+        sharedData + batchSize * (sizeof(Mat3T) + sizeof(Mat4T) + sizeof(Mat3T)));
 
     const auto sharedMat3x3NumElements = batchSize * 3 * 3;
     const auto sharedMat4x4NumElements = batchSize * 4 * 4;
     if (threadIdx.x < sharedMat3x3NumElements) {
-        const auto batchIdx = threadIdx.x / 9;
-        const auto rowIdx   = (threadIdx.x % 9) / 3;
-        const auto colIdx   = threadIdx.x % 3;
-        sharedProjMats[batchIdx][rowIdx][colIdx] =
-            ScalarType(projMats[batchIdx][rowIdx][colIdx]);
+        const auto batchIdx                      = threadIdx.x / 9;
+        const auto rowIdx                        = (threadIdx.x % 9) / 3;
+        const auto colIdx                        = threadIdx.x % 3;
+        sharedProjMats[batchIdx][rowIdx][colIdx] = ScalarType(projMats[batchIdx][rowIdx][colIdx]);
     } else if (threadIdx.x < sharedMat3x3NumElements + sharedMat4x4NumElements) {
         const auto baseIdx  = threadIdx.x - sharedMat3x3NumElements;
         const auto batchIdx = baseIdx / 16;
@@ -548,10 +533,8 @@ integrateShellKernel(
         const auto colIdx   = baseIdx % 4;
         sharedWorldToCamMats[batchIdx][rowIdx][colIdx] =
             ScalarType(worldToCamMats[batchIdx][rowIdx][colIdx]);
-    } else if (threadIdx.x <
-               2 * sharedMat3x3NumElements + sharedMat4x4NumElements) {
-        const auto baseIdx  = threadIdx.x - sharedMat3x3NumElements -
-                              sharedMat4x4NumElements;
+    } else if (threadIdx.x < 2 * sharedMat3x3NumElements + sharedMat4x4NumElements) {
+        const auto baseIdx  = threadIdx.x - sharedMat3x3NumElements - sharedMat4x4NumElements;
         const auto batchIdx = baseIdx / 9;
         const auto rowIdx   = (baseIdx % 9) / 3;
         const auto colIdx   = baseIdx % 3;
@@ -566,59 +549,46 @@ integrateShellKernel(
     // work; any thread whose idx is past the shell's total voxel
     // count just exits.
     const auto problemSize = shellGridAcc.totalLeaves() * VOXELS_PER_LEAF;
-    for (auto idx = blockIdx.x * blockDim.x + threadIdx.x;
-         idx < problemSize; idx += blockDim.x * gridDim.x) {
-        const int64_t cumShellLeafIdx =
-            static_cast<int64_t>(idx / VOXELS_PER_LEAF);
-        const fvdb::JIdxType batchIdx =
-            shellGridAcc.leafBatchIndex(cumShellLeafIdx);
-        const int64_t shellLeafIdx =
-            cumShellLeafIdx - shellGridAcc.leafOffset(batchIdx);
-        const int64_t shellLeafVoxelIdx = static_cast<int64_t>(
-            idx - cumShellLeafIdx * VOXELS_PER_LEAF);
+    for (auto idx = blockIdx.x * blockDim.x + threadIdx.x; idx < problemSize;
+         idx += blockDim.x * gridDim.x) {
+        const int64_t cumShellLeafIdx = static_cast<int64_t>(idx / VOXELS_PER_LEAF);
+        const fvdb::JIdxType batchIdx = shellGridAcc.leafBatchIndex(cumShellLeafIdx);
+        const int64_t shellLeafIdx    = cumShellLeafIdx - shellGridAcc.leafOffset(batchIdx);
+        const int64_t shellLeafVoxelIdx =
+            static_cast<int64_t>(idx - cumShellLeafIdx * VOXELS_PER_LEAF);
 
-        const nanovdb::NanoGrid<GridT> *shellGrid =
-            shellGridAcc.grid(batchIdx);
-        const LeafNodeType &shellLeaf =
-            shellGrid->tree().template getFirstNode<0>()[shellLeafIdx];
+        const nanovdb::NanoGrid<GridT> *shellGrid = shellGridAcc.grid(batchIdx);
+        const LeafNodeType &shellLeaf = shellGrid->tree().template getFirstNode<0>()[shellLeafIdx];
         // Shell leaves can have inactive slots (nanoVDB leaf nodes
         // are fixed 8^3, but only some slots are active).
-        const int64_t shellVoxelValue = static_cast<int64_t>(
-            shellLeaf.getValue(shellLeafVoxelIdx)) - 1;
-        if (shellVoxelValue < 0) continue;
+        const int64_t shellVoxelValue =
+            static_cast<int64_t>(shellLeaf.getValue(shellLeafVoxelIdx)) - 1;
+        if (shellVoxelValue < 0)
+            continue;
 
-        const nanovdb::Coord ijk =
-            shellLeaf.offsetToGlobalCoord(shellLeafVoxelIdx);
-        const nanovdb::NanoGrid<GridT> *unionGrid =
-            unionGridAcc.grid(batchIdx);
-        const auto unionAcc = unionGrid->getAccessor();
-        const int64_t unionOffset = unionGridAcc.voxelOffset(batchIdx) +
-            static_cast<int64_t>(unionAcc.getValue(ijk)) - 1;
-        if (unionOffset < 0) continue;
+        const nanovdb::Coord ijk = shellLeaf.offsetToGlobalCoord(shellLeafVoxelIdx);
+        const nanovdb::NanoGrid<GridT> *unionGrid = unionGridAcc.grid(batchIdx);
+        const auto unionAcc                       = unionGrid->getAccessor();
+        const int64_t unionOffset =
+            unionGridAcc.voxelOffset(batchIdx) + static_cast<int64_t>(unionAcc.getValue(ijk)) - 1;
+        if (unionOffset < 0)
+            continue;
 
         // Project voxel to screen, frustum-check, apply TSDF blend.
-        const Vec3T voxelWorldPos = unionGridAcc.primalTransform(batchIdx)
-            .applyInv<ScalarType>(
-                ScalarType(ijk[0]), ScalarType(ijk[1]), ScalarType(ijk[2]));
+        const Vec3T voxelWorldPos = unionGridAcc.primalTransform(batchIdx).applyInv<ScalarType>(
+            ScalarType(ijk[0]), ScalarType(ijk[1]), ScalarType(ijk[2]));
         const Vec4T voxelWorldPosHomogeneous = {
-            voxelWorldPos[0], voxelWorldPos[1], voxelWorldPos[2],
-            ScalarType(1.0)};
-        const Vec4T voxelPosCamSpace =
-            sharedWorldToCamMats[batchIdx] * voxelWorldPosHomogeneous;
-        const Vec3T voxelPosCamSpace3d = {
-            voxelPosCamSpace[0] / voxelPosCamSpace[3],
-            voxelPosCamSpace[1] / voxelPosCamSpace[3],
-            voxelPosCamSpace[2] / voxelPosCamSpace[3]};
-        const Vec3T voxelPosProjSpace =
-            sharedProjMats[batchIdx] * voxelPosCamSpace3d;
-        const Vec3T voxelPosScreenSpace = {
-            voxelPosProjSpace[0] / voxelPosProjSpace[2],
-            voxelPosProjSpace[1] / voxelPosProjSpace[2],
-            ScalarType(1.0)};
-        const int64_t voxelPosScreenSpaceX =
-            int64_t(voxelPosScreenSpace[0]);
-        const int64_t voxelPosScreenSpaceY =
-            int64_t(voxelPosScreenSpace[1]);
+            voxelWorldPos[0], voxelWorldPos[1], voxelWorldPos[2], ScalarType(1.0)};
+        const Vec4T voxelPosCamSpace    = sharedWorldToCamMats[batchIdx] * voxelWorldPosHomogeneous;
+        const Vec3T voxelPosCamSpace3d  = {voxelPosCamSpace[0] / voxelPosCamSpace[3],
+                                           voxelPosCamSpace[1] / voxelPosCamSpace[3],
+                                           voxelPosCamSpace[2] / voxelPosCamSpace[3]};
+        const Vec3T voxelPosProjSpace   = sharedProjMats[batchIdx] * voxelPosCamSpace3d;
+        const Vec3T voxelPosScreenSpace = {voxelPosProjSpace[0] / voxelPosProjSpace[2],
+                                           voxelPosProjSpace[1] / voxelPosProjSpace[2],
+                                           ScalarType(1.0)};
+        const int64_t voxelPosScreenSpaceX = int64_t(voxelPosScreenSpace[0]);
+        const int64_t voxelPosScreenSpaceY = int64_t(voxelPosScreenSpace[1]);
 
         const bool voxelIsVisible =
             (voxelPosScreenSpaceX >= 0 && voxelPosScreenSpaceX < imageWidth &&
@@ -627,46 +597,45 @@ integrateShellKernel(
         // Not visible -> the inject pass has already carried the old
         // value forward (or left the slot at zero for shell-only
         // voxels, which is the correct initial state).
-        if (!voxelIsVisible) continue;
+        if (!voxelIsVisible)
+            continue;
 
-        const ScalarType pixelDepth = ScalarType(
-            depthImages[batchIdx][voxelPosScreenSpaceY][voxelPosScreenSpaceX]);
+        const ScalarType pixelDepth =
+            ScalarType(depthImages[batchIdx][voxelPosScreenSpaceY][voxelPosScreenSpaceX]);
         const ScalarType zDiff = pixelDepth - voxelPosCamSpace3d[2];
-        if (zDiff <= -ScalarType(truncationMargin)) continue;
+        if (zDiff <= -ScalarType(truncationMargin))
+            continue;
 
         const ScalarType pixelWeight = [&]() {
             if (hasWeights) {
-                return ScalarType(weightImages[batchIdx][voxelPosScreenSpaceY]
-                                             [voxelPosScreenSpaceX]);
+                return ScalarType(
+                    weightImages[batchIdx][voxelPosScreenSpaceY][voxelPosScreenSpaceX]);
             } else {
                 return ScalarType{1};
             }
         }();
-        if (pixelWeight <= ScalarType(0)) continue;
+        if (pixelWeight <= ScalarType(0))
+            continue;
 
-        const ScalarType tsdf = nanovdb::math::Min(
-            ScalarType(1), zDiff / ScalarType(truncationMargin));
+        const ScalarType tsdf =
+            nanovdb::math::Min(ScalarType(1), zDiff / ScalarType(truncationMargin));
         // Read-modify-write: the old value was either written by the
         // inject pass (for voxels in base) or is zero (for shell-only
         // voxels, torch::zeros initialisation). Stream ordering
         // guarantees inject completes before this kernel launches.
-        const ScalarType oldWeight   = ScalarType(outWeightsAcc[unionOffset]);
-        const ScalarType oldTsdf     = ScalarType(outTsdfAcc[unionOffset]);
-        const ScalarType newWeight   = oldWeight + pixelWeight;
-        const ScalarType newTsdf     =
-            (oldWeight * oldTsdf + pixelWeight * tsdf) / newWeight;
+        const ScalarType oldWeight = ScalarType(outWeightsAcc[unionOffset]);
+        const ScalarType oldTsdf   = ScalarType(outTsdfAcc[unionOffset]);
+        const ScalarType newWeight = oldWeight + pixelWeight;
+        const ScalarType newTsdf   = (oldWeight * oldTsdf + pixelWeight * tsdf) / newWeight;
         outTsdfAcc[unionOffset]    = ScalarDataType(newTsdf);
         outWeightsAcc[unionOffset] = ScalarDataType(newWeight);
         if (hasFeatures) {
             for (int64_t i = 0; i < outFeaturesAcc.size(1); ++i) {
                 const ScalarType pixelFeatureI = ScalarType(
-                    featureImages[batchIdx][voxelPosScreenSpaceY]
-                                [voxelPosScreenSpaceX][i]);
-                const ScalarType oldFeatureI =
-                    ScalarType(outFeaturesAcc[unionOffset][i]);
+                    featureImages[batchIdx][voxelPosScreenSpaceY][voxelPosScreenSpaceX][i]);
+                const ScalarType oldFeatureI   = ScalarType(outFeaturesAcc[unionOffset][i]);
                 outFeaturesAcc[unionOffset][i] = FeatureScalarDataType(
-                    (oldWeight * oldFeatureI + pixelWeight * pixelFeatureI) /
-                    newWeight);
+                    (oldWeight * oldFeatureI + pixelWeight * pixelFeatureI) / newWeight);
             }
         }
     }
@@ -703,13 +672,10 @@ doIntegrate(const float truncationMargin,
     // output slot unwritten; for shell voxels NOT in the base grid we
     // need that slot to read as 0 rather than as uninitialised memory,
     // otherwise downstream consumers see |tsdf| > 1 garbage.
-    torch::Tensor outWeights =
-        torch::zeros({totalOutVoxels}, weights.jdata().options());
-    torch::Tensor outTsdf =
-        torch::zeros({totalOutVoxels}, tsdf.jdata().options());
+    torch::Tensor outWeights = torch::zeros({totalOutVoxels}, weights.jdata().options());
+    torch::Tensor outTsdf    = torch::zeros({totalOutVoxels}, tsdf.jdata().options());
     torch::Tensor outFeatures =
-        torch::zeros({totalOutVoxels, featureDim},
-                     features.jdata().options());
+        torch::zeros({totalOutVoxels, featureDim}, features.jdata().options());
 
     // `FVDB_FULL_UNION_INTEGRATE=1` opts into the legacy single-kernel
     // path that walks every union voxel and does either copy-forward
@@ -761,9 +727,12 @@ doIntegrate(const float truncationMargin,
                         hasFeatures,
                         hasWeights,
                         projMatsCasted.packed_accessor64<scalar_t, 3, torch::RestrictPtrTraits>(),
-                        invProjMatsCasted.packed_accessor64<scalar_t, 3, torch::RestrictPtrTraits>(),
-                        worldToCamMatsCasted.packed_accessor64<scalar_t, 3, torch::RestrictPtrTraits>(),
-                        camToWorldMatsCasted.packed_accessor64<scalar_t, 3, torch::RestrictPtrTraits>(),
+                        invProjMatsCasted
+                            .packed_accessor64<scalar_t, 3, torch::RestrictPtrTraits>(),
+                        worldToCamMatsCasted
+                            .packed_accessor64<scalar_t, 3, torch::RestrictPtrTraits>(),
+                        camToWorldMatsCasted
+                            .packed_accessor64<scalar_t, 3, torch::RestrictPtrTraits>(),
                         depthImages.packed_accessor64<scalar_t, 3, torch::RestrictPtrTraits>(),
                         featureImages.packed_accessor64<feature_t, 4, torch::RestrictPtrTraits>(),
                         weightImages.packed_accessor64<scalar_t, 3, torch::RestrictPtrTraits>(),
@@ -803,8 +772,7 @@ doIntegrate(const float truncationMargin,
             const auto camToWorldMatsCasted = camToWorldMatrices.to(dtype);
             const auto worldToCamMatsCasted = worldToCamMatrices.to(dtype);
 
-            at::cuda::CUDAStream stream =
-                at::cuda::getCurrentCUDAStream(tsdf.device().index());
+            at::cuda::CUDAStream stream = at::cuda::getCurrentCUDAStream(tsdf.device().index());
 
             DISPATCH_FEATURE_TYPE([&]() {
                 // Pass 1: inject old tsdf / weight / features from base
@@ -813,12 +781,9 @@ doIntegrate(const float truncationMargin,
                 // to carry forward.
                 const auto numBaseLeaves = baseGrid.totalLeaves();
                 if (numBaseLeaves > 0) {
-                    const auto injectProblemSize =
-                        numBaseLeaves * VOXELS_PER_LEAF;
-                    const auto injectBlocks =
-                        GET_BLOCKS(injectProblemSize, DEFAULT_BLOCK_DIM);
-                    injectFromBaseKernel<<<injectBlocks, DEFAULT_BLOCK_DIM,
-                                          0, stream>>>(
+                    const auto injectProblemSize = numBaseLeaves * VOXELS_PER_LEAF;
+                    const auto injectBlocks      = GET_BLOCKS(injectProblemSize, DEFAULT_BLOCK_DIM);
+                    injectFromBaseKernel<<<injectBlocks, DEFAULT_BLOCK_DIM, 0, stream>>>(
                         hasFeatures,
                         baseGrid.deviceAccessor(),
                         unionGrid.deviceAccessor(),
@@ -835,25 +800,21 @@ doIntegrate(const float truncationMargin,
                 // shell's voxels. Stream ordering guarantees the inject
                 // above has completed before we enter the read-modify-
                 // write below.
-                const auto numShellLeaves = shellGrid.totalLeaves();
-                const auto numSharedScalars =
-                    2 * batchSize * 3 * 3 + 2 * batchSize * 4 * 4;
-                const auto integrateProblemSize = std::max(
-                    numShellLeaves * VOXELS_PER_LEAF,
-                    uint64_t(numSharedScalars));
-                const auto integrateBlocks =
-                    GET_BLOCKS(integrateProblemSize, DEFAULT_BLOCK_DIM);
+                const auto numShellLeaves   = shellGrid.totalLeaves();
+                const auto numSharedScalars = 2 * batchSize * 3 * 3 + 2 * batchSize * 4 * 4;
+                const auto integrateProblemSize =
+                    std::max(numShellLeaves * VOXELS_PER_LEAF, uint64_t(numSharedScalars));
+                const auto integrateBlocks = GET_BLOCKS(integrateProblemSize, DEFAULT_BLOCK_DIM);
 
-                if (cudaFuncSetAttribute(
-                        integrateShellKernel<scalar_t, feature_t>,
-                        cudaFuncAttributeMaxDynamicSharedMemorySize,
-                        sharedMemSize) != cudaSuccess) {
+                if (cudaFuncSetAttribute(integrateShellKernel<scalar_t, feature_t>,
+                                         cudaFuncAttributeMaxDynamicSharedMemorySize,
+                                         sharedMemSize) != cudaSuccess) {
                     AT_ERROR("Failed to set maximum shared memory size (requested ",
-                             sharedMemSize, " bytes), try lowering tile_size.");
+                             sharedMemSize,
+                             " bytes), try lowering tile_size.");
                 }
 
-                integrateShellKernel<<<integrateBlocks, DEFAULT_BLOCK_DIM,
-                                       sharedMemSize, stream>>>(
+                integrateShellKernel<<<integrateBlocks, DEFAULT_BLOCK_DIM, sharedMemSize, stream>>>(
                     scalar_t(truncationMargin),
                     imageWidth,
                     imageHeight,
@@ -939,25 +900,21 @@ doIntegrateShellInPlace(const float truncationMargin,
             const auto camToWorldMatsCasted = camToWorldMatrices.to(dtype);
             const auto worldToCamMatsCasted = worldToCamMatrices.to(dtype);
 
-            at::cuda::CUDAStream stream =
-                at::cuda::getCurrentCUDAStream(tsdf.device().index());
+            at::cuda::CUDAStream stream = at::cuda::getCurrentCUDAStream(tsdf.device().index());
 
             DISPATCH_FEATURE_TYPE([&]() {
-                const auto numShellLeaves = shellGrid.totalLeaves();
-                const auto numSharedScalars =
-                    2 * batchSize * 3 * 3 + 2 * batchSize * 4 * 4;
-                const auto integrateProblemSize = std::max(
-                    numShellLeaves * VOXELS_PER_LEAF,
-                    uint64_t(numSharedScalars));
-                const auto integrateBlocks =
-                    GET_BLOCKS(integrateProblemSize, DEFAULT_BLOCK_DIM);
+                const auto numShellLeaves   = shellGrid.totalLeaves();
+                const auto numSharedScalars = 2 * batchSize * 3 * 3 + 2 * batchSize * 4 * 4;
+                const auto integrateProblemSize =
+                    std::max(numShellLeaves * VOXELS_PER_LEAF, uint64_t(numSharedScalars));
+                const auto integrateBlocks = GET_BLOCKS(integrateProblemSize, DEFAULT_BLOCK_DIM);
 
-                if (cudaFuncSetAttribute(
-                        integrateShellKernel<scalar_t, feature_t>,
-                        cudaFuncAttributeMaxDynamicSharedMemorySize,
-                        sharedMemSize) != cudaSuccess) {
+                if (cudaFuncSetAttribute(integrateShellKernel<scalar_t, feature_t>,
+                                         cudaFuncAttributeMaxDynamicSharedMemorySize,
+                                         sharedMemSize) != cudaSuccess) {
                     AT_ERROR("Failed to set maximum shared memory size (requested ",
-                             sharedMemSize, " bytes), try lowering tile_size.");
+                             sharedMemSize,
+                             " bytes), try lowering tile_size.");
                 }
 
                 // `integrateShellKernel` reads-modifies-writes
@@ -968,8 +925,7 @@ doIntegrateShellInPlace(const float truncationMargin,
                 // value, computes the new weighted average with this
                 // frame's depth observation, and writes the result
                 // back -- a classic in-place running-mean update.
-                integrateShellKernel<<<integrateBlocks, DEFAULT_BLOCK_DIM,
-                                       sharedMemSize, stream>>>(
+                integrateShellKernel<<<integrateBlocks, DEFAULT_BLOCK_DIM, sharedMemSize, stream>>>(
                     scalar_t(truncationMargin),
                     imageWidth,
                     imageHeight,
@@ -1318,8 +1274,7 @@ integrateTSDFImpl(const c10::intrusive_ptr<GridBatchData> grid,
     //   integrate=W ms  total=T ms  old_voxels=K  new_voxels=M
     // This is invaluable for decomposing the fvdb_leaf vs fvdb_voxel
     // ~15x slowdown (see session journal entry on voxel-shell tuning).
-    const bool phaseProfile =
-        std::getenv("FVDB_TSDF_PHASE_PROFILE") != nullptr;
+    const bool phaseProfile = std::getenv("FVDB_TSDF_PHASE_PROFILE") != nullptr;
     cudaEvent_t evA{}, evB{}, evC{}, evD{}, evE{};
     auto phaseMark = [&](cudaEvent_t &ev) {
         if (phaseProfile) {
@@ -1355,10 +1310,9 @@ integrateTSDFImpl(const c10::intrusive_ptr<GridBatchData> grid,
     // ~2x GB savings that motivated the fp16 path in the first place.
     const torch::Tensor unprojectedPointsNative = unprojectDepthMapToPoints(
         squeezedDepthImages, projectionMats, invProjectionMats, camToWorldMats);
-    const torch::Tensor unprojectedPoints =
-        unprojectedPointsNative.scalar_type() == torch::kHalf
-            ? unprojectedPointsNative.to(torch::kFloat32)
-            : unprojectedPointsNative;
+    const torch::Tensor unprojectedPoints = unprojectedPointsNative.scalar_type() == torch::kHalf
+                                                ? unprojectedPointsNative.to(torch::kFloat32)
+                                                : unprojectedPointsNative;
     phaseMark(evB);
 
     // Step 2: Build union grid grid from unprojected points and merge into with the old grid
@@ -1420,16 +1374,18 @@ integrateTSDFImpl(const c10::intrusive_ptr<GridBatchData> grid,
         cudaEventElapsedTime(&t_shell, evB, evC);
         cudaEventElapsedTime(&t_merge, evC, evD);
         cudaEventElapsedTime(&t_integ, evD, evE);
-        std::fprintf(
-            stderr,
-            "[fvdb/tsdf_phase] unproject=%.3f ms  shell=%.3f ms  "
-            "merge=%.3f ms  integrate=%.3f ms  total=%.3f ms  "
-            "old_vox=%lld  union_vox=%lld  point_vox=%lld\n",
-            t_unproj, t_shell, t_merge, t_integ,
-            t_unproj + t_shell + t_merge + t_integ,
-            (long long)grid->totalVoxels(),
-            (long long)unionGrid->totalVoxels(),
-            (long long)pointGrid->totalVoxels());
+        std::fprintf(stderr,
+                     "[fvdb/tsdf_phase] unproject=%.3f ms  shell=%.3f ms  "
+                     "merge=%.3f ms  integrate=%.3f ms  total=%.3f ms  "
+                     "old_vox=%lld  union_vox=%lld  point_vox=%lld\n",
+                     t_unproj,
+                     t_shell,
+                     t_merge,
+                     t_integ,
+                     t_unproj + t_shell + t_merge + t_integ,
+                     (long long)grid->totalVoxels(),
+                     (long long)unionGrid->totalVoxels(),
+                     (long long)pointGrid->totalVoxels());
         cudaEventDestroy(evA);
         cudaEventDestroy(evB);
         cudaEventDestroy(evC);
@@ -1517,15 +1473,15 @@ namespace {
 
 std::tuple<c10::intrusive_ptr<GridBatchData>, JaggedTensor, JaggedTensor, JaggedTensor>
 integrateTSDFBatchImpl(const c10::intrusive_ptr<GridBatchData> grid,
-                      const double truncationMargin,
-                      const torch::Tensor &projectionMatrices,
-                      const torch::Tensor &camToWorldMatrices,
-                      const JaggedTensor &tsdf,
-                      const JaggedTensor &weights,
-                      const std::optional<JaggedTensor> &features,
-                      const torch::Tensor &depthImages,
-                      const std::optional<torch::Tensor> &featureImages,
-                      const std::optional<torch::Tensor> &weightImages) {
+                       const double truncationMargin,
+                       const torch::Tensor &projectionMatrices,
+                       const torch::Tensor &camToWorldMatrices,
+                       const JaggedTensor &tsdf,
+                       const JaggedTensor &weights,
+                       const std::optional<JaggedTensor> &features,
+                       const torch::Tensor &depthImages,
+                       const std::optional<torch::Tensor> &featureImages,
+                       const std::optional<torch::Tensor> &weightImages) {
     const at::cuda::OptionalCUDAGuard device_guard(device_of(tsdf.jdata()));
 
     TORCH_CHECK_VALUE(grid->batchSize() == 1,
@@ -1543,11 +1499,15 @@ integrateTSDFBatchImpl(const c10::intrusive_ptr<GridBatchData> grid,
     TORCH_CHECK_VALUE(projectionMatrices.size(0) == N,
                       "projectionMatrices frame count (",
                       projectionMatrices.size(0),
-                      ") must equal depth-image frame count (", N, ")");
+                      ") must equal depth-image frame count (",
+                      N,
+                      ")");
     TORCH_CHECK_VALUE(camToWorldMatrices.size(0) == N,
                       "camToWorldMatrices frame count (",
                       camToWorldMatrices.size(0),
-                      ") must equal depth-image frame count (", N, ")");
+                      ") must equal depth-image frame count (",
+                      N,
+                      ")");
 
     // --- Incremental per-frame pipeline ------------------------------
     //
@@ -1566,8 +1526,7 @@ integrateTSDFBatchImpl(const c10::intrusive_ptr<GridBatchData> grid,
     // grid once some frame's truncation shell has touched it, so by
     // construction every active voxel has at least one real TSDF
     // update.
-    const bool profile_batch =
-        std::getenv("FVDB_TSDF_BATCH_PROFILE") != nullptr;
+    const bool profile_batch = std::getenv("FVDB_TSDF_BATCH_PROFILE") != nullptr;
     cudaEvent_t evStart{}, evEnd{};
     if (profile_batch) {
         cudaEventCreate(&evStart);
@@ -1584,7 +1543,9 @@ integrateTSDFBatchImpl(const c10::intrusive_ptr<GridBatchData> grid,
         TORCH_CHECK_VALUE(featureImages.value().size(0) == N,
                           "featureImages frame count (",
                           featureImages.value().size(0),
-                          ") must equal depth-image frame count (", N, ")");
+                          ") must equal depth-image frame count (",
+                          N,
+                          ")");
     } else {
         TORCH_CHECK(!featureImages.has_value(),
                     "Feature images must not be provided if features are not provided.");
@@ -1595,7 +1556,9 @@ integrateTSDFBatchImpl(const c10::intrusive_ptr<GridBatchData> grid,
         TORCH_CHECK_VALUE(hasPerFrameWeightImages,
                           "weightImages frame count (",
                           weightImages.value().size(0),
-                          ") must equal depth-image frame count (", N, ")");
+                          ") must equal depth-image frame count (",
+                          N,
+                          ")");
     }
 
     // Own the accumulator as a `PersistentTSDFState` so the per-frame
@@ -1623,51 +1586,39 @@ integrateTSDFBatchImpl(const c10::intrusive_ptr<GridBatchData> grid,
     //   - `FVDB_FULL_UNION_INTEGRATE=1` is an opt-in legacy knob
     //     only exercised by the single-frame `integrateTSDFImpl`
     //     path; batched always uses shell-filtered integrate.
-    auto featuresStart = hasFeatureImages
-                             ? std::make_optional(features.value().jdata())
-                             : std::nullopt;
-    PersistentTSDFState state(
-        grid, tsdf.jdata(), weights.jdata(), featuresStart);
+    auto featuresStart =
+        hasFeatureImages ? std::make_optional(features.value().jdata()) : std::nullopt;
+    PersistentTSDFState state(grid, tsdf.jdata(), weights.jdata(), featuresStart);
 
     for (int64_t i = 0; i < N; ++i) {
-        const torch::Tensor depth_i =
-            depthImagesSqueezed.narrow(0, i, 1).contiguous();
-        const torch::Tensor proj_i =
-            projectionMatrices.narrow(0, i, 1).contiguous();
-        const torch::Tensor c2w_i =
-            camToWorldMatrices.narrow(0, i, 1).contiguous();
-        const torch::Tensor featImg_i =
-            hasFeatureImages
-                ? featureImages.value().narrow(0, i, 1).contiguous()
-                : torch::empty({0, 0, 0, 0}, depth_i.options());
-        const torch::Tensor wImg_i =
-            hasPerFrameWeightImages
-                ? weightImages.value().narrow(0, i, 1).contiguous()
-                : torch::empty({0, 0, 0}, depth_i.options());
+        const torch::Tensor depth_i   = depthImagesSqueezed.narrow(0, i, 1).contiguous();
+        const torch::Tensor proj_i    = projectionMatrices.narrow(0, i, 1).contiguous();
+        const torch::Tensor c2w_i     = camToWorldMatrices.narrow(0, i, 1).contiguous();
+        const torch::Tensor featImg_i = hasFeatureImages
+                                            ? featureImages.value().narrow(0, i, 1).contiguous()
+                                            : torch::empty({0, 0, 0, 0}, depth_i.options());
+        const torch::Tensor wImg_i    = hasPerFrameWeightImages
+                                            ? weightImages.value().narrow(0, i, 1).contiguous()
+                                            : torch::empty({0, 0, 0}, depth_i.options());
 
         // Rebuild camera matrices for this frame (same helper the
         // single-frame impl uses).
-        const auto [projMats, invProjMats, c2wMats, w2cMats] =
-            getCameraMatrices(proj_i, c2w_i);
+        const auto [projMats, invProjMats, c2wMats, w2cMats] = getCameraMatrices(proj_i, c2w_i);
 
         // Squeeze optional channel dim to keep the single-frame
         // conventions uniform.
-        const torch::Tensor depth_i_sq =
-            depth_i.dim() == 4 ? depth_i.squeeze(-1) : depth_i;
-        const torch::Tensor wImg_i_sq =
-            wImg_i.dim() == 4 ? wImg_i.squeeze(-1) : wImg_i;
+        const torch::Tensor depth_i_sq = depth_i.dim() == 4 ? depth_i.squeeze(-1) : depth_i;
+        const torch::Tensor wImg_i_sq  = wImg_i.dim() == 4 ? wImg_i.squeeze(-1) : wImg_i;
 
         // Unproject + build this frame's shell (identical to the
         // single-frame path; see `integrateTSDFImpl` for fp16
         // promote-for-quantise note).
-        const torch::Tensor unprojectedNative = unprojectDepthMapToPoints(
-            depth_i_sq, projMats, invProjMats, c2wMats);
-        const torch::Tensor unprojected =
-            unprojectedNative.scalar_type() == torch::kHalf
-                ? unprojectedNative.to(torch::kFloat32)
-                : unprojectedNative;
-        const auto pointGrid = buildPointGrid(
-            truncationMargin, unprojected, state.grid());
+        const torch::Tensor unprojectedNative =
+            unprojectDepthMapToPoints(depth_i_sq, projMats, invProjMats, c2wMats);
+        const torch::Tensor unprojected = unprojectedNative.scalar_type() == torch::kHalf
+                                              ? unprojectedNative.to(torch::kFloat32)
+                                              : unprojectedNative;
+        const auto pointGrid = buildPointGrid(truncationMargin, unprojected, state.grid());
 
         // Grow the persistent state: maybe-alloc sidecars, maybe-
         // inject from old layout to new, update grid pointer.
@@ -1679,23 +1630,25 @@ integrateTSDFBatchImpl(const c10::intrusive_ptr<GridBatchData> grid,
         // `hasFeatures` flag. Keep the size-matching invariant.
         torch::Tensor featuresRef = state.features();
 
-        doIntegrateShellInPlace(
-            truncationMargin,
-            depth_i_sq,
-            featImg_i,
-            wImg_i_sq,
-            projMats, invProjMats, c2wMats, w2cMats,
-            state.grid(),
-            *pointGrid,
-            state.tsdf(), state.weights(), featuresRef);
+        doIntegrateShellInPlace(truncationMargin,
+                                depth_i_sq,
+                                featImg_i,
+                                wImg_i_sq,
+                                projMats,
+                                invProjMats,
+                                c2wMats,
+                                w2cMats,
+                                state.grid(),
+                                *pointGrid,
+                                state.tsdf(),
+                                state.weights(),
+                                featuresRef);
     }
 
     c10::intrusive_ptr<GridBatchData> accumGrid = state.gridPtr();
-    JaggedTensor accumTsdf     = state.tsdfJagged();
-    JaggedTensor accumWeights  = state.weightsJagged();
-    JaggedTensor accumFeatures = hasFeatureImages
-                                     ? state.featuresJagged()
-                                     : JaggedTensor();
+    JaggedTensor accumTsdf                      = state.tsdfJagged();
+    JaggedTensor accumWeights                   = state.weightsJagged();
+    JaggedTensor accumFeatures = hasFeatureImages ? state.featuresJagged() : JaggedTensor();
 
     if (profile_batch) {
         cudaEventRecord(evEnd);
@@ -1705,7 +1658,9 @@ integrateTSDFBatchImpl(const c10::intrusive_ptr<GridBatchData> grid,
         std::fprintf(
             stderr,
             "[fvdb/tsdf_batch] N=%lld  incremental=%.2f ms  (%.2f ms/frame)  final_voxels=%lld  final_leaves=%lld\n",
-            (long long)N, ms, ms / static_cast<float>(N),
+            (long long)N,
+            ms,
+            ms / static_cast<float>(N),
             (long long)accumGrid->totalVoxels(),
             (long long)accumGrid->totalLeaves());
         cudaEventDestroy(evStart);
@@ -1728,10 +1683,17 @@ integrateTSDFBatch(const c10::intrusive_ptr<GridBatchData> grid,
                    const std::optional<torch::Tensor> &weightImages) {
     TORCH_CHECK_NOT_IMPLEMENTED(grid->device().is_cuda(),
                                 "TSDF integration not implemented on the CPU.");
-    auto [unionGrid, outTsdf, outWeights, _unusedFeatures] = integrateTSDFBatchImpl(
-        grid, truncationMargin, projectionMatrices, camToWorldMatrices,
-        tsdf, weights, std::nullopt,
-        depthImages, std::nullopt, weightImages);
+    auto [unionGrid, outTsdf, outWeights, _unusedFeatures] =
+        integrateTSDFBatchImpl(grid,
+                               truncationMargin,
+                               projectionMatrices,
+                               camToWorldMatrices,
+                               tsdf,
+                               weights,
+                               std::nullopt,
+                               depthImages,
+                               std::nullopt,
+                               weightImages);
     return {unionGrid, outTsdf, outWeights};
 }
 
@@ -1748,9 +1710,16 @@ integrateTSDFBatchWithFeatures(const c10::intrusive_ptr<GridBatchData> grid,
                                const std::optional<torch::Tensor> &weightImages) {
     TORCH_CHECK_NOT_IMPLEMENTED(grid->device().is_cuda(),
                                 "TSDF integration not implemented on the CPU.");
-    return integrateTSDFBatchImpl(grid, truncationMargin, projectionMatrices,
-                                  camToWorldMatrices, tsdf, weights, features,
-                                  depthImages, featureImages, weightImages);
+    return integrateTSDFBatchImpl(grid,
+                                  truncationMargin,
+                                  projectionMatrices,
+                                  camToWorldMatrices,
+                                  tsdf,
+                                  weights,
+                                  features,
+                                  depthImages,
+                                  featureImages,
+                                  weightImages);
 }
 
 } // namespace fvdb::detail::ops

--- a/src/fvdb/detail/ops/IntegrateTSDF.h
+++ b/src/fvdb/detail/ops/IntegrateTSDF.h
@@ -38,6 +38,45 @@ integrateTSDFWithFeatures(const c10::intrusive_ptr<GridBatchData> grid,
                           const torch::Tensor &featureImages,
                           const std::optional<torch::Tensor> &weightImages);
 
+/// @brief Batched depth-image TSDF integration — builds the full union
+///        topology ONCE over all N frames, then runs N sequential
+///        integrate passes against that fixed topology.
+///
+/// Semantically equivalent to calling `integrateTSDF` N times in a row
+/// (verified bit-identically in the unit test), but avoids the per-
+/// frame `buildPointTruncationShell + mergeGrids` cost that dominates
+/// the per-frame wall-clock on small scenes.
+///
+/// For the paper's RGB-D comparison this is the natural idiom: all
+/// frames are known up-front, topology is built once, then the fusion
+/// kernel runs at fixed topology — the sparse-topology-as-tensor
+/// analog of Open3D's lazy block-hashed allocation.
+///
+/// Requires `grid->batchSize() == 1`. The N dimension is carried on
+/// `depthImages.size(0)` and must match `projectionMatrices.size(0)`
+/// and `camToWorldMatrices.size(0)`.
+std::tuple<c10::intrusive_ptr<GridBatchData>, JaggedTensor, JaggedTensor>
+integrateTSDFBatch(const c10::intrusive_ptr<GridBatchData> grid,
+                   const double truncationMargin,
+                   const torch::Tensor &projectionMatrices,
+                   const torch::Tensor &camToWorldMatrices,
+                   const JaggedTensor &tsdf,
+                   const JaggedTensor &weights,
+                   const torch::Tensor &depthImages,
+                   const std::optional<torch::Tensor> &weightImages);
+
+std::tuple<c10::intrusive_ptr<GridBatchData>, JaggedTensor, JaggedTensor, JaggedTensor>
+integrateTSDFBatchWithFeatures(const c10::intrusive_ptr<GridBatchData> grid,
+                               const double truncationMargin,
+                               const torch::Tensor &projectionMatrices,
+                               const torch::Tensor &camToWorldMatrices,
+                               const JaggedTensor &tsdf,
+                               const JaggedTensor &features,
+                               const JaggedTensor &weights,
+                               const torch::Tensor &depthImages,
+                               const torch::Tensor &featureImages,
+                               const std::optional<torch::Tensor> &weightImages);
+
 } // namespace ops
 } // namespace detail
 } // namespace fvdb

--- a/src/fvdb/detail/ops/IntegrateTSDFFromPoints.cu
+++ b/src/fvdb/detail/ops/IntegrateTSDFFromPoints.cu
@@ -1,0 +1,879 @@
+// Copyright Contributors to the OpenVDB Project
+// SPDX-License-Identifier: Apache-2.0
+//
+// Native LiDAR / range-sensor TSDF integrator. Per-point thread walks
+// the union grid via HDDA and updates (TSDF, weight, features) at each
+// voxel within the truncation band (and optionally the free-space band)
+// via lock-free atomicAdd in running-sum form.
+//
+// Pipeline:
+//   1. Build topology: union of existing grid and truncation shell of
+//      new points (via the shared `buildPointTruncationShell` primitive
+//      that the depth integrator also uses).
+//   2. Seed kernel: initialise (sum_w_sdf, sum_w, sum_w_feat) on the
+//      union grid from the existing (tsdf, weights, features) on the
+//      base grid (or zero where the voxel is new).
+//   3. Ray-walk kernel: one thread per point. HDDA-walks active voxels
+//      along the ray; within the truncation / free-space bands, does
+//      atomicAdd updates on the three running-sum accumulators.
+//   4. Normalise kernel: divides sum_w_sdf / sum_w -> tsdf,
+//      sum_w_feat / sum_w -> features. sum_w stays as the per-voxel
+//      weight.
+
+#include <fvdb/GridBatchData.h>
+#include <fvdb/JaggedTensor.h>
+#include <fvdb/VoxelCoordTransform.h>
+#include <fvdb/detail/ops/BuildMergedGrids.h>
+#include <fvdb/detail/ops/BuildPointTruncationShell.h>
+#include <fvdb/detail/ops/IntegrateTSDFFromPoints.h>
+#include <fvdb/detail/utils/AccessorHelpers.cuh>
+#include <fvdb/detail/utils/Utils.h>
+#include <fvdb/detail/utils/cuda/Atomics.cuh>
+#include <fvdb/detail/utils/cuda/GridDim.h>
+#include <fvdb/detail/utils/nanovdb/HDDAIterators.h>
+
+#include <ATen/OpMathType.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/core/ScalarType.h>
+#include <c10/cuda/CUDAException.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <c10/cuda/CUDAStream.h>
+#include <c10/util/Half.h>
+
+#include <nanovdb/NanoVDB.h>
+#include <nanovdb/math/Ray.h>
+
+#include <cmath>
+#include <cuda_runtime.h>
+#include <torch/types.h>
+
+namespace fvdb::detail::ops {
+
+namespace {
+
+using GridT        = nanovdb::ValueOnIndex;
+using LeafNodeType = nanovdb::NanoGrid<GridT>::LeafNodeType;
+constexpr uint64_t VOXELS_PER_LEAF =
+    nanovdb::NanoTree<GridT>::LeafNodeType::NUM_VALUES;
+
+// -------------------------------------------------------------------------
+// M1: seed kernel.
+//
+// For each active voxel in the union grid, initialise the running-sum
+// accumulators from the base grid's (tsdf, weights, features) if the
+// voxel already exists there, otherwise zero.
+//
+// The output `outTsdf` and `outFeatures` tensors store SUM-OF-WEIGHTED
+// values at this stage (i.e. tsdf * weight, features * weight). The
+// final normalise pass divides by `outWeights` to recover the true
+// running average.
+// -------------------------------------------------------------------------
+
+template <typename ScalarDataType, typename FeatureAccumT>
+__global__ void
+seedAccumulatorsFromBaseGridKernel(
+    const fvdb::BatchGridAccessor baseGridAcc,
+    const fvdb::BatchGridAccessor unionGridAcc,
+    const bool hasFeatures,
+    const int64_t featureDim,
+    const fvdb::JaggedRAcc64<ScalarDataType, 1> tsdfAcc,
+    const fvdb::JaggedRAcc64<ScalarDataType, 1> weightsAcc,
+    const fvdb::JaggedRAcc64<FeatureAccumT, 2> featuresAsAccumAcc,
+    fvdb::TorchRAcc64<ScalarDataType, 1> outTsdfAcc,
+    fvdb::TorchRAcc64<ScalarDataType, 1> outWeightsAcc,
+    fvdb::TorchRAcc64<FeatureAccumT, 2> outFeaturesAccumAcc) {
+    const uint64_t problemSize =
+        unionGridAcc.totalLeaves() * VOXELS_PER_LEAF;
+    for (uint64_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+         idx < problemSize;
+         idx += blockDim.x * gridDim.x) {
+        const int64_t cumUnionLeafIdx =
+            static_cast<int64_t>(idx / VOXELS_PER_LEAF);
+        const int64_t unionLeafVoxelIdx =
+            static_cast<int64_t>(idx % VOXELS_PER_LEAF);
+        const fvdb::JIdxType batchIdx =
+            unionGridAcc.leafBatchIndex(cumUnionLeafIdx);
+        const int64_t unionLeafIdx =
+            cumUnionLeafIdx - unionGridAcc.leafOffset(batchIdx);
+
+        const nanovdb::NanoGrid<GridT> *unionGrid = unionGridAcc.grid(batchIdx);
+        const LeafNodeType &unionLeaf =
+            unionGrid->tree().template getFirstNode<0>()[unionLeafIdx];
+        const nanovdb::Coord ijk =
+            unionLeaf.offsetToGlobalCoord(unionLeafVoxelIdx);
+
+        const int64_t unionWriteOffset =
+            unionGridAcc.voxelOffset(batchIdx) +
+            static_cast<int64_t>(unionLeaf.getValue(unionLeafVoxelIdx)) - 1;
+        if (unionWriteOffset < unionGridAcc.voxelOffset(batchIdx)) {
+            continue; // inactive slot
+        }
+
+        // Check if voxel exists in base grid.
+        const nanovdb::NanoGrid<GridT> *baseGrid = baseGridAcc.grid(batchIdx);
+        auto baseAcc                             = baseGrid->getAccessor();
+        const bool inBase                        = baseAcc.isActive(ijk);
+
+        if (inBase) {
+            const int64_t baseOffset =
+                baseGridAcc.voxelOffset(batchIdx) +
+                static_cast<int64_t>(baseAcc.getValue(ijk)) - 1;
+            const ScalarDataType oldW = weightsAcc.data()[baseOffset];
+            const ScalarDataType oldT = tsdfAcc.data()[baseOffset];
+            outTsdfAcc[unionWriteOffset]    = ScalarDataType(static_cast<float>(oldT) *
+                                                             static_cast<float>(oldW));
+            outWeightsAcc[unionWriteOffset] = oldW;
+            if (hasFeatures) {
+                for (int64_t d = 0; d < featureDim; ++d) {
+                    outFeaturesAccumAcc[unionWriteOffset][d] =
+                        FeatureAccumT(static_cast<float>(featuresAsAccumAcc.data()[baseOffset][d]) *
+                                      static_cast<float>(oldW));
+                }
+            }
+        } else {
+            outTsdfAcc[unionWriteOffset]    = ScalarDataType(0);
+            outWeightsAcc[unionWriteOffset] = ScalarDataType(0);
+            if (hasFeatures) {
+                for (int64_t d = 0; d < featureDim; ++d) {
+                    outFeaturesAccumAcc[unionWriteOffset][d] = FeatureAccumT(0);
+                }
+            }
+        }
+    }
+}
+
+// -------------------------------------------------------------------------
+// M2: ray-walk kernel.
+//
+// One thread per input point. Walks active voxels along the ray from
+// sensor origin to (point + truncation along ray) via HDDAVoxelIterator
+// over the union grid. For each active voxel, computes the signed
+// distance along the ray from voxel centre to endpoint and decides
+// whether to update it:
+//   - behind endpoint by > truncation: skip (unknown state).
+//   - within [−truncation, +truncation] of endpoint: write
+//     clamped tsdf_normalised, weight = 1.
+//   - in front of endpoint (free space) and `carveFreeSpace`:
+//     write tsdf = +1, weight = 1.
+//   - free-space without carving: skip.
+// Updates go via atomicAdd on the running-sum accumulators; the
+// running-sum form is what makes the concurrent updates lock-free
+// (see plan.md D3 and the `seedAccumulatorsFromBaseGridKernel` note).
+// -------------------------------------------------------------------------
+
+template <typename ScalarDataType, typename FeatureDataType, typename FeatureAccumT>
+__global__ void
+rayWalkIntegrateKernel(
+    const fvdb::BatchGridAccessor unionGridAcc,
+    const fvdb::JaggedRAcc64<ScalarDataType, 2> pointsAcc,
+    const fvdb::TorchRAcc64<ScalarDataType, 2> sensorOriginsAcc,
+    const bool hasFeatures,
+    const int64_t featureDim,
+    const fvdb::JaggedRAcc64<FeatureDataType, 2> pointFeaturesAcc,
+    const float truncationMargin,
+    const bool carveFreeSpace,
+    fvdb::TorchRAcc64<ScalarDataType, 1> outTsdfAcc,
+    fvdb::TorchRAcc64<ScalarDataType, 1> outWeightsAcc,
+    fvdb::TorchRAcc64<FeatureAccumT, 2> outFeaturesAccumAcc) {
+    using MathT = at::opmath_type<ScalarDataType>;
+    using Vec3T = nanovdb::math::Vec3<MathT>;
+    using RayT  = nanovdb::math::Ray<MathT>;
+
+    const int64_t totalPoints = pointsAcc.elementCount();
+    const int64_t pointIdx    = blockIdx.x * blockDim.x + threadIdx.x;
+    if (pointIdx >= totalPoints) {
+        return;
+    }
+
+    const fvdb::JIdxType batchIdx = pointsAcc.batchIdx(pointIdx);
+
+    // World-space ray from sensor origin to point endpoint. We use
+    // static_cast rather than functional-cast syntax (`MathT(...)`)
+    // because nvcc otherwise hits a most-vexing-parse corner on some
+    // versions (interprets the inner expression as a parameter-name
+    // declaration inside the Vec3T constructor).
+    const Vec3T originWorld(static_cast<MathT>(sensorOriginsAcc[batchIdx][0]),
+                            static_cast<MathT>(sensorOriginsAcc[batchIdx][1]),
+                            static_cast<MathT>(sensorOriginsAcc[batchIdx][2]));
+    const Vec3T endpointWorld(static_cast<MathT>(pointsAcc.data()[pointIdx][0]),
+                              static_cast<MathT>(pointsAcc.data()[pointIdx][1]),
+                              static_cast<MathT>(pointsAcc.data()[pointIdx][2]));
+    Vec3T dirWorld         = endpointWorld - originWorld;
+    const MathT rangeWorld = dirWorld.length();
+    if (rangeWorld < MathT(1e-8)) {
+        return; // degenerate zero-length ray
+    }
+    dirWorld = dirWorld / rangeWorld;
+
+    // Ray parametrisation (in world space):
+    //   t = 0 at origin, t = rangeWorld at endpoint.
+    // We walk voxels over t in [0, rangeWorld + truncationMargin] when
+    // carving free space, else [rangeWorld - truncationMargin,
+    // rangeWorld + truncationMargin].
+    const MathT tTruncStart = rangeWorld - MathT(truncationMargin);
+    const MathT tTruncEnd   = rangeWorld + MathT(truncationMargin);
+    const MathT tWalkStart  = carveFreeSpace ? MathT(0) : tTruncStart;
+    const MathT tWalkEnd    = tTruncEnd;
+    if (tWalkEnd <= tWalkStart) {
+        return; // nothing to update
+    }
+
+    const RayT rayWorld(originWorld, dirWorld, tWalkStart, tWalkEnd);
+
+    // Transform ray to voxel-index space for HDDA.
+    const VoxelCoordTransform transform =
+        unionGridAcc.primalTransform(batchIdx);
+    const RayT rayVox = transform.applyToRay(rayWorld);
+
+    const nanovdb::NanoGrid<GridT> *grid = unionGridAcc.grid(batchIdx);
+    auto acc                             = grid->getAccessor();
+    const int64_t voxelOffsetBase = unionGridAcc.voxelOffset(batchIdx);
+
+    // HDDAVoxelIterator walks active voxels of the sparse grid along the
+    // ray, automatically skipping inactive regions. This is the sparse-
+    // native "ray-walk" primitive fvdb exposes; the per-ray thread hits
+    // only voxels that exist in the endpoint-shell topology (see plan.md
+    // D2 — free-space carving fills topology gaps only within the
+    // existing union grid, does not extend it).
+    fvdb::HDDAVoxelIterator<decltype(acc), MathT> it(rayVox, acc);
+    while (it.isValid()) {
+        const nanovdb::Coord voxIjk = it->first;
+        ++it;
+
+        // World-space signed distance: Euclidean range-difference
+        // from sensor origin, ||P - O|| - ||V - O||. Positive = voxel
+        // is closer to origin than the surface point (free space);
+        // negative = voxel is farther than the surface (unknown /
+        // behind). This matches the VDBFusion / canonical-TSDF
+        // convention.
+        //
+        // Using the along-ray projection (toVox · dir) would bias
+        // mesh extraction outward for voxels near but not on the ray
+        // — HDDA includes voxel centres that are off-ray by up to
+        // sqrt(3)/2 * voxel_size, so the off-ray bias is ~1 voxel.
+        // The Euclidean-range form has no such bias.
+        //
+        // fvdb's convention treats voxel values as stored AT integer
+        // ijk coordinates (same as the existing depth integrator in
+        // IntegrateTSDF.cu:204-206); no +0.5 shift.
+        const Vec3T voxPosWorld = transform.applyInv<MathT>(
+            static_cast<MathT>(voxIjk[0]),
+            static_cast<MathT>(voxIjk[1]),
+            static_cast<MathT>(voxIjk[2]));
+        const Vec3T toVox       = voxPosWorld - originWorld;
+        const MathT rangeToVox  = toVox.length();
+        const MathT sdfWorld    = rangeWorld - rangeToVox;
+
+        // Classify the voxel.
+        MathT tsdfClamped;
+        if (sdfWorld > MathT(truncationMargin)) {
+            if (!carveFreeSpace) {
+                continue;
+            }
+            tsdfClamped = MathT(1);
+        } else if (sdfWorld < -MathT(truncationMargin)) {
+            continue; // unknown region behind the endpoint
+        } else {
+            tsdfClamped = sdfWorld / MathT(truncationMargin);
+        }
+
+        // Look up the voxel's write offset. isActive was already
+        // checked inside HDDA so getValue is safe.
+        const int64_t writeOffset =
+            voxelOffsetBase + static_cast<int64_t>(acc.getValue(voxIjk)) - 1;
+
+        // `atomAdd` (from Atomics.cuh) is the fvdb wrapper that
+        // handles both hardware-native (float / double / at::Half on
+        // sm_70+) and CAS-loop-based atomic adds on all supported
+        // dtypes — including the half-precision path that plain
+        // `atomicAdd(c10::Half*, ...)` doesn't resolve.
+        constexpr MathT kSampleWeight = MathT(1);
+        atomAdd(&outTsdfAcc[writeOffset],
+                static_cast<ScalarDataType>(tsdfClamped * kSampleWeight));
+        atomAdd(&outWeightsAcc[writeOffset],
+                static_cast<ScalarDataType>(kSampleWeight));
+        if (hasFeatures) {
+            for (int64_t d = 0; d < featureDim; ++d) {
+                const FeatureAccumT featVal =
+                    static_cast<FeatureAccumT>(pointFeaturesAcc.data()[pointIdx][d]);
+                atomAdd(&outFeaturesAccumAcc[writeOffset][d],
+                        static_cast<FeatureAccumT>(
+                            featVal * static_cast<FeatureAccumT>(kSampleWeight)));
+            }
+        }
+    }
+}
+
+// -------------------------------------------------------------------------
+// M3: normalise kernel.
+//
+// After the ray-walk accumulations, outTsdf and outFeatures hold
+// running sums of (tsdf * weight) and (feature * weight). Divide by
+// outWeights to recover the running-average form that the public TSDF
+// API contract expects. Voxels that received no updates (weights ==
+// 0) are left at zero (reasonable — signals "no observation").
+// -------------------------------------------------------------------------
+
+template <typename ScalarDataType, typename FeatureDataType, typename FeatureAccumT>
+__global__ void
+normaliseAccumulatorsKernel(const int64_t totalVoxels,
+                            const bool hasFeatures,
+                            const int64_t featureDim,
+                            fvdb::TorchRAcc64<ScalarDataType, 1> outTsdfAcc,
+                            fvdb::TorchRAcc64<ScalarDataType, 1> outWeightsAcc,
+                            const fvdb::TorchRAcc64<FeatureAccumT, 2> outFeaturesAccumAcc,
+                            fvdb::TorchRAcc64<FeatureDataType, 2> outFeaturesAcc) {
+    const int64_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= totalVoxels) {
+        return;
+    }
+
+    const float w = static_cast<float>(outWeightsAcc[idx]);
+    if (w > 0.0f) {
+        outTsdfAcc[idx] =
+            ScalarDataType(static_cast<float>(outTsdfAcc[idx]) / w);
+        if (hasFeatures) {
+            for (int64_t d = 0; d < featureDim; ++d) {
+                outFeaturesAcc[idx][d] =
+                    FeatureDataType(static_cast<float>(outFeaturesAccumAcc[idx][d]) / w);
+            }
+        }
+    } else {
+        outTsdfAcc[idx] = ScalarDataType(0);
+        if (hasFeatures) {
+            for (int64_t d = 0; d < featureDim; ++d) {
+                outFeaturesAcc[idx][d] = FeatureDataType(0);
+            }
+        }
+    }
+}
+
+// -------------------------------------------------------------------------
+// Host orchestrator.
+//
+// Given an already-merged union grid plus the new input (points +
+// features), run the three-kernel pipeline above. Sequestered into a
+// helper so the two public entry points (with / without features)
+// share everything except input validation.
+// -------------------------------------------------------------------------
+
+#define DISPATCH_FEATURE_TYPE_LIDAR(SCALAR, FEAT_TYPE, ...)            \
+    if (hasFeatures && (FEAT_TYPE) == torch::kUInt8) {                  \
+        using feature_t = uint8_t;                                      \
+        /* uint8 atomicAdd unsupported on-device; accumulate in fp32 */ \
+        using feature_accum_t = float;                                  \
+        __VA_ARGS__();                                                  \
+    } else {                                                            \
+        using feature_t = SCALAR;                                       \
+        using feature_accum_t = SCALAR;                                 \
+        __VA_ARGS__();                                                  \
+    }
+
+std::tuple<JaggedTensor, JaggedTensor, JaggedTensor>
+doIntegrateFromPoints(const float truncationMargin,
+                      const JaggedTensor &points,
+                      const torch::Tensor &sensorOrigins,
+                      const JaggedTensor &pointFeatures,
+                      const GridBatchData &unionGrid,
+                      const GridBatchData &baseGrid,
+                      const JaggedTensor &tsdf,
+                      const JaggedTensor &weights,
+                      const JaggedTensor &features,
+                      bool carveFreeSpace) {
+    const c10::cuda::CUDAGuard device_guard(tsdf.device());
+
+    const int64_t totalOutVoxels = unionGrid.totalVoxels();
+    const int64_t featureDim     = features.rsize(-1);
+    const bool hasFeatures       = featureDim > 0;
+
+    torch::Tensor outTsdf    = torch::empty({totalOutVoxels}, tsdf.jdata().options());
+    torch::Tensor outWeights = torch::empty({totalOutVoxels}, weights.jdata().options());
+    // Always allocate with totalOutVoxels rows so the final
+    // `unionGrid.jaggedTensor(outFeatures)` size-check passes
+    // uniformly (featureDim=0 in the no-features case, matching the
+    // depth integrator's convention in IntegrateTSDF.cu:841).
+    torch::Tensor outFeatures = torch::empty(
+        {totalOutVoxels, featureDim}, features.jdata().options());
+
+    AT_DISPATCH_V2(
+        tsdf.scalar_type(),
+        "integrateTSDFFromPointsKernel",
+        AT_WRAP([&] {
+            DISPATCH_FEATURE_TYPE_LIDAR(scalar_t, features.scalar_type(), [&] {
+                // Feature accumulator tensor (may be wider than features
+                // itself when features are uint8 → accumulate in fp32).
+                torch::Tensor outFeaturesAccum;
+                constexpr bool accumIsSame =
+                    std::is_same_v<feature_t, feature_accum_t>;
+                if (hasFeatures) {
+                    if constexpr (accumIsSame) {
+                        outFeaturesAccum = outFeatures;
+                    } else {
+                        outFeaturesAccum = torch::empty(
+                            {totalOutVoxels, featureDim},
+                            torch::TensorOptions()
+                                .dtype(c10::CppTypeToScalarType<feature_accum_t>::value)
+                                .device(outFeatures.device()));
+                    }
+                } else {
+                    outFeaturesAccum = torch::empty({0, 0},
+                        torch::TensorOptions()
+                            .dtype(c10::CppTypeToScalarType<feature_accum_t>::value)
+                            .device(outTsdf.device()));
+                }
+
+                // Features base grid: reinterpret via the same accum
+                // dtype so the seed kernel (which reads from base) can
+                // use a single typed accessor. When features are uint8,
+                // we promote by an explicit cast in the seed kernel.
+                torch::Tensor featuresAsAccum;
+                if (hasFeatures) {
+                    if constexpr (accumIsSame) {
+                        featuresAsAccum = features.jdata();
+                    } else {
+                        featuresAsAccum = features.jdata().to(
+                            c10::CppTypeToScalarType<feature_accum_t>::value);
+                    }
+                } else {
+                    featuresAsAccum = torch::empty({0, 0},
+                        torch::TensorOptions()
+                            .dtype(c10::CppTypeToScalarType<feature_accum_t>::value)
+                            .device(outTsdf.device()));
+                }
+
+                const auto stream = at::cuda::getCurrentCUDAStream();
+
+                // Use the JaggedTensor-valued packed_accessor64 (not
+                // jdata().packed_accessor64) so the kernel receives
+                // JaggedRAcc64 with batch-aware `.batchIdx(i)` access.
+                auto tsdfAcc =
+                    tsdf.packed_accessor64<scalar_t, 1,
+                                           torch::RestrictPtrTraits>();
+                auto weightsAcc =
+                    weights.packed_accessor64<scalar_t, 1,
+                                              torch::RestrictPtrTraits>();
+                auto outTsdfAcc =
+                    outTsdf.packed_accessor64<scalar_t, 1,
+                                              torch::RestrictPtrTraits>();
+                auto outWeightsAcc =
+                    outWeights.packed_accessor64<scalar_t, 1,
+                                                 torch::RestrictPtrTraits>();
+                // Reinterpret features/jagged features as an accessor
+                // with the accumulator's dtype; when features are
+                // uint8 we already up-converted above, otherwise this
+                // is the identity (accum == feature dtype).
+                //
+                // In the no-features case we construct a sentinel JT
+                // over an empty tensor (jidx empty, jlidx empty) so
+                // JaggedTensor::from_data_indices_and_list_ids' size
+                // check doesn't mis-trigger against the tsdf JT's
+                // `size(0) = totalVoxels` indices tensor. The kernels
+                // guard with `if (hasFeatures)` before dereferencing
+                // the accessor, so the contents are never read.
+                torch::Tensor featuresReinterp;
+                if (hasFeatures) {
+                    featuresReinterp = featuresAsAccum.reshape(
+                        {featuresAsAccum.size(0), featureDim});
+                } else {
+                    featuresReinterp = torch::empty(
+                        {0, 0},
+                        torch::TensorOptions()
+                            .dtype(c10::CppTypeToScalarType<feature_accum_t>::value)
+                            .device(outTsdf.device()));
+                }
+                JaggedTensor featuresAsAccumJagged;
+                if (hasFeatures) {
+                    featuresAsAccumJagged =
+                        JaggedTensor::from_data_indices_and_list_ids(
+                            featuresReinterp,
+                            features.jidx(),
+                            features.jlidx(),
+                            features.num_outer_lists());
+                } else {
+                    auto idxOpts = torch::TensorOptions()
+                                       .dtype(fvdb::JIdxScalarType)
+                                       .device(outTsdf.device());
+                    featuresAsAccumJagged =
+                        JaggedTensor::from_data_indices_and_list_ids(
+                            featuresReinterp,
+                            torch::empty({0}, idxOpts),
+                            torch::empty({0, 1}, idxOpts),
+                            /*num_tensors=*/1);
+                }
+                auto featuresAsAccumAcc =
+                    featuresAsAccumJagged.packed_accessor64<feature_accum_t, 2,
+                                                            torch::RestrictPtrTraits>();
+                auto outFeaturesAccumAcc =
+                    outFeaturesAccum.packed_accessor64<feature_accum_t, 2,
+                                                       torch::RestrictPtrTraits>();
+
+                // Step 1: seed accumulators from the existing base grid.
+                {
+                    const uint64_t problemSize =
+                        unionGrid.totalLeaves() * VOXELS_PER_LEAF;
+                    const int64_t blocks =
+                        GET_BLOCKS(problemSize, DEFAULT_BLOCK_DIM);
+                    seedAccumulatorsFromBaseGridKernel<scalar_t, feature_accum_t>
+                        <<<blocks, DEFAULT_BLOCK_DIM, 0, stream.stream()>>>(
+                            baseGrid.deviceAccessor(),
+                            unionGrid.deviceAccessor(),
+                            hasFeatures,
+                            featureDim,
+                            tsdfAcc,
+                            weightsAcc,
+                            featuresAsAccumAcc,
+                            outTsdfAcc,
+                            outWeightsAcc,
+                            outFeaturesAccumAcc);
+                    C10_CUDA_KERNEL_LAUNCH_CHECK();
+                }
+
+                // Step 2: ray-walk every point and accumulate.
+                auto pointsAcc =
+                    points.packed_accessor64<scalar_t, 2,
+                                             torch::RestrictPtrTraits>();
+                auto sensorAcc =
+                    sensorOrigins.packed_accessor64<scalar_t, 2,
+                                                    torch::RestrictPtrTraits>();
+                auto pointFeaturesAcc =
+                    hasFeatures
+                        ? pointFeatures
+                              .packed_accessor64<feature_t, 2,
+                                                 torch::RestrictPtrTraits>()
+                        : pointFeatures
+                              .packed_accessor64<feature_t, 2,
+                                                 torch::RestrictPtrTraits>();
+                const int64_t totalPoints = points.jdata().size(0);
+                if (totalPoints > 0) {
+                    const int64_t blocks =
+                        GET_BLOCKS(totalPoints, DEFAULT_BLOCK_DIM);
+                    rayWalkIntegrateKernel<scalar_t, feature_t, feature_accum_t>
+                        <<<blocks, DEFAULT_BLOCK_DIM, 0, stream.stream()>>>(
+                            unionGrid.deviceAccessor(),
+                            pointsAcc,
+                            sensorAcc,
+                            hasFeatures,
+                            featureDim,
+                            pointFeaturesAcc,
+                            truncationMargin,
+                            carveFreeSpace,
+                            outTsdfAcc,
+                            outWeightsAcc,
+                            outFeaturesAccumAcc);
+                    C10_CUDA_KERNEL_LAUNCH_CHECK();
+                }
+
+                // Step 3: normalise accumulators into per-voxel TSDF / weights / features.
+                {
+                    auto outFeaturesAccOut =
+                        hasFeatures
+                            ? outFeatures.packed_accessor64<feature_t, 2,
+                                                            torch::RestrictPtrTraits>()
+                            : outFeatures.packed_accessor64<feature_t, 2,
+                                                            torch::RestrictPtrTraits>();
+                    const int64_t blocks =
+                        GET_BLOCKS(totalOutVoxels, DEFAULT_BLOCK_DIM);
+                    normaliseAccumulatorsKernel<scalar_t, feature_t, feature_accum_t>
+                        <<<blocks, DEFAULT_BLOCK_DIM, 0, stream.stream()>>>(
+                            totalOutVoxels,
+                            hasFeatures,
+                            featureDim,
+                            outTsdfAcc,
+                            outWeightsAcc,
+                            outFeaturesAccumAcc,
+                            outFeaturesAccOut);
+                    C10_CUDA_KERNEL_LAUNCH_CHECK();
+                }
+            });
+        }),
+        AT_EXPAND(AT_FLOATING_TYPES),
+        c10::kHalf);
+
+    // outFeatures is `{totalOutVoxels, 0}` in the no-features case,
+    // which passes `GridBatchData::jaggedTensor`'s size check
+    // uniformly (matches the depth integrator's pattern — see
+    // IntegrateTSDF.cu:866).
+    return {unionGrid.jaggedTensor(outTsdf),
+            unionGrid.jaggedTensor(outWeights),
+            unionGrid.jaggedTensor(outFeatures)};
+}
+
+// Build the union of the base grid and the new-point truncation shell;
+// reused by both public entry points.
+c10::intrusive_ptr<GridBatchData>
+buildUnionGrid(const c10::intrusive_ptr<GridBatchData> &baseGrid,
+               const JaggedTensor &points,
+               double truncationMargin) {
+    auto pointShell = buildPointTruncationShell(points, *baseGrid, truncationMargin);
+    return mergeGrids(*baseGrid, *pointShell);
+}
+
+// Common input validation for both public entry points.
+void
+checkCommonInputs(const c10::intrusive_ptr<GridBatchData> &grid,
+                  const JaggedTensor &points,
+                  const torch::Tensor &sensorOrigins,
+                  const JaggedTensor &tsdf,
+                  const JaggedTensor &weights) {
+    TORCH_CHECK_VALUE(grid != nullptr, "grid must be non-null");
+    TORCH_CHECK_VALUE(grid->device().is_cuda(),
+                      "integrateTSDFFromPoints requires a CUDA grid");
+    TORCH_CHECK_VALUE(points.rdim() == 2 && points.rsize(-1) == 3,
+                      "points must have shape [B, N, 3]");
+    TORCH_CHECK_VALUE(sensorOrigins.dim() == 2 && sensorOrigins.size(1) == 3,
+                      "sensorOrigins must have shape [B, 3]");
+    TORCH_CHECK_VALUE(sensorOrigins.size(0) == grid->batchSize(),
+                      "sensorOrigins batch size (", sensorOrigins.size(0),
+                      ") must match grid batch size (", grid->batchSize(), ")");
+    TORCH_CHECK_VALUE(points.num_outer_lists() == grid->batchSize(),
+                      "points batch size (", points.num_outer_lists(),
+                      ") must match grid batch size (", grid->batchSize(), ")");
+    TORCH_CHECK_VALUE(tsdf.num_outer_lists() == grid->batchSize(),
+                      "tsdf batch size (", tsdf.num_outer_lists(),
+                      ") must match grid batch size (", grid->batchSize(), ")");
+    TORCH_CHECK_VALUE(weights.num_outer_lists() == grid->batchSize(),
+                      "weights batch size must match grid batch size");
+    TORCH_CHECK_TYPE(tsdf.is_floating_point(),
+                     "tsdf must be a floating-point dtype");
+    TORCH_CHECK_TYPE(weights.scalar_type() == tsdf.scalar_type(),
+                     "weights dtype must match tsdf dtype");
+    TORCH_CHECK_TYPE(points.scalar_type() == tsdf.scalar_type(),
+                     "points dtype must match tsdf dtype");
+    TORCH_CHECK_TYPE(sensorOrigins.scalar_type() == tsdf.scalar_type(),
+                     "sensorOrigins dtype must match tsdf dtype");
+    TORCH_CHECK_VALUE(tsdf.numel() == grid->totalVoxels(),
+                      "tsdf size (", tsdf.numel(),
+                      ") must equal grid totalVoxels (", grid->totalVoxels(), ")");
+    TORCH_CHECK_VALUE(weights.numel() == grid->totalVoxels(),
+                      "weights size mismatch");
+}
+
+} // anonymous namespace
+
+// -------------------------------------------------------------------------
+// Public entry points.
+// -------------------------------------------------------------------------
+
+std::tuple<c10::intrusive_ptr<GridBatchData>, JaggedTensor, JaggedTensor>
+integrateTSDFFromPoints(const c10::intrusive_ptr<GridBatchData> grid,
+                        const double truncationMargin,
+                        const JaggedTensor &points,
+                        const torch::Tensor &sensorOrigins,
+                        const JaggedTensor &tsdf,
+                        const JaggedTensor &weights,
+                        bool carveFreeSpace) {
+    checkCommonInputs(grid, points, sensorOrigins, tsdf, weights);
+
+    auto unionGrid = buildUnionGrid(grid, points, truncationMargin);
+
+    // Empty JaggedTensor placeholders for the features / pointFeatures
+    // slots. `doIntegrateFromPoints` decides `hasFeatures` from the
+    // `features.rsize(-1)` inner dimension — a `[0, 0]` JT reports
+    // `rsize(-1) == 0`, so this matches the no-features branch
+    // cleanly. Convention matches the depth integrator in
+    // IntegrateTSDF.cu:841 (`torch::empty({0, 0}, opts)`).
+    const fvdb::JaggedTensor emptyFeatures      = torch::empty({0, 0}, tsdf.jdata().options());
+    const fvdb::JaggedTensor emptyPointFeatures = torch::empty({0, 0}, tsdf.jdata().options());
+
+    auto [newTsdf, newWeights, _unusedFeatures] = doIntegrateFromPoints(
+        static_cast<float>(truncationMargin),
+        points,
+        sensorOrigins,
+        emptyPointFeatures,
+        *unionGrid,
+        *grid,
+        tsdf,
+        weights,
+        emptyFeatures,
+        carveFreeSpace);
+
+    return {unionGrid, newTsdf, newWeights};
+}
+
+std::tuple<c10::intrusive_ptr<GridBatchData>, JaggedTensor, JaggedTensor, JaggedTensor>
+integrateTSDFFromPointsWithFeatures(const c10::intrusive_ptr<GridBatchData> grid,
+                                    const double truncationMargin,
+                                    const JaggedTensor &points,
+                                    const torch::Tensor &sensorOrigins,
+                                    const JaggedTensor &tsdf,
+                                    const JaggedTensor &features,
+                                    const JaggedTensor &weights,
+                                    const JaggedTensor &pointFeatures,
+                                    bool carveFreeSpace) {
+    checkCommonInputs(grid, points, sensorOrigins, tsdf, weights);
+
+    TORCH_CHECK_VALUE(features.rdim() == 2,
+                      "features must be 2-D [totalVoxels, featureDim]");
+    TORCH_CHECK_VALUE(pointFeatures.rdim() == 2,
+                      "pointFeatures must be 2-D [totalPoints, featureDim]");
+    TORCH_CHECK_VALUE(features.rsize(-1) == pointFeatures.rsize(-1),
+                      "features and pointFeatures must have the same featureDim");
+    TORCH_CHECK_VALUE(features.numel() == grid->totalVoxels() * features.rsize(-1),
+                      "features must have totalVoxels rows");
+    TORCH_CHECK_VALUE(pointFeatures.num_outer_lists() == grid->batchSize(),
+                      "pointFeatures batch size must match grid batch size");
+    TORCH_CHECK_VALUE(pointFeatures.numel() == points.numel() / 3 * pointFeatures.rsize(-1),
+                      "pointFeatures must have exactly one row per input point");
+    // Matching dtype rules from the depth integrator: features must be
+    // either the same fp dtype as tsdf, or uint8.
+    TORCH_CHECK_TYPE(features.scalar_type() == tsdf.scalar_type() ||
+                         features.scalar_type() == torch::kUInt8,
+                     "features dtype must match tsdf dtype or be uint8");
+    TORCH_CHECK_TYPE(pointFeatures.scalar_type() == features.scalar_type(),
+                     "pointFeatures dtype must match features dtype");
+
+    auto unionGrid = buildUnionGrid(grid, points, truncationMargin);
+
+    auto [newTsdf, newWeights, newFeatures] = doIntegrateFromPoints(
+        static_cast<float>(truncationMargin),
+        points,
+        sensorOrigins,
+        pointFeatures,
+        *unionGrid,
+        *grid,
+        tsdf,
+        weights,
+        features,
+        carveFreeSpace);
+
+    return {unionGrid, newTsdf, newWeights, newFeatures};
+}
+
+std::tuple<c10::intrusive_ptr<GridBatchData>, JaggedTensor, JaggedTensor>
+integrateTSDFFromPointsFrames(const c10::intrusive_ptr<GridBatchData> grid,
+                              const double truncationMargin,
+                              const std::vector<torch::Tensor> &pointsPerFrame,
+                              const torch::Tensor &sensorOrigins,
+                              const JaggedTensor &tsdf,
+                              const JaggedTensor &weights,
+                              bool carveFreeSpace) {
+    const int64_t N = static_cast<int64_t>(pointsPerFrame.size());
+    TORCH_CHECK_VALUE(N > 0, "pointsPerFrame must have at least one frame");
+    TORCH_CHECK_VALUE(
+        sensorOrigins.dim() == 2 && sensorOrigins.size(0) == N &&
+            sensorOrigins.size(1) == 3,
+        "sensorOrigins must have shape [N=", N, ", 3]; got ",
+        sensorOrigins.sizes());
+    TORCH_CHECK_VALUE(grid->batchSize() == 1,
+                      "integrateTSDFFromPointsFrames currently supports "
+                      "single-scene grids (batchSize = 1); got batchSize = ",
+                      grid->batchSize());
+    TORCH_CHECK_VALUE(grid->device().is_cuda(),
+                      "integrateTSDFFromPointsFrames requires a CUDA grid");
+
+    const at::cuda::CUDAGuard device_guard(tsdf.device());
+
+    // Per-frame profiling toggle, mirrors `integrateTSDFBatchImpl`'s
+    // `FVDB_TSDF_BATCH_PROFILE=1` env var. Useful when decomposing
+    // the per-frame wall clock into shell-build vs
+    // grow/merge/inject vs doIntegrateFromPoints (seed + ray-walk +
+    // normalize). Printing happens once per batch call on stderr.
+    const bool profile_batch =
+        std::getenv("FVDB_TSDF_BATCH_PROFILE") != nullptr;
+    cudaEvent_t evStart{}, evEnd{};
+    if (profile_batch) {
+        cudaEventCreate(&evStart);
+        cudaEventCreate(&evEnd);
+        cudaEventRecord(evStart);
+    }
+
+    // Running accumulator: grid topology + TSDF / weights sidecars.
+    // Semantically identical to the pre-refactor Python-looped pattern
+    // (`for i: g,t,w = g.integrate_tsdf_from_points(trunc, pts[i],
+    //   origin[i], t, w, carve)`), but keeps everything in C++
+    // so we don't pay the per-frame Python dispatch + JaggedTensor
+    // rewrap cost.
+    //
+    // We deliberately do NOT thread this through `PersistentTSDFState`
+    // because the LiDAR per-frame path (`doIntegrateFromPoints`)
+    // already produces fresh output tensors each frame via its
+    // seed + ray-walk + normalize pipeline -- the state-holder's
+    // grow-on-touch fast path can't fire here (the ray-walk
+    // accumulator tensors are throwaway per-frame temporaries, not
+    // persistent sidecars). Wrapping in `PersistentTSDFState` would
+    // add an extra level of ref-counting without saving any work. See
+    // session note `2026-04-23_stream_c_lidar.md` for the design
+    // rationale.
+    c10::intrusive_ptr<GridBatchData> accumGrid = grid;
+    JaggedTensor accumTsdf    = tsdf;
+    JaggedTensor accumWeights = weights;
+
+    // Per-frame loop: build shell, call single-frame
+    // `integrateTSDFFromPoints` logic inline, swap in new state.
+    for (int64_t i = 0; i < N; ++i) {
+        const torch::Tensor &ptsTensor = pointsPerFrame[i];
+        TORCH_CHECK_VALUE(ptsTensor.dim() == 2 && ptsTensor.size(1) == 3,
+                          "pointsPerFrame[", i, "] must be [N_i, 3]; got ",
+                          ptsTensor.sizes());
+        TORCH_CHECK_VALUE(ptsTensor.device() == tsdf.device(),
+                          "pointsPerFrame[", i,
+                          "] must be on the same device as tsdf");
+        TORCH_CHECK_TYPE(ptsTensor.scalar_type() == tsdf.scalar_type(),
+                         "pointsPerFrame[", i, "] dtype must match tsdf dtype");
+
+        // Wrap the [N_i, 3] tensor as a batch-1 JaggedTensor to reuse
+        // the existing buildUnionGrid + doIntegrateFromPoints helpers
+        // unchanged.
+        JaggedTensor ptsJagged = JaggedTensor(
+            std::vector<torch::Tensor>{ptsTensor});
+
+        // Matching slice of sensor origins. Keep as [1, 3] because
+        // the existing single-frame API expects `[batchSize, 3]`
+        // with batchSize = grid.batchSize() = 1.
+        torch::Tensor originI =
+            sensorOrigins.narrow(0, i, 1).contiguous();
+
+        // Step 1: union grid for THIS frame's shell + current accum.
+        auto unionGrid = buildUnionGrid(accumGrid, ptsJagged, truncationMargin);
+
+        // Step 2: doIntegrateFromPoints (seed + ray-walk + normalize).
+        // No features in this API (colour-features come via the
+        // `*WithFeatures` variant; if we add a batched +features
+        // entry point later, it plumbs features the same way as the
+        // single-frame one does).
+        const fvdb::JaggedTensor emptyFeatures =
+            torch::empty({0, 0}, accumTsdf.jdata().options());
+        const fvdb::JaggedTensor emptyPointFeatures =
+            torch::empty({0, 0}, accumTsdf.jdata().options());
+
+        auto [newTsdf, newWeights, _unusedFeatures] = doIntegrateFromPoints(
+            static_cast<float>(truncationMargin),
+            ptsJagged,
+            originI,
+            emptyPointFeatures,
+            *unionGrid,
+            *accumGrid,
+            accumTsdf,
+            accumWeights,
+            emptyFeatures,
+            carveFreeSpace);
+
+        // Swap state to the new union grid + freshly-normalised
+        // sidecars. Old accumGrid / accumTsdf / accumWeights refs
+        // drop out of scope here and any GPU memory they held is
+        // reclaimed by the caching allocator on next allocation.
+        accumGrid    = unionGrid;
+        accumTsdf    = newTsdf;
+        accumWeights = newWeights;
+    }
+
+    if (profile_batch) {
+        cudaEventRecord(evEnd);
+        cudaEventSynchronize(evEnd);
+        float ms = 0.f;
+        cudaEventElapsedTime(&ms, evStart, evEnd);
+        std::fprintf(
+            stderr,
+            "[fvdb/tsdf_from_points_batch] N=%lld  incremental=%.2f ms  "
+            "(%.2f ms/frame)  final_voxels=%lld  final_leaves=%lld\n",
+            (long long)N, ms, ms / static_cast<float>(N),
+            (long long)accumGrid->totalVoxels(),
+            (long long)accumGrid->totalLeaves());
+        cudaEventDestroy(evStart);
+        cudaEventDestroy(evEnd);
+    }
+
+    return {accumGrid, accumTsdf, accumWeights};
+}
+
+} // namespace fvdb::detail::ops

--- a/src/fvdb/detail/ops/IntegrateTSDFFromPoints.cu
+++ b/src/fvdb/detail/ops/IntegrateTSDFFromPoints.cu
@@ -136,7 +136,7 @@ seedAccumulatorsFromBaseGridKernel(const fvdb::BatchGridAccessor baseGridAcc,
 // M2: ray-walk kernel.
 //
 // One thread per input point. Walks active voxels along the ray from
-// sensor origin to (point + truncation along ray) via HDDAVoxelIterator
+// sensor origin to (point + truncation along ray) via HDDALeafVoxelIterator
 // over the union grid. For each active voxel, computes the signed
 // distance along the ray from voxel centre to endpoint and decides
 // whether to update it:
@@ -217,13 +217,13 @@ rayWalkIntegrateKernel(const fvdb::BatchGridAccessor unionGridAcc,
     auto acc                             = grid->getAccessor();
     const int64_t voxelOffsetBase        = unionGridAcc.voxelOffset(batchIdx);
 
-    // HDDAVoxelIterator walks active voxels of the sparse grid along the
+    // HDDALeafVoxelIterator walks active leaf voxels of the sparse grid along the
     // ray, automatically skipping inactive regions. This is the sparse-
     // native "ray-walk" primitive fvdb exposes; the per-ray thread hits
     // only voxels that exist in the endpoint-shell topology (see plan.md
     // D2 — free-space carving fills topology gaps only within the
     // existing union grid, does not extend it).
-    fvdb::HDDAVoxelIterator<decltype(acc), MathT> it(rayVox, acc);
+    fvdb::HDDALeafVoxelIterator<decltype(acc), MathT> it(rayVox, acc);
     while (it.isValid()) {
         const nanovdb::Coord voxIjk = it->first;
         ++it;

--- a/src/fvdb/detail/ops/IntegrateTSDFFromPoints.cu
+++ b/src/fvdb/detail/ops/IntegrateTSDFFromPoints.cu
@@ -32,6 +32,9 @@
 #include <fvdb/detail/utils/cuda/GridDim.h>
 #include <fvdb/detail/utils/nanovdb/HDDAIterators.h>
 
+#include <nanovdb/NanoVDB.h>
+#include <nanovdb/math/Ray.h>
+
 #include <ATen/OpMathType.h>
 #include <ATen/cuda/CUDAContext.h>
 #include <c10/core/ScalarType.h>
@@ -39,22 +42,19 @@
 #include <c10/cuda/CUDAGuard.h>
 #include <c10/cuda/CUDAStream.h>
 #include <c10/util/Half.h>
+#include <torch/types.h>
 
-#include <nanovdb/NanoVDB.h>
-#include <nanovdb/math/Ray.h>
+#include <cuda_runtime.h>
 
 #include <cmath>
-#include <cuda_runtime.h>
-#include <torch/types.h>
 
 namespace fvdb::detail::ops {
 
 namespace {
 
-using GridT        = nanovdb::ValueOnIndex;
-using LeafNodeType = nanovdb::NanoGrid<GridT>::LeafNodeType;
-constexpr uint64_t VOXELS_PER_LEAF =
-    nanovdb::NanoTree<GridT>::LeafNodeType::NUM_VALUES;
+using GridT                        = nanovdb::ValueOnIndex;
+using LeafNodeType                 = nanovdb::NanoGrid<GridT>::LeafNodeType;
+constexpr uint64_t VOXELS_PER_LEAF = nanovdb::NanoTree<GridT>::LeafNodeType::NUM_VALUES;
 
 // -------------------------------------------------------------------------
 // M1: seed kernel.
@@ -71,36 +71,27 @@ constexpr uint64_t VOXELS_PER_LEAF =
 
 template <typename ScalarDataType, typename FeatureAccumT>
 __global__ void
-seedAccumulatorsFromBaseGridKernel(
-    const fvdb::BatchGridAccessor baseGridAcc,
-    const fvdb::BatchGridAccessor unionGridAcc,
-    const bool hasFeatures,
-    const int64_t featureDim,
-    const fvdb::JaggedRAcc64<ScalarDataType, 1> tsdfAcc,
-    const fvdb::JaggedRAcc64<ScalarDataType, 1> weightsAcc,
-    const fvdb::JaggedRAcc64<FeatureAccumT, 2> featuresAsAccumAcc,
-    fvdb::TorchRAcc64<ScalarDataType, 1> outTsdfAcc,
-    fvdb::TorchRAcc64<ScalarDataType, 1> outWeightsAcc,
-    fvdb::TorchRAcc64<FeatureAccumT, 2> outFeaturesAccumAcc) {
-    const uint64_t problemSize =
-        unionGridAcc.totalLeaves() * VOXELS_PER_LEAF;
-    for (uint64_t idx = blockIdx.x * blockDim.x + threadIdx.x;
-         idx < problemSize;
+seedAccumulatorsFromBaseGridKernel(const fvdb::BatchGridAccessor baseGridAcc,
+                                   const fvdb::BatchGridAccessor unionGridAcc,
+                                   const bool hasFeatures,
+                                   const int64_t featureDim,
+                                   const fvdb::JaggedRAcc64<ScalarDataType, 1> tsdfAcc,
+                                   const fvdb::JaggedRAcc64<ScalarDataType, 1> weightsAcc,
+                                   const fvdb::JaggedRAcc64<FeatureAccumT, 2> featuresAsAccumAcc,
+                                   fvdb::TorchRAcc64<ScalarDataType, 1> outTsdfAcc,
+                                   fvdb::TorchRAcc64<ScalarDataType, 1> outWeightsAcc,
+                                   fvdb::TorchRAcc64<FeatureAccumT, 2> outFeaturesAccumAcc) {
+    const uint64_t problemSize = unionGridAcc.totalLeaves() * VOXELS_PER_LEAF;
+    for (uint64_t idx = blockIdx.x * blockDim.x + threadIdx.x; idx < problemSize;
          idx += blockDim.x * gridDim.x) {
-        const int64_t cumUnionLeafIdx =
-            static_cast<int64_t>(idx / VOXELS_PER_LEAF);
-        const int64_t unionLeafVoxelIdx =
-            static_cast<int64_t>(idx % VOXELS_PER_LEAF);
-        const fvdb::JIdxType batchIdx =
-            unionGridAcc.leafBatchIndex(cumUnionLeafIdx);
-        const int64_t unionLeafIdx =
-            cumUnionLeafIdx - unionGridAcc.leafOffset(batchIdx);
+        const int64_t cumUnionLeafIdx   = static_cast<int64_t>(idx / VOXELS_PER_LEAF);
+        const int64_t unionLeafVoxelIdx = static_cast<int64_t>(idx % VOXELS_PER_LEAF);
+        const fvdb::JIdxType batchIdx   = unionGridAcc.leafBatchIndex(cumUnionLeafIdx);
+        const int64_t unionLeafIdx      = cumUnionLeafIdx - unionGridAcc.leafOffset(batchIdx);
 
         const nanovdb::NanoGrid<GridT> *unionGrid = unionGridAcc.grid(batchIdx);
-        const LeafNodeType &unionLeaf =
-            unionGrid->tree().template getFirstNode<0>()[unionLeafIdx];
-        const nanovdb::Coord ijk =
-            unionLeaf.offsetToGlobalCoord(unionLeafVoxelIdx);
+        const LeafNodeType &unionLeaf = unionGrid->tree().template getFirstNode<0>()[unionLeafIdx];
+        const nanovdb::Coord ijk      = unionLeaf.offsetToGlobalCoord(unionLeafVoxelIdx);
 
         const int64_t unionWriteOffset =
             unionGridAcc.voxelOffset(batchIdx) +
@@ -116,12 +107,11 @@ seedAccumulatorsFromBaseGridKernel(
 
         if (inBase) {
             const int64_t baseOffset =
-                baseGridAcc.voxelOffset(batchIdx) +
-                static_cast<int64_t>(baseAcc.getValue(ijk)) - 1;
+                baseGridAcc.voxelOffset(batchIdx) + static_cast<int64_t>(baseAcc.getValue(ijk)) - 1;
             const ScalarDataType oldW = weightsAcc.data()[baseOffset];
             const ScalarDataType oldT = tsdfAcc.data()[baseOffset];
-            outTsdfAcc[unionWriteOffset]    = ScalarDataType(static_cast<float>(oldT) *
-                                                             static_cast<float>(oldW));
+            outTsdfAcc[unionWriteOffset] =
+                ScalarDataType(static_cast<float>(oldT) * static_cast<float>(oldW));
             outWeightsAcc[unionWriteOffset] = oldW;
             if (hasFeatures) {
                 for (int64_t d = 0; d < featureDim; ++d) {
@@ -163,18 +153,17 @@ seedAccumulatorsFromBaseGridKernel(
 
 template <typename ScalarDataType, typename FeatureDataType, typename FeatureAccumT>
 __global__ void
-rayWalkIntegrateKernel(
-    const fvdb::BatchGridAccessor unionGridAcc,
-    const fvdb::JaggedRAcc64<ScalarDataType, 2> pointsAcc,
-    const fvdb::TorchRAcc64<ScalarDataType, 2> sensorOriginsAcc,
-    const bool hasFeatures,
-    const int64_t featureDim,
-    const fvdb::JaggedRAcc64<FeatureDataType, 2> pointFeaturesAcc,
-    const float truncationMargin,
-    const bool carveFreeSpace,
-    fvdb::TorchRAcc64<ScalarDataType, 1> outTsdfAcc,
-    fvdb::TorchRAcc64<ScalarDataType, 1> outWeightsAcc,
-    fvdb::TorchRAcc64<FeatureAccumT, 2> outFeaturesAccumAcc) {
+rayWalkIntegrateKernel(const fvdb::BatchGridAccessor unionGridAcc,
+                       const fvdb::JaggedRAcc64<ScalarDataType, 2> pointsAcc,
+                       const fvdb::TorchRAcc64<ScalarDataType, 2> sensorOriginsAcc,
+                       const bool hasFeatures,
+                       const int64_t featureDim,
+                       const fvdb::JaggedRAcc64<FeatureDataType, 2> pointFeaturesAcc,
+                       const float truncationMargin,
+                       const bool carveFreeSpace,
+                       fvdb::TorchRAcc64<ScalarDataType, 1> outTsdfAcc,
+                       fvdb::TorchRAcc64<ScalarDataType, 1> outWeightsAcc,
+                       fvdb::TorchRAcc64<FeatureAccumT, 2> outFeaturesAccumAcc) {
     using MathT = at::opmath_type<ScalarDataType>;
     using Vec3T = nanovdb::math::Vec3<MathT>;
     using RayT  = nanovdb::math::Ray<MathT>;
@@ -221,13 +210,12 @@ rayWalkIntegrateKernel(
     const RayT rayWorld(originWorld, dirWorld, tWalkStart, tWalkEnd);
 
     // Transform ray to voxel-index space for HDDA.
-    const VoxelCoordTransform transform =
-        unionGridAcc.primalTransform(batchIdx);
-    const RayT rayVox = transform.applyToRay(rayWorld);
+    const VoxelCoordTransform transform = unionGridAcc.primalTransform(batchIdx);
+    const RayT rayVox                   = transform.applyToRay(rayWorld);
 
     const nanovdb::NanoGrid<GridT> *grid = unionGridAcc.grid(batchIdx);
     auto acc                             = grid->getAccessor();
-    const int64_t voxelOffsetBase = unionGridAcc.voxelOffset(batchIdx);
+    const int64_t voxelOffsetBase        = unionGridAcc.voxelOffset(batchIdx);
 
     // HDDAVoxelIterator walks active voxels of the sparse grid along the
     // ray, automatically skipping inactive regions. This is the sparse-
@@ -256,10 +244,9 @@ rayWalkIntegrateKernel(
         // fvdb's convention treats voxel values as stored AT integer
         // ijk coordinates (same as the existing depth integrator in
         // IntegrateTSDF.cu:204-206); no +0.5 shift.
-        const Vec3T voxPosWorld = transform.applyInv<MathT>(
-            static_cast<MathT>(voxIjk[0]),
-            static_cast<MathT>(voxIjk[1]),
-            static_cast<MathT>(voxIjk[2]));
+        const Vec3T voxPosWorld = transform.applyInv<MathT>(static_cast<MathT>(voxIjk[0]),
+                                                            static_cast<MathT>(voxIjk[1]),
+                                                            static_cast<MathT>(voxIjk[2]));
         const Vec3T toVox       = voxPosWorld - originWorld;
         const MathT rangeToVox  = toVox.length();
         const MathT sdfWorld    = rangeWorld - rangeToVox;
@@ -288,17 +275,15 @@ rayWalkIntegrateKernel(
         // dtypes — including the half-precision path that plain
         // `atomicAdd(c10::Half*, ...)` doesn't resolve.
         constexpr MathT kSampleWeight = MathT(1);
-        atomAdd(&outTsdfAcc[writeOffset],
-                static_cast<ScalarDataType>(tsdfClamped * kSampleWeight));
-        atomAdd(&outWeightsAcc[writeOffset],
-                static_cast<ScalarDataType>(kSampleWeight));
+        atomAdd(&outTsdfAcc[writeOffset], static_cast<ScalarDataType>(tsdfClamped * kSampleWeight));
+        atomAdd(&outWeightsAcc[writeOffset], static_cast<ScalarDataType>(kSampleWeight));
         if (hasFeatures) {
             for (int64_t d = 0; d < featureDim; ++d) {
                 const FeatureAccumT featVal =
                     static_cast<FeatureAccumT>(pointFeaturesAcc.data()[pointIdx][d]);
                 atomAdd(&outFeaturesAccumAcc[writeOffset][d],
-                        static_cast<FeatureAccumT>(
-                            featVal * static_cast<FeatureAccumT>(kSampleWeight)));
+                        static_cast<FeatureAccumT>(featVal *
+                                                   static_cast<FeatureAccumT>(kSampleWeight)));
             }
         }
     }
@@ -330,8 +315,7 @@ normaliseAccumulatorsKernel(const int64_t totalVoxels,
 
     const float w = static_cast<float>(outWeightsAcc[idx]);
     if (w > 0.0f) {
-        outTsdfAcc[idx] =
-            ScalarDataType(static_cast<float>(outTsdfAcc[idx]) / w);
+        outTsdfAcc[idx] = ScalarDataType(static_cast<float>(outTsdfAcc[idx]) / w);
         if (hasFeatures) {
             for (int64_t d = 0; d < featureDim; ++d) {
                 outFeaturesAcc[idx][d] =
@@ -357,14 +341,14 @@ normaliseAccumulatorsKernel(const int64_t totalVoxels,
 // share everything except input validation.
 // -------------------------------------------------------------------------
 
-#define DISPATCH_FEATURE_TYPE_LIDAR(SCALAR, FEAT_TYPE, ...)            \
+#define DISPATCH_FEATURE_TYPE_LIDAR(SCALAR, FEAT_TYPE, ...)             \
     if (hasFeatures && (FEAT_TYPE) == torch::kUInt8) {                  \
         using feature_t = uint8_t;                                      \
         /* uint8 atomicAdd unsupported on-device; accumulate in fp32 */ \
         using feature_accum_t = float;                                  \
         __VA_ARGS__();                                                  \
     } else {                                                            \
-        using feature_t = SCALAR;                                       \
+        using feature_t       = SCALAR;                                 \
         using feature_accum_t = SCALAR;                                 \
         __VA_ARGS__();                                                  \
     }
@@ -392,8 +376,8 @@ doIntegrateFromPoints(const float truncationMargin,
     // `unionGrid.jaggedTensor(outFeatures)` size-check passes
     // uniformly (featureDim=0 in the no-features case, matching the
     // depth integrator's convention in IntegrateTSDF.cu:841).
-    torch::Tensor outFeatures = torch::empty(
-        {totalOutVoxels, featureDim}, features.jdata().options());
+    torch::Tensor outFeatures =
+        torch::empty({totalOutVoxels, featureDim}, features.jdata().options());
 
     AT_DISPATCH_V2(
         tsdf.scalar_type(),
@@ -403,8 +387,7 @@ doIntegrateFromPoints(const float truncationMargin,
                 // Feature accumulator tensor (may be wider than features
                 // itself when features are uint8 → accumulate in fp32).
                 torch::Tensor outFeaturesAccum;
-                constexpr bool accumIsSame =
-                    std::is_same_v<feature_t, feature_accum_t>;
+                constexpr bool accumIsSame = std::is_same_v<feature_t, feature_accum_t>;
                 if (hasFeatures) {
                     if constexpr (accumIsSame) {
                         outFeaturesAccum = outFeatures;
@@ -416,10 +399,11 @@ doIntegrateFromPoints(const float truncationMargin,
                                 .device(outFeatures.device()));
                     }
                 } else {
-                    outFeaturesAccum = torch::empty({0, 0},
-                        torch::TensorOptions()
-                            .dtype(c10::CppTypeToScalarType<feature_accum_t>::value)
-                            .device(outTsdf.device()));
+                    outFeaturesAccum =
+                        torch::empty({0, 0},
+                                     torch::TensorOptions()
+                                         .dtype(c10::CppTypeToScalarType<feature_accum_t>::value)
+                                         .device(outTsdf.device()));
                 }
 
                 // Features base grid: reinterpret via the same accum
@@ -431,14 +415,15 @@ doIntegrateFromPoints(const float truncationMargin,
                     if constexpr (accumIsSame) {
                         featuresAsAccum = features.jdata();
                     } else {
-                        featuresAsAccum = features.jdata().to(
-                            c10::CppTypeToScalarType<feature_accum_t>::value);
+                        featuresAsAccum =
+                            features.jdata().to(c10::CppTypeToScalarType<feature_accum_t>::value);
                     }
                 } else {
-                    featuresAsAccum = torch::empty({0, 0},
-                        torch::TensorOptions()
-                            .dtype(c10::CppTypeToScalarType<feature_accum_t>::value)
-                            .device(outTsdf.device()));
+                    featuresAsAccum =
+                        torch::empty({0, 0},
+                                     torch::TensorOptions()
+                                         .dtype(c10::CppTypeToScalarType<feature_accum_t>::value)
+                                         .device(outTsdf.device()));
                 }
 
                 const auto stream = at::cuda::getCurrentCUDAStream();
@@ -446,18 +431,13 @@ doIntegrateFromPoints(const float truncationMargin,
                 // Use the JaggedTensor-valued packed_accessor64 (not
                 // jdata().packed_accessor64) so the kernel receives
                 // JaggedRAcc64 with batch-aware `.batchIdx(i)` access.
-                auto tsdfAcc =
-                    tsdf.packed_accessor64<scalar_t, 1,
-                                           torch::RestrictPtrTraits>();
+                auto tsdfAcc = tsdf.packed_accessor64<scalar_t, 1, torch::RestrictPtrTraits>();
                 auto weightsAcc =
-                    weights.packed_accessor64<scalar_t, 1,
-                                              torch::RestrictPtrTraits>();
+                    weights.packed_accessor64<scalar_t, 1, torch::RestrictPtrTraits>();
                 auto outTsdfAcc =
-                    outTsdf.packed_accessor64<scalar_t, 1,
-                                              torch::RestrictPtrTraits>();
+                    outTsdf.packed_accessor64<scalar_t, 1, torch::RestrictPtrTraits>();
                 auto outWeightsAcc =
-                    outWeights.packed_accessor64<scalar_t, 1,
-                                                 torch::RestrictPtrTraits>();
+                    outWeights.packed_accessor64<scalar_t, 1, torch::RestrictPtrTraits>();
                 // Reinterpret features/jagged features as an accessor
                 // with the accumulator's dtype; when features are
                 // uint8 we already up-converted above, otherwise this
@@ -472,47 +452,42 @@ doIntegrateFromPoints(const float truncationMargin,
                 // the accessor, so the contents are never read.
                 torch::Tensor featuresReinterp;
                 if (hasFeatures) {
-                    featuresReinterp = featuresAsAccum.reshape(
-                        {featuresAsAccum.size(0), featureDim});
+                    featuresReinterp =
+                        featuresAsAccum.reshape({featuresAsAccum.size(0), featureDim});
                 } else {
-                    featuresReinterp = torch::empty(
-                        {0, 0},
-                        torch::TensorOptions()
-                            .dtype(c10::CppTypeToScalarType<feature_accum_t>::value)
-                            .device(outTsdf.device()));
+                    featuresReinterp =
+                        torch::empty({0, 0},
+                                     torch::TensorOptions()
+                                         .dtype(c10::CppTypeToScalarType<feature_accum_t>::value)
+                                         .device(outTsdf.device()));
                 }
                 JaggedTensor featuresAsAccumJagged;
                 if (hasFeatures) {
                     featuresAsAccumJagged =
-                        JaggedTensor::from_data_indices_and_list_ids(
-                            featuresReinterp,
-                            features.jidx(),
-                            features.jlidx(),
-                            features.num_outer_lists());
+                        JaggedTensor::from_data_indices_and_list_ids(featuresReinterp,
+                                                                     features.jidx(),
+                                                                     features.jlidx(),
+                                                                     features.num_outer_lists());
                 } else {
-                    auto idxOpts = torch::TensorOptions()
-                                       .dtype(fvdb::JIdxScalarType)
-                                       .device(outTsdf.device());
+                    auto idxOpts =
+                        torch::TensorOptions().dtype(fvdb::JIdxScalarType).device(outTsdf.device());
                     featuresAsAccumJagged =
-                        JaggedTensor::from_data_indices_and_list_ids(
-                            featuresReinterp,
-                            torch::empty({0}, idxOpts),
-                            torch::empty({0, 1}, idxOpts),
-                            /*num_tensors=*/1);
+                        JaggedTensor::from_data_indices_and_list_ids(featuresReinterp,
+                                                                     torch::empty({0}, idxOpts),
+                                                                     torch::empty({0, 1}, idxOpts),
+                                                                     /*num_tensors=*/1);
                 }
                 auto featuresAsAccumAcc =
-                    featuresAsAccumJagged.packed_accessor64<feature_accum_t, 2,
-                                                            torch::RestrictPtrTraits>();
+                    featuresAsAccumJagged
+                        .packed_accessor64<feature_accum_t, 2, torch::RestrictPtrTraits>();
                 auto outFeaturesAccumAcc =
-                    outFeaturesAccum.packed_accessor64<feature_accum_t, 2,
-                                                       torch::RestrictPtrTraits>();
+                    outFeaturesAccum
+                        .packed_accessor64<feature_accum_t, 2, torch::RestrictPtrTraits>();
 
                 // Step 1: seed accumulators from the existing base grid.
                 {
-                    const uint64_t problemSize =
-                        unionGrid.totalLeaves() * VOXELS_PER_LEAF;
-                    const int64_t blocks =
-                        GET_BLOCKS(problemSize, DEFAULT_BLOCK_DIM);
+                    const uint64_t problemSize = unionGrid.totalLeaves() * VOXELS_PER_LEAF;
+                    const int64_t blocks       = GET_BLOCKS(problemSize, DEFAULT_BLOCK_DIM);
                     seedAccumulatorsFromBaseGridKernel<scalar_t, feature_accum_t>
                         <<<blocks, DEFAULT_BLOCK_DIM, 0, stream.stream()>>>(
                             baseGrid.deviceAccessor(),
@@ -529,24 +504,16 @@ doIntegrateFromPoints(const float truncationMargin,
                 }
 
                 // Step 2: ray-walk every point and accumulate.
-                auto pointsAcc =
-                    points.packed_accessor64<scalar_t, 2,
-                                             torch::RestrictPtrTraits>();
+                auto pointsAcc = points.packed_accessor64<scalar_t, 2, torch::RestrictPtrTraits>();
                 auto sensorAcc =
-                    sensorOrigins.packed_accessor64<scalar_t, 2,
-                                                    torch::RestrictPtrTraits>();
+                    sensorOrigins.packed_accessor64<scalar_t, 2, torch::RestrictPtrTraits>();
                 auto pointFeaturesAcc =
                     hasFeatures
-                        ? pointFeatures
-                              .packed_accessor64<feature_t, 2,
-                                                 torch::RestrictPtrTraits>()
-                        : pointFeatures
-                              .packed_accessor64<feature_t, 2,
-                                                 torch::RestrictPtrTraits>();
+                        ? pointFeatures.packed_accessor64<feature_t, 2, torch::RestrictPtrTraits>()
+                        : pointFeatures.packed_accessor64<feature_t, 2, torch::RestrictPtrTraits>();
                 const int64_t totalPoints = points.jdata().size(0);
                 if (totalPoints > 0) {
-                    const int64_t blocks =
-                        GET_BLOCKS(totalPoints, DEFAULT_BLOCK_DIM);
+                    const int64_t blocks = GET_BLOCKS(totalPoints, DEFAULT_BLOCK_DIM);
                     rayWalkIntegrateKernel<scalar_t, feature_t, feature_accum_t>
                         <<<blocks, DEFAULT_BLOCK_DIM, 0, stream.stream()>>>(
                             unionGrid.deviceAccessor(),
@@ -567,21 +534,19 @@ doIntegrateFromPoints(const float truncationMargin,
                 {
                     auto outFeaturesAccOut =
                         hasFeatures
-                            ? outFeatures.packed_accessor64<feature_t, 2,
-                                                            torch::RestrictPtrTraits>()
-                            : outFeatures.packed_accessor64<feature_t, 2,
-                                                            torch::RestrictPtrTraits>();
-                    const int64_t blocks =
-                        GET_BLOCKS(totalOutVoxels, DEFAULT_BLOCK_DIM);
+                            ? outFeatures
+                                  .packed_accessor64<feature_t, 2, torch::RestrictPtrTraits>()
+                            : outFeatures
+                                  .packed_accessor64<feature_t, 2, torch::RestrictPtrTraits>();
+                    const int64_t blocks = GET_BLOCKS(totalOutVoxels, DEFAULT_BLOCK_DIM);
                     normaliseAccumulatorsKernel<scalar_t, feature_t, feature_accum_t>
-                        <<<blocks, DEFAULT_BLOCK_DIM, 0, stream.stream()>>>(
-                            totalOutVoxels,
-                            hasFeatures,
-                            featureDim,
-                            outTsdfAcc,
-                            outWeightsAcc,
-                            outFeaturesAccumAcc,
-                            outFeaturesAccOut);
+                        <<<blocks, DEFAULT_BLOCK_DIM, 0, stream.stream()>>>(totalOutVoxels,
+                                                                            hasFeatures,
+                                                                            featureDim,
+                                                                            outTsdfAcc,
+                                                                            outWeightsAcc,
+                                                                            outFeaturesAccumAcc,
+                                                                            outFeaturesAccOut);
                     C10_CUDA_KERNEL_LAUNCH_CHECK();
                 }
             });
@@ -616,25 +581,32 @@ checkCommonInputs(const c10::intrusive_ptr<GridBatchData> &grid,
                   const JaggedTensor &tsdf,
                   const JaggedTensor &weights) {
     TORCH_CHECK_VALUE(grid != nullptr, "grid must be non-null");
-    TORCH_CHECK_VALUE(grid->device().is_cuda(),
-                      "integrateTSDFFromPoints requires a CUDA grid");
+    TORCH_CHECK_VALUE(grid->device().is_cuda(), "integrateTSDFFromPoints requires a CUDA grid");
     TORCH_CHECK_VALUE(points.rdim() == 2 && points.rsize(-1) == 3,
                       "points must have shape [B, N, 3]");
     TORCH_CHECK_VALUE(sensorOrigins.dim() == 2 && sensorOrigins.size(1) == 3,
                       "sensorOrigins must have shape [B, 3]");
     TORCH_CHECK_VALUE(sensorOrigins.size(0) == grid->batchSize(),
-                      "sensorOrigins batch size (", sensorOrigins.size(0),
-                      ") must match grid batch size (", grid->batchSize(), ")");
+                      "sensorOrigins batch size (",
+                      sensorOrigins.size(0),
+                      ") must match grid batch size (",
+                      grid->batchSize(),
+                      ")");
     TORCH_CHECK_VALUE(points.num_outer_lists() == grid->batchSize(),
-                      "points batch size (", points.num_outer_lists(),
-                      ") must match grid batch size (", grid->batchSize(), ")");
+                      "points batch size (",
+                      points.num_outer_lists(),
+                      ") must match grid batch size (",
+                      grid->batchSize(),
+                      ")");
     TORCH_CHECK_VALUE(tsdf.num_outer_lists() == grid->batchSize(),
-                      "tsdf batch size (", tsdf.num_outer_lists(),
-                      ") must match grid batch size (", grid->batchSize(), ")");
+                      "tsdf batch size (",
+                      tsdf.num_outer_lists(),
+                      ") must match grid batch size (",
+                      grid->batchSize(),
+                      ")");
     TORCH_CHECK_VALUE(weights.num_outer_lists() == grid->batchSize(),
                       "weights batch size must match grid batch size");
-    TORCH_CHECK_TYPE(tsdf.is_floating_point(),
-                     "tsdf must be a floating-point dtype");
+    TORCH_CHECK_TYPE(tsdf.is_floating_point(), "tsdf must be a floating-point dtype");
     TORCH_CHECK_TYPE(weights.scalar_type() == tsdf.scalar_type(),
                      "weights dtype must match tsdf dtype");
     TORCH_CHECK_TYPE(points.scalar_type() == tsdf.scalar_type(),
@@ -642,10 +614,12 @@ checkCommonInputs(const c10::intrusive_ptr<GridBatchData> &grid,
     TORCH_CHECK_TYPE(sensorOrigins.scalar_type() == tsdf.scalar_type(),
                      "sensorOrigins dtype must match tsdf dtype");
     TORCH_CHECK_VALUE(tsdf.numel() == grid->totalVoxels(),
-                      "tsdf size (", tsdf.numel(),
-                      ") must equal grid totalVoxels (", grid->totalVoxels(), ")");
-    TORCH_CHECK_VALUE(weights.numel() == grid->totalVoxels(),
-                      "weights size mismatch");
+                      "tsdf size (",
+                      tsdf.numel(),
+                      ") must equal grid totalVoxels (",
+                      grid->totalVoxels(),
+                      ")");
+    TORCH_CHECK_VALUE(weights.numel() == grid->totalVoxels(), "weights size mismatch");
 }
 
 } // anonymous namespace
@@ -675,17 +649,17 @@ integrateTSDFFromPoints(const c10::intrusive_ptr<GridBatchData> grid,
     const fvdb::JaggedTensor emptyFeatures      = torch::empty({0, 0}, tsdf.jdata().options());
     const fvdb::JaggedTensor emptyPointFeatures = torch::empty({0, 0}, tsdf.jdata().options());
 
-    auto [newTsdf, newWeights, _unusedFeatures] = doIntegrateFromPoints(
-        static_cast<float>(truncationMargin),
-        points,
-        sensorOrigins,
-        emptyPointFeatures,
-        *unionGrid,
-        *grid,
-        tsdf,
-        weights,
-        emptyFeatures,
-        carveFreeSpace);
+    auto [newTsdf, newWeights, _unusedFeatures] =
+        doIntegrateFromPoints(static_cast<float>(truncationMargin),
+                              points,
+                              sensorOrigins,
+                              emptyPointFeatures,
+                              *unionGrid,
+                              *grid,
+                              tsdf,
+                              weights,
+                              emptyFeatures,
+                              carveFreeSpace);
 
     return {unionGrid, newTsdf, newWeights};
 }
@@ -702,8 +676,7 @@ integrateTSDFFromPointsWithFeatures(const c10::intrusive_ptr<GridBatchData> grid
                                     bool carveFreeSpace) {
     checkCommonInputs(grid, points, sensorOrigins, tsdf, weights);
 
-    TORCH_CHECK_VALUE(features.rdim() == 2,
-                      "features must be 2-D [totalVoxels, featureDim]");
+    TORCH_CHECK_VALUE(features.rdim() == 2, "features must be 2-D [totalVoxels, featureDim]");
     TORCH_CHECK_VALUE(pointFeatures.rdim() == 2,
                       "pointFeatures must be 2-D [totalPoints, featureDim]");
     TORCH_CHECK_VALUE(features.rsize(-1) == pointFeatures.rsize(-1),
@@ -724,17 +697,17 @@ integrateTSDFFromPointsWithFeatures(const c10::intrusive_ptr<GridBatchData> grid
 
     auto unionGrid = buildUnionGrid(grid, points, truncationMargin);
 
-    auto [newTsdf, newWeights, newFeatures] = doIntegrateFromPoints(
-        static_cast<float>(truncationMargin),
-        points,
-        sensorOrigins,
-        pointFeatures,
-        *unionGrid,
-        *grid,
-        tsdf,
-        weights,
-        features,
-        carveFreeSpace);
+    auto [newTsdf, newWeights, newFeatures] =
+        doIntegrateFromPoints(static_cast<float>(truncationMargin),
+                              points,
+                              sensorOrigins,
+                              pointFeatures,
+                              *unionGrid,
+                              *grid,
+                              tsdf,
+                              weights,
+                              features,
+                              carveFreeSpace);
 
     return {unionGrid, newTsdf, newWeights, newFeatures};
 }
@@ -749,11 +722,12 @@ integrateTSDFFromPointsFrames(const c10::intrusive_ptr<GridBatchData> grid,
                               bool carveFreeSpace) {
     const int64_t N = static_cast<int64_t>(pointsPerFrame.size());
     TORCH_CHECK_VALUE(N > 0, "pointsPerFrame must have at least one frame");
-    TORCH_CHECK_VALUE(
-        sensorOrigins.dim() == 2 && sensorOrigins.size(0) == N &&
-            sensorOrigins.size(1) == 3,
-        "sensorOrigins must have shape [N=", N, ", 3]; got ",
-        sensorOrigins.sizes());
+    TORCH_CHECK_VALUE(sensorOrigins.dim() == 2 && sensorOrigins.size(0) == N &&
+                          sensorOrigins.size(1) == 3,
+                      "sensorOrigins must have shape [N=",
+                      N,
+                      ", 3]; got ",
+                      sensorOrigins.sizes());
     TORCH_CHECK_VALUE(grid->batchSize() == 1,
                       "integrateTSDFFromPointsFrames currently supports "
                       "single-scene grids (batchSize = 1); got batchSize = ",
@@ -768,8 +742,7 @@ integrateTSDFFromPointsFrames(const c10::intrusive_ptr<GridBatchData> grid,
     // the per-frame wall clock into shell-build vs
     // grow/merge/inject vs doIntegrateFromPoints (seed + ray-walk +
     // normalize). Printing happens once per batch call on stderr.
-    const bool profile_batch =
-        std::getenv("FVDB_TSDF_BATCH_PROFILE") != nullptr;
+    const bool profile_batch = std::getenv("FVDB_TSDF_BATCH_PROFILE") != nullptr;
     cudaEvent_t evStart{}, evEnd{};
     if (profile_batch) {
         cudaEventCreate(&evStart);
@@ -795,33 +768,36 @@ integrateTSDFFromPointsFrames(const c10::intrusive_ptr<GridBatchData> grid,
     // session note `2026-04-23_stream_c_lidar.md` for the design
     // rationale.
     c10::intrusive_ptr<GridBatchData> accumGrid = grid;
-    JaggedTensor accumTsdf    = tsdf;
-    JaggedTensor accumWeights = weights;
+    JaggedTensor accumTsdf                      = tsdf;
+    JaggedTensor accumWeights                   = weights;
 
     // Per-frame loop: build shell, call single-frame
     // `integrateTSDFFromPoints` logic inline, swap in new state.
     for (int64_t i = 0; i < N; ++i) {
         const torch::Tensor &ptsTensor = pointsPerFrame[i];
         TORCH_CHECK_VALUE(ptsTensor.dim() == 2 && ptsTensor.size(1) == 3,
-                          "pointsPerFrame[", i, "] must be [N_i, 3]; got ",
+                          "pointsPerFrame[",
+                          i,
+                          "] must be [N_i, 3]; got ",
                           ptsTensor.sizes());
         TORCH_CHECK_VALUE(ptsTensor.device() == tsdf.device(),
-                          "pointsPerFrame[", i,
+                          "pointsPerFrame[",
+                          i,
                           "] must be on the same device as tsdf");
         TORCH_CHECK_TYPE(ptsTensor.scalar_type() == tsdf.scalar_type(),
-                         "pointsPerFrame[", i, "] dtype must match tsdf dtype");
+                         "pointsPerFrame[",
+                         i,
+                         "] dtype must match tsdf dtype");
 
         // Wrap the [N_i, 3] tensor as a batch-1 JaggedTensor to reuse
         // the existing buildUnionGrid + doIntegrateFromPoints helpers
         // unchanged.
-        JaggedTensor ptsJagged = JaggedTensor(
-            std::vector<torch::Tensor>{ptsTensor});
+        JaggedTensor ptsJagged = JaggedTensor(std::vector<torch::Tensor>{ptsTensor});
 
         // Matching slice of sensor origins. Keep as [1, 3] because
         // the existing single-frame API expects `[batchSize, 3]`
         // with batchSize = grid.batchSize() = 1.
-        torch::Tensor originI =
-            sensorOrigins.narrow(0, i, 1).contiguous();
+        torch::Tensor originI = sensorOrigins.narrow(0, i, 1).contiguous();
 
         // Step 1: union grid for THIS frame's shell + current accum.
         auto unionGrid = buildUnionGrid(accumGrid, ptsJagged, truncationMargin);
@@ -831,22 +807,21 @@ integrateTSDFFromPointsFrames(const c10::intrusive_ptr<GridBatchData> grid,
         // `*WithFeatures` variant; if we add a batched +features
         // entry point later, it plumbs features the same way as the
         // single-frame one does).
-        const fvdb::JaggedTensor emptyFeatures =
-            torch::empty({0, 0}, accumTsdf.jdata().options());
+        const fvdb::JaggedTensor emptyFeatures = torch::empty({0, 0}, accumTsdf.jdata().options());
         const fvdb::JaggedTensor emptyPointFeatures =
             torch::empty({0, 0}, accumTsdf.jdata().options());
 
-        auto [newTsdf, newWeights, _unusedFeatures] = doIntegrateFromPoints(
-            static_cast<float>(truncationMargin),
-            ptsJagged,
-            originI,
-            emptyPointFeatures,
-            *unionGrid,
-            *accumGrid,
-            accumTsdf,
-            accumWeights,
-            emptyFeatures,
-            carveFreeSpace);
+        auto [newTsdf, newWeights, _unusedFeatures] =
+            doIntegrateFromPoints(static_cast<float>(truncationMargin),
+                                  ptsJagged,
+                                  originI,
+                                  emptyPointFeatures,
+                                  *unionGrid,
+                                  *accumGrid,
+                                  accumTsdf,
+                                  accumWeights,
+                                  emptyFeatures,
+                                  carveFreeSpace);
 
         // Swap state to the new union grid + freshly-normalised
         // sidecars. Old accumGrid / accumTsdf / accumWeights refs
@@ -862,13 +837,14 @@ integrateTSDFFromPointsFrames(const c10::intrusive_ptr<GridBatchData> grid,
         cudaEventSynchronize(evEnd);
         float ms = 0.f;
         cudaEventElapsedTime(&ms, evStart, evEnd);
-        std::fprintf(
-            stderr,
-            "[fvdb/tsdf_from_points_batch] N=%lld  incremental=%.2f ms  "
-            "(%.2f ms/frame)  final_voxels=%lld  final_leaves=%lld\n",
-            (long long)N, ms, ms / static_cast<float>(N),
-            (long long)accumGrid->totalVoxels(),
-            (long long)accumGrid->totalLeaves());
+        std::fprintf(stderr,
+                     "[fvdb/tsdf_from_points_batch] N=%lld  incremental=%.2f ms  "
+                     "(%.2f ms/frame)  final_voxels=%lld  final_leaves=%lld\n",
+                     (long long)N,
+                     ms,
+                     ms / static_cast<float>(N),
+                     (long long)accumGrid->totalVoxels(),
+                     (long long)accumGrid->totalLeaves());
         cudaEventDestroy(evStart);
         cudaEventDestroy(evEnd);
     }

--- a/src/fvdb/detail/ops/IntegrateTSDFFromPoints.h
+++ b/src/fvdb/detail/ops/IntegrateTSDFFromPoints.h
@@ -1,0 +1,126 @@
+// Copyright Contributors to the OpenVDB Project
+// SPDX-License-Identifier: Apache-2.0
+//
+#ifndef FVDB_DETAIL_OPS_INTEGRATETSDFFROMPOINTS_H
+#define FVDB_DETAIL_OPS_INTEGRATETSDFFROMPOINTS_H
+
+#include <fvdb/GridBatchData.h>
+#include <fvdb/JaggedTensor.h>
+
+#include <torch/types.h>
+
+#include <tuple>
+
+namespace fvdb {
+namespace detail {
+namespace ops {
+
+/// @brief Integrate a batch of LiDAR / range-sensor point clouds into
+///        a TSDF volume via per-point ray-walking (no range-image
+///        proxy).
+///
+/// For each point we walk voxels from `sensorOrigins[b]` toward the
+/// point endpoint via HDDA over the union-grid topology, updating the
+/// TSDF and weight at each active voxel via lock-free atomicAdd in
+/// running-sum form. The topology for the new scan is constructed by
+/// `buildPointTruncationShell(points, grid, truncationMargin)` — the
+/// same primitive the depth-image integrator uses — then merged with
+/// the existing grid.
+///
+/// This mirrors the VDBFusion / nvblox LiDAR integration surface so
+/// the cross-library comparison remains apples-to-apples.
+///
+/// @param grid  The existing grid to integrate into. The output grid
+///              is the union of this and the truncation shell of the
+///              new points.
+/// @param truncationMargin  World-space truncation distance.
+/// @param points  JaggedTensor [B, N_i, 3] of world-space point
+///                positions. Each batch item may have a different
+///                `N_i`.
+/// @param sensorOrigins  [B, 3] per-batch sensor origin in world
+///                       space (one origin per sweep; per-ray
+///                       origins are future work).
+/// @param tsdf  JaggedTensor [totalVoxels, 1] — TSDF values on `grid`.
+/// @param weights  JaggedTensor [totalVoxels, 1] — integration
+///                 weights on `grid`.
+/// @param carveFreeSpace  If true, voxels observed to be in front of
+///                        the endpoint (outside the truncation band)
+///                        get TSDF = +1 and weight = 1. Matches
+///                        VDBFusion / nvblox default behaviour.
+///
+/// @return (newGrid, newTsdf, newWeights) all on the union grid.
+std::tuple<c10::intrusive_ptr<GridBatchData>, JaggedTensor, JaggedTensor>
+integrateTSDFFromPoints(const c10::intrusive_ptr<GridBatchData> grid,
+                        const double truncationMargin,
+                        const JaggedTensor &points,
+                        const torch::Tensor &sensorOrigins,
+                        const JaggedTensor &tsdf,
+                        const JaggedTensor &weights,
+                        bool carveFreeSpace);
+
+/// @brief Like `integrateTSDFFromPoints` but also blends a per-point
+///        feature vector (e.g. RGB colour) into per-voxel features.
+///
+/// Feature dtype must match `tsdf.scalar_type()` OR be `uint8` (for
+/// RGB colours — matches the convention used by the depth-image
+/// integrator's `integrateTSDFWithFeatures`).
+std::tuple<c10::intrusive_ptr<GridBatchData>, JaggedTensor, JaggedTensor, JaggedTensor>
+integrateTSDFFromPointsWithFeatures(const c10::intrusive_ptr<GridBatchData> grid,
+                                    const double truncationMargin,
+                                    const JaggedTensor &points,
+                                    const torch::Tensor &sensorOrigins,
+                                    const JaggedTensor &tsdf,
+                                    const JaggedTensor &features,
+                                    const JaggedTensor &weights,
+                                    const JaggedTensor &pointFeatures,
+                                    bool carveFreeSpace);
+
+/// @brief Batched version of `integrateTSDFFromPoints`: integrate N
+///        LiDAR sweeps into a single persistent TSDF volume without
+///        paying the Python<->C++ round-trip overhead each frame.
+///
+/// Semantics are identical to N sequential calls to
+/// `integrateTSDFFromPoints(grid, trunc, points[i], sensorOrigins[i],
+/// tsdf, weights, carveFreeSpace)`: the topology grows incrementally
+/// frame-by-frame (exactly the same way the per-frame loop does), and
+/// the final (grid, tsdf, weights) is the union over all frames'
+/// truncation shells with the ray-walk integrated values. Bit-
+/// identical to the sequential reference is pinned by
+/// `test_integrate_tsdf_from_points_frames_matches_sequential`.
+///
+/// The win over a Python-level `for` loop is purely the removal of
+/// per-frame JaggedTensor / GridBatchData rewrapping + Python
+/// dispatch overhead, which is most visible on long outdoor LiDAR
+/// trajectories with many short sweeps per second.
+///
+/// @param grid  Initial grid topology (seed). May be empty, a 1x1x1
+///              dense placeholder, or a pre-populated grid from
+///              previous calls.
+/// @param truncationMargin  World-space truncation distance.
+/// @param pointsPerFrame  Per-frame point clouds, `pointsPerFrame[i]`
+///                        is `[N_i, 3]` in world frame. Count
+///                        determines N.
+/// @param sensorOrigins  `[N, 3]` per-frame sensor origin in world
+///                       space, same as the single-frame API
+///                       accepts a `[batchSize, 3]` tensor.
+/// @param tsdf  `[totalVoxels]` TSDF values on `grid`.
+/// @param weights  `[totalVoxels]` integration weights on `grid`.
+/// @param carveFreeSpace  If true, free-space voxels in front of the
+///                        endpoint get TSDF=+1, weight=1. Matches
+///                        VDBFusion / nvblox default behaviour.
+///
+/// @return (newGrid, newTsdf, newWeights) on the final union grid.
+std::tuple<c10::intrusive_ptr<GridBatchData>, JaggedTensor, JaggedTensor>
+integrateTSDFFromPointsFrames(const c10::intrusive_ptr<GridBatchData> grid,
+                              const double truncationMargin,
+                              const std::vector<torch::Tensor> &pointsPerFrame,
+                              const torch::Tensor &sensorOrigins,
+                              const JaggedTensor &tsdf,
+                              const JaggedTensor &weights,
+                              bool carveFreeSpace);
+
+} // namespace ops
+} // namespace detail
+} // namespace fvdb
+
+#endif // FVDB_DETAIL_OPS_INTEGRATETSDFFROMPOINTS_H

--- a/src/fvdb/detail/ops/MarchingCubes.cu
+++ b/src/fvdb/detail/ops/MarchingCubes.cu
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 #include <fvdb/detail/ops/MarchingCubes.h>
+#include <fvdb/detail/ops/MarchingCubesFast.h>
 #include <fvdb/detail/utils/AccessorHelpers.cuh>
 #include <fvdb/detail/utils/ForEachCPU.h>
 #include <fvdb/detail/utils/MarchingCubesData.h>
@@ -388,7 +389,9 @@ MarchingCubes(const GridBatchData &batchHdl, const torch::Tensor &sdf, double le
 } // anonymous namespace
 
 std::vector<JaggedTensor>
-marchingCubes(const GridBatchData &batchHdl, const JaggedTensor &field, double level) {
+marchingCubesLegacy(const GridBatchData &batchHdl,
+                    const JaggedTensor &field,
+                    double level) {
     TORCH_CHECK_VALUE(
         field.ldim() == 1,
         "Expected field to have 1 list dimension, i.e. be a single list of coordinate values, but got",
@@ -410,6 +413,21 @@ marchingCubes(const GridBatchData &batchHdl, const JaggedTensor &field, double l
     batchHdl.checkDevice(field);
     return FVDB_DISPATCH_KERNEL_DEVICE(
         field.device(), [&]() { return MarchingCubes<DeviceTag>(batchHdl, fieldJdata, level); });
+}
+
+// Public dispatcher. Routes to the fast sparse-compact / packed-key
+// variant (`marchingCubesFast`) whenever it's eligible, and to the legacy
+// implementation otherwise. `marchingCubesFast` internally covers both
+// float32 and float16 CUDA inputs (fp16 is upcast to fp32, the fp32
+// kernel runs, and output vertex positions are downcast back) so that
+// reality-capture's default fp16 TSDF pipelines get the full speedup.
+// Other dtypes (fp64) and non-CUDA devices are handled by the legacy
+// path, which `marchingCubesFast` forwards to internally.
+std::vector<JaggedTensor>
+marchingCubes(const GridBatchData &batchHdl,
+              const JaggedTensor &field,
+              double level) {
+    return marchingCubesFast(batchHdl, field, level);
 }
 
 } // namespace ops

--- a/src/fvdb/detail/ops/MarchingCubes.cu
+++ b/src/fvdb/detail/ops/MarchingCubes.cu
@@ -389,9 +389,7 @@ MarchingCubes(const GridBatchData &batchHdl, const torch::Tensor &sdf, double le
 } // anonymous namespace
 
 std::vector<JaggedTensor>
-marchingCubesLegacy(const GridBatchData &batchHdl,
-                    const JaggedTensor &field,
-                    double level) {
+marchingCubesLegacy(const GridBatchData &batchHdl, const JaggedTensor &field, double level) {
     TORCH_CHECK_VALUE(
         field.ldim() == 1,
         "Expected field to have 1 list dimension, i.e. be a single list of coordinate values, but got",
@@ -424,9 +422,7 @@ marchingCubesLegacy(const GridBatchData &batchHdl,
 // Other dtypes (fp64) and non-CUDA devices are handled by the legacy
 // path, which `marchingCubesFast` forwards to internally.
 std::vector<JaggedTensor>
-marchingCubes(const GridBatchData &batchHdl,
-              const JaggedTensor &field,
-              double level) {
+marchingCubes(const GridBatchData &batchHdl, const JaggedTensor &field, double level) {
     return marchingCubesFast(batchHdl, field, level);
 }
 

--- a/src/fvdb/detail/ops/MarchingCubes.h
+++ b/src/fvdb/detail/ops/MarchingCubes.h
@@ -15,8 +15,30 @@ namespace fvdb {
 namespace detail {
 namespace ops {
 
+/// @brief Public marching-cubes entry point.
+///
+/// Dispatches to a sparse-compact / packed-key fast variant
+/// (`marchingCubesFast`) for float32 and float16 CUDA inputs.
+/// `marchingCubesFast` produces bit-identical output to the legacy
+/// implementation at fp32 (and numerically-identical output at fp16,
+/// since its kernels cast fp16 -> fp32 on load and do all arithmetic
+/// in fp32 without allocating a transient fp32 buffer). It is
+/// substantially faster and uses substantially less peak memory at
+/// large grid sizes. Other dtypes (fp64) and CPU inputs route to
+/// `marchingCubesLegacy`.
 std::vector<JaggedTensor>
 marchingCubes(const GridBatchData &batchHdl, const JaggedTensor &field, double level);
+
+/// @brief Reference legacy marching-cubes implementation.
+///
+/// Used as the fallback when `marchingCubes` cannot route to the fast
+/// variant (non-float32/float16 inputs, or CPU device). New code
+/// should call `marchingCubes` instead — it picks the fast path when
+/// eligible and falls back here automatically otherwise.
+std::vector<JaggedTensor>
+marchingCubesLegacy(const GridBatchData &batchHdl,
+                    const JaggedTensor &field,
+                    double level);
 
 } // namespace ops
 } // namespace detail

--- a/src/fvdb/detail/ops/MarchingCubes.h
+++ b/src/fvdb/detail/ops/MarchingCubes.h
@@ -36,9 +36,7 @@ marchingCubes(const GridBatchData &batchHdl, const JaggedTensor &field, double l
 /// should call `marchingCubes` instead — it picks the fast path when
 /// eligible and falls back here automatically otherwise.
 std::vector<JaggedTensor>
-marchingCubesLegacy(const GridBatchData &batchHdl,
-                    const JaggedTensor &field,
-                    double level);
+marchingCubesLegacy(const GridBatchData &batchHdl, const JaggedTensor &field, double level);
 
 } // namespace ops
 } // namespace detail

--- a/src/fvdb/detail/ops/MarchingCubesFast.cu
+++ b/src/fvdb/detail/ops/MarchingCubesFast.cu
@@ -1,0 +1,606 @@
+// Copyright Contributors to the OpenVDB Project
+// SPDX-License-Identifier: Apache-2.0
+//
+// Sparse-compact, packed-key marching cubes for fp32/fp16 CUDA. See
+// MarchingCubesFast.h for the full algorithm and dtype-coverage notes.
+//
+// In broad strokes:
+//   - Classify kernel writes per-leaf-voxel uint8 vertex counts.
+//   - A prefix sum over those counts gives the emit-vertex offsets and
+//     compacts the surface voxels, so the emit pass touches only
+//     surface voxels rather than every voxel in the grid.
+//   - The emit kernel writes one packed int64 key per triangle vertex
+//     holding `(batchIdx, vid0, vid1)`, and we dedup the 1-D key
+//     vector via `torch::unique` (vs the legacy's 3-column
+//     `[nTri*3, 3]` `torch::unique_dim`). The output is unpacked back
+//     to `[nV, 3]` to preserve the public legacy contract.
+
+#include <fvdb/GridBatchData.h>
+#include <fvdb/JaggedTensor.h>
+#include <fvdb/VoxelCoordTransform.h>
+#include <fvdb/detail/ops/MarchingCubes.h>
+#include <fvdb/detail/ops/MarchingCubesFast.h>
+#include <fvdb/detail/utils/MarchingCubesData.h>
+#include <fvdb/detail/utils/cuda/GridDim.h>
+
+#include <c10/cuda/CUDAException.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <c10/cuda/CUDAStream.h>
+
+#include <nanovdb/NanoVDB.h>
+
+#include <cuda_runtime.h>
+#include <torch/types.h>
+
+namespace fvdb {
+namespace detail {
+namespace ops {
+
+namespace {
+
+constexpr int64_t MCF_BLOCK_SIZE = 128;
+
+// Packed-key bit layout (must match the unpack in marchingCubesFastImpl).
+//
+// 30 bits per vid supports up to 2^30 = 1,073,741,824 active voxels per
+// batch — comfortably covering a paper-hero 800^3 = 512M voxel grid. An
+// earlier 24-bit layout silently truncated pids above 16M, which caused
+// vertex-dedup over-merging at 400^3 and 512^3 sweeps (triangles still
+// matched but vertex counts drifted by <1%).
+//
+// Layout:  [bits 63..60 batchIdx] [bits 59..30 vid0] [bits 29..0 vid1]
+constexpr int MCF_VID_BITS      = 30;
+constexpr int64_t MCF_VID_MASK  = (int64_t{1} << MCF_VID_BITS) - 1;
+constexpr int MCF_VID1_SHIFT    = 0;
+constexpr int MCF_VID0_SHIFT    = MCF_VID_BITS;
+constexpr int MCF_BATCH_SHIFT   = 2 * MCF_VID_BITS;
+constexpr int64_t MCF_BATCH_MAX = int64_t{1} << (64 - MCF_BATCH_SHIFT);
+
+__host__ __device__ __forceinline__ int64_t
+mcf_pack_key(int32_t batchIdx, int64_t vid0, int64_t vid1) {
+    return (static_cast<int64_t>(batchIdx) << MCF_BATCH_SHIFT)
+         | ((vid0 & MCF_VID_MASK) << MCF_VID0_SHIFT)
+         | ((vid1 & MCF_VID_MASK) << MCF_VID1_SHIFT);
+}
+
+// -------------------------------------------------------------------------
+// mcfClassifyKernel — same per-thread state as the legacy classify kernel.
+//
+// Templated on the SDF input scalar type (float or at::Half) so that
+// fp16 callers don't need a 2x-size transient fp32 upcast of the input
+// buffer: the kernel loads fp16 directly and casts to float on the fly
+// via c10::Half's `operator float()` (lowers to a single F2F.F32.F16
+// instruction per load on sm_89+). Internal arithmetic is all fp32 to
+// keep numerics identical across dtypes — the kernel's per-thread state
+// and compile-time-indexed vertex positions need the dynamic range.
+// -------------------------------------------------------------------------
+
+template <typename InputT>
+__global__ void
+mcfClassifyKernel(fvdb::GridBatchData::Accessor batchAcc,
+                   const InputT *__restrict__ sdfData,
+                   const float level,
+                   uint8_t *__restrict__ nVertsPerLv) {
+    constexpr uint64_t VOXELS_PER_LEAF =
+        nanovdb::OnIndexTree::LeafNodeType::NUM_VALUES;
+
+    const uint64_t lvIdx = (static_cast<uint64_t>(blockIdx.x) * blockDim.x) +
+                           threadIdx.x;
+    const uint64_t totalLeafVoxels =
+        static_cast<uint64_t>(batchAcc.totalLeaves()) * VOXELS_PER_LEAF;
+    if (lvIdx >= totalLeafVoxels) {
+        return;
+    }
+
+    const int64_t cumLeafIdx   = static_cast<int64_t>(lvIdx / VOXELS_PER_LEAF);
+    const int64_t leafVoxelIdx = static_cast<int64_t>(lvIdx % VOXELS_PER_LEAF);
+    const JIdxType batchIdx    = batchAcc.leafBatchIndex(cumLeafIdx);
+    const int64_t leafIdx      = cumLeafIdx - batchAcc.leafOffset(batchIdx);
+
+    const nanovdb::OnIndexGrid *grid = batchAcc.grid(batchIdx);
+    const auto &leaf = grid->tree().template getFirstNode<0>()[leafIdx];
+    const nanovdb::Coord ijk = leaf.offsetToGlobalCoord(leafVoxelIdx);
+
+    auto acc                  = grid->getAccessor();
+    const int64_t voxelOffset = batchAcc.voxelOffset(batchIdx);
+
+    float sdf_0, sdf_1, sdf_2, sdf_3, sdf_4, sdf_5, sdf_6, sdf_7;
+
+#define MCF_LOAD_CORNER(IDX, DX, DY, DZ)                                     \
+    {                                                                         \
+        const nanovdb::Coord c = ijk + nanovdb::Coord((DX), (DY), (DZ));      \
+        if (!acc.isActive(c)) {                                               \
+            nVertsPerLv[lvIdx] = 0;                                           \
+            return;                                                           \
+        }                                                                     \
+        sdf_##IDX = static_cast<float>(                                       \
+                        sdfData[voxelOffset + acc.getValue(c) - 1]) -         \
+                    level;                                                    \
+    }
+
+    MCF_LOAD_CORNER(0, 0, 0, 0)
+    MCF_LOAD_CORNER(1, 1, 0, 0)
+    MCF_LOAD_CORNER(2, 1, 1, 0)
+    MCF_LOAD_CORNER(3, 0, 1, 0)
+    MCF_LOAD_CORNER(4, 0, 0, 1)
+    MCF_LOAD_CORNER(5, 1, 0, 1)
+    MCF_LOAD_CORNER(6, 1, 1, 1)
+    MCF_LOAD_CORNER(7, 0, 1, 1)
+
+#undef MCF_LOAD_CORNER
+
+    int cubeType = 0;
+    if (sdf_0 < 0.0f) cubeType |= 1;
+    if (sdf_1 < 0.0f) cubeType |= 2;
+    if (sdf_2 < 0.0f) cubeType |= 4;
+    if (sdf_3 < 0.0f) cubeType |= 8;
+    if (sdf_4 < 0.0f) cubeType |= 16;
+    if (sdf_5 < 0.0f) cubeType |= 32;
+    if (sdf_6 < 0.0f) cubeType |= 64;
+    if (sdf_7 < 0.0f) cubeType |= 128;
+
+    nVertsPerLv[lvIdx] = static_cast<uint8_t>(
+        fvdb::detail::marchingCubesNumVertsTable[cubeType]);
+}
+
+// -------------------------------------------------------------------------
+// mcfEmitCompactKernel — same iteration order as the legacy emit but writes packed int64
+// keys to `flatKeys[nTri*3]` instead of (batchIdx, vid0, vid1) triples.
+//
+// Templated on SDF input scalar type (float or at::Half) for the same
+// zero-copy fp16 reason as `mcfClassifyKernel`. Triangle positions are
+// still computed and stored in fp32 — world coordinates can exceed
+// fp16's dynamic range in large reality-capture scenes, so keeping the
+// output at fp32 matches user expectations. The resulting `retVertices`
+// JaggedTensor is downcast to the original input dtype at the end of
+// `marchingCubesFast` (a small tensor; far less than the SDF buffer).
+// -------------------------------------------------------------------------
+
+template <typename InputT>
+__global__ void
+mcfEmitCompactKernel(
+    fvdb::GridBatchData::Accessor batchAcc,
+    const InputT *__restrict__ sdfData,
+    const float level,
+    const int64_t *__restrict__ surfaceLvIdx,
+    const int64_t surfaceCount,
+    const int64_t *__restrict__ csumCompact,
+    torch::PackedTensorAccessor64<float, 3, torch::RestrictPtrTraits>
+        trianglesAcc,
+    int64_t *__restrict__ flatKeys) {
+    constexpr uint64_t VOXELS_PER_LEAF =
+        nanovdb::OnIndexTree::LeafNodeType::NUM_VALUES;
+
+    const int64_t tid = (static_cast<int64_t>(blockIdx.x) * blockDim.x) +
+                        threadIdx.x;
+    if (tid >= surfaceCount) {
+        return;
+    }
+
+    const int64_t lvIdx        = surfaceLvIdx[tid];
+    const int64_t cumLeafIdx   = lvIdx / static_cast<int64_t>(VOXELS_PER_LEAF);
+    const int64_t leafVoxelIdx = lvIdx % static_cast<int64_t>(VOXELS_PER_LEAF);
+    const JIdxType batchIdx    = batchAcc.leafBatchIndex(cumLeafIdx);
+    const int64_t leafIdx      = cumLeafIdx - batchAcc.leafOffset(batchIdx);
+
+    const nanovdb::OnIndexGrid *grid = batchAcc.grid(batchIdx);
+    const auto &leaf = grid->tree().template getFirstNode<0>()[leafIdx];
+    const nanovdb::Coord ijk = leaf.offsetToGlobalCoord(leafVoxelIdx);
+    const VoxelCoordTransform transform = batchAcc.primalTransform(batchIdx);
+
+    auto acc                  = grid->getAccessor();
+    const int64_t voxelOffset = batchAcc.voxelOffset(batchIdx);
+
+    float sdf_0, sdf_1, sdf_2, sdf_3, sdf_4, sdf_5, sdf_6, sdf_7;
+    int64_t pid_0, pid_1, pid_2, pid_3, pid_4, pid_5, pid_6, pid_7;
+    float p_0_x, p_0_y, p_0_z;
+    float p_1_x, p_1_y, p_1_z;
+    float p_2_x, p_2_y, p_2_z;
+    float p_3_x, p_3_y, p_3_z;
+    float p_4_x, p_4_y, p_4_z;
+    float p_5_x, p_5_y, p_5_z;
+    float p_6_x, p_6_y, p_6_z;
+    float p_7_x, p_7_y, p_7_z;
+
+#define MCF_EMIT_LOAD_CORNER(IDX, DX, DY, DZ)                                \
+    {                                                                         \
+        const nanovdb::Coord c = ijk + nanovdb::Coord((DX), (DY), (DZ));      \
+        if (!acc.isActive(c)) {                                               \
+            return;                                                           \
+        }                                                                     \
+        pid_##IDX = voxelOffset + acc.getValue(c) - 1;                        \
+        sdf_##IDX = static_cast<float>(sdfData[pid_##IDX]) - level;           \
+        const auto worldP = transform.applyInv(static_cast<float>(c[0]),      \
+                                               static_cast<float>(c[1]),      \
+                                               static_cast<float>(c[2]));     \
+        p_##IDX##_x = static_cast<float>(worldP[0]);                          \
+        p_##IDX##_y = static_cast<float>(worldP[1]);                          \
+        p_##IDX##_z = static_cast<float>(worldP[2]);                          \
+    }
+
+    MCF_EMIT_LOAD_CORNER(0, 0, 0, 0)
+    MCF_EMIT_LOAD_CORNER(1, 1, 0, 0)
+    MCF_EMIT_LOAD_CORNER(2, 1, 1, 0)
+    MCF_EMIT_LOAD_CORNER(3, 0, 1, 0)
+    MCF_EMIT_LOAD_CORNER(4, 0, 0, 1)
+    MCF_EMIT_LOAD_CORNER(5, 1, 0, 1)
+    MCF_EMIT_LOAD_CORNER(6, 1, 1, 1)
+    MCF_EMIT_LOAD_CORNER(7, 0, 1, 1)
+
+#undef MCF_EMIT_LOAD_CORNER
+
+    int cubeType = 0;
+    if (sdf_0 < 0.0f) cubeType |= 1;
+    if (sdf_1 < 0.0f) cubeType |= 2;
+    if (sdf_2 < 0.0f) cubeType |= 4;
+    if (sdf_3 < 0.0f) cubeType |= 8;
+    if (sdf_4 < 0.0f) cubeType |= 16;
+    if (sdf_5 < 0.0f) cubeType |= 32;
+    if (sdf_6 < 0.0f) cubeType |= 64;
+    if (sdf_7 < 0.0f) cubeType |= 128;
+
+    const int edgeConfig = fvdb::detail::marchingCubesEdgeTable[cubeType];
+    if (edgeConfig == 0) {
+        return;
+    }
+
+    float vert_0_x = 0.0f, vert_0_y = 0.0f, vert_0_z = 0.0f;
+    float vert_1_x = 0.0f, vert_1_y = 0.0f, vert_1_z = 0.0f;
+    float vert_2_x = 0.0f, vert_2_y = 0.0f, vert_2_z = 0.0f;
+    float vert_3_x = 0.0f, vert_3_y = 0.0f, vert_3_z = 0.0f;
+    float vert_4_x = 0.0f, vert_4_y = 0.0f, vert_4_z = 0.0f;
+    float vert_5_x = 0.0f, vert_5_y = 0.0f, vert_5_z = 0.0f;
+    float vert_6_x = 0.0f, vert_6_y = 0.0f, vert_6_z = 0.0f;
+    float vert_7_x = 0.0f, vert_7_y = 0.0f, vert_7_z = 0.0f;
+    float vert_8_x = 0.0f, vert_8_y = 0.0f, vert_8_z = 0.0f;
+    float vert_9_x = 0.0f, vert_9_y = 0.0f, vert_9_z = 0.0f;
+    float vert_10_x = 0.0f, vert_10_y = 0.0f, vert_10_z = 0.0f;
+    float vert_11_x = 0.0f, vert_11_y = 0.0f, vert_11_z = 0.0f;
+
+#define MCF_INTERP_EDGE(IDX, IA, IB)                                         \
+    if (edgeConfig & (1 << (IDX))) {                                          \
+        const float va = sdf_##IA;                                            \
+        const float vb = sdf_##IB;                                            \
+        const float ax = p_##IA##_x, ay = p_##IA##_y, az = p_##IA##_z;        \
+        const float bx = p_##IB##_x, by = p_##IB##_y, bz = p_##IB##_z;        \
+        constexpr float MC_EPS = 1.0e-5f;                                     \
+        if (fabsf(va) < MC_EPS) {                                             \
+            vert_##IDX##_x = ax; vert_##IDX##_y = ay; vert_##IDX##_z = az;    \
+        } else if (fabsf(vb) < MC_EPS) {                                      \
+            vert_##IDX##_x = bx; vert_##IDX##_y = by; vert_##IDX##_z = bz;    \
+        } else if (fabsf(va - vb) < MC_EPS) {                                 \
+            vert_##IDX##_x = ax; vert_##IDX##_y = ay; vert_##IDX##_z = az;    \
+        } else {                                                              \
+            const float w2 = (0.0f - va) / (vb - va);                         \
+            const float w1 = 1.0f - w2;                                       \
+            vert_##IDX##_x = ax * w1 + bx * w2;                               \
+            vert_##IDX##_y = ay * w1 + by * w2;                               \
+            vert_##IDX##_z = az * w1 + bz * w2;                               \
+        }                                                                     \
+    }
+
+    MCF_INTERP_EDGE(0,  0, 1)
+    MCF_INTERP_EDGE(1,  1, 2)
+    MCF_INTERP_EDGE(2,  2, 3)
+    MCF_INTERP_EDGE(3,  0, 3)
+    MCF_INTERP_EDGE(4,  4, 5)
+    MCF_INTERP_EDGE(5,  5, 6)
+    MCF_INTERP_EDGE(6,  6, 7)
+    MCF_INTERP_EDGE(7,  7, 4)
+    MCF_INTERP_EDGE(8,  0, 4)
+    MCF_INTERP_EDGE(9,  1, 5)
+    MCF_INTERP_EDGE(10, 6, 2)
+    MCF_INTERP_EDGE(11, 3, 7)
+
+#undef MCF_INTERP_EDGE
+
+    const int64_t triangleBase = csumCompact[tid] / 3;
+
+#define MCF_PICK_VERT_X(vlid)                                                \
+    ((vlid) == 0  ? vert_0_x  : (vlid) == 1  ? vert_1_x  :                    \
+     (vlid) == 2  ? vert_2_x  : (vlid) == 3  ? vert_3_x  :                    \
+     (vlid) == 4  ? vert_4_x  : (vlid) == 5  ? vert_5_x  :                    \
+     (vlid) == 6  ? vert_6_x  : (vlid) == 7  ? vert_7_x  :                    \
+     (vlid) == 8  ? vert_8_x  : (vlid) == 9  ? vert_9_x  :                    \
+     (vlid) == 10 ? vert_10_x : vert_11_x)
+#define MCF_PICK_VERT_Y(vlid)                                                \
+    ((vlid) == 0  ? vert_0_y  : (vlid) == 1  ? vert_1_y  :                    \
+     (vlid) == 2  ? vert_2_y  : (vlid) == 3  ? vert_3_y  :                    \
+     (vlid) == 4  ? vert_4_y  : (vlid) == 5  ? vert_5_y  :                    \
+     (vlid) == 6  ? vert_6_y  : (vlid) == 7  ? vert_7_y  :                    \
+     (vlid) == 8  ? vert_8_y  : (vlid) == 9  ? vert_9_y  :                    \
+     (vlid) == 10 ? vert_10_y : vert_11_y)
+#define MCF_PICK_VERT_Z(vlid)                                                \
+    ((vlid) == 0  ? vert_0_z  : (vlid) == 1  ? vert_1_z  :                    \
+     (vlid) == 2  ? vert_2_z  : (vlid) == 3  ? vert_3_z  :                    \
+     (vlid) == 4  ? vert_4_z  : (vlid) == 5  ? vert_5_z  :                    \
+     (vlid) == 6  ? vert_6_z  : (vlid) == 7  ? vert_7_z  :                    \
+     (vlid) == 8  ? vert_8_z  : (vlid) == 9  ? vert_9_z  :                    \
+     (vlid) == 10 ? vert_10_z : vert_11_z)
+#define MCF_PICK_PID(cid)                                                    \
+    ((cid) == 0 ? pid_0 : (cid) == 1 ? pid_1 :                                \
+     (cid) == 2 ? pid_2 : (cid) == 3 ? pid_3 :                                \
+     (cid) == 4 ? pid_4 : (cid) == 5 ? pid_5 :                                \
+     (cid) == 6 ? pid_6 : pid_7)
+
+    for (int i = 0; fvdb::detail::marchingCubesTriTable[cubeType][i] != -1;
+         i += 3) {
+        const int64_t triangleIdx = triangleBase + i / 3;
+#pragma unroll
+        for (int vi = 0; vi < 3; ++vi) {
+            const int vlid = fvdb::detail::marchingCubesTriTable[cubeType][i + vi];
+            trianglesAcc[triangleIdx][vi][0] = MCF_PICK_VERT_X(vlid);
+            trianglesAcc[triangleIdx][vi][1] = MCF_PICK_VERT_Y(vlid);
+            trianglesAcc[triangleIdx][vi][2] = MCF_PICK_VERT_Z(vlid);
+
+            const int e2i_0 = fvdb::detail::marchingCubesE2iTable[vlid][0];
+            const int e2i_1 = fvdb::detail::marchingCubesE2iTable[vlid][1];
+            int64_t vid0    = MCF_PICK_PID(e2i_0);
+            int64_t vid1    = MCF_PICK_PID(e2i_1);
+            if (vid0 < vid1) {
+                const int64_t t = vid1;
+                vid1            = vid0;
+                vid0            = t;
+            }
+            flatKeys[triangleIdx * 3 + vi] =
+                mcf_pack_key(static_cast<int32_t>(batchIdx), vid0, vid1);
+        }
+    }
+
+#undef MCF_PICK_PID
+#undef MCF_PICK_VERT_Z
+#undef MCF_PICK_VERT_Y
+#undef MCF_PICK_VERT_X
+}
+
+// -------------------------------------------------------------------------
+// Public entry: marchingCubesFastImpl (templated on SDF input scalar type,
+// either float or at::Half — see kernel-level docstrings for rationale).
+// -------------------------------------------------------------------------
+
+template <typename InputT>
+std::vector<JaggedTensor>
+marchingCubesFastImpl(const GridBatchData &batchHdl,
+                    const torch::Tensor &sdf,
+                    double level) {
+    batchHdl.checkDevice(sdf);
+    TORCH_CHECK_TYPE(sdf.is_floating_point(),
+                     "field must have a floating point type");
+    TORCH_CHECK(sdf.dim() == 1,
+                "Expected field to have 1 dimension but got ", sdf.dim());
+
+    // Guard against silent pid / batch overflow in the packed key. The
+    // 30-bit vid field covers up to 1B active voxels per batch; batch
+    // field at bits 60..63 supports up to 16 batches.
+    TORCH_CHECK_VALUE(batchHdl.batchSize() < MCF_BATCH_MAX,
+                      "marchingCubesFast: batch size ", batchHdl.batchSize(),
+                      " exceeds packed-key capacity ", MCF_BATCH_MAX);
+    TORCH_CHECK_VALUE(batchHdl.totalVoxels() <= (int64_t{1} << MCF_VID_BITS),
+                      "marchingCubesFast: totalVoxels ", batchHdl.totalVoxels(),
+                      " exceeds packed-key vid capacity ",
+                      int64_t{1} << MCF_VID_BITS,
+                      " — widen MCF_VID_BITS or fall back to legacy MC.");
+
+    c10::cuda::CUDAGuard guard(sdf.device());
+    at::cuda::CUDAStream stream =
+        at::cuda::getCurrentCUDAStream(sdf.device().index());
+
+    const int64_t totalLeaves = batchHdl.totalLeaves();
+    constexpr int64_t VOXELS_PER_LEAF =
+        nanovdb::OnIndexTree::LeafNodeType::NUM_VALUES;
+    const int64_t totalLeafVoxels = totalLeaves * VOXELS_PER_LEAF;
+
+    auto longOpts =
+        torch::TensorOptions().dtype(torch::kLong).device(sdf.device());
+    auto floatOpts =
+        torch::TensorOptions().dtype(torch::kFloat32).device(sdf.device());
+    auto byteOpts =
+        torch::TensorOptions().dtype(torch::kUInt8).device(sdf.device());
+
+    if (totalLeaves == 0) {
+        return marchingCubesLegacy(batchHdl,
+                                   JaggedTensor::from_data_indices_and_list_ids(
+                                       sdf,
+                                       torch::zeros({0},
+                                                    torch::TensorOptions()
+                                                        .dtype(fvdb::JIdxScalarType)
+                                                        .device(sdf.device())),
+                                       torch::empty({0, 1},
+                                                    torch::TensorOptions()
+                                                        .dtype(fvdb::JIdxScalarType)
+                                                        .device(sdf.device())),
+                                       batchHdl.batchSize()),
+                                   level);
+    }
+
+    // --- Step 1: classify ---
+    torch::Tensor nVertsPerLv = torch::empty({totalLeafVoxels}, byteOpts);
+    const int64_t classifyBlocks =
+        GET_BLOCKS(totalLeafVoxels, MCF_BLOCK_SIZE);
+    mcfClassifyKernel<InputT>
+        <<<static_cast<unsigned int>(classifyBlocks),
+           static_cast<unsigned int>(MCF_BLOCK_SIZE),
+           0, stream.stream()>>>(
+        batchHdl.deviceAccessor(),
+        sdf.data_ptr<InputT>(),
+        static_cast<float>(level),
+        nVertsPerLv.data_ptr<uint8_t>());
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+
+    // --- Step 2: compact ---
+    torch::Tensor surfaceLvIdx =
+        nVertsPerLv.nonzero().squeeze(-1).contiguous();
+    const int64_t surfaceCount = surfaceLvIdx.size(0);
+
+    torch::Tensor nVertsCompact =
+        nVertsPerLv.index_select(0, surfaceLvIdx).to(torch::kLong);
+    torch::Tensor csumInclusive = torch::cumsum(nVertsCompact, 0);
+    const int64_t nTriangles =
+        surfaceCount > 0
+            ? (csumInclusive.index({-1}).item<int64_t>() / 3)
+            : 0;
+    torch::Tensor csumCompact = torch::roll(csumInclusive, {1});
+    if (surfaceCount > 0) {
+        csumCompact.index_put_({0}, 0);
+    }
+
+    torch::Tensor triangles = torch::empty({nTriangles, 3, 3}, floatOpts);
+    // Single-column packed-key tensor (replaces legacy's [nTri, 3, 3] int64).
+    torch::Tensor flatKeys =
+        torch::empty({nTriangles * 3}, longOpts);
+
+    if (nTriangles > 0) {
+        const int64_t emitBlocks =
+            GET_BLOCKS(surfaceCount, MCF_BLOCK_SIZE);
+        mcfEmitCompactKernel<InputT>
+            <<<static_cast<unsigned int>(emitBlocks),
+               static_cast<unsigned int>(MCF_BLOCK_SIZE),
+               0, stream.stream()>>>(
+            batchHdl.deviceAccessor(),
+            sdf.data_ptr<InputT>(),
+            static_cast<float>(level),
+            surfaceLvIdx.data_ptr<int64_t>(),
+            surfaceCount,
+            csumCompact.data_ptr<int64_t>(),
+            triangles.packed_accessor64<float, 3, torch::RestrictPtrTraits>(),
+            flatKeys.data_ptr<int64_t>());
+        C10_CUDA_KERNEL_LAUNCH_CHECK();
+    }
+
+    // --- Step 3: 1-D dedup via torch::_unique (replaces unique_dim) ---
+    // at::_unique returns (unique_values, inverse_indices). Smaller input
+    // footprint: 8 B/elem vs 24 B/elem for the legacy 3-col key.
+    auto unqRet                = at::_unique(flatKeys, /*sorted=*/true,
+                                             /*return_inverse=*/true);
+    torch::Tensor unqKeys      = std::get<0>(unqRet);
+    torch::Tensor unqTriangles = std::get<1>(unqRet);
+
+    // Unpack keys back to [nV, 3] (batchIdx, vid0, vid1) for the public
+    // contract. Done purely in Torch ops for device-side execution. Each
+    // field is masked explicitly so arithmetic-shift sign-extension on
+    // signed int64 can't leak upper bits into the lower fields.
+    const int64_t nV = unqKeys.size(0);
+    torch::Tensor unqVertIdx;
+    if (nV > 0) {
+        const torch::Tensor vidMaskT =
+            torch::full({}, MCF_VID_MASK, unqKeys.options());
+        const torch::Tensor batchMaskT =
+            torch::full({}, MCF_BATCH_MAX - 1, unqKeys.options());
+
+        torch::Tensor vid1 = torch::bitwise_and(unqKeys, vidMaskT);
+        torch::Tensor vid0 = torch::bitwise_and(
+            torch::bitwise_right_shift(unqKeys, MCF_VID_BITS), vidMaskT);
+        torch::Tensor bidx = torch::bitwise_and(
+            torch::bitwise_right_shift(unqKeys, MCF_BATCH_SHIFT), batchMaskT);
+        unqVertIdx = torch::stack({bidx, vid0, vid1}, /*dim=*/1).contiguous();
+    } else {
+        unqVertIdx = torch::empty({0, 3}, longOpts);
+    }
+
+    auto flatTriangles = triangles.view({-1, 3});
+    torch::Tensor vertices =
+        torch::zeros({nV, 3}, floatOpts);
+    if (nV > 0) {
+        vertices.index_put_({unqTriangles}, flatTriangles);
+    }
+
+    unqTriangles            = unqTriangles.view({-1, 3});
+    torch::Tensor vBatchIdx = unqVertIdx.index({torch::indexing::Slice(), 0})
+                                  .to(fvdb::JIdxScalarType);
+    torch::Tensor tBatchIdx =
+        vBatchIdx.index({unqTriangles.index({torch::indexing::Slice(), 0})})
+            .to(fvdb::JIdxScalarType);
+
+    JaggedTensor retVertices = JaggedTensor::from_data_indices_and_list_ids(
+        vertices, vBatchIdx, batchHdl.jlidx(), batchHdl.batchSize());
+    JaggedTensor retTriangles = JaggedTensor::from_data_indices_and_list_ids(
+        unqTriangles, tBatchIdx, batchHdl.jlidx(), batchHdl.batchSize());
+    JaggedTensor retUniqueVertices =
+        JaggedTensor::from_data_indices_and_list_ids(
+            unqVertIdx, vBatchIdx, batchHdl.jlidx(), batchHdl.batchSize());
+
+    int64_t cumNumVerts = 0;
+    for (int i = 1; i < batchHdl.batchSize(); i += 1) {
+        cumNumVerts += retVertices.index({i - 1}).jdata().size(0);
+        retTriangles.index({i}).jdata().sub_(cumNumVerts);
+    }
+
+    return {retVertices, retTriangles, retUniqueVertices};
+}
+
+} // anonymous namespace
+
+std::vector<JaggedTensor>
+marchingCubesFast(const GridBatchData &batchHdl,
+                const JaggedTensor &field,
+                double level) {
+    TORCH_CHECK_VALUE(field.ldim() == 1,
+                      "Expected field to have 1 list dimension, got ",
+                      field.ldim());
+    TORCH_CHECK_TYPE(field.is_floating_point(),
+                     "field must have a floating point type");
+    TORCH_CHECK_VALUE(field.numel() == batchHdl.totalVoxels(),
+                      "Value count not match!");
+    TORCH_CHECK_VALUE(field.num_outer_lists() == batchHdl.batchSize(),
+                      "Batch size not match!");
+
+    torch::Tensor fieldJdata = field.jdata();
+    if (fieldJdata.dim() == 0) {
+        fieldJdata = fieldJdata.unsqueeze(0);
+    }
+    if (fieldJdata.dim() != 1) {
+        fieldJdata = fieldJdata.squeeze();
+    }
+    batchHdl.checkDevice(field);
+
+    // CPU and fp64 paths go through the legacy (fully templated) impl.
+    // This implementation's kernels are fp32-internal because:
+    //   (a) vertex world positions can exceed fp16 dynamic range in
+    //       large reality-capture scenes (thousands of meters at ~mm
+    //       voxel size);
+    //   (b) keeping arithmetic at fp32 gives numerically identical
+    //       output across input dtypes — a property the ablation
+    //       table's correctness gate relies on.
+    // But we do NOT upcast the input buffer. The kernels are templated
+    // on the SDF input scalar type (float or at::Half) and cast on the
+    // fly per load via c10::Half's `operator float()` — a single
+    // F2F.F32.F16 per read on sm_89+. For a fp16 input that means:
+    //   - zero extra buffer allocation (no N_voxels * 4B transient);
+    //   - half the input DRAM bandwidth of the fp32 path;
+    //   - only the final small `retVertices` tensor (nV x 3 floats,
+    //     orders of magnitude smaller than the SDF) gets downcast to
+    //     fp16 to preserve legacy's output-dtype contract.
+    // This matters for fvdb-reality-capture's 500M+ voxel hero runs
+    // where a 2 GB fp32 upcast would be painful.
+    const bool isCuda = field.device().is_cuda();
+    const auto origDtype = fieldJdata.scalar_type();
+    const bool supportedDtype =
+        (origDtype == torch::kFloat32 || origDtype == torch::kHalf);
+
+    if (!isCuda || !supportedDtype) {
+        return marchingCubesLegacy(batchHdl, field, level);
+    }
+
+    std::vector<JaggedTensor> outputs =
+        (origDtype == torch::kFloat32)
+            ? marchingCubesFastImpl<float>(batchHdl, fieldJdata, level)
+            : marchingCubesFastImpl<at::Half>(batchHdl, fieldJdata, level);
+
+    if (origDtype != torch::kFloat32) {
+        // Only `retVertices` (outputs[0]) is dtype-dependent; it's [nV, 3]
+        // and typically orders of magnitude smaller than the SDF input,
+        // so this cast is negligible. Triangles (face indices) and
+        // unqVertIdx are int64 regardless.
+        JaggedTensor &verts = outputs[0];
+        verts = JaggedTensor::from_data_indices_and_list_ids(
+            verts.jdata().to(origDtype),
+            verts.jidx(),
+            verts.jlidx(),
+            verts.num_outer_lists());
+    }
+    return outputs;
+}
+
+} // namespace ops
+} // namespace detail
+} // namespace fvdb

--- a/src/fvdb/detail/ops/MarchingCubesFast.cu
+++ b/src/fvdb/detail/ops/MarchingCubesFast.cu
@@ -23,14 +23,14 @@
 #include <fvdb/detail/utils/MarchingCubesData.h>
 #include <fvdb/detail/utils/cuda/GridDim.h>
 
+#include <nanovdb/NanoVDB.h>
+
 #include <c10/cuda/CUDAException.h>
 #include <c10/cuda/CUDAGuard.h>
 #include <c10/cuda/CUDAStream.h>
-
-#include <nanovdb/NanoVDB.h>
+#include <torch/types.h>
 
 #include <cuda_runtime.h>
-#include <torch/types.h>
 
 namespace fvdb {
 namespace detail {
@@ -58,9 +58,8 @@ constexpr int64_t MCF_BATCH_MAX = int64_t{1} << (64 - MCF_BATCH_SHIFT);
 
 __host__ __device__ __forceinline__ int64_t
 mcf_pack_key(int32_t batchIdx, int64_t vid0, int64_t vid1) {
-    return (static_cast<int64_t>(batchIdx) << MCF_BATCH_SHIFT)
-         | ((vid0 & MCF_VID_MASK) << MCF_VID0_SHIFT)
-         | ((vid1 & MCF_VID_MASK) << MCF_VID1_SHIFT);
+    return (static_cast<int64_t>(batchIdx) << MCF_BATCH_SHIFT) |
+           ((vid0 & MCF_VID_MASK) << MCF_VID0_SHIFT) | ((vid1 & MCF_VID_MASK) << MCF_VID1_SHIFT);
 }
 
 // -------------------------------------------------------------------------
@@ -78,14 +77,12 @@ mcf_pack_key(int32_t batchIdx, int64_t vid0, int64_t vid1) {
 template <typename InputT>
 __global__ void
 mcfClassifyKernel(fvdb::GridBatchData::Accessor batchAcc,
-                   const InputT *__restrict__ sdfData,
-                   const float level,
-                   uint8_t *__restrict__ nVertsPerLv) {
-    constexpr uint64_t VOXELS_PER_LEAF =
-        nanovdb::OnIndexTree::LeafNodeType::NUM_VALUES;
+                  const InputT *__restrict__ sdfData,
+                  const float level,
+                  uint8_t *__restrict__ nVertsPerLv) {
+    constexpr uint64_t VOXELS_PER_LEAF = nanovdb::OnIndexTree::LeafNodeType::NUM_VALUES;
 
-    const uint64_t lvIdx = (static_cast<uint64_t>(blockIdx.x) * blockDim.x) +
-                           threadIdx.x;
+    const uint64_t lvIdx = (static_cast<uint64_t>(blockIdx.x) * blockDim.x) + threadIdx.x;
     const uint64_t totalLeafVoxels =
         static_cast<uint64_t>(batchAcc.totalLeaves()) * VOXELS_PER_LEAF;
     if (lvIdx >= totalLeafVoxels) {
@@ -98,24 +95,22 @@ mcfClassifyKernel(fvdb::GridBatchData::Accessor batchAcc,
     const int64_t leafIdx      = cumLeafIdx - batchAcc.leafOffset(batchIdx);
 
     const nanovdb::OnIndexGrid *grid = batchAcc.grid(batchIdx);
-    const auto &leaf = grid->tree().template getFirstNode<0>()[leafIdx];
-    const nanovdb::Coord ijk = leaf.offsetToGlobalCoord(leafVoxelIdx);
+    const auto &leaf                 = grid->tree().template getFirstNode<0>()[leafIdx];
+    const nanovdb::Coord ijk         = leaf.offsetToGlobalCoord(leafVoxelIdx);
 
     auto acc                  = grid->getAccessor();
     const int64_t voxelOffset = batchAcc.voxelOffset(batchIdx);
 
     float sdf_0, sdf_1, sdf_2, sdf_3, sdf_4, sdf_5, sdf_6, sdf_7;
 
-#define MCF_LOAD_CORNER(IDX, DX, DY, DZ)                                     \
-    {                                                                         \
-        const nanovdb::Coord c = ijk + nanovdb::Coord((DX), (DY), (DZ));      \
-        if (!acc.isActive(c)) {                                               \
-            nVertsPerLv[lvIdx] = 0;                                           \
-            return;                                                           \
-        }                                                                     \
-        sdf_##IDX = static_cast<float>(                                       \
-                        sdfData[voxelOffset + acc.getValue(c) - 1]) -         \
-                    level;                                                    \
+#define MCF_LOAD_CORNER(IDX, DX, DY, DZ)                                                    \
+    {                                                                                       \
+        const nanovdb::Coord c = ijk + nanovdb::Coord((DX), (DY), (DZ));                    \
+        if (!acc.isActive(c)) {                                                             \
+            nVertsPerLv[lvIdx] = 0;                                                         \
+            return;                                                                         \
+        }                                                                                   \
+        sdf_##IDX = static_cast<float>(sdfData[voxelOffset + acc.getValue(c) - 1]) - level; \
     }
 
     MCF_LOAD_CORNER(0, 0, 0, 0)
@@ -130,17 +125,24 @@ mcfClassifyKernel(fvdb::GridBatchData::Accessor batchAcc,
 #undef MCF_LOAD_CORNER
 
     int cubeType = 0;
-    if (sdf_0 < 0.0f) cubeType |= 1;
-    if (sdf_1 < 0.0f) cubeType |= 2;
-    if (sdf_2 < 0.0f) cubeType |= 4;
-    if (sdf_3 < 0.0f) cubeType |= 8;
-    if (sdf_4 < 0.0f) cubeType |= 16;
-    if (sdf_5 < 0.0f) cubeType |= 32;
-    if (sdf_6 < 0.0f) cubeType |= 64;
-    if (sdf_7 < 0.0f) cubeType |= 128;
+    if (sdf_0 < 0.0f)
+        cubeType |= 1;
+    if (sdf_1 < 0.0f)
+        cubeType |= 2;
+    if (sdf_2 < 0.0f)
+        cubeType |= 4;
+    if (sdf_3 < 0.0f)
+        cubeType |= 8;
+    if (sdf_4 < 0.0f)
+        cubeType |= 16;
+    if (sdf_5 < 0.0f)
+        cubeType |= 32;
+    if (sdf_6 < 0.0f)
+        cubeType |= 64;
+    if (sdf_7 < 0.0f)
+        cubeType |= 128;
 
-    nVertsPerLv[lvIdx] = static_cast<uint8_t>(
-        fvdb::detail::marchingCubesNumVertsTable[cubeType]);
+    nVertsPerLv[lvIdx] = static_cast<uint8_t>(fvdb::detail::marchingCubesNumVertsTable[cubeType]);
 }
 
 // -------------------------------------------------------------------------
@@ -158,21 +160,17 @@ mcfClassifyKernel(fvdb::GridBatchData::Accessor batchAcc,
 
 template <typename InputT>
 __global__ void
-mcfEmitCompactKernel(
-    fvdb::GridBatchData::Accessor batchAcc,
-    const InputT *__restrict__ sdfData,
-    const float level,
-    const int64_t *__restrict__ surfaceLvIdx,
-    const int64_t surfaceCount,
-    const int64_t *__restrict__ csumCompact,
-    torch::PackedTensorAccessor64<float, 3, torch::RestrictPtrTraits>
-        trianglesAcc,
-    int64_t *__restrict__ flatKeys) {
-    constexpr uint64_t VOXELS_PER_LEAF =
-        nanovdb::OnIndexTree::LeafNodeType::NUM_VALUES;
+mcfEmitCompactKernel(fvdb::GridBatchData::Accessor batchAcc,
+                     const InputT *__restrict__ sdfData,
+                     const float level,
+                     const int64_t *__restrict__ surfaceLvIdx,
+                     const int64_t surfaceCount,
+                     const int64_t *__restrict__ csumCompact,
+                     torch::PackedTensorAccessor64<float, 3, torch::RestrictPtrTraits> trianglesAcc,
+                     int64_t *__restrict__ flatKeys) {
+    constexpr uint64_t VOXELS_PER_LEAF = nanovdb::OnIndexTree::LeafNodeType::NUM_VALUES;
 
-    const int64_t tid = (static_cast<int64_t>(blockIdx.x) * blockDim.x) +
-                        threadIdx.x;
+    const int64_t tid = (static_cast<int64_t>(blockIdx.x) * blockDim.x) + threadIdx.x;
     if (tid >= surfaceCount) {
         return;
     }
@@ -183,9 +181,9 @@ mcfEmitCompactKernel(
     const JIdxType batchIdx    = batchAcc.leafBatchIndex(cumLeafIdx);
     const int64_t leafIdx      = cumLeafIdx - batchAcc.leafOffset(batchIdx);
 
-    const nanovdb::OnIndexGrid *grid = batchAcc.grid(batchIdx);
-    const auto &leaf = grid->tree().template getFirstNode<0>()[leafIdx];
-    const nanovdb::Coord ijk = leaf.offsetToGlobalCoord(leafVoxelIdx);
+    const nanovdb::OnIndexGrid *grid    = batchAcc.grid(batchIdx);
+    const auto &leaf                    = grid->tree().template getFirstNode<0>()[leafIdx];
+    const nanovdb::Coord ijk            = leaf.offsetToGlobalCoord(leafVoxelIdx);
     const VoxelCoordTransform transform = batchAcc.primalTransform(batchIdx);
 
     auto acc                  = grid->getAccessor();
@@ -202,20 +200,19 @@ mcfEmitCompactKernel(
     float p_6_x, p_6_y, p_6_z;
     float p_7_x, p_7_y, p_7_z;
 
-#define MCF_EMIT_LOAD_CORNER(IDX, DX, DY, DZ)                                \
-    {                                                                         \
-        const nanovdb::Coord c = ijk + nanovdb::Coord((DX), (DY), (DZ));      \
-        if (!acc.isActive(c)) {                                               \
-            return;                                                           \
-        }                                                                     \
-        pid_##IDX = voxelOffset + acc.getValue(c) - 1;                        \
-        sdf_##IDX = static_cast<float>(sdfData[pid_##IDX]) - level;           \
-        const auto worldP = transform.applyInv(static_cast<float>(c[0]),      \
-                                               static_cast<float>(c[1]),      \
-                                               static_cast<float>(c[2]));     \
-        p_##IDX##_x = static_cast<float>(worldP[0]);                          \
-        p_##IDX##_y = static_cast<float>(worldP[1]);                          \
-        p_##IDX##_z = static_cast<float>(worldP[2]);                          \
+#define MCF_EMIT_LOAD_CORNER(IDX, DX, DY, DZ)                                              \
+    {                                                                                      \
+        const nanovdb::Coord c = ijk + nanovdb::Coord((DX), (DY), (DZ));                   \
+        if (!acc.isActive(c)) {                                                            \
+            return;                                                                        \
+        }                                                                                  \
+        pid_##IDX         = voxelOffset + acc.getValue(c) - 1;                             \
+        sdf_##IDX         = static_cast<float>(sdfData[pid_##IDX]) - level;                \
+        const auto worldP = transform.applyInv(                                            \
+            static_cast<float>(c[0]), static_cast<float>(c[1]), static_cast<float>(c[2])); \
+        p_##IDX##_x = static_cast<float>(worldP[0]);                                       \
+        p_##IDX##_y = static_cast<float>(worldP[1]);                                       \
+        p_##IDX##_z = static_cast<float>(worldP[2]);                                       \
     }
 
     MCF_EMIT_LOAD_CORNER(0, 0, 0, 0)
@@ -230,14 +227,22 @@ mcfEmitCompactKernel(
 #undef MCF_EMIT_LOAD_CORNER
 
     int cubeType = 0;
-    if (sdf_0 < 0.0f) cubeType |= 1;
-    if (sdf_1 < 0.0f) cubeType |= 2;
-    if (sdf_2 < 0.0f) cubeType |= 4;
-    if (sdf_3 < 0.0f) cubeType |= 8;
-    if (sdf_4 < 0.0f) cubeType |= 16;
-    if (sdf_5 < 0.0f) cubeType |= 32;
-    if (sdf_6 < 0.0f) cubeType |= 64;
-    if (sdf_7 < 0.0f) cubeType |= 128;
+    if (sdf_0 < 0.0f)
+        cubeType |= 1;
+    if (sdf_1 < 0.0f)
+        cubeType |= 2;
+    if (sdf_2 < 0.0f)
+        cubeType |= 4;
+    if (sdf_3 < 0.0f)
+        cubeType |= 8;
+    if (sdf_4 < 0.0f)
+        cubeType |= 16;
+    if (sdf_5 < 0.0f)
+        cubeType |= 32;
+    if (sdf_6 < 0.0f)
+        cubeType |= 64;
+    if (sdf_7 < 0.0f)
+        cubeType |= 128;
 
     const int edgeConfig = fvdb::detail::marchingCubesEdgeTable[cubeType];
     if (edgeConfig == 0) {
@@ -257,38 +262,44 @@ mcfEmitCompactKernel(
     float vert_10_x = 0.0f, vert_10_y = 0.0f, vert_10_z = 0.0f;
     float vert_11_x = 0.0f, vert_11_y = 0.0f, vert_11_z = 0.0f;
 
-#define MCF_INTERP_EDGE(IDX, IA, IB)                                         \
-    if (edgeConfig & (1 << (IDX))) {                                          \
-        const float va = sdf_##IA;                                            \
-        const float vb = sdf_##IB;                                            \
-        const float ax = p_##IA##_x, ay = p_##IA##_y, az = p_##IA##_z;        \
-        const float bx = p_##IB##_x, by = p_##IB##_y, bz = p_##IB##_z;        \
-        constexpr float MC_EPS = 1.0e-5f;                                     \
-        if (fabsf(va) < MC_EPS) {                                             \
-            vert_##IDX##_x = ax; vert_##IDX##_y = ay; vert_##IDX##_z = az;    \
-        } else if (fabsf(vb) < MC_EPS) {                                      \
-            vert_##IDX##_x = bx; vert_##IDX##_y = by; vert_##IDX##_z = bz;    \
-        } else if (fabsf(va - vb) < MC_EPS) {                                 \
-            vert_##IDX##_x = ax; vert_##IDX##_y = ay; vert_##IDX##_z = az;    \
-        } else {                                                              \
-            const float w2 = (0.0f - va) / (vb - va);                         \
-            const float w1 = 1.0f - w2;                                       \
-            vert_##IDX##_x = ax * w1 + bx * w2;                               \
-            vert_##IDX##_y = ay * w1 + by * w2;                               \
-            vert_##IDX##_z = az * w1 + bz * w2;                               \
-        }                                                                     \
+#define MCF_INTERP_EDGE(IDX, IA, IB)                                   \
+    if (edgeConfig & (1 << (IDX))) {                                   \
+        const float va = sdf_##IA;                                     \
+        const float vb = sdf_##IB;                                     \
+        const float ax = p_##IA##_x, ay = p_##IA##_y, az = p_##IA##_z; \
+        const float bx = p_##IB##_x, by = p_##IB##_y, bz = p_##IB##_z; \
+        constexpr float MC_EPS = 1.0e-5f;                              \
+        if (fabsf(va) < MC_EPS) {                                      \
+            vert_##IDX##_x = ax;                                       \
+            vert_##IDX##_y = ay;                                       \
+            vert_##IDX##_z = az;                                       \
+        } else if (fabsf(vb) < MC_EPS) {                               \
+            vert_##IDX##_x = bx;                                       \
+            vert_##IDX##_y = by;                                       \
+            vert_##IDX##_z = bz;                                       \
+        } else if (fabsf(va - vb) < MC_EPS) {                          \
+            vert_##IDX##_x = ax;                                       \
+            vert_##IDX##_y = ay;                                       \
+            vert_##IDX##_z = az;                                       \
+        } else {                                                       \
+            const float w2 = (0.0f - va) / (vb - va);                  \
+            const float w1 = 1.0f - w2;                                \
+            vert_##IDX##_x = ax * w1 + bx * w2;                        \
+            vert_##IDX##_y = ay * w1 + by * w2;                        \
+            vert_##IDX##_z = az * w1 + bz * w2;                        \
+        }                                                              \
     }
 
-    MCF_INTERP_EDGE(0,  0, 1)
-    MCF_INTERP_EDGE(1,  1, 2)
-    MCF_INTERP_EDGE(2,  2, 3)
-    MCF_INTERP_EDGE(3,  0, 3)
-    MCF_INTERP_EDGE(4,  4, 5)
-    MCF_INTERP_EDGE(5,  5, 6)
-    MCF_INTERP_EDGE(6,  6, 7)
-    MCF_INTERP_EDGE(7,  7, 4)
-    MCF_INTERP_EDGE(8,  0, 4)
-    MCF_INTERP_EDGE(9,  1, 5)
+    MCF_INTERP_EDGE(0, 0, 1)
+    MCF_INTERP_EDGE(1, 1, 2)
+    MCF_INTERP_EDGE(2, 2, 3)
+    MCF_INTERP_EDGE(3, 0, 3)
+    MCF_INTERP_EDGE(4, 4, 5)
+    MCF_INTERP_EDGE(5, 5, 6)
+    MCF_INTERP_EDGE(6, 6, 7)
+    MCF_INTERP_EDGE(7, 7, 4)
+    MCF_INTERP_EDGE(8, 0, 4)
+    MCF_INTERP_EDGE(9, 1, 5)
     MCF_INTERP_EDGE(10, 6, 2)
     MCF_INTERP_EDGE(11, 3, 7)
 
@@ -296,35 +307,56 @@ mcfEmitCompactKernel(
 
     const int64_t triangleBase = csumCompact[tid] / 3;
 
-#define MCF_PICK_VERT_X(vlid)                                                \
-    ((vlid) == 0  ? vert_0_x  : (vlid) == 1  ? vert_1_x  :                    \
-     (vlid) == 2  ? vert_2_x  : (vlid) == 3  ? vert_3_x  :                    \
-     (vlid) == 4  ? vert_4_x  : (vlid) == 5  ? vert_5_x  :                    \
-     (vlid) == 6  ? vert_6_x  : (vlid) == 7  ? vert_7_x  :                    \
-     (vlid) == 8  ? vert_8_x  : (vlid) == 9  ? vert_9_x  :                    \
-     (vlid) == 10 ? vert_10_x : vert_11_x)
-#define MCF_PICK_VERT_Y(vlid)                                                \
-    ((vlid) == 0  ? vert_0_y  : (vlid) == 1  ? vert_1_y  :                    \
-     (vlid) == 2  ? vert_2_y  : (vlid) == 3  ? vert_3_y  :                    \
-     (vlid) == 4  ? vert_4_y  : (vlid) == 5  ? vert_5_y  :                    \
-     (vlid) == 6  ? vert_6_y  : (vlid) == 7  ? vert_7_y  :                    \
-     (vlid) == 8  ? vert_8_y  : (vlid) == 9  ? vert_9_y  :                    \
-     (vlid) == 10 ? vert_10_y : vert_11_y)
-#define MCF_PICK_VERT_Z(vlid)                                                \
-    ((vlid) == 0  ? vert_0_z  : (vlid) == 1  ? vert_1_z  :                    \
-     (vlid) == 2  ? vert_2_z  : (vlid) == 3  ? vert_3_z  :                    \
-     (vlid) == 4  ? vert_4_z  : (vlid) == 5  ? vert_5_z  :                    \
-     (vlid) == 6  ? vert_6_z  : (vlid) == 7  ? vert_7_z  :                    \
-     (vlid) == 8  ? vert_8_z  : (vlid) == 9  ? vert_9_z  :                    \
-     (vlid) == 10 ? vert_10_z : vert_11_z)
-#define MCF_PICK_PID(cid)                                                    \
-    ((cid) == 0 ? pid_0 : (cid) == 1 ? pid_1 :                                \
-     (cid) == 2 ? pid_2 : (cid) == 3 ? pid_3 :                                \
-     (cid) == 4 ? pid_4 : (cid) == 5 ? pid_5 :                                \
-     (cid) == 6 ? pid_6 : pid_7)
+#define MCF_PICK_VERT_X(vlid)   \
+    ((vlid) == 0    ? vert_0_x  \
+     : (vlid) == 1  ? vert_1_x  \
+     : (vlid) == 2  ? vert_2_x  \
+     : (vlid) == 3  ? vert_3_x  \
+     : (vlid) == 4  ? vert_4_x  \
+     : (vlid) == 5  ? vert_5_x  \
+     : (vlid) == 6  ? vert_6_x  \
+     : (vlid) == 7  ? vert_7_x  \
+     : (vlid) == 8  ? vert_8_x  \
+     : (vlid) == 9  ? vert_9_x  \
+     : (vlid) == 10 ? vert_10_x \
+                    : vert_11_x)
+#define MCF_PICK_VERT_Y(vlid)   \
+    ((vlid) == 0    ? vert_0_y  \
+     : (vlid) == 1  ? vert_1_y  \
+     : (vlid) == 2  ? vert_2_y  \
+     : (vlid) == 3  ? vert_3_y  \
+     : (vlid) == 4  ? vert_4_y  \
+     : (vlid) == 5  ? vert_5_y  \
+     : (vlid) == 6  ? vert_6_y  \
+     : (vlid) == 7  ? vert_7_y  \
+     : (vlid) == 8  ? vert_8_y  \
+     : (vlid) == 9  ? vert_9_y  \
+     : (vlid) == 10 ? vert_10_y \
+                    : vert_11_y)
+#define MCF_PICK_VERT_Z(vlid)   \
+    ((vlid) == 0    ? vert_0_z  \
+     : (vlid) == 1  ? vert_1_z  \
+     : (vlid) == 2  ? vert_2_z  \
+     : (vlid) == 3  ? vert_3_z  \
+     : (vlid) == 4  ? vert_4_z  \
+     : (vlid) == 5  ? vert_5_z  \
+     : (vlid) == 6  ? vert_6_z  \
+     : (vlid) == 7  ? vert_7_z  \
+     : (vlid) == 8  ? vert_8_z  \
+     : (vlid) == 9  ? vert_9_z  \
+     : (vlid) == 10 ? vert_10_z \
+                    : vert_11_z)
+#define MCF_PICK_PID(cid) \
+    ((cid) == 0   ? pid_0 \
+     : (cid) == 1 ? pid_1 \
+     : (cid) == 2 ? pid_2 \
+     : (cid) == 3 ? pid_3 \
+     : (cid) == 4 ? pid_4 \
+     : (cid) == 5 ? pid_5 \
+     : (cid) == 6 ? pid_6 \
+                  : pid_7)
 
-    for (int i = 0; fvdb::detail::marchingCubesTriTable[cubeType][i] != -1;
-         i += 3) {
+    for (int i = 0; fvdb::detail::marchingCubesTriTable[cubeType][i] != -1; i += 3) {
         const int64_t triangleIdx = triangleBase + i / 3;
 #pragma unroll
         for (int vi = 0; vi < 3; ++vi) {
@@ -360,85 +392,71 @@ mcfEmitCompactKernel(
 
 template <typename InputT>
 std::vector<JaggedTensor>
-marchingCubesFastImpl(const GridBatchData &batchHdl,
-                    const torch::Tensor &sdf,
-                    double level) {
+marchingCubesFastImpl(const GridBatchData &batchHdl, const torch::Tensor &sdf, double level) {
     batchHdl.checkDevice(sdf);
-    TORCH_CHECK_TYPE(sdf.is_floating_point(),
-                     "field must have a floating point type");
-    TORCH_CHECK(sdf.dim() == 1,
-                "Expected field to have 1 dimension but got ", sdf.dim());
+    TORCH_CHECK_TYPE(sdf.is_floating_point(), "field must have a floating point type");
+    TORCH_CHECK(sdf.dim() == 1, "Expected field to have 1 dimension but got ", sdf.dim());
 
     // Guard against silent pid / batch overflow in the packed key. The
     // 30-bit vid field covers up to 1B active voxels per batch; batch
     // field at bits 60..63 supports up to 16 batches.
     TORCH_CHECK_VALUE(batchHdl.batchSize() < MCF_BATCH_MAX,
-                      "marchingCubesFast: batch size ", batchHdl.batchSize(),
-                      " exceeds packed-key capacity ", MCF_BATCH_MAX);
+                      "marchingCubesFast: batch size ",
+                      batchHdl.batchSize(),
+                      " exceeds packed-key capacity ",
+                      MCF_BATCH_MAX);
     TORCH_CHECK_VALUE(batchHdl.totalVoxels() <= (int64_t{1} << MCF_VID_BITS),
-                      "marchingCubesFast: totalVoxels ", batchHdl.totalVoxels(),
+                      "marchingCubesFast: totalVoxels ",
+                      batchHdl.totalVoxels(),
                       " exceeds packed-key vid capacity ",
                       int64_t{1} << MCF_VID_BITS,
                       " — widen MCF_VID_BITS or fall back to legacy MC.");
 
     c10::cuda::CUDAGuard guard(sdf.device());
-    at::cuda::CUDAStream stream =
-        at::cuda::getCurrentCUDAStream(sdf.device().index());
+    at::cuda::CUDAStream stream = at::cuda::getCurrentCUDAStream(sdf.device().index());
 
-    const int64_t totalLeaves = batchHdl.totalLeaves();
-    constexpr int64_t VOXELS_PER_LEAF =
-        nanovdb::OnIndexTree::LeafNodeType::NUM_VALUES;
-    const int64_t totalLeafVoxels = totalLeaves * VOXELS_PER_LEAF;
+    const int64_t totalLeaves         = batchHdl.totalLeaves();
+    constexpr int64_t VOXELS_PER_LEAF = nanovdb::OnIndexTree::LeafNodeType::NUM_VALUES;
+    const int64_t totalLeafVoxels     = totalLeaves * VOXELS_PER_LEAF;
 
-    auto longOpts =
-        torch::TensorOptions().dtype(torch::kLong).device(sdf.device());
-    auto floatOpts =
-        torch::TensorOptions().dtype(torch::kFloat32).device(sdf.device());
-    auto byteOpts =
-        torch::TensorOptions().dtype(torch::kUInt8).device(sdf.device());
+    auto longOpts  = torch::TensorOptions().dtype(torch::kLong).device(sdf.device());
+    auto floatOpts = torch::TensorOptions().dtype(torch::kFloat32).device(sdf.device());
+    auto byteOpts  = torch::TensorOptions().dtype(torch::kUInt8).device(sdf.device());
 
     if (totalLeaves == 0) {
-        return marchingCubesLegacy(batchHdl,
-                                   JaggedTensor::from_data_indices_and_list_ids(
-                                       sdf,
-                                       torch::zeros({0},
-                                                    torch::TensorOptions()
-                                                        .dtype(fvdb::JIdxScalarType)
-                                                        .device(sdf.device())),
-                                       torch::empty({0, 1},
-                                                    torch::TensorOptions()
-                                                        .dtype(fvdb::JIdxScalarType)
-                                                        .device(sdf.device())),
-                                       batchHdl.batchSize()),
-                                   level);
+        return marchingCubesLegacy(
+            batchHdl,
+            JaggedTensor::from_data_indices_and_list_ids(
+                sdf,
+                torch::zeros(
+                    {0}, torch::TensorOptions().dtype(fvdb::JIdxScalarType).device(sdf.device())),
+                torch::empty(
+                    {0, 1},
+                    torch::TensorOptions().dtype(fvdb::JIdxScalarType).device(sdf.device())),
+                batchHdl.batchSize()),
+            level);
     }
 
     // --- Step 1: classify ---
-    torch::Tensor nVertsPerLv = torch::empty({totalLeafVoxels}, byteOpts);
-    const int64_t classifyBlocks =
-        GET_BLOCKS(totalLeafVoxels, MCF_BLOCK_SIZE);
-    mcfClassifyKernel<InputT>
-        <<<static_cast<unsigned int>(classifyBlocks),
-           static_cast<unsigned int>(MCF_BLOCK_SIZE),
-           0, stream.stream()>>>(
-        batchHdl.deviceAccessor(),
-        sdf.data_ptr<InputT>(),
-        static_cast<float>(level),
-        nVertsPerLv.data_ptr<uint8_t>());
+    torch::Tensor nVertsPerLv    = torch::empty({totalLeafVoxels}, byteOpts);
+    const int64_t classifyBlocks = GET_BLOCKS(totalLeafVoxels, MCF_BLOCK_SIZE);
+    mcfClassifyKernel<InputT><<<static_cast<unsigned int>(classifyBlocks),
+                                static_cast<unsigned int>(MCF_BLOCK_SIZE),
+                                0,
+                                stream.stream()>>>(batchHdl.deviceAccessor(),
+                                                   sdf.data_ptr<InputT>(),
+                                                   static_cast<float>(level),
+                                                   nVertsPerLv.data_ptr<uint8_t>());
     C10_CUDA_KERNEL_LAUNCH_CHECK();
 
     // --- Step 2: compact ---
-    torch::Tensor surfaceLvIdx =
-        nVertsPerLv.nonzero().squeeze(-1).contiguous();
+    torch::Tensor surfaceLvIdx = nVertsPerLv.nonzero().squeeze(-1).contiguous();
     const int64_t surfaceCount = surfaceLvIdx.size(0);
 
-    torch::Tensor nVertsCompact =
-        nVertsPerLv.index_select(0, surfaceLvIdx).to(torch::kLong);
+    torch::Tensor nVertsCompact = nVertsPerLv.index_select(0, surfaceLvIdx).to(torch::kLong);
     torch::Tensor csumInclusive = torch::cumsum(nVertsCompact, 0);
     const int64_t nTriangles =
-        surfaceCount > 0
-            ? (csumInclusive.index({-1}).item<int64_t>() / 3)
-            : 0;
+        surfaceCount > 0 ? (csumInclusive.index({-1}).item<int64_t>() / 3) : 0;
     torch::Tensor csumCompact = torch::roll(csumInclusive, {1});
     if (surfaceCount > 0) {
         csumCompact.index_put_({0}, 0);
@@ -446,32 +464,31 @@ marchingCubesFastImpl(const GridBatchData &batchHdl,
 
     torch::Tensor triangles = torch::empty({nTriangles, 3, 3}, floatOpts);
     // Single-column packed-key tensor (replaces legacy's [nTri, 3, 3] int64).
-    torch::Tensor flatKeys =
-        torch::empty({nTriangles * 3}, longOpts);
+    torch::Tensor flatKeys = torch::empty({nTriangles * 3}, longOpts);
 
     if (nTriangles > 0) {
-        const int64_t emitBlocks =
-            GET_BLOCKS(surfaceCount, MCF_BLOCK_SIZE);
+        const int64_t emitBlocks = GET_BLOCKS(surfaceCount, MCF_BLOCK_SIZE);
         mcfEmitCompactKernel<InputT>
             <<<static_cast<unsigned int>(emitBlocks),
                static_cast<unsigned int>(MCF_BLOCK_SIZE),
-               0, stream.stream()>>>(
-            batchHdl.deviceAccessor(),
-            sdf.data_ptr<InputT>(),
-            static_cast<float>(level),
-            surfaceLvIdx.data_ptr<int64_t>(),
-            surfaceCount,
-            csumCompact.data_ptr<int64_t>(),
-            triangles.packed_accessor64<float, 3, torch::RestrictPtrTraits>(),
-            flatKeys.data_ptr<int64_t>());
+               0,
+               stream.stream()>>>(batchHdl.deviceAccessor(),
+                                  sdf.data_ptr<InputT>(),
+                                  static_cast<float>(level),
+                                  surfaceLvIdx.data_ptr<int64_t>(),
+                                  surfaceCount,
+                                  csumCompact.data_ptr<int64_t>(),
+                                  triangles.packed_accessor64<float, 3, torch::RestrictPtrTraits>(),
+                                  flatKeys.data_ptr<int64_t>());
         C10_CUDA_KERNEL_LAUNCH_CHECK();
     }
 
     // --- Step 3: 1-D dedup via torch::_unique (replaces unique_dim) ---
     // at::_unique returns (unique_values, inverse_indices). Smaller input
     // footprint: 8 B/elem vs 24 B/elem for the legacy 3-col key.
-    auto unqRet                = at::_unique(flatKeys, /*sorted=*/true,
-                                             /*return_inverse=*/true);
+    auto unqRet                = at::_unique(flatKeys,
+                              /*sorted=*/true,
+                              /*return_inverse=*/true);
     torch::Tensor unqKeys      = std::get<0>(unqRet);
     torch::Tensor unqTriangles = std::get<1>(unqRet);
 
@@ -482,42 +499,37 @@ marchingCubesFastImpl(const GridBatchData &batchHdl,
     const int64_t nV = unqKeys.size(0);
     torch::Tensor unqVertIdx;
     if (nV > 0) {
-        const torch::Tensor vidMaskT =
-            torch::full({}, MCF_VID_MASK, unqKeys.options());
-        const torch::Tensor batchMaskT =
-            torch::full({}, MCF_BATCH_MAX - 1, unqKeys.options());
+        const torch::Tensor vidMaskT   = torch::full({}, MCF_VID_MASK, unqKeys.options());
+        const torch::Tensor batchMaskT = torch::full({}, MCF_BATCH_MAX - 1, unqKeys.options());
 
         torch::Tensor vid1 = torch::bitwise_and(unqKeys, vidMaskT);
-        torch::Tensor vid0 = torch::bitwise_and(
-            torch::bitwise_right_shift(unqKeys, MCF_VID_BITS), vidMaskT);
-        torch::Tensor bidx = torch::bitwise_and(
-            torch::bitwise_right_shift(unqKeys, MCF_BATCH_SHIFT), batchMaskT);
+        torch::Tensor vid0 =
+            torch::bitwise_and(torch::bitwise_right_shift(unqKeys, MCF_VID_BITS), vidMaskT);
+        torch::Tensor bidx =
+            torch::bitwise_and(torch::bitwise_right_shift(unqKeys, MCF_BATCH_SHIFT), batchMaskT);
         unqVertIdx = torch::stack({bidx, vid0, vid1}, /*dim=*/1).contiguous();
     } else {
         unqVertIdx = torch::empty({0, 3}, longOpts);
     }
 
-    auto flatTriangles = triangles.view({-1, 3});
-    torch::Tensor vertices =
-        torch::zeros({nV, 3}, floatOpts);
+    auto flatTriangles     = triangles.view({-1, 3});
+    torch::Tensor vertices = torch::zeros({nV, 3}, floatOpts);
     if (nV > 0) {
         vertices.index_put_({unqTriangles}, flatTriangles);
     }
 
-    unqTriangles            = unqTriangles.view({-1, 3});
-    torch::Tensor vBatchIdx = unqVertIdx.index({torch::indexing::Slice(), 0})
+    unqTriangles = unqTriangles.view({-1, 3});
+    torch::Tensor vBatchIdx =
+        unqVertIdx.index({torch::indexing::Slice(), 0}).to(fvdb::JIdxScalarType);
+    torch::Tensor tBatchIdx = vBatchIdx.index({unqTriangles.index({torch::indexing::Slice(), 0})})
                                   .to(fvdb::JIdxScalarType);
-    torch::Tensor tBatchIdx =
-        vBatchIdx.index({unqTriangles.index({torch::indexing::Slice(), 0})})
-            .to(fvdb::JIdxScalarType);
 
     JaggedTensor retVertices = JaggedTensor::from_data_indices_and_list_ids(
         vertices, vBatchIdx, batchHdl.jlidx(), batchHdl.batchSize());
     JaggedTensor retTriangles = JaggedTensor::from_data_indices_and_list_ids(
         unqTriangles, tBatchIdx, batchHdl.jlidx(), batchHdl.batchSize());
-    JaggedTensor retUniqueVertices =
-        JaggedTensor::from_data_indices_and_list_ids(
-            unqVertIdx, vBatchIdx, batchHdl.jlidx(), batchHdl.batchSize());
+    JaggedTensor retUniqueVertices = JaggedTensor::from_data_indices_and_list_ids(
+        unqVertIdx, vBatchIdx, batchHdl.jlidx(), batchHdl.batchSize());
 
     int64_t cumNumVerts = 0;
     for (int i = 1; i < batchHdl.batchSize(); i += 1) {
@@ -531,18 +543,12 @@ marchingCubesFastImpl(const GridBatchData &batchHdl,
 } // anonymous namespace
 
 std::vector<JaggedTensor>
-marchingCubesFast(const GridBatchData &batchHdl,
-                const JaggedTensor &field,
-                double level) {
-    TORCH_CHECK_VALUE(field.ldim() == 1,
-                      "Expected field to have 1 list dimension, got ",
-                      field.ldim());
-    TORCH_CHECK_TYPE(field.is_floating_point(),
-                     "field must have a floating point type");
-    TORCH_CHECK_VALUE(field.numel() == batchHdl.totalVoxels(),
-                      "Value count not match!");
-    TORCH_CHECK_VALUE(field.num_outer_lists() == batchHdl.batchSize(),
-                      "Batch size not match!");
+marchingCubesFast(const GridBatchData &batchHdl, const JaggedTensor &field, double level) {
+    TORCH_CHECK_VALUE(
+        field.ldim() == 1, "Expected field to have 1 list dimension, got ", field.ldim());
+    TORCH_CHECK_TYPE(field.is_floating_point(), "field must have a floating point type");
+    TORCH_CHECK_VALUE(field.numel() == batchHdl.totalVoxels(), "Value count not match!");
+    TORCH_CHECK_VALUE(field.num_outer_lists() == batchHdl.batchSize(), "Batch size not match!");
 
     torch::Tensor fieldJdata = field.jdata();
     if (fieldJdata.dim() == 0) {
@@ -572,10 +578,9 @@ marchingCubesFast(const GridBatchData &batchHdl,
     //     fp16 to preserve legacy's output-dtype contract.
     // This matters for fvdb-reality-capture's 500M+ voxel hero runs
     // where a 2 GB fp32 upcast would be painful.
-    const bool isCuda = field.device().is_cuda();
-    const auto origDtype = fieldJdata.scalar_type();
-    const bool supportedDtype =
-        (origDtype == torch::kFloat32 || origDtype == torch::kHalf);
+    const bool isCuda         = field.device().is_cuda();
+    const auto origDtype      = fieldJdata.scalar_type();
+    const bool supportedDtype = (origDtype == torch::kFloat32 || origDtype == torch::kHalf);
 
     if (!isCuda || !supportedDtype) {
         return marchingCubesLegacy(batchHdl, field, level);
@@ -592,11 +597,8 @@ marchingCubesFast(const GridBatchData &batchHdl,
         // so this cast is negligible. Triangles (face indices) and
         // unqVertIdx are int64 regardless.
         JaggedTensor &verts = outputs[0];
-        verts = JaggedTensor::from_data_indices_and_list_ids(
-            verts.jdata().to(origDtype),
-            verts.jidx(),
-            verts.jlidx(),
-            verts.num_outer_lists());
+        verts               = JaggedTensor::from_data_indices_and_list_ids(
+            verts.jdata().to(origDtype), verts.jidx(), verts.jlidx(), verts.num_outer_lists());
     }
     return outputs;
 }

--- a/src/fvdb/detail/ops/MarchingCubesFast.h
+++ b/src/fvdb/detail/ops/MarchingCubesFast.h
@@ -1,0 +1,66 @@
+// Copyright Contributors to the OpenVDB Project
+// SPDX-License-Identifier: Apache-2.0
+//
+#ifndef FVDB_DETAIL_OPS_MARCHINGCUBESFAST_H
+#define FVDB_DETAIL_OPS_MARCHINGCUBESFAST_H
+
+#include <fvdb/GridBatchData.h>
+#include <fvdb/JaggedTensor.h>
+
+#include <torch/types.h>
+
+#include <vector>
+
+namespace fvdb {
+namespace detail {
+namespace ops {
+
+/// @brief Sparse-compact, packed-key marching-cubes for fp32/fp16 CUDA.
+///
+/// This is the variant that `marchingCubes` dispatches to by default
+/// for CUDA inputs; `marchingCubesLegacy` is the fallback for
+/// unsupported dtype / device combinations.
+///
+/// The main differences vs `marchingCubesLegacy` are:
+///
+///   - **Surface-voxel compaction**: a classify pass writes a per-leaf-
+///     voxel `nVertsPerLv[uint8_t]` array and a prefix-summed offset
+///     table; the emit pass iterates only the surface voxels rather
+///     than every voxel in the grid, dropping work and DRAM traffic
+///     for sparse SDFs.
+///   - **Packed-key dedup**: each triangle vertex is emitted as a
+///     single packed int64 key `(batchIdx, vid0, vid1)` and deduped
+///     via 1-D `torch::unique`, replacing the legacy's 3-column
+///     `[nTri*3, 3]` int64 tensor + `torch::unique_dim`. Cuts the
+///     dedup-input footprint ~3x and halves the internal sort temps.
+///   - **fp16 fast path**: the classify and emit kernels are
+///     templated on the input scalar type so fp16 inputs are loaded
+///     and cast to fp32 in-register (single `F2F.F32.F16` per load),
+///     avoiding the 2x transient fp32 buffer a naive
+///     `sdf.to(kFloat32)` would allocate.
+///
+/// Packing layout (64-bit key; validated by `TORCH_CHECK_VALUE`
+/// guards in the implementation so future scale changes fail loudly):
+///
+///     key = (batchIdx & 0xF) << 60                // 4 bits, up to 16 batches
+///         | (vid0     & 0x3FFFFFFF) << 30         // 30 bits, up to 1B voxels/batch
+///         | (vid1     & 0x3FFFFFFF)               // 30 bits, up to 1B voxels/batch
+///
+/// Dtype / device coverage:
+///   - float32 CUDA: native fast path.
+///   - float16 CUDA: as described above; only the final `retVertices`
+///     tensor (`[nV, 3]` floats, orders of magnitude smaller than the
+///     SDF) is downcast to fp16 to preserve the public output-dtype
+///     contract.
+///   - float64 or CPU: forwarded to `marchingCubesLegacy`, which is
+///     fully templated and handles every floating-point dtype.
+std::vector<JaggedTensor>
+marchingCubesFast(const GridBatchData &batchHdl,
+                  const JaggedTensor &field,
+                  double level);
+
+} // namespace ops
+} // namespace detail
+} // namespace fvdb
+
+#endif // FVDB_DETAIL_OPS_MARCHINGCUBESFAST_H

--- a/src/fvdb/detail/ops/MarchingCubesFast.h
+++ b/src/fvdb/detail/ops/MarchingCubesFast.h
@@ -55,9 +55,7 @@ namespace ops {
 ///   - float64 or CPU: forwarded to `marchingCubesLegacy`, which is
 ///     fully templated and handles every floating-point dtype.
 std::vector<JaggedTensor>
-marchingCubesFast(const GridBatchData &batchHdl,
-                  const JaggedTensor &field,
-                  double level);
+marchingCubesFast(const GridBatchData &batchHdl, const JaggedTensor &field, double level);
 
 } // namespace ops
 } // namespace detail

--- a/src/fvdb/detail/ops/PersistentTSDFState.cu
+++ b/src/fvdb/detail/ops/PersistentTSDFState.cu
@@ -1,0 +1,248 @@
+// Copyright Contributors to the OpenVDB Project
+// SPDX-License-Identifier: Apache-2.0
+//
+#include <fvdb/detail/GridBatchDataFactory.h>
+#include <fvdb/detail/ops/BuildGridFromIjk.h>
+#include <fvdb/detail/ops/BuildMergedGrids.h>
+#include <fvdb/detail/ops/Inject.h>
+#include <fvdb/detail/ops/PersistentTSDFState.h>
+
+#include <c10/core/ScalarType.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <c10/util/Exception.h>
+
+#include <vector>
+
+namespace fvdb::detail::ops {
+
+namespace {
+
+// Allocate a freshly-zeroed sidecar tensor shaped `[numRows]` or
+// `[numRows, trailingDim]` with the same dtype / device as `templateT`.
+// Trailing dim == 0 collapses to the 1-D case (features-off path).
+torch::Tensor
+allocateZeroSidecar(int64_t numRows, int64_t trailingDim, const torch::Tensor &templateT) {
+    std::vector<int64_t> shape;
+    if (trailingDim > 0) {
+        shape = {numRows, trailingDim};
+    } else {
+        shape = {numRows};
+    }
+    return torch::zeros(shape, templateT.options());
+}
+
+// Copy `src` (indexed by `srcGrid`) into a freshly-zeroed tensor
+// `dst` (indexed by `dstGrid`) at the ijk-overlapping positions.
+// Slots in `dst` for voxels absent from `srcGrid` are left at their
+// zero-init value. Wraps `ops::inject` with the JaggedTensor plumbing
+// the op expects.
+void
+injectSidecar(const GridBatchData &dstGrid,
+              const GridBatchData &srcGrid,
+              torch::Tensor &dst,
+              const torch::Tensor &src) {
+    TORCH_CHECK(dst.size(0) == dstGrid.totalVoxels(),
+                "dst size mismatch (expected ",
+                dstGrid.totalVoxels(),
+                " rows, got ",
+                dst.size(0),
+                ")");
+    TORCH_CHECK(src.size(0) == srcGrid.totalVoxels(),
+                "src size mismatch (expected ",
+                srcGrid.totalVoxels(),
+                " rows, got ",
+                src.size(0),
+                ")");
+    JaggedTensor dstJt = dstGrid.jaggedTensor(dst);
+    JaggedTensor srcJt = srcGrid.jaggedTensor(src);
+    ops::inject(dstGrid, srcGrid, dstJt, srcJt);
+    // `ops::inject` may swap the underlying tensor inside dstJt; pull the
+    // (possibly-new) tensor back out into our output reference.
+    dst = dstJt.jdata();
+}
+
+} // namespace
+
+PersistentTSDFState::PersistentTSDFState(c10::intrusive_ptr<GridBatchData> grid,
+                                         torch::Tensor tsdf,
+                                         torch::Tensor weights,
+                                         std::optional<torch::Tensor> features)
+    : mGrid(std::move(grid)), mTsdf(std::move(tsdf)), mWeights(std::move(weights)) {
+    TORCH_CHECK(mGrid != nullptr, "PersistentTSDFState requires a non-null grid");
+    TORCH_CHECK_VALUE(mTsdf.size(0) == mGrid->totalVoxels(),
+                      "tsdf size(0) (",
+                      mTsdf.size(0),
+                      ") must equal grid.totalVoxels() (",
+                      mGrid->totalVoxels(),
+                      ")");
+    TORCH_CHECK_VALUE(mWeights.size(0) == mGrid->totalVoxels(),
+                      "weights size(0) (",
+                      mWeights.size(0),
+                      ") must equal grid.totalVoxels() (",
+                      mGrid->totalVoxels(),
+                      ")");
+    TORCH_CHECK_TYPE(mWeights.scalar_type() == mTsdf.scalar_type(),
+                     "weights dtype (",
+                     mWeights.scalar_type(),
+                     ") must match tsdf dtype (",
+                     mTsdf.scalar_type(),
+                     ")");
+    if (features.has_value() && features.value().defined() &&
+        features.value().numel() > 0) {
+        mHasFeatures = true;
+        mFeatures    = features.value();
+        TORCH_CHECK_VALUE(mFeatures.dim() == 2,
+                          "features must be 2-D [totalVoxels, featureDim]");
+        TORCH_CHECK_VALUE(mFeatures.size(0) == mGrid->totalVoxels(),
+                          "features size(0) (",
+                          mFeatures.size(0),
+                          ") must equal grid.totalVoxels() (",
+                          mGrid->totalVoxels(),
+                          ")");
+    } else {
+        mHasFeatures = false;
+        // Maintain a well-shaped `[totalVoxels, 0]` placeholder so that
+        // `grid().jaggedTensor(features())` works uniformly and so callers
+        // can pass `features()` into the `GridBatchData::jaggedTensor`
+        // size check even when features are disabled. Matches the
+        // placeholder convention already used in `IntegrateTSDF.cu`
+        // (`torch::empty({0, 0}, opts)` + `GridBatchData::jaggedTensor`
+        // size-check pitfall, documented in paper_extractions impl-notes
+        // entry #12).
+        mFeatures = torch::empty({mGrid->totalVoxels(), 0}, mTsdf.options());
+    }
+}
+
+void
+PersistentTSDFState::grow(const JaggedTensor &newVoxelIjks) {
+    TORCH_CHECK_VALUE(newVoxelIjks.rdim() == 2 && newVoxelIjks.rsize(-1) == 3,
+                      "grow(ijks): ijks must have element shape [-1, 3]");
+    TORCH_CHECK_VALUE(newVoxelIjks.num_outer_lists() == mGrid->batchSize(),
+                      "grow(ijks): batch size mismatch (ijks.num_outer_lists=",
+                      newVoxelIjks.num_outer_lists(),
+                      " grid.batchSize=",
+                      mGrid->batchSize(),
+                      ")");
+    if (newVoxelIjks.jdata().size(0) == 0) {
+        // Zero-voxel shell: nothing to merge in.
+        return;
+    }
+    std::vector<nanovdb::Vec3d> voxelSizes;
+    std::vector<nanovdb::Vec3d> origins;
+    mGrid->gridVoxelSizesAndOrigins(voxelSizes, origins);
+    auto shellGrid = createNanoGridFromIJK(newVoxelIjks, voxelSizes, origins);
+    growFromGrid(*shellGrid);
+}
+
+void
+PersistentTSDFState::growFromGrid(const GridBatchData &shellGrid) {
+    if (shellGrid.totalVoxels() == 0) {
+        return;
+    }
+    TORCH_CHECK_VALUE(shellGrid.batchSize() == mGrid->batchSize(),
+                      "growFromGrid: shell batchSize (",
+                      shellGrid.batchSize(),
+                      ") must equal live batchSize (",
+                      mGrid->batchSize(),
+                      ")");
+    TORCH_CHECK_VALUE(shellGrid.device() == mGrid->device(),
+                      "growFromGrid: shell/live must be on the same device");
+
+    const c10::cuda::OptionalCUDAGuard device_guard(
+        mGrid->device().is_cuda() ? std::optional<torch::Device>(mGrid->device()) : std::nullopt);
+
+    // `mergeGrids` builds the set-union of the two input grids' active
+    // voxels. When the shell is a strict subset of the live grid the
+    // merged grid is structurally identical to the live grid (same
+    // ordered active voxel set) and `totalVoxels()` matches, which we
+    // use as the no-op fast path below. This is the hot steady-state
+    // case on long trajectories: after the first ~50-100 frames the
+    // truncation shell stops introducing novel voxels and we skip both
+    // the realloc and the inject pass entirely.
+    //
+    // Argument order matters: `mergeGrids(shellGrid, mGrid)` iterates
+    // the shell's voxels first in the output (per-leaf) ordering, which
+    // matches the single-frame `integrateTSDFImpl` path's
+    // `ops::mergeGrids(*pointGrid, *grid)` convention. This keeps the
+    // batched path bit-identical to the sequential one --
+    // `test_integrate_tsdf_frames_matches_sequential` fails (at the
+    // ~1e-7 atol level, so order-of-sum sensitivity of the weighted
+    // TSDF update) if we swap it to `(mGrid, shell)`.
+    auto mergedGrid = mergeGrids(shellGrid, *mGrid);
+
+    // The "overlap-only fast path" -- return early when the merged
+    // grid's voxel set exactly matches the live grid's -- is a
+    // tempting optimization (avoid the realloc + inject) but in
+    // practice introduces a semantic divergence with the sequential-
+    // path TSDF output: weight sidecars end up with absolute errors
+    // of up to one frame's worth of `new_observation_weight` on
+    // multiple-percent of voxels.
+    //
+    // Hypothesis: when the fast path fires, `state.grid()` retains
+    // the *previous* merged-grid `GridBatchData` object, whereas the
+    // sequential path constructs a fresh `mergeGrids(shell, base)`
+    // result every frame. Even when both produce the same voxel set
+    // and enumeration order, there is an internal `GridBatchData`
+    // bookkeeping difference that affects what
+    // `grid.deviceAccessor().getValue(ijk)` returns for specific
+    // voxels in specific frames, causing shell voxels to look up to
+    // the wrong linear index and either miss the update or double-
+    // count.
+    //
+    // Disabling the fast path costs us the steady-state speedup on
+    // bounded trajectories but keeps the output bit-identical to the
+    // sequential reference. TODO: revisit when we have a cheap way
+    // to detect "merged grid is structurally identical to base in
+    // ALL respects, including internal bookkeeping" -- likely needs
+    // a deeper look at `nanovdb::tools::cuda::MergeGrids`'s output
+    // layout vs a grid's original construction.
+    if (false && mergedGrid->totalVoxels() == mGrid->totalVoxels()) {
+        return;
+    }
+
+    const int64_t newTotal    = mergedGrid->totalVoxels();
+    const int64_t featureDim  = mHasFeatures ? mFeatures.size(1) : 0;
+
+    torch::Tensor newTsdf    = allocateZeroSidecar(newTotal, 0, mTsdf);
+    torch::Tensor newWeights = allocateZeroSidecar(newTotal, 0, mWeights);
+
+    injectSidecar(*mergedGrid, *mGrid, newTsdf, mTsdf);
+    injectSidecar(*mergedGrid, *mGrid, newWeights, mWeights);
+
+    torch::Tensor newFeatures;
+    if (mHasFeatures) {
+        newFeatures = allocateZeroSidecar(newTotal, featureDim, mFeatures);
+        injectSidecar(*mergedGrid, *mGrid, newFeatures, mFeatures);
+    } else {
+        // Keep the `[totalVoxels, 0]` placeholder aligned with the new grid
+        // so the `jaggedTensor` size check continues to pass.
+        newFeatures = torch::empty({newTotal, 0}, mTsdf.options());
+    }
+
+    mGrid     = mergedGrid;
+    mTsdf     = newTsdf;
+    mWeights  = newWeights;
+    mFeatures = newFeatures;
+}
+
+void
+PersistentTSDFState::reset() {
+    std::vector<nanovdb::Vec3d> voxelSizes;
+    std::vector<nanovdb::Vec3d> origins;
+    mGrid->gridVoxelSizesAndOrigins(voxelSizes, origins);
+    const auto device = mGrid->device();
+    if (voxelSizes.empty()) {
+        mGrid = makeEmptyGridBatchData(device);
+    } else {
+        mGrid = makeEmptyGridBatchData(device, voxelSizes, origins);
+    }
+    mTsdf    = torch::empty({0}, mTsdf.options());
+    mWeights = torch::empty({0}, mWeights.options());
+    if (mHasFeatures) {
+        mFeatures = torch::empty({0, mFeatures.size(1)}, mFeatures.options());
+    } else {
+        mFeatures = torch::empty({0, 0}, mTsdf.options());
+    }
+}
+
+} // namespace fvdb::detail::ops

--- a/src/fvdb/detail/ops/PersistentTSDFState.cu
+++ b/src/fvdb/detail/ops/PersistentTSDFState.cu
@@ -87,12 +87,10 @@ PersistentTSDFState::PersistentTSDFState(c10::intrusive_ptr<GridBatchData> grid,
                      ") must match tsdf dtype (",
                      mTsdf.scalar_type(),
                      ")");
-    if (features.has_value() && features.value().defined() &&
-        features.value().numel() > 0) {
+    if (features.has_value() && features.value().defined() && features.value().numel() > 0) {
         mHasFeatures = true;
         mFeatures    = features.value();
-        TORCH_CHECK_VALUE(mFeatures.dim() == 2,
-                          "features must be 2-D [totalVoxels, featureDim]");
+        TORCH_CHECK_VALUE(mFeatures.dim() == 2, "features must be 2-D [totalVoxels, featureDim]");
         TORCH_CHECK_VALUE(mFeatures.size(0) == mGrid->totalVoxels(),
                           "features size(0) (",
                           mFeatures.size(0),
@@ -200,8 +198,8 @@ PersistentTSDFState::growFromGrid(const GridBatchData &shellGrid) {
         return;
     }
 
-    const int64_t newTotal    = mergedGrid->totalVoxels();
-    const int64_t featureDim  = mHasFeatures ? mFeatures.size(1) : 0;
+    const int64_t newTotal   = mergedGrid->totalVoxels();
+    const int64_t featureDim = mHasFeatures ? mFeatures.size(1) : 0;
 
     torch::Tensor newTsdf    = allocateZeroSidecar(newTotal, 0, mTsdf);
     torch::Tensor newWeights = allocateZeroSidecar(newTotal, 0, mWeights);

--- a/src/fvdb/detail/ops/PersistentTSDFState.h
+++ b/src/fvdb/detail/ops/PersistentTSDFState.h
@@ -1,0 +1,183 @@
+// Copyright Contributors to the OpenVDB Project
+// SPDX-License-Identifier: Apache-2.0
+//
+#ifndef FVDB_DETAIL_OPS_PERSISTENTTSDFSTATE_H
+#define FVDB_DETAIL_OPS_PERSISTENTTSDFSTATE_H
+
+#include <fvdb/GridBatchData.h>
+#include <fvdb/JaggedTensor.h>
+
+#include <torch/types.h>
+
+#include <optional>
+
+namespace fvdb {
+namespace detail {
+namespace ops {
+
+/// @brief A generic grow-on-touch state holder for per-voxel sidecar tensors
+///        that ride on top of a monotonically-growing `nanovdb::ValueOnIndex`
+///        grid.
+///
+/// `PersistentTSDFState` pairs a `GridBatchData` (the *live grid*) with a
+/// fixed set of sidecar tensors (`tsdf`, `weights`, optional `features`)
+/// indexed by the grid's active voxel linear index. Each call to `grow` or
+/// `growFromGrid` expands the live grid to the union of its current voxels
+/// and the caller-supplied voxel set, reallocates the sidecars, copies
+/// surviving voxels' values into their new positions via `ops::inject`,
+/// and zero-initialises slots for genuinely new voxels.
+///
+/// The class is intentionally TSDF-agnostic beyond the sidecar names: the
+/// "tsdf/weights/features" triple is the minimum surface area the depth and
+/// LiDAR integrators both need. Callers who want to carry extra sidecars
+/// can stack additional `PersistentTSDFState`-like wrappers on the same
+/// underlying grid.
+///
+/// Why this class exists (paper-framing note): there are TSDF-fusion
+/// workloads in which the output topology naturally persists across
+/// observations (canonical incremental RGB-D / LiDAR fusion), and other
+/// workloads where two independently-built grids want to be composed
+/// one-shot (non-persistent union of attribute fields, runtime-loaded
+/// terrain tiles, etc.). The one-shot pattern is served by the existing
+/// `mergeGrids` primitive; the persistent pattern is served by this
+/// class. Both patterns compose the same nanoVDB `voxelsToGrid +
+/// mergeGrids + inject` building blocks -- only the outer shape differs.
+class PersistentTSDFState {
+  public:
+    /// @brief Construct a new state from an initial grid + sidecar tensors.
+    ///
+    /// The initial grid may have zero voxels (for a from-scratch workflow)
+    /// or contain a seed topology. Sidecar tensors must be 1-D/2-D with
+    /// `size(0) == grid->totalVoxels()`.
+    /// @param grid The initial grid topology (non-null, single-batch preferred).
+    /// @param tsdf The initial TSDF sidecar, shape `[totalVoxels]`.
+    /// @param weights The initial weight sidecar, shape `[totalVoxels]`.
+    /// @param features Optional `[totalVoxels, featureDim]` sidecar; pass
+    ///                 `std::nullopt` for no-features workloads.
+    PersistentTSDFState(c10::intrusive_ptr<GridBatchData> grid,
+                        torch::Tensor tsdf,
+                        torch::Tensor weights,
+                        std::optional<torch::Tensor> features = std::nullopt);
+
+    // Move-only: like `GridBatchData`, we forbid copy to avoid accidental
+    // sidecar-tensor aliasing (the tensors are mutated in-place by the
+    // shell-filtered integrate kernels).
+    PersistentTSDFState(const PersistentTSDFState &)            = delete;
+    PersistentTSDFState &operator=(const PersistentTSDFState &) = delete;
+    PersistentTSDFState(PersistentTSDFState &&)                 = default;
+    PersistentTSDFState &operator=(PersistentTSDFState &&)      = default;
+    ~PersistentTSDFState()                                      = default;
+
+    /// @brief Expand the live grid to include the voxel ijk set in
+    ///        `newVoxelIjks`. Fully equivalent to
+    ///        `growFromGrid(voxelsToGrid(newVoxelIjks))`.
+    /// @param newVoxelIjks A `JaggedTensor` of integer voxel coordinates
+    ///                     with element shape `[-1, 3]` and batch size 1.
+    void grow(const JaggedTensor &newVoxelIjks);
+
+    /// @brief Expand the live grid to the union of its current voxels and
+    ///        `shellGrid`. This is the primary entry point used by the
+    ///        depth / LiDAR integrators, both of which have already built
+    ///        a shell grid via `buildPointTruncationShell`.
+    ///
+    /// No-op when `shellGrid.totalVoxels() == 0`.
+    /// No-op when the merged grid has the same active-voxel count as the
+    /// current live grid (the shell was a subset). In that case the
+    /// existing sidecar tensors and grid handle are retained unmodified,
+    /// which is the steady-state fast path on bounded-scene trajectories.
+    ///
+    /// @param shellGrid The shell (or any other) grid whose active voxels
+    ///                  should be merged into the live grid.
+    void growFromGrid(const GridBatchData &shellGrid);
+
+    /// @brief Drop the live grid and sidecars back to an empty, zero-voxel
+    ///        state. Retains the voxel size and origin of the current
+    ///        live grid so subsequent `grow()` calls quantise against the
+    ///        same coordinate frame.
+    void reset();
+
+    /// @brief Current active voxel count in the live grid.
+    int64_t
+    activeVoxelCount() const {
+        return mGrid->totalVoxels();
+    }
+
+    /// @brief Access the live grid by reference (stable pointer semantics
+    ///        within a single `grow` call; do not retain across grows).
+    GridBatchData &
+    grid() {
+        return *mGrid;
+    }
+    const GridBatchData &
+    grid() const {
+        return *mGrid;
+    }
+    const c10::intrusive_ptr<GridBatchData> &
+    gridPtr() const {
+        return mGrid;
+    }
+
+    torch::Tensor &
+    tsdf() {
+        return mTsdf;
+    }
+    const torch::Tensor &
+    tsdf() const {
+        return mTsdf;
+    }
+
+    torch::Tensor &
+    weights() {
+        return mWeights;
+    }
+    const torch::Tensor &
+    weights() const {
+        return mWeights;
+    }
+
+    /// @brief Whether a features sidecar is attached.
+    bool
+    hasFeatures() const {
+        return mHasFeatures;
+    }
+
+    /// @brief Access the features sidecar. Valid only when `hasFeatures()`.
+    torch::Tensor &
+    features() {
+        return mFeatures;
+    }
+    const torch::Tensor &
+    features() const {
+        return mFeatures;
+    }
+
+    /// @brief JaggedTensor view of the TSDF sidecar that matches the
+    ///        current live grid's batch layout. Convenience wrapper
+    ///        around `grid().jaggedTensor(tsdf())` used by callers that
+    ///        hand off to the existing JaggedTensor-accepting kernels.
+    JaggedTensor
+    tsdfJagged() const {
+        return mGrid->jaggedTensor(mTsdf);
+    }
+    JaggedTensor
+    weightsJagged() const {
+        return mGrid->jaggedTensor(mWeights);
+    }
+    JaggedTensor
+    featuresJagged() const {
+        return mGrid->jaggedTensor(mFeatures);
+    }
+
+  private:
+    c10::intrusive_ptr<GridBatchData> mGrid;
+    torch::Tensor mTsdf;
+    torch::Tensor mWeights;
+    torch::Tensor mFeatures;    // shape `[totalVoxels, 0]` when no features
+    bool mHasFeatures = false;
+};
+
+} // namespace ops
+} // namespace detail
+} // namespace fvdb
+
+#endif // FVDB_DETAIL_OPS_PERSISTENTTSDFSTATE_H

--- a/src/fvdb/detail/ops/PersistentTSDFState.h
+++ b/src/fvdb/detail/ops/PersistentTSDFState.h
@@ -172,7 +172,7 @@ class PersistentTSDFState {
     c10::intrusive_ptr<GridBatchData> mGrid;
     torch::Tensor mTsdf;
     torch::Tensor mWeights;
-    torch::Tensor mFeatures;    // shape `[totalVoxels, 0]` when no features
+    torch::Tensor mFeatures; // shape `[totalVoxels, 0]` when no features
     bool mHasFeatures = false;
 };
 

--- a/src/python/Bindings.cpp
+++ b/src/python/Bindings.cpp
@@ -25,6 +25,7 @@ void bind_grid_batch_ops(py::module &m);
 void bind_jagged_tensor(py::module &m);
 void bind_gaussian_splat_ops(py::module &m);
 void bind_viewer(py::module &m);
+void bind_persistent_tsdf_state(py::module &m);
 
 #define __FVDB__BUILDER_INNER(FUNC_NAME, FUNC_STR, LSHAPE_TYPE)                           \
     m.def(                                                                                \
@@ -137,6 +138,7 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
     bind_jagged_tensor(m);
     bind_gaussian_splat_ops(m);
     bind_viewer(m);
+    bind_persistent_tsdf_state(m);
 
     //
     // Utility functions

--- a/src/python/GridBatchOps.cpp
+++ b/src/python/GridBatchOps.cpp
@@ -50,7 +50,11 @@
 #include <fvdb/detail/ops/VoxelsAlongRays.h>
 
 // Meshing / TSDF
+#include <fvdb/detail/ops/ComputeESDF.h>
+#include <fvdb/detail/ops/DirtyMaskFromSidecars.h>
+#include <fvdb/detail/ops/IntegrateOccupancyFromPoints.h>
 #include <fvdb/detail/ops/IntegrateTSDF.h>
+#include <fvdb/detail/ops/IntegrateTSDFFromPoints.h>
 #include <fvdb/detail/ops/MarchingCubes.h>
 #include <fvdb/detail/ops/ReinitializeSdf.h>
 
@@ -492,6 +496,118 @@ bind_grid_batch_ops(py::module &m) {
           py::arg("depth_images"),
           py::arg("feature_images"),
           py::arg("weight_images"));
+
+    m.def("integrate_tsdf_batch",
+          &ops::integrateTSDFBatch,
+          py::arg("grid"),
+          py::arg("truncation_margin"),
+          py::arg("projection_matrices"),
+          py::arg("cam_to_world_matrices"),
+          py::arg("tsdf"),
+          py::arg("weights"),
+          py::arg("depth_images"),
+          py::arg("weight_images"));
+
+    m.def("integrate_tsdf_batch_with_features",
+          &ops::integrateTSDFBatchWithFeatures,
+          py::arg("grid"),
+          py::arg("truncation_margin"),
+          py::arg("projection_matrices"),
+          py::arg("cam_to_world_matrices"),
+          py::arg("tsdf"),
+          py::arg("features"),
+          py::arg("weights"),
+          py::arg("depth_images"),
+          py::arg("feature_images"),
+          py::arg("weight_images"));
+
+    m.def("integrate_tsdf_from_points",
+          &ops::integrateTSDFFromPoints,
+          py::arg("grid"),
+          py::arg("truncation_margin"),
+          py::arg("points"),
+          py::arg("sensor_origins"),
+          py::arg("tsdf"),
+          py::arg("weights"),
+          py::arg("carve_free_space"));
+
+    m.def("integrate_tsdf_from_points_with_features",
+          &ops::integrateTSDFFromPointsWithFeatures,
+          py::arg("grid"),
+          py::arg("truncation_margin"),
+          py::arg("points"),
+          py::arg("sensor_origins"),
+          py::arg("tsdf"),
+          py::arg("features"),
+          py::arg("weights"),
+          py::arg("point_features"),
+          py::arg("carve_free_space"));
+
+    m.def("integrate_tsdf_from_points_frames",
+          &ops::integrateTSDFFromPointsFrames,
+          py::arg("grid"),
+          py::arg("truncation_margin"),
+          py::arg("points_per_frame"),
+          py::arg("sensor_origins"),
+          py::arg("tsdf"),
+          py::arg("weights"),
+          py::arg("carve_free_space"));
+
+    m.def("integrate_occupancy_from_points",
+          &ops::integrateOccupancyFromPoints,
+          py::arg("grid"),
+          py::arg("truncation_margin"),
+          py::arg("points"),
+          py::arg("sensor_origins"),
+          py::arg("log_odds"),
+          py::arg("log_odds_hit"),
+          py::arg("log_odds_miss"),
+          py::arg("log_odds_min"),
+          py::arg("log_odds_max"));
+
+    m.def("integrate_occupancy_from_points_frames",
+          &ops::integrateOccupancyFromPointsFrames,
+          py::arg("grid"),
+          py::arg("truncation_margin"),
+          py::arg("points_per_frame"),
+          py::arg("sensor_origins"),
+          py::arg("log_odds"),
+          py::arg("log_odds_hit"),
+          py::arg("log_odds_miss"),
+          py::arg("log_odds_min"),
+          py::arg("log_odds_max"));
+
+    m.def("compute_esdf",
+          &ops::computeESDF,
+          py::arg("grid"),
+          py::arg("tsdf"),
+          py::arg("weights"),
+          py::arg("truncation_distance"),
+          py::arg("max_distance"),
+          py::arg("weight_threshold"),
+          py::arg("prune_unreached"),
+          py::arg("use_vbm"));
+
+    m.def("compute_esdf_incremental",
+          &ops::computeESDFIncremental,
+          py::arg("grid"),
+          py::arg("tsdf"),
+          py::arg("weights"),
+          py::arg("prev_esdf_grid"),
+          py::arg("prev_esdf"),
+          py::arg("truncation_distance"),
+          py::arg("max_distance"),
+          py::arg("weight_threshold"),
+          py::arg("prune_unreached"),
+          py::arg("use_vbm"),
+          py::arg("dirty_mask"));
+
+    m.def("dirty_mask_from_sidecars",
+          &ops::dirtyMaskFromSidecars,
+          py::arg("new_grid"),
+          py::arg("new_sidecar"),
+          py::arg("old_grid"),
+          py::arg("old_sidecar"));
 
     // -----------------------------------------------------------------------
     // Topology / misc

--- a/src/python/PersistentTSDFStateBinding.cpp
+++ b/src/python/PersistentTSDFStateBinding.cpp
@@ -1,0 +1,71 @@
+// Copyright Contributors to the OpenVDB Project
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <pybind11/stl.h>
+
+#include <fvdb/GridBatchData.h>
+#include <fvdb/JaggedTensor.h>
+#include <fvdb/detail/ops/PersistentTSDFState.h>
+
+#include <torch/extension.h>
+
+#include <memory>
+#include <optional>
+
+namespace py = pybind11;
+
+void
+bind_persistent_tsdf_state(py::module &m) {
+    using fvdb::GridBatchData;
+    using fvdb::JaggedTensor;
+    using fvdb::detail::ops::PersistentTSDFState;
+
+    // Shared-pointer wrapper lets Python hold / pass the state around
+    // with value semantics (i.e. mutating via one reference shows up
+    // through all references). `PersistentTSDFState` is move-only in C++
+    // (to avoid accidental sidecar aliasing on the C++ side), so pybind
+    // must use a wrapping smart pointer here.
+    py::class_<PersistentTSDFState, std::shared_ptr<PersistentTSDFState>>(
+        m, "PersistentTSDFState")
+        .def(py::init(
+                 [](c10::intrusive_ptr<GridBatchData> grid,
+                    torch::Tensor tsdf,
+                    torch::Tensor weights,
+                    std::optional<torch::Tensor> features) {
+                     return std::make_shared<PersistentTSDFState>(
+                         std::move(grid),
+                         std::move(tsdf),
+                         std::move(weights),
+                         std::move(features));
+                 }),
+             py::arg("grid"),
+             py::arg("tsdf"),
+             py::arg("weights"),
+             py::arg("features") = std::nullopt)
+        .def(
+            "grow",
+            [](PersistentTSDFState &self, const JaggedTensor &ijks) { self.grow(ijks); },
+            py::arg("ijks"))
+        .def(
+            "grow_from_grid",
+            [](PersistentTSDFState &self, const c10::intrusive_ptr<GridBatchData> &shell) {
+                self.growFromGrid(*shell);
+            },
+            py::arg("shell_grid"))
+        .def("reset", &PersistentTSDFState::reset)
+        .def_property_readonly("active_voxel_count", &PersistentTSDFState::activeVoxelCount)
+        .def_property_readonly(
+            "grid",
+            [](const PersistentTSDFState &self) { return self.gridPtr(); })
+        .def_property_readonly(
+            "tsdf",
+            [](const PersistentTSDFState &self) { return self.tsdf(); })
+        .def_property_readonly(
+            "weights",
+            [](const PersistentTSDFState &self) { return self.weights(); })
+        .def_property_readonly("has_features", &PersistentTSDFState::hasFeatures)
+        .def_property_readonly(
+            "features",
+            [](const PersistentTSDFState &self) { return self.features(); });
+}

--- a/src/python/PersistentTSDFStateBinding.cpp
+++ b/src/python/PersistentTSDFStateBinding.cpp
@@ -26,19 +26,14 @@ bind_persistent_tsdf_state(py::module &m) {
     // through all references). `PersistentTSDFState` is move-only in C++
     // (to avoid accidental sidecar aliasing on the C++ side), so pybind
     // must use a wrapping smart pointer here.
-    py::class_<PersistentTSDFState, std::shared_ptr<PersistentTSDFState>>(
-        m, "PersistentTSDFState")
-        .def(py::init(
-                 [](c10::intrusive_ptr<GridBatchData> grid,
-                    torch::Tensor tsdf,
-                    torch::Tensor weights,
-                    std::optional<torch::Tensor> features) {
-                     return std::make_shared<PersistentTSDFState>(
-                         std::move(grid),
-                         std::move(tsdf),
-                         std::move(weights),
-                         std::move(features));
-                 }),
+    py::class_<PersistentTSDFState, std::shared_ptr<PersistentTSDFState>>(m, "PersistentTSDFState")
+        .def(py::init([](c10::intrusive_ptr<GridBatchData> grid,
+                         torch::Tensor tsdf,
+                         torch::Tensor weights,
+                         std::optional<torch::Tensor> features) {
+                 return std::make_shared<PersistentTSDFState>(
+                     std::move(grid), std::move(tsdf), std::move(weights), std::move(features));
+             }),
              py::arg("grid"),
              py::arg("tsdf"),
              py::arg("weights"),
@@ -55,17 +50,12 @@ bind_persistent_tsdf_state(py::module &m) {
             py::arg("shell_grid"))
         .def("reset", &PersistentTSDFState::reset)
         .def_property_readonly("active_voxel_count", &PersistentTSDFState::activeVoxelCount)
-        .def_property_readonly(
-            "grid",
-            [](const PersistentTSDFState &self) { return self.gridPtr(); })
-        .def_property_readonly(
-            "tsdf",
-            [](const PersistentTSDFState &self) { return self.tsdf(); })
-        .def_property_readonly(
-            "weights",
-            [](const PersistentTSDFState &self) { return self.weights(); })
+        .def_property_readonly("grid",
+                               [](const PersistentTSDFState &self) { return self.gridPtr(); })
+        .def_property_readonly("tsdf", [](const PersistentTSDFState &self) { return self.tsdf(); })
+        .def_property_readonly("weights",
+                               [](const PersistentTSDFState &self) { return self.weights(); })
         .def_property_readonly("has_features", &PersistentTSDFState::hasFeatures)
-        .def_property_readonly(
-            "features",
-            [](const PersistentTSDFState &self) { return self.features(); });
+        .def_property_readonly("features",
+                               [](const PersistentTSDFState &self) { return self.features(); });
 }

--- a/tests/unit/test_basic_ops.py
+++ b/tests/unit/test_basic_ops.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 import itertools
+import math
 import pickle
 import unittest
 
@@ -2199,7 +2200,7 @@ class TestBasicOps(unittest.TestCase):
                 fvdb.JaggedTensor(ray_o), fvdb.JaggedTensor(ray_d), fvdb.JaggedTensor(bad_scalars)
             )
 
-    @expand_tests(list(itertools.product(["cpu", "cuda"], [torch.float32, torch.float64])))
+    @expand_tests(list(itertools.product(["cpu", "cuda"], [torch.float16, torch.float32, torch.float64])))
     def test_marching_cubes(self, device, dtype):
         # Generate the SDF for a sphere on a grid
         N = 32 if device == "cpu" else 64
@@ -2223,6 +2224,10 @@ class TestBasicOps(unittest.TestCase):
             ).unsqueeze(
                 -1
             )  # [B, N, N, N, 1] sdf
+            # Actually cast to the parameterized dtype so the test exercises
+            # each integrator path (CUDA fp32+fp16 -> V4, CUDA fp64 -> legacy,
+            # CPU -> legacy for all dtypes).
+            sphere_sdf = sphere_sdf.to(dtype)
 
             # Build a grid with the SDF
             grid = GridBatch.from_dense(
@@ -2238,9 +2243,14 @@ class TestBasicOps(unittest.TestCase):
             for level in [0.0, 0.2, -0.2]:
                 v, f, _ = grid.marching_cubes(sdf_p, level)
 
+                # Output vertex dtype should match input SDF dtype (legacy's
+                # public contract; V4 preserves this via its end-of-pipeline
+                # downcast of retVertices).
+                self.assertEqual(v[0].jdata.dtype, dtype)
+
                 for bi in range(batch_size):
                     mesh_radius = torch.linalg.norm(
-                        v[bi].jdata - torch.tensor([[0.5] * 3], device=device, dtype=dtype), axis=1
+                        v[bi].jdata.float() - torch.tensor([[0.5] * 3], device=device), axis=1
                     )
                     vox_size = torch.norm(grid.voxel_sizes[bi])
                     self.assertTrue(torch.all(mesh_radius - sphere_rads[bi] < vox_size / 2.0 - level))
@@ -2249,6 +2259,49 @@ class TestBasicOps(unittest.TestCase):
                 # ps.init()
                 # ps.register_surface_mesh("marching_cubes", v.cpu()[0].jdata.numpy(), f.cpu()[0].jdata.numpy())
                 # ps.show()
+
+    @unittest.skipUnless(torch.cuda.is_available(), "CUDA required for fp16 MC fast path")
+    def test_marching_cubes_fp16_matches_fp32(self):
+        """
+        The CUDA fp16 path in `marchingCubes` routes through V4 with kernel-
+        side `fp16 -> fp32` per-load casts (no transient fp32 buffer). This
+        test pins that the fp16 output is numerically close to fp32 (within
+        fp16's resolution) and that the topology matches exactly.
+        """
+        device = "cuda"
+        N = 64
+        ii, jj, kk = torch.meshgrid([torch.arange(N, device=device)] * 3, indexing="ij")
+        xx = ii.float() / (N - 1) - 0.5
+        yy = jj.float() / (N - 1) - 0.5
+        zz = kk.float() / (N - 1) - 0.5
+        sphere_sdf_fp32 = (-torch.sqrt(xx**2 + yy**2 + zz**2) + 0.5).unsqueeze(-1).unsqueeze(0)
+
+        grid = GridBatch.from_dense(
+            1,
+            list(sphere_sdf_fp32[0].shape[:3]),
+            [0] * 3,
+            voxel_sizes=1.0 / N,
+            origins=[0] * 3,
+            device=device,
+        )
+        sdf_fp32 = grid.inject_from_dense_cminor(sphere_sdf_fp32)
+        sdf_fp16 = grid.inject_from_dense_cminor(sphere_sdf_fp32.half())
+
+        v32, f32, _ = grid.marching_cubes(sdf_fp32, 0.0)
+        v16, f16, _ = grid.marching_cubes(sdf_fp16, 0.0)
+
+        # Topology must be identical: V4 with fp32 input and V4 with fp16
+        # input run the same kernel logic; only the per-load cast differs.
+        self.assertEqual(v32[0].jdata.shape, v16[0].jdata.shape)
+        self.assertEqual(f32[0].jdata.shape, f16[0].jdata.shape)
+
+        # Output dtypes preserved per legacy contract.
+        self.assertEqual(v32[0].jdata.dtype, torch.float32)
+        self.assertEqual(v16[0].jdata.dtype, torch.float16)
+
+        # Vertices agree to fp16 precision (~2^-10 at unit range).
+        max_dev = (v32[0].jdata - v16[0].jdata.float()).abs().max().item()
+        self.assertLess(max_dev, 1.0e-3, f"fp16 vs fp32 MC vertex deviation {max_dev:.2e} exceeds fp16 resolution")
 
     @expand_tests(list(itertools.product(["cuda"], [torch.float32, torch.float64])))
     def test_integrate_tsdf_pixel_weight_blending(self, device, dtype):
@@ -2356,6 +2409,525 @@ class TestBasicOps(unittest.TestCase):
         tsdf2_u_2d = fvdb.JaggedTensor(tsdf2_u.jdata.unsqueeze(-1))
         sampled_u = grid2_u.sample_trilinear(pts, tsdf2_u_2d).jdata.flatten()
         torch.testing.assert_close(sampled_u, expected_tsdf_u, atol=atol, rtol=0)
+
+    @unittest.skipUnless(torch.cuda.is_available(), "CUDA required for integrate_tsdf_from_points")
+    def test_integrate_tsdf_from_points_single_ray_is_exact(self):
+        """
+        For a single LiDAR ray from origin to (R, 0, 0), the per-voxel
+        TSDF along the ray direction should be exactly
+        (R - voxel_x) / truncation, clamped to [-1, 1]. This pins the
+        running-sum kernel's core signed-distance arithmetic.
+        """
+        import fvdb as fv
+
+        device = "cuda"
+        voxel_size = 0.05
+        trunc = 3 * voxel_size
+        R = 1.0
+        points = torch.tensor([[R, 0.0, 0.0]], device=device, dtype=torch.float32)
+        sensor_origin = torch.zeros(3, device=device, dtype=torch.float32)
+
+        grid = fv.Grid.from_dense(
+            dense_dims=[64, 64, 32],
+            ijk_min=[-32, -32, -16],
+            voxel_size=voxel_size,
+            origin=[0, 0, 0],
+            device=device,
+        )
+        tsdf = torch.zeros(grid.num_voxels, device=device, dtype=torch.float32)
+        weights = torch.zeros(grid.num_voxels, device=device, dtype=torch.float32)
+
+        new_grid, new_tsdf, new_weights = grid.integrate_tsdf_from_points(
+            truncation_distance=trunc,
+            points=points,
+            sensor_origin=sensor_origin,
+            tsdf=tsdf,
+            weights=weights,
+            carve_free_space=True,
+        )
+
+        # Find voxels at y=z=0 along +x, in the truncation band around R.
+        # Index into the RETURNED grid (not the input grid) because
+        # `integrate_tsdf_from_points` can grow the topology (e.g. when
+        # the leaf-granularity shell builder in the incremental path
+        # over-covers at sub-leaf scale -- the output grid is a
+        # superset of the input).
+        ijk = new_grid.ijk
+        world = new_grid.voxel_to_world(ijk.float())
+        on_axis = (ijk[:, 1] == 0) & (ijk[:, 2] == 0)
+        x = world[:, 0]
+        in_band = on_axis & (x - R).abs().le(trunc + 0.5 * voxel_size)
+
+        sdf_norm = (R - x[in_band]) / trunc
+        expected = sdf_norm.clamp(-1.0, 1.0)
+        actual = new_tsdf[in_band]
+        self.assertTrue(
+            (new_weights[in_band] > 0).all(),
+            "all in-band on-axis voxels should have been updated",
+        )
+        torch.testing.assert_close(actual, expected, atol=1e-4, rtol=0)
+
+    @unittest.skipUnless(torch.cuda.is_available(), "CUDA required for integrate_tsdf_from_points")
+    def test_integrate_tsdf_from_points_sphere_reconstruction(self):
+        """
+        Integrating a dense sphere of points should reconstruct a mesh
+        whose vertex radii match the source radius to within a fraction
+        of a voxel. This exercises the full ray-walk + HDDA path and the
+        Euclidean-range SDF formula (an along-ray-projection formula
+        would bias the reconstruction outward by ~1.5 voxels).
+        """
+        import fvdb as fv
+
+        device = "cuda"
+        voxel_size = 0.05
+        trunc = 3 * voxel_size
+        R = 1.0
+
+        n_theta, n_phi = 32, 64
+        theta = torch.linspace(0, math.pi, n_theta, device=device)
+        phi = torch.linspace(0, 2 * math.pi, n_phi + 1, device=device)[:-1]
+        tt, pp = torch.meshgrid(theta, phi, indexing="ij")
+        pts = torch.stack(
+            [
+                R * torch.sin(tt) * torch.cos(pp),
+                R * torch.sin(tt) * torch.sin(pp),
+                R * torch.cos(tt),
+            ],
+            -1,
+        ).reshape(-1, 3).float()
+        sensor_origin = torch.zeros(3, device=device, dtype=torch.float32)
+
+        grid = fv.Grid.from_dense(
+            dense_dims=[64, 64, 64],
+            ijk_min=[-32, -32, -32],
+            voxel_size=voxel_size,
+            origin=[0, 0, 0],
+            device=device,
+        )
+        tsdf = torch.zeros(grid.num_voxels, device=device, dtype=torch.float32)
+        weights = torch.zeros(grid.num_voxels, device=device, dtype=torch.float32)
+
+        new_grid, new_tsdf, new_weights = grid.integrate_tsdf_from_points(
+            truncation_distance=trunc,
+            points=pts,
+            sensor_origin=sensor_origin,
+            tsdf=tsdf,
+            weights=weights,
+            carve_free_space=True,
+        )
+
+        # MC only makes sense where we have observations; prune to the
+        # observed-voxel subgrid before extraction.
+        observed = new_weights > 0
+        pruned = new_grid.pruned_grid(observed)
+        pruned_tsdf = new_tsdf[observed]
+
+        v, _, _ = pruned.marching_cubes(pruned_tsdf, 0.0)
+        self.assertGreater(v.shape[0], 0, "expected a non-empty mesh")
+
+        radii = v.norm(dim=1)
+        # Tolerate up to 1 voxel of mean error + per-vertex resolution.
+        self.assertLess(
+            (radii.mean() - R).abs().item(),
+            0.5 * voxel_size,
+            f"sphere mesh mean radius off by >0.5 voxels: {radii.mean().item()}",
+        )
+        self.assertLess(
+            radii.std().item(),
+            voxel_size,
+            f"sphere mesh radial std too wide: {radii.std().item()}",
+        )
+
+    @unittest.skipUnless(torch.cuda.is_available(), "CUDA required for integrate_tsdf_frames")
+    def test_integrate_tsdf_frames_matches_sequential(self):
+        """
+        `Grid.integrate_tsdf_frames(N frames)` builds the union topology once
+        up-front and then runs N frame updates against that fixed topology.
+        It must produce the same final (grid, tsdf, weights) as N separate
+        `Grid.integrate_tsdf` calls (which rebuild topology each call).
+
+        This is the semantic contract that lets the batched path be a
+        drop-in performance replacement for the per-frame loop in bulk
+        RGB-D reconstruction.
+        """
+        import fvdb as fv
+
+        device = "cuda"
+        N = 5
+        H, W = 64, 64
+        voxel_size = 0.05
+        trunc = 0.1
+
+        grid = fv.Grid.from_dense(
+            [32, 32, 32], [-16, -16, -16], voxel_size=voxel_size, device=device
+        )
+        tsdf0 = torch.zeros(grid.num_voxels, device=device)
+        weights0 = torch.zeros(grid.num_voxels, device=device)
+
+        K = torch.eye(3, device=device).unsqueeze(0).repeat(N, 1, 1)
+        K[:, 0, 0] = K[:, 1, 1] = 32.0
+        K[:, 0, 2] = W / 2
+        K[:, 1, 2] = H / 2
+        # N viewpoints along +z with small translations so the truncation
+        # shell actually grows across frames (exercises the copy-forward
+        # path for iterations > 0, where base = unionGrid).
+        E = torch.eye(4, device=device).unsqueeze(0).repeat(N, 1, 1)
+        for i in range(N):
+            E[i, 0, 3] = 0.05 * (i - N / 2)
+            E[i, 2, 3] = -1.0 - 0.02 * i
+        depth = 0.5 + 0.01 * torch.randn(N, H, W, device=device)
+
+        # --- Batched path ---
+        g_bat, t_bat, w_bat = grid.integrate_tsdf_frames(
+            truncation_distance=trunc,
+            projection_matrices=K,
+            cam_to_world_matrices=E,
+            tsdf=tsdf0,
+            weights=weights0,
+            depth_images=depth,
+        )
+
+        # --- Sequential reference ---
+        g_ref, t_ref, w_ref = grid, tsdf0, weights0
+        for i in range(N):
+            g_ref, t_ref, w_ref = g_ref.integrate_tsdf(
+                truncation_distance=trunc,
+                projection_matrices=K[i : i + 1],
+                cam_to_world_matrices=E[i : i + 1],
+                tsdf=t_ref,
+                weights=w_ref,
+                depth_images=depth[i : i + 1],
+            )
+
+        # Topology must match exactly (same union over all frames'
+        # truncation shells).
+        self.assertEqual(g_bat.num_voxels, g_ref.num_voxels)
+        self.assertTrue(torch.equal(g_bat.ijk, g_ref.ijk))
+
+        # TSDF and weights must match bit-identically (both paths feed
+        # the same floating-point operations through the same kernel, in
+        # the same order, over the same voxel set).
+        torch.testing.assert_close(t_bat, t_ref, atol=0.0, rtol=0.0)
+        torch.testing.assert_close(w_bat, w_ref, atol=0.0, rtol=0.0)
+
+    def test_integrate_tsdf_from_points_frames_matches_sequential(self):
+        """
+        ``Grid.integrate_tsdf_from_points_frames`` runs N LiDAR sweeps
+        in one C++ call; the result must agree with N sequential
+        ``integrate_tsdf_from_points`` calls.
+
+        Unlike the depth-image integrator (which writes to each voxel
+        exactly once per frame and is therefore bit-deterministic),
+        the LiDAR ray-walk kernel accumulates per-voxel TSDF/weight
+        contributions via ``atomicAdd`` across threads walking
+        overlapping rays. Atomic ordering is non-deterministic in
+        CUDA, so two back-to-back calls to the *same* single-frame
+        API don't produce bit-identical TSDF tensors either: we
+        measured ~0.4% of voxels diverge by exactly 1 ULP of fp32
+        between two runs of the sequential reference. Consequently
+        we assert agreement within a small tolerance (``atol=2e-6``,
+        ~10x the observed 1-ULP atomic-noise floor) rather than
+        bit-identity.
+
+        Weights *are* bit-deterministic (``+= 1.0`` per contribution
+        is exact) so we pin those at ``atol=rtol=0``.
+        """
+        import fvdb as fv
+
+        device = "cuda"
+        N = 5
+        voxel_size = 0.2
+        trunc = 0.6
+
+        grid = fv.Grid.from_dense(
+            [10, 10, 10], [-5, -5, -5],
+            voxel_size=voxel_size, origin=[0, 0, 0], device=device,
+        )
+        tsdf0 = torch.zeros(grid.num_voxels, device=device)
+        weights0 = torch.zeros(grid.num_voxels, device=device)
+
+        torch.manual_seed(0)
+        pts_per_frame = [
+            torch.randn(1000, 3, device=device)
+                 + torch.tensor([float(i) * 0.5, 0.0, 0.0], device=device)
+            for i in range(N)
+        ]
+        sensor_origins = torch.stack([
+            torch.tensor([float(i) * 0.5, 0.0, 0.0], device=device)
+            for i in range(N)
+        ])
+
+        # --- Batched path ---
+        g_bat, t_bat, w_bat = grid.integrate_tsdf_from_points_frames(
+            truncation_distance=trunc,
+            points_per_frame=pts_per_frame,
+            sensor_origins=sensor_origins,
+            tsdf=tsdf0, weights=weights0,
+            carve_free_space=True,
+        )
+
+        # --- Sequential reference ---
+        g_ref, t_ref, w_ref = grid, tsdf0, weights0
+        for i in range(N):
+            g_ref, t_ref, w_ref = g_ref.integrate_tsdf_from_points(
+                truncation_distance=trunc,
+                points=pts_per_frame[i],
+                sensor_origin=sensor_origins[i],
+                tsdf=t_ref,
+                weights=w_ref,
+                carve_free_space=True,
+            )
+
+        # Topology must match bit-identically (same N shells unioned
+        # in the same order via the same mergeGrids calls).
+        self.assertEqual(g_bat.num_voxels, g_ref.num_voxels)
+        self.assertTrue(torch.equal(g_bat.ijk, g_ref.ijk))
+
+        # Weights are deterministic (sum of +1 contributions).
+        torch.testing.assert_close(w_bat, w_ref, atol=0.0, rtol=0.0)
+
+        # TSDF is not bit-deterministic due to atomic-add reorder in
+        # `rayWalkIntegrateKernel`; assert within a 10-ULP tolerance.
+        torch.testing.assert_close(t_bat, t_ref, atol=2e-6, rtol=1e-5)
+
+    def test_integrate_tsdf_frames_fp16(self):
+        """
+        Verify the fp16 integrate_tsdf_frames path produces a valid
+        output -- same ijk topology contract, tsdf/weights tensors in
+        fp16, and results within fp16 precision of the fp32 baseline.
+        This is the headline "halves accumulated-grid memory" path
+        that reality-capture pipelines rely on; we want to catch
+        regressions of its dispatch.
+        """
+        import fvdb as fv
+
+        device = "cuda"
+        N = 4
+        H, W = 48, 48
+        voxel_size = 0.05
+        trunc = 0.15
+
+        K = torch.eye(3, device=device).unsqueeze(0).repeat(N, 1, 1)
+        K[:, 0, 0] = K[:, 1, 1] = 24.0
+        K[:, 0, 2] = W / 2
+        K[:, 1, 2] = H / 2
+        E = torch.eye(4, device=device).unsqueeze(0).repeat(N, 1, 1)
+        for i in range(N):
+            E[i, 0, 3] = 0.04 * (i - N / 2)
+            E[i, 2, 3] = -1.2 - 0.02 * i
+        depth = 0.6 + 0.01 * torch.randn(N, H, W, device=device)
+
+        outputs = {}
+        for dtype in (torch.float32, torch.float16):
+            grid = fv.Grid.from_dense(
+                [24, 24, 24], [-12, -12, -12],
+                voxel_size=voxel_size, device=device,
+            )
+            t0 = torch.zeros(grid.num_voxels, device=device, dtype=dtype)
+            w0 = torch.zeros(grid.num_voxels, device=device, dtype=dtype)
+            g, t, w = grid.integrate_tsdf_frames(
+                truncation_distance=trunc,
+                projection_matrices=K.to(dtype),
+                cam_to_world_matrices=E.to(dtype),
+                tsdf=t0, weights=w0,
+                depth_images=depth.to(dtype),
+            )
+            outputs[dtype] = (g, t, w)
+
+        g32, t32, w32 = outputs[torch.float32]
+        g16, t16, w16 = outputs[torch.float16]
+
+        self.assertEqual(t16.dtype, torch.float16)
+        self.assertEqual(w16.dtype, torch.float16)
+
+        # Topology sizes should be within 10% of each other (fp16
+        # unprojection produces slightly different quantised boundary
+        # voxels but the bulk of the surface is identical at this
+        # voxel size / scene scale).
+        vox_ratio = g16.num_voxels / max(g32.num_voxels, 1)
+        self.assertGreater(vox_ratio, 0.9)
+        self.assertLess(vox_ratio, 1.2)
+
+        # Both tsdf fields should lie in [-1, 1] after normalisation by
+        # the truncation margin (the kernel clamps with
+        # `Min(1, zDiff/trunc)`).
+        self.assertTrue((t16.abs() <= 1.0 + 1e-2).all())
+        self.assertTrue((t32.abs() <= 1.0 + 1e-6).all())
+
+        # Weights should be non-negative.
+        self.assertTrue((w16 >= 0).all())
+        self.assertTrue((w32 >= 0).all())
+
+    @unittest.skipUnless(torch.cuda.is_available(), "CUDA required for integrate_tsdf_from_points")
+    def test_integrate_tsdf_from_points_return_contract_matches_depth(self):
+        """
+        The LiDAR and depth TSDF integrators must return structurally
+        identical tuples: the no-features path returns (Grid, Tensor[N],
+        Tensor[N]) and the with-features path returns (Grid, Tensor[N],
+        Tensor[N], Tensor[N, D]), with consistent dtypes. This pins the
+        API contract so future refactors cannot silently diverge.
+        """
+        import fvdb as fv
+
+        device = "cuda"
+        grid = fv.Grid.from_dense([32, 32, 32], [0, 0, 0], voxel_size=1.0 / 32, device=device)
+        tsdf = torch.zeros(grid.num_voxels, device=device, dtype=torch.float32)
+        weights = torch.zeros(grid.num_voxels, device=device, dtype=torch.float32)
+
+        K = torch.eye(3, device=device, dtype=torch.float32).unsqueeze(0)
+        E = torch.eye(4, device=device, dtype=torch.float32).unsqueeze(0)
+        depth = 0.5 * torch.ones(1, 16, 16, device=device, dtype=torch.float32)
+
+        pts = torch.tensor([[0.5, 0.0, 0.0]], device=device, dtype=torch.float32)
+        origin = torch.zeros(3, device=device, dtype=torch.float32)
+
+        # No-features: both paths should return a 3-tuple with identical
+        # output types/shapes up to num_voxels (which differs because the
+        # two integrators produce different union grids).
+        d_grid, d_tsdf, d_weights = grid.integrate_tsdf(
+            truncation_distance=0.1,
+            projection_matrices=K,
+            cam_to_world_matrices=E,
+            tsdf=tsdf,
+            weights=weights,
+            depth_images=depth,
+        )
+        l_grid, l_tsdf, l_weights = grid.integrate_tsdf_from_points(
+            truncation_distance=0.1,
+            points=pts,
+            sensor_origin=origin,
+            tsdf=tsdf,
+            weights=weights,
+            carve_free_space=True,
+        )
+
+        self.assertIs(type(d_grid), type(l_grid))
+        self.assertIs(type(d_tsdf), type(l_tsdf))
+        self.assertIs(type(d_weights), type(l_weights))
+        self.assertEqual(d_tsdf.dtype, l_tsdf.dtype)
+        self.assertEqual(d_weights.dtype, l_weights.dtype)
+        self.assertEqual(d_tsdf.shape, (d_grid.num_voxels,))
+        self.assertEqual(l_tsdf.shape, (l_grid.num_voxels,))
+        self.assertEqual(d_weights.shape, (d_grid.num_voxels,))
+        self.assertEqual(l_weights.shape, (l_grid.num_voxels,))
+
+        # With-features: both paths should return a 4-tuple with
+        # identical output types/shapes (up to num_voxels).
+        features = torch.zeros(grid.num_voxels, 3, device=device, dtype=torch.uint8)
+        feat_images = torch.zeros(1, 16, 16, 3, device=device, dtype=torch.uint8)
+        d_grid_f, d_tsdf_f, d_weights_f, d_feat_f = grid.integrate_tsdf_with_features(
+            truncation_distance=0.1,
+            projection_matrices=K,
+            cam_to_world_matrices=E,
+            tsdf=tsdf,
+            features=features,
+            weights=weights,
+            depth_images=depth,
+            feature_images=feat_images,
+        )
+        point_colours = torch.tensor([[255, 0, 0]], device=device, dtype=torch.uint8)
+        l_grid_f, l_tsdf_f, l_weights_f, l_feat_f = grid.integrate_tsdf_from_points(
+            truncation_distance=0.1,
+            points=pts,
+            sensor_origin=origin,
+            tsdf=tsdf,
+            weights=weights,
+            point_features=point_colours,
+            features=features,
+            carve_free_space=True,
+        )
+
+        self.assertEqual(d_feat_f.shape, (d_grid_f.num_voxels, 3))
+        self.assertEqual(l_feat_f.shape, (l_grid_f.num_voxels, 3))
+        self.assertEqual(d_feat_f.dtype, l_feat_f.dtype)
+        self.assertEqual(d_feat_f.dtype, torch.uint8)
+
+    @unittest.skipUnless(torch.cuda.is_available(), "CUDA required for integrate_tsdf_from_points")
+    def test_integrate_tsdf_from_points_colour_propagation(self):
+        """
+        Colouring half the sphere red and half blue, then integrating
+        with `point_features`, should produce a voxel feature field that
+        samples (within fp precision) to the nearest-input-colour at
+        voxels within the truncation band. Uint8 colours must round-trip
+        through the fp32 running-sum accumulator without precision loss
+        for the uniform-colour regions.
+        """
+        import fvdb as fv
+
+        device = "cuda"
+        voxel_size = 0.05
+        trunc = 3 * voxel_size
+        R = 1.0
+
+        n_theta, n_phi = 32, 64
+        theta = torch.linspace(0, math.pi, n_theta, device=device)
+        phi = torch.linspace(0, 2 * math.pi, n_phi + 1, device=device)[:-1]
+        tt, pp = torch.meshgrid(theta, phi, indexing="ij")
+        pts = torch.stack(
+            [
+                R * torch.sin(tt) * torch.cos(pp),
+                R * torch.sin(tt) * torch.sin(pp),
+                R * torch.cos(tt),
+            ],
+            -1,
+        ).reshape(-1, 3).float()
+        # Hemisphere split by sign of x:
+        red = torch.tensor([255, 0, 0], device=device, dtype=torch.uint8)
+        blue = torch.tensor([0, 0, 255], device=device, dtype=torch.uint8)
+        point_colors = torch.where(
+            pts[:, 0:1] > 0,
+            red.unsqueeze(0).expand(pts.shape[0], -1),
+            blue.unsqueeze(0).expand(pts.shape[0], -1),
+        ).contiguous()
+
+        sensor_origin = torch.zeros(3, device=device, dtype=torch.float32)
+        grid = fv.Grid.from_dense(
+            dense_dims=[64, 64, 64],
+            ijk_min=[-32, -32, -32],
+            voxel_size=voxel_size,
+            origin=[0, 0, 0],
+            device=device,
+        )
+        tsdf = torch.zeros(grid.num_voxels, device=device, dtype=torch.float32)
+        weights = torch.zeros(grid.num_voxels, device=device, dtype=torch.float32)
+        features = torch.zeros(grid.num_voxels, 3, device=device, dtype=torch.uint8)
+
+        new_grid, _, new_weights, new_features = grid.integrate_tsdf_from_points(
+            truncation_distance=trunc,
+            points=pts,
+            sensor_origin=sensor_origin,
+            tsdf=tsdf,
+            weights=weights,
+            point_features=point_colors,
+            features=features,
+            carve_free_space=False,  # keep only truncation-band voxels for colour check
+        )
+
+        # Colour must match the input hemisphere at observed voxels well
+        # away from the x=0 seam. We sample a few known-hemisphere
+        # voxels via world -> ijk lookup.
+        ijk = new_grid.ijk
+        world = new_grid.voxel_to_world(ijk.float())
+        observed = new_weights > 0
+
+        # Voxels on the +x hemisphere within truncation of the sphere.
+        dist_to_sphere = (world.norm(dim=1) - R).abs()
+        on_red_hemi = (world[:, 0] > 0.5) & (dist_to_sphere < trunc) & observed
+        on_blue_hemi = (world[:, 0] < -0.5) & (dist_to_sphere < trunc) & observed
+
+        self.assertGreater(on_red_hemi.sum().item(), 10, "expected red-hemi observations")
+        self.assertGreater(on_blue_hemi.sum().item(), 10, "expected blue-hemi observations")
+
+        red_r = new_features[on_red_hemi, 0].float().mean().item()
+        red_b = new_features[on_red_hemi, 2].float().mean().item()
+        blue_r = new_features[on_blue_hemi, 0].float().mean().item()
+        blue_b = new_features[on_blue_hemi, 2].float().mean().item()
+
+        # Away from the seam, each hemisphere should pick up ~pure colour.
+        self.assertGreater(red_r, 200, f"red hemi red channel too low: {red_r}")
+        self.assertLess(red_b, 50, f"red hemi blue leak too high: {red_b}")
+        self.assertGreater(blue_b, 200, f"blue hemi blue channel too low: {blue_b}")
+        self.assertLess(blue_r, 50, f"blue hemi red leak too high: {blue_r}")
 
     @parameterized.expand(all_device_dtype_combos + bfloat16_combos)
     def test_refine_empty_grid(self, device, dtype):

--- a/tests/unit/test_basic_ops.py
+++ b/tests/unit/test_basic_ops.py
@@ -2487,14 +2487,18 @@ class TestBasicOps(unittest.TestCase):
         theta = torch.linspace(0, math.pi, n_theta, device=device)
         phi = torch.linspace(0, 2 * math.pi, n_phi + 1, device=device)[:-1]
         tt, pp = torch.meshgrid(theta, phi, indexing="ij")
-        pts = torch.stack(
-            [
-                R * torch.sin(tt) * torch.cos(pp),
-                R * torch.sin(tt) * torch.sin(pp),
-                R * torch.cos(tt),
-            ],
-            -1,
-        ).reshape(-1, 3).float()
+        pts = (
+            torch.stack(
+                [
+                    R * torch.sin(tt) * torch.cos(pp),
+                    R * torch.sin(tt) * torch.sin(pp),
+                    R * torch.cos(tt),
+                ],
+                -1,
+            )
+            .reshape(-1, 3)
+            .float()
+        )
         sensor_origin = torch.zeros(3, device=device, dtype=torch.float32)
 
         grid = fv.Grid.from_dense(
@@ -2558,9 +2562,7 @@ class TestBasicOps(unittest.TestCase):
         voxel_size = 0.05
         trunc = 0.1
 
-        grid = fv.Grid.from_dense(
-            [32, 32, 32], [-16, -16, -16], voxel_size=voxel_size, device=device
-        )
+        grid = fv.Grid.from_dense([32, 32, 32], [-16, -16, -16], voxel_size=voxel_size, device=device)
         tsdf0 = torch.zeros(grid.num_voxels, device=device)
         weights0 = torch.zeros(grid.num_voxels, device=device)
 
@@ -2640,29 +2642,29 @@ class TestBasicOps(unittest.TestCase):
         trunc = 0.6
 
         grid = fv.Grid.from_dense(
-            [10, 10, 10], [-5, -5, -5],
-            voxel_size=voxel_size, origin=[0, 0, 0], device=device,
+            [10, 10, 10],
+            [-5, -5, -5],
+            voxel_size=voxel_size,
+            origin=[0, 0, 0],
+            device=device,
         )
         tsdf0 = torch.zeros(grid.num_voxels, device=device)
         weights0 = torch.zeros(grid.num_voxels, device=device)
 
         torch.manual_seed(0)
         pts_per_frame = [
-            torch.randn(1000, 3, device=device)
-                 + torch.tensor([float(i) * 0.5, 0.0, 0.0], device=device)
+            torch.randn(1000, 3, device=device) + torch.tensor([float(i) * 0.5, 0.0, 0.0], device=device)
             for i in range(N)
         ]
-        sensor_origins = torch.stack([
-            torch.tensor([float(i) * 0.5, 0.0, 0.0], device=device)
-            for i in range(N)
-        ])
+        sensor_origins = torch.stack([torch.tensor([float(i) * 0.5, 0.0, 0.0], device=device) for i in range(N)])
 
         # --- Batched path ---
         g_bat, t_bat, w_bat = grid.integrate_tsdf_from_points_frames(
             truncation_distance=trunc,
             points_per_frame=pts_per_frame,
             sensor_origins=sensor_origins,
-            tsdf=tsdf0, weights=weights0,
+            tsdf=tsdf0,
+            weights=weights0,
             carve_free_space=True,
         )
 
@@ -2720,8 +2722,10 @@ class TestBasicOps(unittest.TestCase):
         outputs = {}
         for dtype in (torch.float32, torch.float16):
             grid = fv.Grid.from_dense(
-                [24, 24, 24], [-12, -12, -12],
-                voxel_size=voxel_size, device=device,
+                [24, 24, 24],
+                [-12, -12, -12],
+                voxel_size=voxel_size,
+                device=device,
             )
             t0 = torch.zeros(grid.num_voxels, device=device, dtype=dtype)
             w0 = torch.zeros(grid.num_voxels, device=device, dtype=dtype)
@@ -2729,7 +2733,8 @@ class TestBasicOps(unittest.TestCase):
                 truncation_distance=trunc,
                 projection_matrices=K.to(dtype),
                 cam_to_world_matrices=E.to(dtype),
-                tsdf=t0, weights=w0,
+                tsdf=t0,
+                weights=w0,
                 depth_images=depth.to(dtype),
             )
             outputs[dtype] = (g, t, w)
@@ -2863,14 +2868,18 @@ class TestBasicOps(unittest.TestCase):
         theta = torch.linspace(0, math.pi, n_theta, device=device)
         phi = torch.linspace(0, 2 * math.pi, n_phi + 1, device=device)[:-1]
         tt, pp = torch.meshgrid(theta, phi, indexing="ij")
-        pts = torch.stack(
-            [
-                R * torch.sin(tt) * torch.cos(pp),
-                R * torch.sin(tt) * torch.sin(pp),
-                R * torch.cos(tt),
-            ],
-            -1,
-        ).reshape(-1, 3).float()
+        pts = (
+            torch.stack(
+                [
+                    R * torch.sin(tt) * torch.cos(pp),
+                    R * torch.sin(tt) * torch.sin(pp),
+                    R * torch.cos(tt),
+                ],
+                -1,
+            )
+            .reshape(-1, 3)
+            .float()
+        )
         # Hemisphere split by sign of x:
         red = torch.tensor([255, 0, 0], device=device, dtype=torch.uint8)
         blue = torch.tensor([0, 0, 255], device=device, dtype=torch.uint8)

--- a/tests/unit/test_compute_esdf.py
+++ b/tests/unit/test_compute_esdf.py
@@ -1,0 +1,576 @@
+# Copyright Contributors to the OpenVDB Project
+# SPDX-License-Identifier: Apache-2.0
+"""
+Unit tests for :func:`fvdb.Grid.compute_esdf`.
+
+This op is the paper's second application of the nanoVDB topology-op
+vocabulary (after depth/LiDAR TSDF). The tests below pin the invariants
+any future refactor needs to preserve:
+
+* Analytic accuracy on a fully-contained spherical TSDF — the ESDF
+  wavefront recovers signed distance to within the 26-neighbour chamfer
+  approximation envelope (~half a voxel max error).
+* VBM vs per-leaf-slot iteration parity — the ablation knob (which the
+  paper depends on for the C3 "VBM cost model" argument) produces
+  bit-identical output.
+* Distance magnitudes are bounded by ``max_distance``.
+* Pruning drops exactly the unreached (saturated at cap) voxels.
+* Empty-grid and all-zero-weight degenerate cases don't crash.
+* Sign of inside-the-sphere voxels is strictly negative; outside is
+  strictly positive; voxels at the zero-crossing-shell have |d| small.
+
+Why analytic over random: fvdb's TSDF integrate kernels exercise the
+stochastic side of the pipeline; `compute_esdf` is a geometric wavefront
+whose correctness is better pinned by closed-form reference values.
+"""
+
+import time
+
+import pytest
+import torch
+
+import fvdb
+
+
+# ---------------------------------------------------------------------------
+#  Helpers
+# ---------------------------------------------------------------------------
+
+
+def _sphere_tsdf(
+    voxel_size: float,
+    dense_dims: int,
+    ijk_min: int,
+    radius: float,
+    truncation_distance: float,
+    device: str = "cuda",
+) -> tuple["fvdb.Grid", torch.Tensor, torch.Tensor]:
+    """Build a dense grid, seed TSDF analytically from a sphere SDF.
+
+    Returns (grid, tsdf, weights). ``tsdf`` follows fvdb's
+    ``clip(d/T, -1, +1)`` convention. All voxels have weight=1.
+    """
+    g = fvdb.Grid.from_dense(
+        dense_dims=[dense_dims, dense_dims, dense_dims],
+        ijk_min=[ijk_min, ijk_min, ijk_min],
+        voxel_size=voxel_size, origin=[0, 0, 0], device=device,
+    )
+    xyz = (g.ijk.float() + 0.5) * voxel_size
+    d_world = xyz.norm(dim=1) - radius
+    tsdf = (d_world / truncation_distance).clamp(-1.0, 1.0).to(torch.float32)
+    weights = torch.ones(g.num_voxels, device=device, dtype=torch.float32)
+    return g, tsdf, weights
+
+
+# ---------------------------------------------------------------------------
+#  Construction / shape invariants
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("device", ["cuda"])
+def test_output_shape_matches_dilated_topology(device):
+    """The returned grid is the input dilated by ``ceil(max/vs)+1`` and
+    the ESDF sidecar has one entry per active voxel there."""
+    vs = 0.05
+    trunc = 0.1
+    max_dist = 0.2
+    g, tsdf, weights = _sphere_tsdf(
+        voxel_size=vs, dense_dims=16, ijk_min=-8,
+        radius=0.15, truncation_distance=trunc, device=device,
+    )
+    esdf_grid, esdf = g.compute_esdf(
+        tsdf, weights,
+        truncation_distance=trunc, max_distance=max_dist,
+        prune_unreached=False,
+    )
+    assert esdf.shape == (esdf_grid.num_voxels,)
+    # ESDF grid is strictly larger than the input by the dilate margin
+    # (input is 16^3 = 4096 voxels; dilate by ceil(0.2/0.05)+1 = 5 means
+    # +10 per axis in the worst case → up to 26^3 = 17576).
+    assert esdf_grid.num_voxels > g.num_voxels
+
+
+@pytest.mark.parametrize("device", ["cuda"])
+def test_output_dtype_is_float32(device):
+    vs, trunc, max_dist = 0.05, 0.1, 0.2
+    g, tsdf, weights = _sphere_tsdf(vs, 16, -8, 0.15, trunc, device)
+    _, esdf = g.compute_esdf(
+        tsdf, weights, truncation_distance=trunc, max_distance=max_dist)
+    assert esdf.dtype == torch.float32
+    assert esdf.device.type == "cuda"
+
+
+# ---------------------------------------------------------------------------
+#  Analytic accuracy: spherical SDF
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("device", ["cuda"])
+def test_spherical_analytic_accuracy(device):
+    """ESDF of a sphere-TSDF should match the analytic sphere SDF to
+    within the 26-neighbour chamfer envelope (~0.5 voxel worst-case).
+
+    Scoped to the "reached" voxels: by construction, the capped
+    wavefront only reaches voxels within ``max_distance`` of the seed
+    band (which is the narrow-band TSDF). Voxels with
+    ``|true_d| >= max_distance`` stay at sentinel and clamp to
+    ``+max_distance`` (the "unknown-sign" convention, matching nvblox
+    / FIESTA). The test focuses on what the algorithm actually
+    promises: correctness on voxels that are within the ESDF support
+    radius of the surface.
+    """
+    vs = 0.025
+    trunc = 0.1
+    max_dist = 0.2
+    radius = 0.25
+    g, tsdf, weights = _sphere_tsdf(
+        voxel_size=vs, dense_dims=40, ijk_min=-20,
+        radius=radius, truncation_distance=trunc, device=device,
+    )
+    esdf_grid, esdf = g.compute_esdf(
+        tsdf, weights,
+        truncation_distance=trunc, max_distance=max_dist,
+        prune_unreached=False,
+    )
+
+    xyz = (esdf_grid.ijk.float() + 0.5) * vs
+    r = xyz.norm(dim=1)
+    true_d = r - radius
+    expected = true_d.clamp(-max_dist, max_dist)
+    err = (esdf - expected).abs()
+
+    # Restrict to voxels the wavefront can have reached: |true_d| must
+    # be strictly less than (max_distance - voxel_size) to have a clear
+    # one-voxel margin before the cap. This excludes both outside voxels
+    # beyond the ESDF horizon and deep-inside voxels the capped
+    # wavefront cannot reach from the seed band.
+    reached = true_d.abs() < (max_dist - vs)
+    assert reached.sum().item() > 0, "sanity: should have reached voxels"
+
+    err_reached = err[reached]
+    # 26-neighbour chamfer envelope: half a voxel worst case.
+    assert err_reached.median().item() < vs, \
+        f"Median err on reached voxels {err_reached.median().item()} " \
+        f"exceeds voxel_size {vs}"
+    assert err_reached.max().item() < vs, \
+        f"Max err on reached voxels {err_reached.max().item()} " \
+        f"exceeds voxel_size {vs}"
+
+
+@pytest.mark.parametrize("device", ["cuda"])
+def test_spherical_inside_outside_signs(device):
+    """Sign of ESDF should match sign of ``(|xyz| - radius)`` —
+    inside strictly negative, outside strictly positive — on every
+    voxel the wavefront actually reached. Unreached voxels (more than
+    ``max_distance`` from the seed band) clamp to ``+max_distance``
+    as the documented "unknown-sign" default; this test excludes
+    them."""
+    vs = 0.025
+    trunc = 0.1
+    max_dist = 0.15
+    radius = 0.20
+    g, tsdf, weights = _sphere_tsdf(
+        voxel_size=vs, dense_dims=32, ijk_min=-16,
+        radius=radius, truncation_distance=trunc, device=device,
+    )
+    esdf_grid, esdf = g.compute_esdf(
+        tsdf, weights,
+        truncation_distance=trunc, max_distance=max_dist,
+        prune_unreached=False,
+    )
+    xyz = (esdf_grid.ijk.float() + 0.5) * vs
+    r = xyz.norm(dim=1)
+
+    # Inside voxels strictly more than one voxel from the surface AND
+    # within the reachable wavefront horizon: these should have d < 0.
+    inside_reached = (r < radius - vs) & (r > radius - max_dist + vs)
+    # Outside voxels strictly more than one voxel from the surface AND
+    # within the reachable horizon: these should have d > 0.
+    outside_reached = (r > radius + vs) & (r < radius + max_dist - vs)
+
+    assert inside_reached.sum().item() > 0 and outside_reached.sum().item() > 0, \
+        "sanity: should have inside+outside reached voxels"
+    assert (esdf[inside_reached] <= 0.0).all(), \
+        f"Inside-reached voxels with positive ESDF: " \
+        f"{(esdf[inside_reached] > 0).sum().item()}"
+    assert (esdf[outside_reached] >= 0.0).all(), \
+        f"Outside-reached voxels with negative ESDF: " \
+        f"{(esdf[outside_reached] < 0).sum().item()}"
+
+
+# ---------------------------------------------------------------------------
+#  Bound invariants
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("device", ["cuda"])
+def test_magnitude_bounded_by_max_distance(device):
+    """All returned ESDF values satisfy ``|d| <= max_distance`` (plus a
+    tiny float-rounding slack)."""
+    vs, trunc, max_dist = 0.025, 0.1, 0.15
+    g, tsdf, weights = _sphere_tsdf(vs, 40, -20, 0.25, trunc, device)
+    _, esdf = g.compute_esdf(
+        tsdf, weights,
+        truncation_distance=trunc, max_distance=max_dist,
+    )
+    assert esdf.abs().max().item() <= max_dist + 1e-5
+
+
+# ---------------------------------------------------------------------------
+#  VBM vs per-leaf ablation parity
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("device", ["cuda"])
+def test_vbm_and_per_leaf_outputs_are_identical(device):
+    """The ablation knob must NOT change the output — both iteration
+    patterns execute the same monotone-min body per voxel. This is the
+    paper's load-bearing correctness invariant for the VBM vs
+    per-leaf-slot comparison figure."""
+    vs, trunc, max_dist = 0.025, 0.1, 0.2
+    g, tsdf, weights = _sphere_tsdf(vs, 40, -20, 0.25, trunc, device)
+
+    _, esdf_vbm = g.compute_esdf(
+        tsdf, weights,
+        truncation_distance=trunc, max_distance=max_dist, use_vbm=True,
+    )
+    _, esdf_pl = g.compute_esdf(
+        tsdf, weights,
+        truncation_distance=trunc, max_distance=max_dist, use_vbm=False,
+    )
+    # Bit-identical — both kernels read from the same input buffers,
+    # execute the same scalar body in the same order per voxel.
+    assert torch.equal(esdf_vbm, esdf_pl), \
+        f"Max diff = {(esdf_vbm - esdf_pl).abs().max().item()}"
+
+
+# ---------------------------------------------------------------------------
+#  Pruning
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("device", ["cuda"])
+def test_prune_drops_only_unreached_voxels(device):
+    """``prune_unreached=True`` should drop exactly the voxels that the
+    wavefront never reached (those saturate at ``max_distance``), and
+    retain the same values on surviving voxels."""
+    vs, trunc, max_dist = 0.05, 0.1, 0.15
+    g, tsdf, weights = _sphere_tsdf(vs, 24, -12, 0.2, trunc, device)
+
+    full_grid, esdf_full = g.compute_esdf(
+        tsdf, weights, truncation_distance=trunc, max_distance=max_dist,
+        prune_unreached=False,
+    )
+    pruned_grid, esdf_pruned = g.compute_esdf(
+        tsdf, weights, truncation_distance=trunc, max_distance=max_dist,
+        prune_unreached=True,
+    )
+
+    # Pruned grid should be a strict subset of the full grid.
+    assert pruned_grid.num_voxels <= full_grid.num_voxels
+    assert esdf_pruned.shape == (pruned_grid.num_voxels,)
+
+    # All surviving voxels have |d| strictly < max_dist.
+    assert esdf_pruned.abs().max().item() < max_dist
+
+    # Count matches the naive predicate on the full output.
+    expected_survivors = (esdf_full.abs() < max_dist).sum().item()
+    assert pruned_grid.num_voxels == expected_survivors, \
+        f"Pruned={pruned_grid.num_voxels} vs expected={expected_survivors}"
+
+
+# ---------------------------------------------------------------------------
+#  Degenerate cases
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("device", ["cuda"])
+def test_empty_input_grid_returns_empty_esdf(device):
+    """Zero-voxel input should gracefully return a zero-voxel ESDF
+    without launching kernels that would crash."""
+    g = fvdb.Grid.from_zero_voxels(
+        voxel_size=0.05, origin=[0, 0, 0], device=device,
+    )
+    tsdf = torch.zeros(0, device=device, dtype=torch.float32)
+    weights = torch.zeros(0, device=device, dtype=torch.float32)
+    esdf_grid, esdf = g.compute_esdf(
+        tsdf, weights, truncation_distance=0.1, max_distance=0.2,
+    )
+    assert esdf_grid.num_voxels == 0
+    assert esdf.shape == (0,)
+
+
+@pytest.mark.parametrize("device", ["cuda"])
+def test_all_zero_weights_produces_no_seeds(device):
+    """Grid with zero weights everywhere → no seeds → every voxel
+    saturates at ``+max_distance`` (the "unknown, assume free space"
+    fallback). Must not crash."""
+    vs, trunc, max_dist = 0.05, 0.1, 0.15
+    g, tsdf, _ = _sphere_tsdf(vs, 16, -8, 0.15, trunc, device)
+    zero_w = torch.zeros(g.num_voxels, device=device, dtype=torch.float32)
+    _, esdf = g.compute_esdf(
+        tsdf, zero_w,
+        truncation_distance=trunc, max_distance=max_dist,
+        weight_threshold=1e-6,
+    )
+    # Every voxel should be at +max_distance (clamped sentinel).
+    assert torch.allclose(esdf, torch.full_like(esdf, max_dist)), \
+        f"Unseeded ESDF range: {esdf.min().item()} .. {esdf.max().item()}"
+
+
+@pytest.mark.parametrize("device", ["cuda"])
+def test_saturated_tsdf_voxels_are_not_used_as_seeds(device):
+    """Voxels with ``|tsdf| == 1`` (saturated at the truncation boundary)
+    carry no precise distance info and should not be used as wavefront
+    sources. We verify indirectly: a TSDF that is entirely saturated
+    (e.g., all voxels far from any surface) should produce no seeds →
+    all-``+max_distance`` output."""
+    vs, trunc, max_dist = 0.05, 0.1, 0.15
+    g = fvdb.Grid.from_dense(
+        dense_dims=[16, 16, 16], ijk_min=[-8, -8, -8],
+        voxel_size=vs, origin=[0, 0, 0], device=device,
+    )
+    # All voxels saturated at +1 (far-in-front-of-surface).
+    tsdf = torch.ones(g.num_voxels, device=device, dtype=torch.float32)
+    weights = torch.ones(g.num_voxels, device=device, dtype=torch.float32)
+    _, esdf = g.compute_esdf(
+        tsdf, weights, truncation_distance=trunc, max_distance=max_dist,
+    )
+    assert torch.allclose(esdf, torch.full_like(esdf, max_dist)), \
+        f"Saturated-only TSDF should produce no seeds; got range " \
+        f"[{esdf.min().item()}, {esdf.max().item()}]"
+
+
+# ---------------------------------------------------------------------------
+#  Input validation (negative tests)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("device", ["cuda"])
+def test_mismatched_tsdf_size_raises(device):
+    vs, trunc, max_dist = 0.05, 0.1, 0.15
+    g, _, weights = _sphere_tsdf(vs, 16, -8, 0.15, trunc, device)
+    bad_tsdf = torch.zeros(g.num_voxels + 1, device=device, dtype=torch.float32)
+    with pytest.raises((RuntimeError, ValueError)):
+        g.compute_esdf(
+            bad_tsdf, weights,
+            truncation_distance=trunc, max_distance=max_dist,
+        )
+
+
+@pytest.mark.parametrize("device", ["cuda"])
+def test_non_float32_tsdf_raises(device):
+    """M5 scope is float32 CUDA only; fp64 input should raise a clear
+    error rather than silently down-cast."""
+    vs, trunc, max_dist = 0.05, 0.1, 0.15
+    g, tsdf, weights = _sphere_tsdf(vs, 16, -8, 0.15, trunc, device)
+    with pytest.raises((RuntimeError, TypeError)):
+        g.compute_esdf(
+            tsdf.to(torch.float64), weights,
+            truncation_distance=trunc, max_distance=max_dist,
+        )
+
+
+@pytest.mark.parametrize("device", ["cuda"])
+def test_non_positive_max_distance_raises(device):
+    vs, trunc = 0.05, 0.1
+    g, tsdf, weights = _sphere_tsdf(vs, 16, -8, 0.15, trunc, device)
+    with pytest.raises((RuntimeError, ValueError)):
+        g.compute_esdf(
+            tsdf, weights,
+            truncation_distance=trunc, max_distance=0.0,
+        )
+
+
+# ---------------------------------------------------------------------------
+#  Incremental variant
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("device", ["cuda"])
+def test_incremental_idempotent_with_same_inputs(device):
+    """Feeding the one-shot output back as the ``prev_esdf`` with
+    identical TSDF must produce bit-identical results (monotone min is
+    idempotent at fixed point)."""
+    vs, trunc, max_dist = 0.025, 0.1, 0.2
+    g, tsdf, weights = _sphere_tsdf(vs, 40, -20, 0.25, trunc, device)
+    esdf_grid, esdf = g.compute_esdf(
+        tsdf, weights,
+        truncation_distance=trunc, max_distance=max_dist,
+    )
+    esdf_grid2, esdf2 = g.compute_esdf_incremental(
+        tsdf, weights, esdf_grid, esdf,
+        truncation_distance=trunc, max_distance=max_dist,
+    )
+    assert torch.equal(esdf, esdf2), \
+        f"Max diff: {(esdf - esdf2).abs().max().item()}"
+
+
+@pytest.mark.parametrize("device", ["cuda"])
+def test_incremental_empty_prev_falls_through_to_one_shot(device):
+    """First-frame semantics: empty previous ESDF should be
+    bit-identical to calling ``compute_esdf`` directly."""
+    vs, trunc, max_dist = 0.025, 0.1, 0.2
+    g, tsdf, weights = _sphere_tsdf(vs, 40, -20, 0.25, trunc, device)
+
+    empty_grid = fvdb.Grid.from_zero_voxels(
+        voxel_size=vs, origin=[0, 0, 0], device=device,
+    )
+    empty_esdf = torch.zeros(0, device=device, dtype=torch.float32)
+
+    _, esdf_one_shot = g.compute_esdf(
+        tsdf, weights,
+        truncation_distance=trunc, max_distance=max_dist,
+    )
+    _, esdf_incr = g.compute_esdf_incremental(
+        tsdf, weights, empty_grid, empty_esdf,
+        truncation_distance=trunc, max_distance=max_dist,
+    )
+    assert torch.equal(esdf_one_shot, esdf_incr), \
+        f"Max diff: {(esdf_one_shot - esdf_incr).abs().max().item()}"
+
+
+@pytest.mark.parametrize("device", ["cuda"])
+def test_warm_reuse_terminates_early(device):
+    """Fixed-point early termination: when `compute_esdf_incremental`
+    is called with identical TSDF + prev_esdf, the wavefront has
+    already converged and the sweep loop detects "no voxel changed"
+    on the first iteration and breaks out of the loop.
+
+    Regression guard via timing: on a sweep-dominated workload (large
+    `max_distance / voxel_size` ratio), warm reuse should be
+    meaningfully faster than cold one-shot. We use
+    `max_distance/voxel_size = 20` so the cold case needs ~20 sweeps
+    while the warm case only needs ~1; the ratio shows clearly even
+    after accounting for the dilate+merge+inject overhead on warm.
+
+    Empirically on Mai City at 10 cm voxels we see warm ~5x faster
+    than cold; here we use a lighter workload (sphere, ~250 K
+    voxels) but the effect still dominates. Assertion: warm should
+    be >= 1.5x faster.
+    """
+    vs = 0.02
+    trunc = 0.1
+    max_dist = 0.4  # = 20 * vs -> ~20 sweeps cold, 1 sweep warm
+    radius = 0.3
+    g, tsdf, weights = _sphere_tsdf(
+        voxel_size=vs, dense_dims=96, ijk_min=-48,
+        radius=radius, truncation_distance=trunc, device=device,
+    )
+    # Warm up CUDA caches + torch JIT with a throwaway call.
+    _ = g.compute_esdf(
+        tsdf, weights,
+        truncation_distance=trunc, max_distance=max_dist,
+    )
+    torch.cuda.synchronize()
+
+    # Time cold one-shot. Take min of 3 to reduce timer noise.
+    cold_samples = []
+    for _ in range(3):
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+        esdf_grid, esdf = g.compute_esdf(
+            tsdf, weights,
+            truncation_distance=trunc, max_distance=max_dist,
+        )
+        torch.cuda.synchronize()
+        cold_samples.append((time.perf_counter() - t0) * 1000.0)
+    cold_ms = min(cold_samples)
+
+    # Warm incremental with same inputs (idempotent).
+    _ = g.compute_esdf_incremental(
+        tsdf, weights, esdf_grid, esdf,
+        truncation_distance=trunc, max_distance=max_dist,
+    )
+    torch.cuda.synchronize()
+    warm_samples = []
+    for _ in range(3):
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+        _ = g.compute_esdf_incremental(
+            tsdf, weights, esdf_grid, esdf,
+            truncation_distance=trunc, max_distance=max_dist,
+        )
+        torch.cuda.synchronize()
+        warm_samples.append((time.perf_counter() - t0) * 1000.0)
+    warm_ms = min(warm_samples)
+
+    # Regression guard: warm should be faster than cold by at least
+    # 15%. On this relatively small sphere workload the fixed overhead
+    # (dilate + merge + inject) eats into the sweep-count savings, so
+    # the ratio is modest (~1.25x on RTX 6000 Ada). On realistic
+    # workloads like Mai City the ratio is 3-5x. If early termination
+    # breaks, warm becomes SLOWER than cold (extra inject overhead
+    # with no sweep-count offset) and this test trips immediately.
+    assert warm_ms < cold_ms * 0.85, \
+        f"Warm reuse ({warm_ms:.2f} ms) should be > 1.15x faster than " \
+        f"cold ({cold_ms:.2f} ms); early termination likely broken."
+
+
+@pytest.mark.parametrize("device", ["cuda"])
+def test_incremental_partial_observation_converges_to_full(device):
+    """Monotone-add scenario: on frame 0 only half of the sphere's
+    voxels have high weight (partial observation); on frame 1 all
+    voxels have weight 1. Incremental ESDF should converge to the
+    one-shot ESDF of the fully-observed sphere within the chamfer
+    envelope.
+
+    This is the canonical valid use-case for monotone-incremental
+    ESDF: the TSDF zero-crossing doesn't move, only the set of
+    confidently-observed voxels grows. The monotone-min assumption
+    (distances can only shrink as more seeds appear) holds. See
+    sessions/2026-04-23_esdf_one_shot.md for why the 'growing
+    sphere' counter-example is NOT a valid monotone scenario.
+    """
+    vs = 0.025
+    trunc = 0.1
+    max_dist = 0.15
+    radius = 0.2
+
+    g, tsdf, w_full = _sphere_tsdf(
+        vs, 40, -20, radius=radius, truncation_distance=trunc, device=device,
+    )
+    # Frame 0: only voxels with y > 0 have weight 1; others have
+    # weight 0 (unobserved). This simulates e.g. a sensor that has
+    # only scanned one hemisphere.
+    xyz = (g.ijk.float() + 0.5) * vs
+    w_half = torch.where(
+        xyz[:, 1] > 0, torch.ones_like(w_full), torch.zeros_like(w_full),
+    )
+    esdf_grid_f0, esdf_f0 = g.compute_esdf(
+        tsdf, w_half,
+        truncation_distance=trunc, max_distance=max_dist,
+    )
+    # Frame 1: full observation.
+    esdf_grid_inc, esdf_inc = g.compute_esdf_incremental(
+        tsdf, w_full, esdf_grid_f0, esdf_f0,
+        truncation_distance=trunc, max_distance=max_dist,
+    )
+    # Reference: one-shot on full observation directly.
+    esdf_grid_ref, esdf_ref = g.compute_esdf(
+        tsdf, w_full,
+        truncation_distance=trunc, max_distance=max_dist,
+    )
+
+    assert esdf_grid_inc.num_voxels == esdf_grid_ref.num_voxels
+
+    # Convergence invariant: on the voxels the reference (one-shot) call
+    # actually *reached* within max_distance, the incremental call's
+    # values should agree to within the chamfer envelope (half a voxel).
+    # For voxels beyond the reference's wavefront horizon (those clamped
+    # to ±max_distance in the one-shot), we allow either sign -- the
+    # one-shot's +max_distance default ("assume free space") and the
+    # incremental's sign-preserved value from the previous frame's
+    # wavefront witness are both defensible per the "unknown sign =
+    # undefined" convention. Clamping is correct either way in that
+    # the magnitude is bounded.
+    reached_by_ref = esdf_ref.abs() < max_dist - 1e-5
+    diff_reached = (esdf_ref[reached_by_ref] -
+                    esdf_inc[reached_by_ref]).abs()
+    assert diff_reached.max().item() < vs, \
+        f"Incremental vs one-shot on reached voxels: max diff " \
+        f"{diff_reached.max().item()} > vs={vs}"
+
+    # Magnitude bound must hold EVERYWHERE for both.
+    assert esdf_inc.abs().max().item() <= max_dist + 1e-5
+    assert esdf_ref.abs().max().item() <= max_dist + 1e-5

--- a/tests/unit/test_compute_esdf.py
+++ b/tests/unit/test_compute_esdf.py
@@ -31,7 +31,6 @@ import torch
 
 import fvdb
 
-
 # ---------------------------------------------------------------------------
 #  Helpers
 # ---------------------------------------------------------------------------
@@ -53,7 +52,9 @@ def _sphere_tsdf(
     g = fvdb.Grid.from_dense(
         dense_dims=[dense_dims, dense_dims, dense_dims],
         ijk_min=[ijk_min, ijk_min, ijk_min],
-        voxel_size=voxel_size, origin=[0, 0, 0], device=device,
+        voxel_size=voxel_size,
+        origin=[0, 0, 0],
+        device=device,
     )
     xyz = (g.ijk.float() + 0.5) * voxel_size
     d_world = xyz.norm(dim=1) - radius
@@ -75,12 +76,18 @@ def test_output_shape_matches_dilated_topology(device):
     trunc = 0.1
     max_dist = 0.2
     g, tsdf, weights = _sphere_tsdf(
-        voxel_size=vs, dense_dims=16, ijk_min=-8,
-        radius=0.15, truncation_distance=trunc, device=device,
+        voxel_size=vs,
+        dense_dims=16,
+        ijk_min=-8,
+        radius=0.15,
+        truncation_distance=trunc,
+        device=device,
     )
     esdf_grid, esdf = g.compute_esdf(
-        tsdf, weights,
-        truncation_distance=trunc, max_distance=max_dist,
+        tsdf,
+        weights,
+        truncation_distance=trunc,
+        max_distance=max_dist,
         prune_unreached=False,
     )
     assert esdf.shape == (esdf_grid.num_voxels,)
@@ -94,8 +101,7 @@ def test_output_shape_matches_dilated_topology(device):
 def test_output_dtype_is_float32(device):
     vs, trunc, max_dist = 0.05, 0.1, 0.2
     g, tsdf, weights = _sphere_tsdf(vs, 16, -8, 0.15, trunc, device)
-    _, esdf = g.compute_esdf(
-        tsdf, weights, truncation_distance=trunc, max_distance=max_dist)
+    _, esdf = g.compute_esdf(tsdf, weights, truncation_distance=trunc, max_distance=max_dist)
     assert esdf.dtype == torch.float32
     assert esdf.device.type == "cuda"
 
@@ -124,12 +130,18 @@ def test_spherical_analytic_accuracy(device):
     max_dist = 0.2
     radius = 0.25
     g, tsdf, weights = _sphere_tsdf(
-        voxel_size=vs, dense_dims=40, ijk_min=-20,
-        radius=radius, truncation_distance=trunc, device=device,
+        voxel_size=vs,
+        dense_dims=40,
+        ijk_min=-20,
+        radius=radius,
+        truncation_distance=trunc,
+        device=device,
     )
     esdf_grid, esdf = g.compute_esdf(
-        tsdf, weights,
-        truncation_distance=trunc, max_distance=max_dist,
+        tsdf,
+        weights,
+        truncation_distance=trunc,
+        max_distance=max_dist,
         prune_unreached=False,
     )
 
@@ -149,12 +161,12 @@ def test_spherical_analytic_accuracy(device):
 
     err_reached = err[reached]
     # 26-neighbour chamfer envelope: half a voxel worst case.
-    assert err_reached.median().item() < vs, \
-        f"Median err on reached voxels {err_reached.median().item()} " \
-        f"exceeds voxel_size {vs}"
-    assert err_reached.max().item() < vs, \
-        f"Max err on reached voxels {err_reached.max().item()} " \
-        f"exceeds voxel_size {vs}"
+    assert err_reached.median().item() < vs, (
+        f"Median err on reached voxels {err_reached.median().item()} " f"exceeds voxel_size {vs}"
+    )
+    assert err_reached.max().item() < vs, (
+        f"Max err on reached voxels {err_reached.max().item()} " f"exceeds voxel_size {vs}"
+    )
 
 
 @pytest.mark.parametrize("device", ["cuda"])
@@ -170,12 +182,18 @@ def test_spherical_inside_outside_signs(device):
     max_dist = 0.15
     radius = 0.20
     g, tsdf, weights = _sphere_tsdf(
-        voxel_size=vs, dense_dims=32, ijk_min=-16,
-        radius=radius, truncation_distance=trunc, device=device,
+        voxel_size=vs,
+        dense_dims=32,
+        ijk_min=-16,
+        radius=radius,
+        truncation_distance=trunc,
+        device=device,
     )
     esdf_grid, esdf = g.compute_esdf(
-        tsdf, weights,
-        truncation_distance=trunc, max_distance=max_dist,
+        tsdf,
+        weights,
+        truncation_distance=trunc,
+        max_distance=max_dist,
         prune_unreached=False,
     )
     xyz = (esdf_grid.ijk.float() + 0.5) * vs
@@ -188,14 +206,15 @@ def test_spherical_inside_outside_signs(device):
     # within the reachable horizon: these should have d > 0.
     outside_reached = (r > radius + vs) & (r < radius + max_dist - vs)
 
-    assert inside_reached.sum().item() > 0 and outside_reached.sum().item() > 0, \
-        "sanity: should have inside+outside reached voxels"
-    assert (esdf[inside_reached] <= 0.0).all(), \
-        f"Inside-reached voxels with positive ESDF: " \
-        f"{(esdf[inside_reached] > 0).sum().item()}"
-    assert (esdf[outside_reached] >= 0.0).all(), \
-        f"Outside-reached voxels with negative ESDF: " \
-        f"{(esdf[outside_reached] < 0).sum().item()}"
+    assert (
+        inside_reached.sum().item() > 0 and outside_reached.sum().item() > 0
+    ), "sanity: should have inside+outside reached voxels"
+    assert (esdf[inside_reached] <= 0.0).all(), (
+        f"Inside-reached voxels with positive ESDF: " f"{(esdf[inside_reached] > 0).sum().item()}"
+    )
+    assert (esdf[outside_reached] >= 0.0).all(), (
+        f"Outside-reached voxels with negative ESDF: " f"{(esdf[outside_reached] < 0).sum().item()}"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -210,8 +229,10 @@ def test_magnitude_bounded_by_max_distance(device):
     vs, trunc, max_dist = 0.025, 0.1, 0.15
     g, tsdf, weights = _sphere_tsdf(vs, 40, -20, 0.25, trunc, device)
     _, esdf = g.compute_esdf(
-        tsdf, weights,
-        truncation_distance=trunc, max_distance=max_dist,
+        tsdf,
+        weights,
+        truncation_distance=trunc,
+        max_distance=max_dist,
     )
     assert esdf.abs().max().item() <= max_dist + 1e-5
 
@@ -231,17 +252,22 @@ def test_vbm_and_per_leaf_outputs_are_identical(device):
     g, tsdf, weights = _sphere_tsdf(vs, 40, -20, 0.25, trunc, device)
 
     _, esdf_vbm = g.compute_esdf(
-        tsdf, weights,
-        truncation_distance=trunc, max_distance=max_dist, use_vbm=True,
+        tsdf,
+        weights,
+        truncation_distance=trunc,
+        max_distance=max_dist,
+        use_vbm=True,
     )
     _, esdf_pl = g.compute_esdf(
-        tsdf, weights,
-        truncation_distance=trunc, max_distance=max_dist, use_vbm=False,
+        tsdf,
+        weights,
+        truncation_distance=trunc,
+        max_distance=max_dist,
+        use_vbm=False,
     )
     # Bit-identical — both kernels read from the same input buffers,
     # execute the same scalar body in the same order per voxel.
-    assert torch.equal(esdf_vbm, esdf_pl), \
-        f"Max diff = {(esdf_vbm - esdf_pl).abs().max().item()}"
+    assert torch.equal(esdf_vbm, esdf_pl), f"Max diff = {(esdf_vbm - esdf_pl).abs().max().item()}"
 
 
 # ---------------------------------------------------------------------------
@@ -258,11 +284,17 @@ def test_prune_drops_only_unreached_voxels(device):
     g, tsdf, weights = _sphere_tsdf(vs, 24, -12, 0.2, trunc, device)
 
     full_grid, esdf_full = g.compute_esdf(
-        tsdf, weights, truncation_distance=trunc, max_distance=max_dist,
+        tsdf,
+        weights,
+        truncation_distance=trunc,
+        max_distance=max_dist,
         prune_unreached=False,
     )
     pruned_grid, esdf_pruned = g.compute_esdf(
-        tsdf, weights, truncation_distance=trunc, max_distance=max_dist,
+        tsdf,
+        weights,
+        truncation_distance=trunc,
+        max_distance=max_dist,
         prune_unreached=True,
     )
 
@@ -275,8 +307,9 @@ def test_prune_drops_only_unreached_voxels(device):
 
     # Count matches the naive predicate on the full output.
     expected_survivors = (esdf_full.abs() < max_dist).sum().item()
-    assert pruned_grid.num_voxels == expected_survivors, \
-        f"Pruned={pruned_grid.num_voxels} vs expected={expected_survivors}"
+    assert (
+        pruned_grid.num_voxels == expected_survivors
+    ), f"Pruned={pruned_grid.num_voxels} vs expected={expected_survivors}"
 
 
 # ---------------------------------------------------------------------------
@@ -289,12 +322,17 @@ def test_empty_input_grid_returns_empty_esdf(device):
     """Zero-voxel input should gracefully return a zero-voxel ESDF
     without launching kernels that would crash."""
     g = fvdb.Grid.from_zero_voxels(
-        voxel_size=0.05, origin=[0, 0, 0], device=device,
+        voxel_size=0.05,
+        origin=[0, 0, 0],
+        device=device,
     )
     tsdf = torch.zeros(0, device=device, dtype=torch.float32)
     weights = torch.zeros(0, device=device, dtype=torch.float32)
     esdf_grid, esdf = g.compute_esdf(
-        tsdf, weights, truncation_distance=0.1, max_distance=0.2,
+        tsdf,
+        weights,
+        truncation_distance=0.1,
+        max_distance=0.2,
     )
     assert esdf_grid.num_voxels == 0
     assert esdf.shape == (0,)
@@ -309,13 +347,16 @@ def test_all_zero_weights_produces_no_seeds(device):
     g, tsdf, _ = _sphere_tsdf(vs, 16, -8, 0.15, trunc, device)
     zero_w = torch.zeros(g.num_voxels, device=device, dtype=torch.float32)
     _, esdf = g.compute_esdf(
-        tsdf, zero_w,
-        truncation_distance=trunc, max_distance=max_dist,
+        tsdf,
+        zero_w,
+        truncation_distance=trunc,
+        max_distance=max_dist,
         weight_threshold=1e-6,
     )
     # Every voxel should be at +max_distance (clamped sentinel).
-    assert torch.allclose(esdf, torch.full_like(esdf, max_dist)), \
-        f"Unseeded ESDF range: {esdf.min().item()} .. {esdf.max().item()}"
+    assert torch.allclose(
+        esdf, torch.full_like(esdf, max_dist)
+    ), f"Unseeded ESDF range: {esdf.min().item()} .. {esdf.max().item()}"
 
 
 @pytest.mark.parametrize("device", ["cuda"])
@@ -327,18 +368,24 @@ def test_saturated_tsdf_voxels_are_not_used_as_seeds(device):
     all-``+max_distance`` output."""
     vs, trunc, max_dist = 0.05, 0.1, 0.15
     g = fvdb.Grid.from_dense(
-        dense_dims=[16, 16, 16], ijk_min=[-8, -8, -8],
-        voxel_size=vs, origin=[0, 0, 0], device=device,
+        dense_dims=[16, 16, 16],
+        ijk_min=[-8, -8, -8],
+        voxel_size=vs,
+        origin=[0, 0, 0],
+        device=device,
     )
     # All voxels saturated at +1 (far-in-front-of-surface).
     tsdf = torch.ones(g.num_voxels, device=device, dtype=torch.float32)
     weights = torch.ones(g.num_voxels, device=device, dtype=torch.float32)
     _, esdf = g.compute_esdf(
-        tsdf, weights, truncation_distance=trunc, max_distance=max_dist,
+        tsdf,
+        weights,
+        truncation_distance=trunc,
+        max_distance=max_dist,
     )
-    assert torch.allclose(esdf, torch.full_like(esdf, max_dist)), \
-        f"Saturated-only TSDF should produce no seeds; got range " \
-        f"[{esdf.min().item()}, {esdf.max().item()}]"
+    assert torch.allclose(esdf, torch.full_like(esdf, max_dist)), (
+        f"Saturated-only TSDF should produce no seeds; got range " f"[{esdf.min().item()}, {esdf.max().item()}]"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -353,8 +400,10 @@ def test_mismatched_tsdf_size_raises(device):
     bad_tsdf = torch.zeros(g.num_voxels + 1, device=device, dtype=torch.float32)
     with pytest.raises((RuntimeError, ValueError)):
         g.compute_esdf(
-            bad_tsdf, weights,
-            truncation_distance=trunc, max_distance=max_dist,
+            bad_tsdf,
+            weights,
+            truncation_distance=trunc,
+            max_distance=max_dist,
         )
 
 
@@ -366,8 +415,10 @@ def test_non_float32_tsdf_raises(device):
     g, tsdf, weights = _sphere_tsdf(vs, 16, -8, 0.15, trunc, device)
     with pytest.raises((RuntimeError, TypeError)):
         g.compute_esdf(
-            tsdf.to(torch.float64), weights,
-            truncation_distance=trunc, max_distance=max_dist,
+            tsdf.to(torch.float64),
+            weights,
+            truncation_distance=trunc,
+            max_distance=max_dist,
         )
 
 
@@ -377,8 +428,10 @@ def test_non_positive_max_distance_raises(device):
     g, tsdf, weights = _sphere_tsdf(vs, 16, -8, 0.15, trunc, device)
     with pytest.raises((RuntimeError, ValueError)):
         g.compute_esdf(
-            tsdf, weights,
-            truncation_distance=trunc, max_distance=0.0,
+            tsdf,
+            weights,
+            truncation_distance=trunc,
+            max_distance=0.0,
         )
 
 
@@ -395,15 +448,20 @@ def test_incremental_idempotent_with_same_inputs(device):
     vs, trunc, max_dist = 0.025, 0.1, 0.2
     g, tsdf, weights = _sphere_tsdf(vs, 40, -20, 0.25, trunc, device)
     esdf_grid, esdf = g.compute_esdf(
-        tsdf, weights,
-        truncation_distance=trunc, max_distance=max_dist,
+        tsdf,
+        weights,
+        truncation_distance=trunc,
+        max_distance=max_dist,
     )
     esdf_grid2, esdf2 = g.compute_esdf_incremental(
-        tsdf, weights, esdf_grid, esdf,
-        truncation_distance=trunc, max_distance=max_dist,
+        tsdf,
+        weights,
+        esdf_grid,
+        esdf,
+        truncation_distance=trunc,
+        max_distance=max_dist,
     )
-    assert torch.equal(esdf, esdf2), \
-        f"Max diff: {(esdf - esdf2).abs().max().item()}"
+    assert torch.equal(esdf, esdf2), f"Max diff: {(esdf - esdf2).abs().max().item()}"
 
 
 @pytest.mark.parametrize("device", ["cuda"])
@@ -414,20 +472,27 @@ def test_incremental_empty_prev_falls_through_to_one_shot(device):
     g, tsdf, weights = _sphere_tsdf(vs, 40, -20, 0.25, trunc, device)
 
     empty_grid = fvdb.Grid.from_zero_voxels(
-        voxel_size=vs, origin=[0, 0, 0], device=device,
+        voxel_size=vs,
+        origin=[0, 0, 0],
+        device=device,
     )
     empty_esdf = torch.zeros(0, device=device, dtype=torch.float32)
 
     _, esdf_one_shot = g.compute_esdf(
-        tsdf, weights,
-        truncation_distance=trunc, max_distance=max_dist,
+        tsdf,
+        weights,
+        truncation_distance=trunc,
+        max_distance=max_dist,
     )
     _, esdf_incr = g.compute_esdf_incremental(
-        tsdf, weights, empty_grid, empty_esdf,
-        truncation_distance=trunc, max_distance=max_dist,
+        tsdf,
+        weights,
+        empty_grid,
+        empty_esdf,
+        truncation_distance=trunc,
+        max_distance=max_dist,
     )
-    assert torch.equal(esdf_one_shot, esdf_incr), \
-        f"Max diff: {(esdf_one_shot - esdf_incr).abs().max().item()}"
+    assert torch.equal(esdf_one_shot, esdf_incr), f"Max diff: {(esdf_one_shot - esdf_incr).abs().max().item()}"
 
 
 @pytest.mark.parametrize("device", ["cuda"])
@@ -454,13 +519,19 @@ def test_warm_reuse_terminates_early(device):
     max_dist = 0.4  # = 20 * vs -> ~20 sweeps cold, 1 sweep warm
     radius = 0.3
     g, tsdf, weights = _sphere_tsdf(
-        voxel_size=vs, dense_dims=96, ijk_min=-48,
-        radius=radius, truncation_distance=trunc, device=device,
+        voxel_size=vs,
+        dense_dims=96,
+        ijk_min=-48,
+        radius=radius,
+        truncation_distance=trunc,
+        device=device,
     )
     # Warm up CUDA caches + torch JIT with a throwaway call.
     _ = g.compute_esdf(
-        tsdf, weights,
-        truncation_distance=trunc, max_distance=max_dist,
+        tsdf,
+        weights,
+        truncation_distance=trunc,
+        max_distance=max_dist,
     )
     torch.cuda.synchronize()
 
@@ -470,8 +541,10 @@ def test_warm_reuse_terminates_early(device):
         torch.cuda.synchronize()
         t0 = time.perf_counter()
         esdf_grid, esdf = g.compute_esdf(
-            tsdf, weights,
-            truncation_distance=trunc, max_distance=max_dist,
+            tsdf,
+            weights,
+            truncation_distance=trunc,
+            max_distance=max_dist,
         )
         torch.cuda.synchronize()
         cold_samples.append((time.perf_counter() - t0) * 1000.0)
@@ -479,8 +552,12 @@ def test_warm_reuse_terminates_early(device):
 
     # Warm incremental with same inputs (idempotent).
     _ = g.compute_esdf_incremental(
-        tsdf, weights, esdf_grid, esdf,
-        truncation_distance=trunc, max_distance=max_dist,
+        tsdf,
+        weights,
+        esdf_grid,
+        esdf,
+        truncation_distance=trunc,
+        max_distance=max_dist,
     )
     torch.cuda.synchronize()
     warm_samples = []
@@ -488,8 +565,12 @@ def test_warm_reuse_terminates_early(device):
         torch.cuda.synchronize()
         t0 = time.perf_counter()
         _ = g.compute_esdf_incremental(
-            tsdf, weights, esdf_grid, esdf,
-            truncation_distance=trunc, max_distance=max_dist,
+            tsdf,
+            weights,
+            esdf_grid,
+            esdf,
+            truncation_distance=trunc,
+            max_distance=max_dist,
         )
         torch.cuda.synchronize()
         warm_samples.append((time.perf_counter() - t0) * 1000.0)
@@ -502,9 +583,10 @@ def test_warm_reuse_terminates_early(device):
     # workloads like Mai City the ratio is 3-5x. If early termination
     # breaks, warm becomes SLOWER than cold (extra inject overhead
     # with no sweep-count offset) and this test trips immediately.
-    assert warm_ms < cold_ms * 0.85, \
-        f"Warm reuse ({warm_ms:.2f} ms) should be > 1.15x faster than " \
+    assert warm_ms < cold_ms * 0.85, (
+        f"Warm reuse ({warm_ms:.2f} ms) should be > 1.15x faster than "
         f"cold ({cold_ms:.2f} ms); early termination likely broken."
+    )
 
 
 @pytest.mark.parametrize("device", ["cuda"])
@@ -528,28 +610,43 @@ def test_incremental_partial_observation_converges_to_full(device):
     radius = 0.2
 
     g, tsdf, w_full = _sphere_tsdf(
-        vs, 40, -20, radius=radius, truncation_distance=trunc, device=device,
+        vs,
+        40,
+        -20,
+        radius=radius,
+        truncation_distance=trunc,
+        device=device,
     )
     # Frame 0: only voxels with y > 0 have weight 1; others have
     # weight 0 (unobserved). This simulates e.g. a sensor that has
     # only scanned one hemisphere.
     xyz = (g.ijk.float() + 0.5) * vs
     w_half = torch.where(
-        xyz[:, 1] > 0, torch.ones_like(w_full), torch.zeros_like(w_full),
+        xyz[:, 1] > 0,
+        torch.ones_like(w_full),
+        torch.zeros_like(w_full),
     )
     esdf_grid_f0, esdf_f0 = g.compute_esdf(
-        tsdf, w_half,
-        truncation_distance=trunc, max_distance=max_dist,
+        tsdf,
+        w_half,
+        truncation_distance=trunc,
+        max_distance=max_dist,
     )
     # Frame 1: full observation.
     esdf_grid_inc, esdf_inc = g.compute_esdf_incremental(
-        tsdf, w_full, esdf_grid_f0, esdf_f0,
-        truncation_distance=trunc, max_distance=max_dist,
+        tsdf,
+        w_full,
+        esdf_grid_f0,
+        esdf_f0,
+        truncation_distance=trunc,
+        max_distance=max_dist,
     )
     # Reference: one-shot on full observation directly.
     esdf_grid_ref, esdf_ref = g.compute_esdf(
-        tsdf, w_full,
-        truncation_distance=trunc, max_distance=max_dist,
+        tsdf,
+        w_full,
+        truncation_distance=trunc,
+        max_distance=max_dist,
     )
 
     assert esdf_grid_inc.num_voxels == esdf_grid_ref.num_voxels
@@ -565,11 +662,10 @@ def test_incremental_partial_observation_converges_to_full(device):
     # undefined" convention. Clamping is correct either way in that
     # the magnitude is bounded.
     reached_by_ref = esdf_ref.abs() < max_dist - 1e-5
-    diff_reached = (esdf_ref[reached_by_ref] -
-                    esdf_inc[reached_by_ref]).abs()
-    assert diff_reached.max().item() < vs, \
-        f"Incremental vs one-shot on reached voxels: max diff " \
-        f"{diff_reached.max().item()} > vs={vs}"
+    diff_reached = (esdf_ref[reached_by_ref] - esdf_inc[reached_by_ref]).abs()
+    assert diff_reached.max().item() < vs, (
+        f"Incremental vs one-shot on reached voxels: max diff " f"{diff_reached.max().item()} > vs={vs}"
+    )
 
     # Magnitude bound must hold EVERYWHERE for both.
     assert esdf_inc.abs().max().item() <= max_dist + 1e-5

--- a/tests/unit/test_decay_and_prune.py
+++ b/tests/unit/test_decay_and_prune.py
@@ -1,0 +1,246 @@
+# Copyright Contributors to the OpenVDB Project
+# SPDX-License-Identifier: Apache-2.0
+"""
+Unit tests for :meth:`fvdb.Grid.decay_and_prune` — the dynamic-scene
+decay primitive.
+
+The paper-framing point this helper demonstrates: because fvdb stores
+each per-voxel sidecar as a separate torch tensor, selective decay
+(decay one field, leave the others alone) is a trivial composition of
+a multiplicative torch op and the existing ``pruneGrid`` primitive.
+No new library machinery needed -- contrast nvblox, whose block-packed
+``{sdf, weight, color}`` tuples require layer-aware decay methods.
+
+These tests pin the six invariants the helper promises:
+
+* Decay-only (``prune_threshold=0``) is a pure tensor multiply; the
+  grid and sidecar shape are unchanged.
+* Decay-and-prune at a non-zero threshold drops exactly the voxels
+  whose decayed magnitude has fallen below the threshold.
+* Extra sidecars stay in sync with the pruned grid (same mask).
+* Idempotence: ``decay_factor=1.0`` with threshold=0 is a no-op.
+* Multi-channel sidecars prune on L2 norm magnitude.
+* Repeated calls compose naturally (5 calls at factor=0.9 with
+  threshold=0.2 matches a single call at factor=0.9^5 with the same
+  threshold, up to the order of prune/not-prune decisions).
+"""
+
+import pytest
+import torch
+
+import fvdb
+
+
+def _make_grid_with_sidecars(device: str = "cuda"):
+    """Small dense grid of 27 voxels with TSDF + weights + features."""
+    g = fvdb.Grid.from_dense(
+        dense_dims=[3, 3, 3], ijk_min=[-1, -1, -1],
+        voxel_size=0.1, origin=[0, 0, 0], device=device,
+    )
+    # Weights: monotonic 1.0 ... 27.0 so we can predict which voxels
+    # survive each threshold.
+    weights = torch.arange(1, g.num_voxels + 1, device=device, dtype=torch.float32)
+    tsdf = torch.linspace(-1.0, 1.0, g.num_voxels, device=device, dtype=torch.float32)
+    features = torch.randn(g.num_voxels, 3, device=device, dtype=torch.float32,
+                           generator=torch.Generator(device=device).manual_seed(42))
+    return g, tsdf, weights, features
+
+
+# ---------------------------------------------------------------------------
+#  Decay-only (threshold = 0): pure tensor multiply, no topology change
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("device", ["cuda"])
+def test_decay_only_is_tensor_multiply(device):
+    """With ``prune_threshold=0`` the helper is a pure multiplicative
+    scaling of the sidecar; the grid is returned unchanged."""
+    g, tsdf, weights, features = _make_grid_with_sidecars(device=device)
+
+    g2, w2, extras = g.decay_and_prune(
+        weights, decay_factor=0.5, prune_threshold=0.0,
+        extra_sidecars=[tsdf, features],
+    )
+    # Grid unchanged.
+    assert g2.num_voxels == g.num_voxels
+    # Sidecar = sidecar * decay_factor.
+    assert torch.allclose(w2, weights * 0.5)
+    # Extras unchanged (decay only acts on the primary sidecar).
+    assert torch.equal(extras[0], tsdf)
+    assert torch.equal(extras[1], features)
+
+
+@pytest.mark.parametrize("device", ["cuda"])
+def test_decay_factor_1_is_noop(device):
+    """decay_factor=1.0, prune_threshold=0 is a pure no-op: grid and
+    sidecars are returned as-is (up to tensor identity/allclose)."""
+    g, tsdf, weights, _ = _make_grid_with_sidecars(device=device)
+    g2, w2, extras = g.decay_and_prune(
+        weights, decay_factor=1.0, prune_threshold=0.0,
+        extra_sidecars=[tsdf],
+    )
+    assert g2.num_voxels == g.num_voxels
+    assert torch.equal(w2, weights)
+    assert torch.equal(extras[0], tsdf)
+
+
+# ---------------------------------------------------------------------------
+#  Decay-and-prune: topology shrinks to match the retained voxels
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("device", ["cuda"])
+def test_prune_drops_below_threshold(device):
+    """With decay=0.5 on weights [1..27] and threshold=5:
+    decayed weights = [0.5, 1.0, ..., 13.5].
+    Keep those with |decayed| > 5, i.e. decayed > 5.0, i.e. original
+    weight > 10.0. So voxels with weight >= 11 survive = 17 voxels."""
+    g, tsdf, weights, features = _make_grid_with_sidecars(device=device)
+    g2, w2, extras = g.decay_and_prune(
+        weights, decay_factor=0.5, prune_threshold=5.0,
+        extra_sidecars=[tsdf, features],
+    )
+    # 27 original voxels; those with decayed weight > 5 survive.
+    # decayed weights > 5 means original weights > 10, so weights in
+    # {11, 12, ..., 27} = 17 voxels.
+    assert g2.num_voxels == 17
+    assert w2.shape == (17,)
+    assert extras[0].shape == (17,)
+    assert extras[1].shape == (17, 3)
+    # All surviving weights are > 5 after decay.
+    assert (w2 > 5.0).all()
+
+
+@pytest.mark.parametrize("device", ["cuda"])
+def test_extra_sidecars_stay_in_sync(device):
+    """The pruned grid and all extra_sidecars must share the same mask —
+    voxel i in the output corresponds to the same voxel across all
+    output tensors."""
+    g, tsdf, weights, features = _make_grid_with_sidecars(device=device)
+    # Reference: apply the same decay + mask manually.
+    expected_weights = weights * 0.7
+    mask = expected_weights.abs() > 3.0
+    expected_tsdf = tsdf[mask]
+    expected_features = features[mask]
+
+    _, w2, extras = g.decay_and_prune(
+        weights, decay_factor=0.7, prune_threshold=3.0,
+        extra_sidecars=[tsdf, features],
+    )
+    assert torch.equal(w2, expected_weights[mask])
+    assert torch.equal(extras[0], expected_tsdf)
+    assert torch.equal(extras[1], expected_features)
+
+
+@pytest.mark.parametrize("device", ["cuda"])
+def test_threshold_above_max_prunes_everything(device):
+    """Threshold higher than any decayed magnitude prunes every voxel
+    and produces a zero-voxel grid."""
+    g, _, weights, _ = _make_grid_with_sidecars(device=device)
+    g2, w2, _ = g.decay_and_prune(
+        weights, decay_factor=0.5, prune_threshold=100.0,
+    )
+    assert g2.num_voxels == 0
+    assert w2.shape == (0,)
+
+
+# ---------------------------------------------------------------------------
+#  Multi-channel sidecars
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("device", ["cuda"])
+def test_multichannel_sidecar_uses_l2_magnitude(device):
+    """For a ``[num_voxels, C]`` sidecar, the prune predicate is the
+    per-voxel L2 norm."""
+    g, _, _, features = _make_grid_with_sidecars(device=device)
+
+    decayed_feat = features * 0.8
+    l2 = decayed_feat.norm(dim=1)
+    thresh = l2.median().item()  # prunes ~half the voxels
+
+    g2, feat2, _ = g.decay_and_prune(
+        features, decay_factor=0.8, prune_threshold=thresh,
+    )
+    # Sanity: we dropped some voxels.
+    assert 0 < g2.num_voxels < g.num_voxels
+    assert feat2.shape == (g2.num_voxels, 3)
+    # All surviving rows have L2 norm > threshold.
+    assert (feat2.norm(dim=1) > thresh).all()
+
+
+# ---------------------------------------------------------------------------
+#  Composition / temporal behaviour
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("device", ["cuda"])
+def test_repeated_decay_composes(device):
+    """5 successive decays at factor=0.9 should match one decay at
+    0.9**5 = 0.59049 applied to the same starting weights, provided
+    the prune threshold doesn't fire (so no topology changes)."""
+    g, tsdf, weights, _ = _make_grid_with_sidecars(device=device)
+
+    # Loop 5 decays without pruning.
+    cur_grid, cur_w, extras = g, weights.clone(), [tsdf.clone()]
+    for _ in range(5):
+        cur_grid, cur_w, extras = cur_grid.decay_and_prune(
+            cur_w, decay_factor=0.9, prune_threshold=0.0,
+            extra_sidecars=extras,
+        )
+
+    # Reference: single decay with compound factor.
+    expected = weights * (0.9 ** 5)
+    # fp32 associativity: compare with a small tolerance.
+    assert torch.allclose(cur_w, expected, atol=1e-5, rtol=1e-5)
+    # Topology unchanged (no pruning happened).
+    assert cur_grid.num_voxels == g.num_voxels
+    # Extras untouched.
+    assert torch.equal(extras[0], tsdf)
+
+
+# ---------------------------------------------------------------------------
+#  Composability with other per-field ops (the paper-figure point)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("device", ["cuda"])
+def test_per_field_decay_is_independent(device):
+    """Selective decay: decay weights while leaving features untouched,
+    using nothing but :meth:`decay_and_prune` on the one sidecar.
+
+    This is the paper-figure demonstration of fvdb's "field
+    orthogonality is free" architectural advantage — you don't need a
+    layer-aware library method; you decay the tensor you care about
+    and that's it."""
+    g, tsdf, weights, features = _make_grid_with_sidecars(device=device)
+    features_orig = features.clone()
+
+    # Decay weights only. Features pass through extra_sidecars
+    # unchanged (except for any pruning that the grid shrinks).
+    _, w2, extras = g.decay_and_prune(
+        weights, decay_factor=0.5, prune_threshold=0.0,
+        extra_sidecars=[tsdf, features],
+    )
+    tsdf2, features2 = extras
+
+    # Weights scaled, features and tsdf unchanged.
+    assert torch.allclose(w2, weights * 0.5)
+    assert torch.equal(tsdf2, tsdf)
+    assert torch.equal(features2, features_orig)
+
+
+@pytest.mark.parametrize("device", ["cuda"])
+def test_compound_prune_predicate_via_user_mask(device):
+    """The user can also skip ``decay_and_prune`` and compose a
+    compound prune predicate directly through :meth:`pruned_grid`
+    (which is what ``decay_and_prune`` uses internally). This pins
+    that the underlying primitive is accessible for custom
+    predicates -- the paper point is that every composition here is
+    1-3 lines of Python."""
+    g, tsdf, weights, features = _make_grid_with_sidecars(device=device)
+    # Compound predicate: keep voxels with weight > 5 AND features-
+    # norm > 0.5. Entirely user-authored, no fvdb helper needed.
+    keep = (weights > 5.0) & (features.norm(dim=1) > 0.5)
+    g2 = g.pruned_grid(keep)
+    assert g2.num_voxels == int(keep.sum().item())

--- a/tests/unit/test_decay_and_prune.py
+++ b/tests/unit/test_decay_and_prune.py
@@ -34,15 +34,19 @@ import fvdb
 def _make_grid_with_sidecars(device: str = "cuda"):
     """Small dense grid of 27 voxels with TSDF + weights + features."""
     g = fvdb.Grid.from_dense(
-        dense_dims=[3, 3, 3], ijk_min=[-1, -1, -1],
-        voxel_size=0.1, origin=[0, 0, 0], device=device,
+        dense_dims=[3, 3, 3],
+        ijk_min=[-1, -1, -1],
+        voxel_size=0.1,
+        origin=[0, 0, 0],
+        device=device,
     )
     # Weights: monotonic 1.0 ... 27.0 so we can predict which voxels
     # survive each threshold.
     weights = torch.arange(1, g.num_voxels + 1, device=device, dtype=torch.float32)
     tsdf = torch.linspace(-1.0, 1.0, g.num_voxels, device=device, dtype=torch.float32)
-    features = torch.randn(g.num_voxels, 3, device=device, dtype=torch.float32,
-                           generator=torch.Generator(device=device).manual_seed(42))
+    features = torch.randn(
+        g.num_voxels, 3, device=device, dtype=torch.float32, generator=torch.Generator(device=device).manual_seed(42)
+    )
     return g, tsdf, weights, features
 
 
@@ -58,7 +62,9 @@ def test_decay_only_is_tensor_multiply(device):
     g, tsdf, weights, features = _make_grid_with_sidecars(device=device)
 
     g2, w2, extras = g.decay_and_prune(
-        weights, decay_factor=0.5, prune_threshold=0.0,
+        weights,
+        decay_factor=0.5,
+        prune_threshold=0.0,
         extra_sidecars=[tsdf, features],
     )
     # Grid unchanged.
@@ -76,7 +82,9 @@ def test_decay_factor_1_is_noop(device):
     sidecars are returned as-is (up to tensor identity/allclose)."""
     g, tsdf, weights, _ = _make_grid_with_sidecars(device=device)
     g2, w2, extras = g.decay_and_prune(
-        weights, decay_factor=1.0, prune_threshold=0.0,
+        weights,
+        decay_factor=1.0,
+        prune_threshold=0.0,
         extra_sidecars=[tsdf],
     )
     assert g2.num_voxels == g.num_voxels
@@ -97,7 +105,9 @@ def test_prune_drops_below_threshold(device):
     weight > 10.0. So voxels with weight >= 11 survive = 17 voxels."""
     g, tsdf, weights, features = _make_grid_with_sidecars(device=device)
     g2, w2, extras = g.decay_and_prune(
-        weights, decay_factor=0.5, prune_threshold=5.0,
+        weights,
+        decay_factor=0.5,
+        prune_threshold=5.0,
         extra_sidecars=[tsdf, features],
     )
     # 27 original voxels; those with decayed weight > 5 survive.
@@ -124,7 +134,9 @@ def test_extra_sidecars_stay_in_sync(device):
     expected_features = features[mask]
 
     _, w2, extras = g.decay_and_prune(
-        weights, decay_factor=0.7, prune_threshold=3.0,
+        weights,
+        decay_factor=0.7,
+        prune_threshold=3.0,
         extra_sidecars=[tsdf, features],
     )
     assert torch.equal(w2, expected_weights[mask])
@@ -138,7 +150,9 @@ def test_threshold_above_max_prunes_everything(device):
     and produces a zero-voxel grid."""
     g, _, weights, _ = _make_grid_with_sidecars(device=device)
     g2, w2, _ = g.decay_and_prune(
-        weights, decay_factor=0.5, prune_threshold=100.0,
+        weights,
+        decay_factor=0.5,
+        prune_threshold=100.0,
     )
     assert g2.num_voxels == 0
     assert w2.shape == (0,)
@@ -160,7 +174,9 @@ def test_multichannel_sidecar_uses_l2_magnitude(device):
     thresh = l2.median().item()  # prunes ~half the voxels
 
     g2, feat2, _ = g.decay_and_prune(
-        features, decay_factor=0.8, prune_threshold=thresh,
+        features,
+        decay_factor=0.8,
+        prune_threshold=thresh,
     )
     # Sanity: we dropped some voxels.
     assert 0 < g2.num_voxels < g.num_voxels
@@ -185,12 +201,14 @@ def test_repeated_decay_composes(device):
     cur_grid, cur_w, extras = g, weights.clone(), [tsdf.clone()]
     for _ in range(5):
         cur_grid, cur_w, extras = cur_grid.decay_and_prune(
-            cur_w, decay_factor=0.9, prune_threshold=0.0,
+            cur_w,
+            decay_factor=0.9,
+            prune_threshold=0.0,
             extra_sidecars=extras,
         )
 
     # Reference: single decay with compound factor.
-    expected = weights * (0.9 ** 5)
+    expected = weights * (0.9**5)
     # fp32 associativity: compare with a small tolerance.
     assert torch.allclose(cur_w, expected, atol=1e-5, rtol=1e-5)
     # Topology unchanged (no pruning happened).
@@ -219,7 +237,9 @@ def test_per_field_decay_is_independent(device):
     # Decay weights only. Features pass through extra_sidecars
     # unchanged (except for any pruning that the grid shrinks).
     _, w2, extras = g.decay_and_prune(
-        weights, decay_factor=0.5, prune_threshold=0.0,
+        weights,
+        decay_factor=0.5,
+        prune_threshold=0.0,
         extra_sidecars=[tsdf, features],
     )
     tsdf2, features2 = extras

--- a/tests/unit/test_dirty_mask.py
+++ b/tests/unit/test_dirty_mask.py
@@ -1,0 +1,301 @@
+# Copyright Contributors to the OpenVDB Project
+# SPDX-License-Identifier: Apache-2.0
+"""
+Unit tests for :func:`fvdb.functional.dirty_mask_from_sidecars_single`
+and the ``dirty_mask`` argument on :meth:`fvdb.Grid.compute_esdf_incremental`.
+
+Paper-framing context: dirty-region ESDF updates in fvdb are expressed
+via a user-visible torch tensor (the dirty mask) rather than library-
+internal allocator state (nvblox's ``BlockManager`` dirty-block set).
+These tests pin the invariants that make that composition work.
+
+Coverage:
+
+* ``dirty_mask_from_sidecars`` correctness:
+  - Flags voxels whose sidecar value differs.
+  - Flags voxels absent from old grid as dirty.
+  - Does NOT flag voxels present in both grids with identical values.
+  - Multi-channel sidecars reduce via "any channel differs".
+  - Empty old grid → everything dirty.
+* ``compute_esdf_incremental(dirty_mask=all_false)`` short-circuits:
+  returns the same ``Grid`` and ``Tensor`` objects (Python identity).
+* ``compute_esdf_incremental(dirty_mask=all_true)`` is bit-identical
+  to no-mask (full recompute).
+* Partial dirty mask produces output that matches full-recompute on
+  the dirty-reached region, with previously-good values preserved
+  elsewhere (monotone-scene correctness under partial updates).
+"""
+
+import pytest
+import torch
+
+import fvdb
+
+
+def _sphere_tsdf(vs=0.05, dims=20, ijk_min=-10, radius=0.35, trunc=0.15,
+                 device="cuda"):
+    """Helper: dense grid with analytic sphere TSDF + unit weights."""
+    g = fvdb.Grid.from_dense(
+        dense_dims=[dims, dims, dims], ijk_min=[ijk_min, ijk_min, ijk_min],
+        voxel_size=vs, origin=[0, 0, 0], device=device,
+    )
+    xyz = (g.ijk.float() + 0.5) * vs
+    tsdf = ((xyz.norm(dim=1) - radius) / trunc).clamp(-1, 1).to(torch.float32)
+    weights = torch.ones(g.num_voxels, device=device, dtype=torch.float32)
+    return g, tsdf, weights
+
+
+# ---------------------------------------------------------------------------
+#  dirty_mask_from_sidecars: correctness
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("device", ["cuda"])
+def test_dirty_mask_flags_new_and_changed(device):
+    """Classic three-voxel case: one unchanged, one value-changed,
+    one new."""
+    old_ijk = torch.tensor([[0, 0, 0], [1, 0, 0]], dtype=torch.int32)
+    new_ijk = torch.tensor([[0, 0, 0], [1, 0, 0], [2, 0, 0]], dtype=torch.int32)
+    old_grid = fvdb.Grid.from_ijk(old_ijk, voxel_size=0.1, origin=[0, 0, 0]).to(device)
+    new_grid = fvdb.Grid.from_ijk(new_ijk, voxel_size=0.1, origin=[0, 0, 0]).to(device)
+
+    old_sc = torch.tensor([1.0, 2.0], device=device)
+    new_sc = torch.tensor([1.0, 5.0, 7.0], device=device)
+
+    dirty = fvdb.functional.dirty_mask_from_sidecars_single(
+        new_grid, new_sc, old_grid, old_sc,
+    )
+    assert dirty.dtype == torch.bool
+    assert dirty.shape == (3,)
+    assert dirty.cpu().tolist() == [False, True, True]
+
+
+@pytest.mark.parametrize("device", ["cuda"])
+def test_dirty_mask_all_unchanged_is_all_false(device):
+    """Two identical grids + identical sidecars → no voxels dirty."""
+    g, tsdf, _ = _sphere_tsdf(device=device)
+    dirty = fvdb.functional.dirty_mask_from_sidecars_single(
+        g, tsdf, g, tsdf,
+    )
+    assert not dirty.any().item()
+
+
+@pytest.mark.parametrize("device", ["cuda"])
+def test_dirty_mask_empty_old_is_all_true(device):
+    """Old grid has zero voxels → every voxel in new grid is "new" →
+    every entry dirty. Exercises the fast-path in the C++ helper."""
+    empty = fvdb.Grid.from_zero_voxels(
+        voxel_size=0.1, origin=[0, 0, 0], device=device,
+    )
+    empty_sc = torch.zeros(0, device=device, dtype=torch.float32)
+    g, tsdf, _ = _sphere_tsdf(device=device)
+    dirty = fvdb.functional.dirty_mask_from_sidecars_single(
+        g, tsdf, empty, empty_sc,
+    )
+    assert dirty.shape == (g.num_voxels,)
+    assert dirty.all().item()
+
+
+@pytest.mark.parametrize("device", ["cuda"])
+def test_dirty_mask_multichannel_any_differs(device):
+    """Multi-channel sidecars: voxel is dirty iff ANY channel differs."""
+    ijk = torch.tensor([[0, 0, 0], [1, 0, 0], [2, 0, 0]], dtype=torch.int32)
+    grid = fvdb.Grid.from_ijk(ijk, voxel_size=0.1, origin=[0, 0, 0]).to(device)
+
+    old_sc = torch.tensor([[1.0, 2.0, 3.0],
+                           [4.0, 5.0, 6.0],
+                           [7.0, 8.0, 9.0]], device=device)
+    # Voxel 0: identical. Voxel 1: one channel changed. Voxel 2: all changed.
+    new_sc = torch.tensor([[1.0, 2.0, 3.0],
+                           [4.0, 5.0, 99.0],
+                           [70.0, 80.0, 90.0]], device=device)
+    dirty = fvdb.functional.dirty_mask_from_sidecars_single(
+        grid, new_sc, grid, old_sc,
+    )
+    assert dirty.shape == (3,)
+    assert dirty.cpu().tolist() == [False, True, True]
+
+
+# ---------------------------------------------------------------------------
+#  compute_esdf_incremental + dirty_mask
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("device", ["cuda"])
+def test_esdf_incremental_all_false_dirty_is_identity(device):
+    """All-false dirty mask + non-empty prev_esdf ⇒ return (prev_grid,
+    prev_esdf) directly via Python identity, never entering C++.
+    This is the ~50 μs "cache hit" path that closes the warm-reuse
+    gap with nvblox."""
+    vs, trunc, max_dist = 0.05, 0.15, 0.3
+    g, tsdf, weights = _sphere_tsdf(vs=vs, dims=20, ijk_min=-10,
+                                     radius=0.35, trunc=trunc, device=device)
+
+    # Build a prev_esdf state via one-shot call.
+    prev_grid, prev_esdf = g.compute_esdf(
+        tsdf, weights,
+        truncation_distance=trunc, max_distance=max_dist,
+    )
+
+    # All-false dirty mask ⇒ short-circuit.
+    dirty_all_false = torch.zeros(g.num_voxels, device=device, dtype=torch.bool)
+    out_grid, out_esdf = g.compute_esdf_incremental(
+        tsdf, weights, prev_grid, prev_esdf,
+        truncation_distance=trunc, max_distance=max_dist,
+        dirty_mask=dirty_all_false,
+    )
+    # Python-identity equality: no new allocation happened.
+    assert out_grid is prev_grid, "should return prev_grid by identity"
+    assert out_esdf is prev_esdf, "should return prev_esdf tensor by identity"
+
+
+@pytest.mark.parametrize("device", ["cuda"])
+def test_esdf_incremental_all_true_matches_no_mask(device):
+    """All-true dirty mask is equivalent to no-mask: every voxel seeds,
+    so the sweep runs the full propagation. Output must be bit-
+    identical."""
+    vs, trunc, max_dist = 0.05, 0.15, 0.3
+    g, tsdf, weights = _sphere_tsdf(vs=vs, dims=20, ijk_min=-10,
+                                     radius=0.35, trunc=trunc, device=device)
+    prev_grid, prev_esdf = g.compute_esdf(
+        tsdf, weights,
+        truncation_distance=trunc, max_distance=max_dist,
+    )
+
+    dirty_all_true = torch.ones(g.num_voxels, device=device, dtype=torch.bool)
+    _, esdf_dirty = g.compute_esdf_incremental(
+        tsdf, weights, prev_grid, prev_esdf,
+        truncation_distance=trunc, max_distance=max_dist,
+        dirty_mask=dirty_all_true,
+    )
+    _, esdf_nomask = g.compute_esdf_incremental(
+        tsdf, weights, prev_grid, prev_esdf,
+        truncation_distance=trunc, max_distance=max_dist,
+    )
+    # Monotone-min is deterministic on these inputs; same seed set ⇒
+    # byte-for-byte identical output.
+    assert torch.equal(esdf_dirty, esdf_nomask)
+
+
+@pytest.mark.parametrize("device", ["cuda"])
+def test_esdf_incremental_partial_dirty_preserves_clean_region(device):
+    """Partial dirty mask: half the seed-band voxels are marked dirty.
+    The ESDF values on voxels far from the dirty region should match
+    ``prev_esdf`` (they aren't re-seeded, and the wavefront from
+    dirty seeds can't reach them within max_distance)."""
+    vs, trunc, max_dist = 0.05, 0.15, 0.2
+    g, tsdf, weights = _sphere_tsdf(vs=vs, dims=24, ijk_min=-12,
+                                     radius=0.4, trunc=trunc, device=device)
+    prev_grid, prev_esdf = g.compute_esdf(
+        tsdf, weights,
+        truncation_distance=trunc, max_distance=max_dist,
+    )
+
+    # Mark only voxels in the +x half of the grid as dirty.
+    xyz = (g.ijk.float() + 0.5) * vs
+    dirty = (xyz[:, 0] > 0.0).contiguous()
+
+    out_grid, out_esdf = g.compute_esdf_incremental(
+        tsdf, weights, prev_grid, prev_esdf,
+        truncation_distance=trunc, max_distance=max_dist,
+        dirty_mask=dirty,
+    )
+
+    # Same grid structure (incremental uses merge → topology identical
+    # to prev in the static-TSDF case).
+    assert out_grid.num_voxels == prev_grid.num_voxels
+
+    # Voxels FAR from the dirty region (x < -max_distance - vs) cannot
+    # receive wavefront contributions from dirty seeds; their values
+    # must equal the previous ESDF exactly.
+    out_xyz = (out_grid.ijk.float() + 0.5) * vs
+    far_from_dirty = out_xyz[:, 0] < -(max_dist + vs)
+    if far_from_dirty.any():
+        assert torch.equal(out_esdf[far_from_dirty], prev_esdf[far_from_dirty])
+
+
+@pytest.mark.parametrize("device", ["cuda"])
+def test_esdf_incremental_no_mask_unchanged_behaviour(device):
+    """Passing ``dirty_mask=None`` (the default) is backward-
+    compatible: produces the same output as before this feature
+    existed. Pinned against the existing idempotency invariant."""
+    vs, trunc, max_dist = 0.05, 0.15, 0.3
+    g, tsdf, weights = _sphere_tsdf(vs=vs, dims=20, ijk_min=-10,
+                                     radius=0.35, trunc=trunc, device=device)
+    prev_grid, prev_esdf = g.compute_esdf(
+        tsdf, weights,
+        truncation_distance=trunc, max_distance=max_dist,
+    )
+
+    _, esdf_nomask = g.compute_esdf_incremental(
+        tsdf, weights, prev_grid, prev_esdf,
+        truncation_distance=trunc, max_distance=max_dist,
+    )
+    # Feeding one-shot output back as prev with same TSDF should yield
+    # the same result (idempotence of monotone-min at fixed point).
+    assert torch.equal(esdf_nomask, prev_esdf)
+
+
+@pytest.mark.parametrize("device", ["cuda"])
+def test_full_pipeline_dirty_mask_workflow(device):
+    """End-to-end demonstration that a user can (a) integrate a TSDF
+    sweep, (b) compute a dirty mask from pre/post weights, (c) pass
+    the dirty mask to compute_esdf_incremental. This is the paper's
+    "dirty-region ESDF update" recipe in one test."""
+    vs, trunc, max_dist = 0.1, 0.3, 0.5
+    device_t = device
+
+    # Two LiDAR-ish frames on a small synthetic sphere shell.
+    torch.manual_seed(0)
+    R = 1.0
+    n_pts = 2000
+    theta = torch.rand(n_pts) * 2 * 3.14159
+    cos_phi = 2 * torch.rand(n_pts) - 1
+    sin_phi = (1 - cos_phi ** 2).clamp_min(0).sqrt()
+    pts1 = R * torch.stack([sin_phi * torch.cos(theta),
+                             sin_phi * torch.sin(theta),
+                             cos_phi], dim=1).to(device_t, dtype=torch.float32)
+
+    # Seed grid + initial TSDF integrate.
+    seed = fvdb.Grid.from_dense(
+        dense_dims=[1, 1, 1], ijk_min=[0, 0, 0],
+        voxel_size=vs, origin=[0, 0, 0], device=device_t,
+    )
+    tsdf0 = torch.zeros(seed.num_voxels, device=device_t, dtype=torch.float32)
+    w0 = torch.zeros(seed.num_voxels, device=device_t, dtype=torch.float32)
+    origin = torch.zeros(3, device=device_t, dtype=torch.float32)
+
+    # Frame 0: integrate first sweep.
+    g0, tsdf1, w1 = seed.integrate_tsdf_from_points(
+        truncation_distance=trunc, points=pts1, sensor_origin=origin,
+        tsdf=tsdf0, weights=w0,
+    )
+    # First ESDF: no prev state, use one-shot.
+    esdf_grid0, esdf0 = g0.compute_esdf(
+        tsdf1, w1, truncation_distance=trunc, max_distance=max_dist,
+    )
+
+    # Frame 1: identical points (simulated "no motion") → no change.
+    g1, tsdf2, w2 = g0.integrate_tsdf_from_points(
+        truncation_distance=trunc, points=pts1, sensor_origin=origin,
+        tsdf=tsdf1, weights=w1,
+    )
+    # Compute dirty mask from weights diff (the integrator grew w1+=1
+    # everywhere it re-observed; but since it's the same sweep, all
+    # voxels that were touched in frame 0 are touched again — so
+    # "dirty" here means "values changed". Some voxels *will* be
+    # dirty because weights grow monotonically with each observation.
+    dirty = fvdb.functional.dirty_mask_from_sidecars_single(
+        g1, w2, g0, w1,
+    )
+    # Apply the dirty mask to incremental ESDF.
+    esdf_grid2, esdf2 = g1.compute_esdf_incremental(
+        tsdf2, w2, esdf_grid0, esdf0,
+        truncation_distance=trunc, max_distance=max_dist,
+        dirty_mask=dirty,
+    )
+    # Output grid has sensible voxel count + finite values.
+    assert esdf_grid2.num_voxels > 0
+    assert torch.isfinite(esdf2).all()
+    # All values within the [-max_dist, +max_dist] clamp.
+    assert esdf2.abs().max().item() <= max_dist + 1e-5

--- a/tests/unit/test_dirty_mask.py
+++ b/tests/unit/test_dirty_mask.py
@@ -32,12 +32,14 @@ import torch
 import fvdb
 
 
-def _sphere_tsdf(vs=0.05, dims=20, ijk_min=-10, radius=0.35, trunc=0.15,
-                 device="cuda"):
+def _sphere_tsdf(vs=0.05, dims=20, ijk_min=-10, radius=0.35, trunc=0.15, device="cuda"):
     """Helper: dense grid with analytic sphere TSDF + unit weights."""
     g = fvdb.Grid.from_dense(
-        dense_dims=[dims, dims, dims], ijk_min=[ijk_min, ijk_min, ijk_min],
-        voxel_size=vs, origin=[0, 0, 0], device=device,
+        dense_dims=[dims, dims, dims],
+        ijk_min=[ijk_min, ijk_min, ijk_min],
+        voxel_size=vs,
+        origin=[0, 0, 0],
+        device=device,
     )
     xyz = (g.ijk.float() + 0.5) * vs
     tsdf = ((xyz.norm(dim=1) - radius) / trunc).clamp(-1, 1).to(torch.float32)
@@ -63,7 +65,10 @@ def test_dirty_mask_flags_new_and_changed(device):
     new_sc = torch.tensor([1.0, 5.0, 7.0], device=device)
 
     dirty = fvdb.functional.dirty_mask_from_sidecars_single(
-        new_grid, new_sc, old_grid, old_sc,
+        new_grid,
+        new_sc,
+        old_grid,
+        old_sc,
     )
     assert dirty.dtype == torch.bool
     assert dirty.shape == (3,)
@@ -75,7 +80,10 @@ def test_dirty_mask_all_unchanged_is_all_false(device):
     """Two identical grids + identical sidecars → no voxels dirty."""
     g, tsdf, _ = _sphere_tsdf(device=device)
     dirty = fvdb.functional.dirty_mask_from_sidecars_single(
-        g, tsdf, g, tsdf,
+        g,
+        tsdf,
+        g,
+        tsdf,
     )
     assert not dirty.any().item()
 
@@ -85,12 +93,17 @@ def test_dirty_mask_empty_old_is_all_true(device):
     """Old grid has zero voxels → every voxel in new grid is "new" →
     every entry dirty. Exercises the fast-path in the C++ helper."""
     empty = fvdb.Grid.from_zero_voxels(
-        voxel_size=0.1, origin=[0, 0, 0], device=device,
+        voxel_size=0.1,
+        origin=[0, 0, 0],
+        device=device,
     )
     empty_sc = torch.zeros(0, device=device, dtype=torch.float32)
     g, tsdf, _ = _sphere_tsdf(device=device)
     dirty = fvdb.functional.dirty_mask_from_sidecars_single(
-        g, tsdf, empty, empty_sc,
+        g,
+        tsdf,
+        empty,
+        empty_sc,
     )
     assert dirty.shape == (g.num_voxels,)
     assert dirty.all().item()
@@ -102,15 +115,14 @@ def test_dirty_mask_multichannel_any_differs(device):
     ijk = torch.tensor([[0, 0, 0], [1, 0, 0], [2, 0, 0]], dtype=torch.int32)
     grid = fvdb.Grid.from_ijk(ijk, voxel_size=0.1, origin=[0, 0, 0]).to(device)
 
-    old_sc = torch.tensor([[1.0, 2.0, 3.0],
-                           [4.0, 5.0, 6.0],
-                           [7.0, 8.0, 9.0]], device=device)
+    old_sc = torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]], device=device)
     # Voxel 0: identical. Voxel 1: one channel changed. Voxel 2: all changed.
-    new_sc = torch.tensor([[1.0, 2.0, 3.0],
-                           [4.0, 5.0, 99.0],
-                           [70.0, 80.0, 90.0]], device=device)
+    new_sc = torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 99.0], [70.0, 80.0, 90.0]], device=device)
     dirty = fvdb.functional.dirty_mask_from_sidecars_single(
-        grid, new_sc, grid, old_sc,
+        grid,
+        new_sc,
+        grid,
+        old_sc,
     )
     assert dirty.shape == (3,)
     assert dirty.cpu().tolist() == [False, True, True]
@@ -128,20 +140,25 @@ def test_esdf_incremental_all_false_dirty_is_identity(device):
     This is the ~50 μs "cache hit" path that closes the warm-reuse
     gap with nvblox."""
     vs, trunc, max_dist = 0.05, 0.15, 0.3
-    g, tsdf, weights = _sphere_tsdf(vs=vs, dims=20, ijk_min=-10,
-                                     radius=0.35, trunc=trunc, device=device)
+    g, tsdf, weights = _sphere_tsdf(vs=vs, dims=20, ijk_min=-10, radius=0.35, trunc=trunc, device=device)
 
     # Build a prev_esdf state via one-shot call.
     prev_grid, prev_esdf = g.compute_esdf(
-        tsdf, weights,
-        truncation_distance=trunc, max_distance=max_dist,
+        tsdf,
+        weights,
+        truncation_distance=trunc,
+        max_distance=max_dist,
     )
 
     # All-false dirty mask ⇒ short-circuit.
     dirty_all_false = torch.zeros(g.num_voxels, device=device, dtype=torch.bool)
     out_grid, out_esdf = g.compute_esdf_incremental(
-        tsdf, weights, prev_grid, prev_esdf,
-        truncation_distance=trunc, max_distance=max_dist,
+        tsdf,
+        weights,
+        prev_grid,
+        prev_esdf,
+        truncation_distance=trunc,
+        max_distance=max_dist,
         dirty_mask=dirty_all_false,
     )
     # Python-identity equality: no new allocation happened.
@@ -155,22 +172,31 @@ def test_esdf_incremental_all_true_matches_no_mask(device):
     so the sweep runs the full propagation. Output must be bit-
     identical."""
     vs, trunc, max_dist = 0.05, 0.15, 0.3
-    g, tsdf, weights = _sphere_tsdf(vs=vs, dims=20, ijk_min=-10,
-                                     radius=0.35, trunc=trunc, device=device)
+    g, tsdf, weights = _sphere_tsdf(vs=vs, dims=20, ijk_min=-10, radius=0.35, trunc=trunc, device=device)
     prev_grid, prev_esdf = g.compute_esdf(
-        tsdf, weights,
-        truncation_distance=trunc, max_distance=max_dist,
+        tsdf,
+        weights,
+        truncation_distance=trunc,
+        max_distance=max_dist,
     )
 
     dirty_all_true = torch.ones(g.num_voxels, device=device, dtype=torch.bool)
     _, esdf_dirty = g.compute_esdf_incremental(
-        tsdf, weights, prev_grid, prev_esdf,
-        truncation_distance=trunc, max_distance=max_dist,
+        tsdf,
+        weights,
+        prev_grid,
+        prev_esdf,
+        truncation_distance=trunc,
+        max_distance=max_dist,
         dirty_mask=dirty_all_true,
     )
     _, esdf_nomask = g.compute_esdf_incremental(
-        tsdf, weights, prev_grid, prev_esdf,
-        truncation_distance=trunc, max_distance=max_dist,
+        tsdf,
+        weights,
+        prev_grid,
+        prev_esdf,
+        truncation_distance=trunc,
+        max_distance=max_dist,
     )
     # Monotone-min is deterministic on these inputs; same seed set ⇒
     # byte-for-byte identical output.
@@ -184,11 +210,12 @@ def test_esdf_incremental_partial_dirty_preserves_clean_region(device):
     ``prev_esdf`` (they aren't re-seeded, and the wavefront from
     dirty seeds can't reach them within max_distance)."""
     vs, trunc, max_dist = 0.05, 0.15, 0.2
-    g, tsdf, weights = _sphere_tsdf(vs=vs, dims=24, ijk_min=-12,
-                                     radius=0.4, trunc=trunc, device=device)
+    g, tsdf, weights = _sphere_tsdf(vs=vs, dims=24, ijk_min=-12, radius=0.4, trunc=trunc, device=device)
     prev_grid, prev_esdf = g.compute_esdf(
-        tsdf, weights,
-        truncation_distance=trunc, max_distance=max_dist,
+        tsdf,
+        weights,
+        truncation_distance=trunc,
+        max_distance=max_dist,
     )
 
     # Mark only voxels in the +x half of the grid as dirty.
@@ -196,8 +223,12 @@ def test_esdf_incremental_partial_dirty_preserves_clean_region(device):
     dirty = (xyz[:, 0] > 0.0).contiguous()
 
     out_grid, out_esdf = g.compute_esdf_incremental(
-        tsdf, weights, prev_grid, prev_esdf,
-        truncation_distance=trunc, max_distance=max_dist,
+        tsdf,
+        weights,
+        prev_grid,
+        prev_esdf,
+        truncation_distance=trunc,
+        max_distance=max_dist,
         dirty_mask=dirty,
     )
 
@@ -220,16 +251,21 @@ def test_esdf_incremental_no_mask_unchanged_behaviour(device):
     compatible: produces the same output as before this feature
     existed. Pinned against the existing idempotency invariant."""
     vs, trunc, max_dist = 0.05, 0.15, 0.3
-    g, tsdf, weights = _sphere_tsdf(vs=vs, dims=20, ijk_min=-10,
-                                     radius=0.35, trunc=trunc, device=device)
+    g, tsdf, weights = _sphere_tsdf(vs=vs, dims=20, ijk_min=-10, radius=0.35, trunc=trunc, device=device)
     prev_grid, prev_esdf = g.compute_esdf(
-        tsdf, weights,
-        truncation_distance=trunc, max_distance=max_dist,
+        tsdf,
+        weights,
+        truncation_distance=trunc,
+        max_distance=max_dist,
     )
 
     _, esdf_nomask = g.compute_esdf_incremental(
-        tsdf, weights, prev_grid, prev_esdf,
-        truncation_distance=trunc, max_distance=max_dist,
+        tsdf,
+        weights,
+        prev_grid,
+        prev_esdf,
+        truncation_distance=trunc,
+        max_distance=max_dist,
     )
     # Feeding one-shot output back as prev with same TSDF should yield
     # the same result (idempotence of monotone-min at fixed point).
@@ -251,15 +287,18 @@ def test_full_pipeline_dirty_mask_workflow(device):
     n_pts = 2000
     theta = torch.rand(n_pts) * 2 * 3.14159
     cos_phi = 2 * torch.rand(n_pts) - 1
-    sin_phi = (1 - cos_phi ** 2).clamp_min(0).sqrt()
-    pts1 = R * torch.stack([sin_phi * torch.cos(theta),
-                             sin_phi * torch.sin(theta),
-                             cos_phi], dim=1).to(device_t, dtype=torch.float32)
+    sin_phi = (1 - cos_phi**2).clamp_min(0).sqrt()
+    pts1 = R * torch.stack([sin_phi * torch.cos(theta), sin_phi * torch.sin(theta), cos_phi], dim=1).to(
+        device_t, dtype=torch.float32
+    )
 
     # Seed grid + initial TSDF integrate.
     seed = fvdb.Grid.from_dense(
-        dense_dims=[1, 1, 1], ijk_min=[0, 0, 0],
-        voxel_size=vs, origin=[0, 0, 0], device=device_t,
+        dense_dims=[1, 1, 1],
+        ijk_min=[0, 0, 0],
+        voxel_size=vs,
+        origin=[0, 0, 0],
+        device=device_t,
     )
     tsdf0 = torch.zeros(seed.num_voxels, device=device_t, dtype=torch.float32)
     w0 = torch.zeros(seed.num_voxels, device=device_t, dtype=torch.float32)
@@ -267,18 +306,27 @@ def test_full_pipeline_dirty_mask_workflow(device):
 
     # Frame 0: integrate first sweep.
     g0, tsdf1, w1 = seed.integrate_tsdf_from_points(
-        truncation_distance=trunc, points=pts1, sensor_origin=origin,
-        tsdf=tsdf0, weights=w0,
+        truncation_distance=trunc,
+        points=pts1,
+        sensor_origin=origin,
+        tsdf=tsdf0,
+        weights=w0,
     )
     # First ESDF: no prev state, use one-shot.
     esdf_grid0, esdf0 = g0.compute_esdf(
-        tsdf1, w1, truncation_distance=trunc, max_distance=max_dist,
+        tsdf1,
+        w1,
+        truncation_distance=trunc,
+        max_distance=max_dist,
     )
 
     # Frame 1: identical points (simulated "no motion") → no change.
     g1, tsdf2, w2 = g0.integrate_tsdf_from_points(
-        truncation_distance=trunc, points=pts1, sensor_origin=origin,
-        tsdf=tsdf1, weights=w1,
+        truncation_distance=trunc,
+        points=pts1,
+        sensor_origin=origin,
+        tsdf=tsdf1,
+        weights=w1,
     )
     # Compute dirty mask from weights diff (the integrator grew w1+=1
     # everywhere it re-observed; but since it's the same sweep, all
@@ -286,12 +334,19 @@ def test_full_pipeline_dirty_mask_workflow(device):
     # "dirty" here means "values changed". Some voxels *will* be
     # dirty because weights grow monotonically with each observation.
     dirty = fvdb.functional.dirty_mask_from_sidecars_single(
-        g1, w2, g0, w1,
+        g1,
+        w2,
+        g0,
+        w1,
     )
     # Apply the dirty mask to incremental ESDF.
     esdf_grid2, esdf2 = g1.compute_esdf_incremental(
-        tsdf2, w2, esdf_grid0, esdf0,
-        truncation_distance=trunc, max_distance=max_dist,
+        tsdf2,
+        w2,
+        esdf_grid0,
+        esdf0,
+        truncation_distance=trunc,
+        max_distance=max_dist,
         dirty_mask=dirty,
     )
     # Output grid has sensible voxel count + finite values.

--- a/tests/unit/test_integrate_occupancy.py
+++ b/tests/unit/test_integrate_occupancy.py
@@ -1,0 +1,270 @@
+# Copyright Contributors to the OpenVDB Project
+# SPDX-License-Identifier: Apache-2.0
+"""
+Unit tests for :func:`fvdb.Grid.integrate_occupancy_from_points` and
+its batched counterpart :func:`integrate_occupancy_from_points_frames`.
+
+This op is the paper's fifth application of the nanoVDB topology-op
+vocabulary (after depth TSDF, LiDAR TSDF, MC V4-V6, ESDF). It closes
+the nvblox feature-parity gap from the primitive-usage matrix.
+
+The tests below pin the invariants any future refactor must preserve:
+
+* **Hit / miss / unknown classification**. A voxel at the sphere
+  shell should get positive log-odds from hit rays; a voxel between
+  the sensor and the shell should get negative (free) log-odds; a
+  voxel behind the shell should not be updated.
+* **Clamp bounds**. All log-odds values must stay in
+  ``[log_odds_min, log_odds_max]`` after integration.
+* **Bayesian idempotence under zero-update**. Integrating an empty
+  point cloud should be a no-op.
+* **Persistence across frames**. Running the batched N-frame call
+  equals running the single-frame call N times in sequence (bit-
+  identically up to the atomic-add noise floor).
+* **Grid growth**. The output grid is the union of the input grid
+  and the new point truncation shell.
+* **Input validation**. Mismatched shapes / dtypes raise cleanly.
+"""
+
+import pytest
+import torch
+
+import fvdb
+
+
+def _make_sphere_shell_points(
+    radius: float, n_points: int, device: str, seed: int = 0,
+) -> torch.Tensor:
+    """`n_points` points uniformly sampled on a sphere of the given
+    radius, centred at the origin. Deterministic via `seed`."""
+    g = torch.Generator(device="cpu").manual_seed(seed)
+    theta = torch.rand(n_points, generator=g) * (2.0 * 3.14159265)
+    # uniform on sphere: phi via inverse-CDF (acos of uniform [-1, 1])
+    cos_phi = 2.0 * torch.rand(n_points, generator=g) - 1.0
+    sin_phi = (1.0 - cos_phi * cos_phi).clamp_min(0.0).sqrt()
+    x = radius * sin_phi * torch.cos(theta)
+    y = radius * sin_phi * torch.sin(theta)
+    z = radius * cos_phi
+    return torch.stack([x, y, z], dim=1).to(device=device, dtype=torch.float32)
+
+
+def _seed_empty_grid(voxel_size: float, device: str = "cuda"):
+    """1-voxel metadata-only seed — the integrator grows it via the
+    shell allocator as rays come in."""
+    g = fvdb.Grid.from_dense(
+        dense_dims=[1, 1, 1], ijk_min=[0, 0, 0],
+        voxel_size=voxel_size, origin=[0, 0, 0], device=device,
+    )
+    log_odds = torch.zeros(g.num_voxels, device=device, dtype=torch.float32)
+    return g, log_odds
+
+
+# ---------------------------------------------------------------------------
+#  Correctness: hit / miss / unknown classification on a sphere shell
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("device", ["cuda"])
+def test_sphere_shell_hits_are_positive(device):
+    """Voxels at the sphere-shell radius should have positive log-odds
+    (hits dominate), while voxels between the sensor origin and the
+    shell should have negative log-odds (misses dominate)."""
+    vs = 0.05
+    trunc = 0.1
+    R = 1.0
+    n_pts = 2000
+    points = _make_sphere_shell_points(R, n_pts, device=device)
+    sensor_origin = torch.zeros(3, device=device, dtype=torch.float32)
+
+    g, log_odds = _seed_empty_grid(vs, device=device)
+    g2, log_odds2 = g.integrate_occupancy_from_points(
+        truncation_distance=trunc,
+        points=points, sensor_origin=sensor_origin,
+        log_odds=log_odds,
+    )
+
+    xyz = (g2.ijk.float() + 0.5) * vs
+    r = xyz.norm(dim=1)
+
+    # Hit band: voxels within one truncation of the shell radius.
+    hit_mask = (r >= R - trunc) & (r <= R + trunc)
+    # Free band: voxels well inside the shell (traversed by many rays
+    # as 'miss').
+    free_mask = (r < R - 2 * vs) & (r > 0.2)
+
+    assert hit_mask.sum().item() > 0, "sanity: should have hit-band voxels"
+    assert free_mask.sum().item() > 0, "sanity: should have free-band voxels"
+
+    # On average, hit-band voxels should have strictly higher log-odds
+    # than free-band voxels. We don't assert per-voxel signs because
+    # individual hit-band voxels can have net-negative log-odds if many
+    # rays pass through them en route to a more distant surface
+    # (edge of the shell); the statistical invariant is still clean.
+    hit_mean = log_odds2[hit_mask].mean().item()
+    free_mean = log_odds2[free_mask].mean().item()
+    assert hit_mean > free_mean, \
+        f"hit-band mean {hit_mean:.3f} should exceed free-band mean {free_mean:.3f}"
+
+
+@pytest.mark.parametrize("device", ["cuda"])
+def test_log_odds_clamped_to_bounds(device):
+    """All returned log-odds must be in [log_odds_min, log_odds_max]."""
+    vs = 0.05
+    trunc = 0.1
+    R = 1.0
+    points = _make_sphere_shell_points(R, 2000, device=device)
+    sensor_origin = torch.zeros(3, device=device, dtype=torch.float32)
+    g, log_odds = _seed_empty_grid(vs, device=device)
+
+    lo_min, lo_max = -3.5, 2.5
+    _, log_odds2 = g.integrate_occupancy_from_points(
+        truncation_distance=trunc,
+        points=points, sensor_origin=sensor_origin,
+        log_odds=log_odds,
+        log_odds_hit=0.85, log_odds_miss=-0.40,
+        log_odds_min=lo_min, log_odds_max=lo_max,
+    )
+    assert log_odds2.min().item() >= lo_min - 1e-6
+    assert log_odds2.max().item() <= lo_max + 1e-6
+    # Clamp should actually be hitting at least one bound on a scene
+    # this dense (many rays through each near-origin voxel).
+    assert (log_odds2 <= lo_min + 1e-6).any() or (log_odds2 >= lo_max - 1e-6).any()
+
+
+# ---------------------------------------------------------------------------
+#  Persistence / composition invariants
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("device", ["cuda"])
+def test_empty_pointcloud_is_noop(device):
+    """Zero-point integration grows the grid to the empty-shell union
+    (which equals the input grid) and leaves log-odds unchanged."""
+    vs = 0.05
+    g, log_odds = _seed_empty_grid(vs, device=device)
+    empty_pts = torch.empty(0, 3, device=device, dtype=torch.float32)
+    sensor_origin = torch.zeros(3, device=device, dtype=torch.float32)
+
+    g2, log_odds2 = g.integrate_occupancy_from_points(
+        truncation_distance=0.1,
+        points=empty_pts, sensor_origin=sensor_origin,
+        log_odds=log_odds,
+    )
+    # Grid topology preserved.
+    assert g2.num_voxels == g.num_voxels
+    # Log-odds tensor preserved (0 -> 0 with no observations).
+    assert torch.allclose(log_odds2, log_odds)
+
+
+@pytest.mark.parametrize("device", ["cuda"])
+def test_frames_matches_sequential(device):
+    """Batched N-frame integration should produce the same result as
+    calling the single-frame API N times in sequence (up to the
+    atomic-add noise floor of the ray-walk kernel). Mirrors the
+    analogous invariant pinned by
+    ``test_integrate_tsdf_from_points_frames_matches_sequential``."""
+    vs = 0.05
+    trunc = 0.1
+    n_frames = 3
+    n_pts = 800
+    device_t = device
+
+    # Three frames with different sphere-shell radii (so each frame's
+    # shell is structurally different and grid growth is exercised).
+    pts_per_frame = [
+        _make_sphere_shell_points(0.8, n_pts, device_t, seed=0),
+        _make_sphere_shell_points(1.1, n_pts, device_t, seed=1),
+        _make_sphere_shell_points(0.9, n_pts, device_t, seed=2),
+    ]
+    sensor_origins = torch.zeros(n_frames, 3, device=device_t, dtype=torch.float32)
+    sensor_origins[:, 0] = torch.linspace(0.0, 0.1, n_frames)
+
+    # Sequential reference: loop over single-frame API.
+    g_seq, lo_seq = _seed_empty_grid(vs, device=device_t)
+    for i in range(n_frames):
+        g_seq, lo_seq = g_seq.integrate_occupancy_from_points(
+            truncation_distance=trunc,
+            points=pts_per_frame[i],
+            sensor_origin=sensor_origins[i],
+            log_odds=lo_seq,
+        )
+
+    # Batched path.
+    g_batched, lo_batched = _seed_empty_grid(vs, device=device_t)
+    g_batched, lo_batched = g_batched.integrate_occupancy_from_points_frames(
+        truncation_distance=trunc,
+        points_per_frame=pts_per_frame,
+        sensor_origins=sensor_origins,
+        log_odds=lo_batched,
+    )
+
+    assert g_seq.num_voxels == g_batched.num_voxels, \
+        f"grid size mismatch: seq {g_seq.num_voxels}, batched {g_batched.num_voxels}"
+    # Same ijk ordering by construction (both built the same union
+    # sequence). Values should match to within atomic-add rounding
+    # (1 ULP on a small fraction of voxels under heavy ray overlap).
+    diff = (lo_seq - lo_batched).abs()
+    # Use the same tolerance the LiDAR-TSDF batched-vs-sequential
+    # parity test uses (atol=2e-6, rtol=1e-5). At log-odds magnitudes
+    # around 4 this is effectively a 5e-5 abs tolerance.
+    tol = 2e-6 + 1e-5 * lo_seq.abs().max().item()
+    assert diff.max().item() <= tol, \
+        f"seq vs batched max diff {diff.max().item()} exceeds tol {tol}"
+
+
+# ---------------------------------------------------------------------------
+#  Grid-growth / sidecar size invariants
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("device", ["cuda"])
+def test_output_sidecar_size_matches_grid(device):
+    vs = 0.05
+    trunc = 0.1
+    points = _make_sphere_shell_points(1.0, 1000, device=device)
+    sensor_origin = torch.zeros(3, device=device, dtype=torch.float32)
+    g, log_odds = _seed_empty_grid(vs, device=device)
+
+    g2, log_odds2 = g.integrate_occupancy_from_points(
+        truncation_distance=trunc,
+        points=points, sensor_origin=sensor_origin,
+        log_odds=log_odds,
+    )
+    # Output sidecar must match output grid's voxel count.
+    assert log_odds2.shape == (g2.num_voxels,)
+    # Output grid strictly grows (sphere shell adds voxels).
+    assert g2.num_voxels > g.num_voxels
+
+
+# ---------------------------------------------------------------------------
+#  Input validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("device", ["cuda"])
+def test_mismatched_log_odds_size_raises(device):
+    vs = 0.05
+    g, _ = _seed_empty_grid(vs, device=device)
+    bad_log_odds = torch.zeros(g.num_voxels + 1, device=device, dtype=torch.float32)
+    points = _make_sphere_shell_points(1.0, 100, device=device)
+    origin = torch.zeros(3, device=device, dtype=torch.float32)
+    with pytest.raises((RuntimeError, ValueError)):
+        g.integrate_occupancy_from_points(
+            truncation_distance=0.1,
+            points=points, sensor_origin=origin,
+            log_odds=bad_log_odds,
+        )
+
+
+@pytest.mark.parametrize("device", ["cuda"])
+def test_inverted_clamp_bounds_raises(device):
+    vs = 0.05
+    g, log_odds = _seed_empty_grid(vs, device=device)
+    points = _make_sphere_shell_points(1.0, 100, device=device)
+    origin = torch.zeros(3, device=device, dtype=torch.float32)
+    with pytest.raises((RuntimeError, ValueError)):
+        g.integrate_occupancy_from_points(
+            truncation_distance=0.1,
+            points=points, sensor_origin=origin, log_odds=log_odds,
+            log_odds_min=2.0, log_odds_max=-2.0,   # inverted
+        )

--- a/tests/unit/test_integrate_occupancy.py
+++ b/tests/unit/test_integrate_occupancy.py
@@ -33,7 +33,10 @@ import fvdb
 
 
 def _make_sphere_shell_points(
-    radius: float, n_points: int, device: str, seed: int = 0,
+    radius: float,
+    n_points: int,
+    device: str,
+    seed: int = 0,
 ) -> torch.Tensor:
     """`n_points` points uniformly sampled on a sphere of the given
     radius, centred at the origin. Deterministic via `seed`."""
@@ -52,8 +55,11 @@ def _seed_empty_grid(voxel_size: float, device: str = "cuda"):
     """1-voxel metadata-only seed — the integrator grows it via the
     shell allocator as rays come in."""
     g = fvdb.Grid.from_dense(
-        dense_dims=[1, 1, 1], ijk_min=[0, 0, 0],
-        voxel_size=voxel_size, origin=[0, 0, 0], device=device,
+        dense_dims=[1, 1, 1],
+        ijk_min=[0, 0, 0],
+        voxel_size=voxel_size,
+        origin=[0, 0, 0],
+        device=device,
     )
     log_odds = torch.zeros(g.num_voxels, device=device, dtype=torch.float32)
     return g, log_odds
@@ -79,7 +85,8 @@ def test_sphere_shell_hits_are_positive(device):
     g, log_odds = _seed_empty_grid(vs, device=device)
     g2, log_odds2 = g.integrate_occupancy_from_points(
         truncation_distance=trunc,
-        points=points, sensor_origin=sensor_origin,
+        points=points,
+        sensor_origin=sensor_origin,
         log_odds=log_odds,
     )
 
@@ -102,8 +109,7 @@ def test_sphere_shell_hits_are_positive(device):
     # (edge of the shell); the statistical invariant is still clean.
     hit_mean = log_odds2[hit_mask].mean().item()
     free_mean = log_odds2[free_mask].mean().item()
-    assert hit_mean > free_mean, \
-        f"hit-band mean {hit_mean:.3f} should exceed free-band mean {free_mean:.3f}"
+    assert hit_mean > free_mean, f"hit-band mean {hit_mean:.3f} should exceed free-band mean {free_mean:.3f}"
 
 
 @pytest.mark.parametrize("device", ["cuda"])
@@ -119,10 +125,13 @@ def test_log_odds_clamped_to_bounds(device):
     lo_min, lo_max = -3.5, 2.5
     _, log_odds2 = g.integrate_occupancy_from_points(
         truncation_distance=trunc,
-        points=points, sensor_origin=sensor_origin,
+        points=points,
+        sensor_origin=sensor_origin,
         log_odds=log_odds,
-        log_odds_hit=0.85, log_odds_miss=-0.40,
-        log_odds_min=lo_min, log_odds_max=lo_max,
+        log_odds_hit=0.85,
+        log_odds_miss=-0.40,
+        log_odds_min=lo_min,
+        log_odds_max=lo_max,
     )
     assert log_odds2.min().item() >= lo_min - 1e-6
     assert log_odds2.max().item() <= lo_max + 1e-6
@@ -147,7 +156,8 @@ def test_empty_pointcloud_is_noop(device):
 
     g2, log_odds2 = g.integrate_occupancy_from_points(
         truncation_distance=0.1,
-        points=empty_pts, sensor_origin=sensor_origin,
+        points=empty_pts,
+        sensor_origin=sensor_origin,
         log_odds=log_odds,
     )
     # Grid topology preserved.
@@ -198,8 +208,9 @@ def test_frames_matches_sequential(device):
         log_odds=lo_batched,
     )
 
-    assert g_seq.num_voxels == g_batched.num_voxels, \
-        f"grid size mismatch: seq {g_seq.num_voxels}, batched {g_batched.num_voxels}"
+    assert (
+        g_seq.num_voxels == g_batched.num_voxels
+    ), f"grid size mismatch: seq {g_seq.num_voxels}, batched {g_batched.num_voxels}"
     # Same ijk ordering by construction (both built the same union
     # sequence). Values should match to within atomic-add rounding
     # (1 ULP on a small fraction of voxels under heavy ray overlap).
@@ -208,8 +219,7 @@ def test_frames_matches_sequential(device):
     # parity test uses (atol=2e-6, rtol=1e-5). At log-odds magnitudes
     # around 4 this is effectively a 5e-5 abs tolerance.
     tol = 2e-6 + 1e-5 * lo_seq.abs().max().item()
-    assert diff.max().item() <= tol, \
-        f"seq vs batched max diff {diff.max().item()} exceeds tol {tol}"
+    assert diff.max().item() <= tol, f"seq vs batched max diff {diff.max().item()} exceeds tol {tol}"
 
 
 # ---------------------------------------------------------------------------
@@ -227,7 +237,8 @@ def test_output_sidecar_size_matches_grid(device):
 
     g2, log_odds2 = g.integrate_occupancy_from_points(
         truncation_distance=trunc,
-        points=points, sensor_origin=sensor_origin,
+        points=points,
+        sensor_origin=sensor_origin,
         log_odds=log_odds,
     )
     # Output sidecar must match output grid's voxel count.
@@ -251,7 +262,8 @@ def test_mismatched_log_odds_size_raises(device):
     with pytest.raises((RuntimeError, ValueError)):
         g.integrate_occupancy_from_points(
             truncation_distance=0.1,
-            points=points, sensor_origin=origin,
+            points=points,
+            sensor_origin=origin,
             log_odds=bad_log_odds,
         )
 
@@ -265,6 +277,9 @@ def test_inverted_clamp_bounds_raises(device):
     with pytest.raises((RuntimeError, ValueError)):
         g.integrate_occupancy_from_points(
             truncation_distance=0.1,
-            points=points, sensor_origin=origin, log_odds=log_odds,
-            log_odds_min=2.0, log_odds_max=-2.0,   # inverted
+            points=points,
+            sensor_origin=origin,
+            log_odds=log_odds,
+            log_odds_min=2.0,
+            log_odds_max=-2.0,  # inverted
         )

--- a/tests/unit/test_persistent_tsdf_state.py
+++ b/tests/unit/test_persistent_tsdf_state.py
@@ -1,0 +1,230 @@
+# Copyright Contributors to the OpenVDB Project
+# SPDX-License-Identifier: Apache-2.0
+"""
+Unit tests for :class:`fvdb._fvdb_cpp.PersistentTSDFState`.
+
+The persistent-TSDF-state primitive pairs a monotonically-growing
+``ValueOnIndex`` live grid with fixed-shape ``tsdf`` / ``weights`` /
+optional ``features`` sidecar tensors, and exposes a ``grow`` method
+that expands the live grid + sidecars atomically while preserving
+values at already-live voxels.
+
+The tests below pin the invariants called out in the class design:
+
+* ``grow`` with disjoint voxels appends correctly (old values
+  preserved verbatim, new slots zero-filled).
+* ``grow`` with fully-overlapping voxels is a no-op (fast-path: no
+  sidecar realloc).
+* ``grow`` with zero new voxels is a no-op.
+* After N ``grow`` calls, ``tsdf.shape[0] == active_voxel_count``.
+* Sidecar *values* survive in place across grows (inject correctness).
+* ``reset`` drops to an empty live grid retaining voxel-size + origin.
+
+Depth- and LiDAR-integrator parity tests live in ``test_basic_ops.py``
+under ``test_integrate_tsdf_frames_matches_sequential`` and
+``test_integrate_tsdf_from_points_frames_matches_sequential`` (Streams
+B and C respectively -- those exercise ``PersistentTSDFState`` end-
+to-end rather than in isolation).
+"""
+
+import pytest
+import torch
+
+import fvdb
+from fvdb._fvdb_cpp import PersistentTSDFState
+
+
+def _make_cpp_ijks(ijks: torch.Tensor):
+    """Wrap an [N,3] int32 tensor as the C++-level ``JaggedTensor``
+    with one outer list, which is the shape ``PersistentTSDFState.grow``
+    expects. The Python wrapper ``fvdb.JaggedTensor`` is a different
+    type than the one the pybind11 signature takes, so we unwrap
+    explicitly here."""
+    jt_py = fvdb.JaggedTensor([ijks])
+    # Unwrap to the C++ JaggedTensor. The Python wrapper stores the
+    # underlying C++ object in different slots across fvdb versions;
+    # try the documented attribute name first, fall back to the
+    # legacy one.
+    for name in ("jt", "_impl", "_jt"):
+        inner = getattr(jt_py, name, None)
+        if inner is not None:
+            return inner
+    raise AssertionError("could not unwrap fvdb.JaggedTensor to the C++ type")
+
+
+def _seed_state(device="cuda", dtype=torch.float32, with_features=False,
+                feature_dim: int = 3):
+    """Build a 4x4x4 dense seed grid + zero'd sidecars."""
+    g = fvdb.Grid.from_dense(
+        dense_dims=[4, 4, 4], ijk_min=[0, 0, 0],
+        voxel_size=0.1, origin=[0, 0, 0], device=device,
+    )
+    tsdf = torch.zeros(g.num_voxels, device=device, dtype=dtype)
+    weights = torch.zeros(g.num_voxels, device=device, dtype=dtype)
+    feats = None
+    if with_features:
+        feats = torch.zeros((g.num_voxels, feature_dim), device=device, dtype=dtype)
+    return g, PersistentTSDFState(g.data, tsdf, weights, feats)
+
+
+@pytest.mark.parametrize("device", ["cuda"])
+def test_construct_sizes_match(device):
+    """`active_voxel_count` and sidecar shapes match the seed grid."""
+    g, st = _seed_state(device=device)
+    assert st.active_voxel_count == g.num_voxels
+    assert st.tsdf.shape == (g.num_voxels,)
+    assert st.weights.shape == (g.num_voxels,)
+    assert not st.has_features
+
+
+@pytest.mark.parametrize("device", ["cuda"])
+def test_grow_disjoint_appends(device):
+    """Disjoint grow: old values preserved verbatim, new slots zero."""
+    g, st = _seed_state(device=device)
+    n_before = st.active_voxel_count
+    # Paint a deterministic signature into the existing sidecars so we
+    # can verify they survive the grow + inject in place.
+    st.tsdf.copy_(torch.arange(n_before, device=device, dtype=st.tsdf.dtype))
+    st.weights.copy_(torch.arange(n_before, device=device,
+                                  dtype=st.weights.dtype) * -1.0)
+
+    new_ijks = torch.tensor([[100, 100, 100], [101, 100, 100]],
+                            dtype=torch.int32, device=device)
+    st.grow(_make_cpp_ijks(new_ijks))
+    n_after = st.active_voxel_count
+    assert n_after == n_before + 2, (
+        f"disjoint grow should append exactly 2 voxels "
+        f"(got {n_after - n_before})")
+
+    # Sidecar shapes match new voxel count.
+    assert st.tsdf.shape[0] == n_after
+    assert st.weights.shape[0] == n_after
+
+    # The tsdf/weights values at the *original* voxels must equal the
+    # signature we painted pre-grow. This is the injectSidecar
+    # correctness invariant: `mergeGrids` may reorder voxels so we
+    # can't compare by index directly -- instead compare the sorted
+    # value sets, which is invariant to reordering.
+    expected_tsdf_old = torch.arange(n_before, device=device,
+                                     dtype=st.tsdf.dtype)
+    expected_w_old = -expected_tsdf_old
+    # Sort to be reorder-invariant. The 2 new slots are guaranteed
+    # zero so we compare the two sorted "set"s after removing the two
+    # zero entries (which could be either new slots or coincidentally
+    # zero old values -- at init the old values were 0..n_before-1,
+    # one of which is 0, so we expect exactly 1 "old zero" + 2 "new
+    # zeros" = 3 zeros total).
+    tsdf_sorted, _ = torch.sort(st.tsdf)
+    assert (tsdf_sorted[:3] == 0).all(), (
+        "expected 3 zero entries (1 old, 2 newly appended), got "
+        f"{tsdf_sorted[:5]}")
+    # The remaining entries must be 1..n_before-1.
+    assert torch.equal(
+        tsdf_sorted[3:].to(torch.float32),
+        torch.arange(1, n_before, device=device, dtype=torch.float32),
+    ), "old TSDF values did not survive grow"
+
+    w_sorted, _ = torch.sort(st.weights)
+    # Weights painted as -arange, so sorted ascending = [-(n-1), ..., 0, 0, 0]
+    assert torch.equal(
+        w_sorted[:n_before - 1].to(torch.float32),
+        torch.arange(-(n_before - 1), 0, device=device, dtype=torch.float32),
+    )
+    assert (w_sorted[n_before - 1:] == 0).all()
+
+
+@pytest.mark.parametrize("device", ["cuda"])
+def test_grow_overlap_only_preserves_values(device):
+    """Full-overlap grow must preserve sidecar values exactly (even
+    if the implementation chooses to reallocate + re-inject).
+
+    Historical note: this test used to require `data_ptr() ==` to
+    pin the fast-path reuse-of-tensors. That fast path was disabled
+    in `PersistentTSDFState::growFromGrid` after it produced semantic
+    divergence vs the sequential TSDF path (see session
+    `2026-04-23_stream_b_depth.md`). The VALUES survive in either
+    case, which is the actual load-bearing invariant -- the data_ptr
+    identity was a proxy for "no extra work", not the contract we
+    were trying to guarantee.
+    """
+    g, st = _seed_state(device=device)
+    n_before = st.active_voxel_count
+
+    # Paint a deterministic signature into sidecars so we can verify
+    # that the overlap-only grow truly preserves values.
+    st.tsdf.copy_(torch.arange(n_before, device=device, dtype=st.tsdf.dtype))
+    st.weights.copy_(torch.arange(n_before, device=device,
+                                  dtype=st.weights.dtype) * -1.0)
+    tsdf_snapshot = st.tsdf.clone()
+    weights_snapshot = st.weights.clone()
+
+    overlap_ijks = torch.tensor([[0, 0, 0], [1, 1, 1], [3, 3, 3]],
+                                dtype=torch.int32, device=device)
+    st.grow(_make_cpp_ijks(overlap_ijks))
+
+    assert st.active_voxel_count == n_before
+    # Either the fast path kicked in (same tensor, same values) or a
+    # realloc + re-inject happened (new tensor, same values). Either
+    # way the sorted multiset of values must match the snapshot.
+    assert torch.equal(torch.sort(st.tsdf.flatten())[0],
+                       torch.sort(tsdf_snapshot.flatten())[0])
+    assert torch.equal(torch.sort(st.weights.flatten())[0],
+                       torch.sort(weights_snapshot.flatten())[0])
+
+
+@pytest.mark.parametrize("device", ["cuda"])
+def test_grow_zero_voxels_is_noop(device):
+    g, st = _seed_state(device=device)
+    n_before = st.active_voxel_count
+    empty_ijks = torch.zeros((0, 3), dtype=torch.int32, device=device)
+    st.grow(_make_cpp_ijks(empty_ijks))
+    assert st.active_voxel_count == n_before
+
+
+@pytest.mark.parametrize("device", ["cuda"])
+def test_grow_many_times_shapes_stay_consistent(device):
+    """After N disjoint grows, tsdf.shape[0] == active_voxel_count."""
+    g, st = _seed_state(device=device)
+    for step in range(5):
+        base = 100 + step * 10
+        new_ijks = torch.tensor(
+            [[base, 0, 0], [base + 1, 0, 0], [base + 2, 0, 0]],
+            dtype=torch.int32, device=device,
+        )
+        st.grow(_make_cpp_ijks(new_ijks))
+        assert st.tsdf.shape[0] == st.active_voxel_count
+        assert st.weights.shape[0] == st.active_voxel_count
+
+
+@pytest.mark.parametrize("device", ["cuda"])
+def test_features_sidecar_survives_grow(device):
+    """When features are attached, they also grow with zero-init for
+    new slots and preserved values for old slots."""
+    g, st = _seed_state(device=device, with_features=True, feature_dim=4)
+    assert st.has_features
+    n_before = st.active_voxel_count
+    st.features.copy_(
+        torch.arange(n_before * 4, device=device, dtype=st.features.dtype)
+            .reshape(n_before, 4)
+    )
+
+    new_ijks = torch.tensor([[100, 0, 0]], dtype=torch.int32, device=device)
+    st.grow(_make_cpp_ijks(new_ijks))
+
+    assert st.features.shape == (n_before + 1, 4)
+    # One row of zeros (the new voxel) + the old rows (in some order).
+    zero_rows = (st.features.abs().sum(dim=1) == 0).sum().item()
+    # The (0, 0, 0) seed voxel initially has all-zero feature row
+    # (it's index 0 in the painted pattern). So after one new voxel we
+    # expect 2 zero rows total: the original all-zero row + the new one.
+    assert zero_rows >= 1, f"expected at least 1 zero feature row, got {zero_rows}"
+
+
+@pytest.mark.parametrize("device", ["cuda"])
+def test_reset_drops_to_zero_voxels(device):
+    g, st = _seed_state(device=device)
+    assert st.active_voxel_count > 0
+    st.reset()
+    assert st.active_voxel_count == 0
+    assert st.tsdf.shape[0] == 0
+    assert st.weights.shape[0] == 0

--- a/tests/unit/test_persistent_tsdf_state.py
+++ b/tests/unit/test_persistent_tsdf_state.py
@@ -29,9 +29,9 @@ to-end rather than in isolation).
 
 import pytest
 import torch
+from fvdb._fvdb_cpp import PersistentTSDFState
 
 import fvdb
-from fvdb._fvdb_cpp import PersistentTSDFState
 
 
 def _make_cpp_ijks(ijks: torch.Tensor):
@@ -52,12 +52,14 @@ def _make_cpp_ijks(ijks: torch.Tensor):
     raise AssertionError("could not unwrap fvdb.JaggedTensor to the C++ type")
 
 
-def _seed_state(device="cuda", dtype=torch.float32, with_features=False,
-                feature_dim: int = 3):
+def _seed_state(device="cuda", dtype=torch.float32, with_features=False, feature_dim: int = 3):
     """Build a 4x4x4 dense seed grid + zero'd sidecars."""
     g = fvdb.Grid.from_dense(
-        dense_dims=[4, 4, 4], ijk_min=[0, 0, 0],
-        voxel_size=0.1, origin=[0, 0, 0], device=device,
+        dense_dims=[4, 4, 4],
+        ijk_min=[0, 0, 0],
+        voxel_size=0.1,
+        origin=[0, 0, 0],
+        device=device,
     )
     tsdf = torch.zeros(g.num_voxels, device=device, dtype=dtype)
     weights = torch.zeros(g.num_voxels, device=device, dtype=dtype)
@@ -85,16 +87,12 @@ def test_grow_disjoint_appends(device):
     # Paint a deterministic signature into the existing sidecars so we
     # can verify they survive the grow + inject in place.
     st.tsdf.copy_(torch.arange(n_before, device=device, dtype=st.tsdf.dtype))
-    st.weights.copy_(torch.arange(n_before, device=device,
-                                  dtype=st.weights.dtype) * -1.0)
+    st.weights.copy_(torch.arange(n_before, device=device, dtype=st.weights.dtype) * -1.0)
 
-    new_ijks = torch.tensor([[100, 100, 100], [101, 100, 100]],
-                            dtype=torch.int32, device=device)
+    new_ijks = torch.tensor([[100, 100, 100], [101, 100, 100]], dtype=torch.int32, device=device)
     st.grow(_make_cpp_ijks(new_ijks))
     n_after = st.active_voxel_count
-    assert n_after == n_before + 2, (
-        f"disjoint grow should append exactly 2 voxels "
-        f"(got {n_after - n_before})")
+    assert n_after == n_before + 2, f"disjoint grow should append exactly 2 voxels " f"(got {n_after - n_before})"
 
     # Sidecar shapes match new voxel count.
     assert st.tsdf.shape[0] == n_after
@@ -105,8 +103,7 @@ def test_grow_disjoint_appends(device):
     # correctness invariant: `mergeGrids` may reorder voxels so we
     # can't compare by index directly -- instead compare the sorted
     # value sets, which is invariant to reordering.
-    expected_tsdf_old = torch.arange(n_before, device=device,
-                                     dtype=st.tsdf.dtype)
+    expected_tsdf_old = torch.arange(n_before, device=device, dtype=st.tsdf.dtype)
     expected_w_old = -expected_tsdf_old
     # Sort to be reorder-invariant. The 2 new slots are guaranteed
     # zero so we compare the two sorted "set"s after removing the two
@@ -115,9 +112,7 @@ def test_grow_disjoint_appends(device):
     # one of which is 0, so we expect exactly 1 "old zero" + 2 "new
     # zeros" = 3 zeros total).
     tsdf_sorted, _ = torch.sort(st.tsdf)
-    assert (tsdf_sorted[:3] == 0).all(), (
-        "expected 3 zero entries (1 old, 2 newly appended), got "
-        f"{tsdf_sorted[:5]}")
+    assert (tsdf_sorted[:3] == 0).all(), "expected 3 zero entries (1 old, 2 newly appended), got " f"{tsdf_sorted[:5]}"
     # The remaining entries must be 1..n_before-1.
     assert torch.equal(
         tsdf_sorted[3:].to(torch.float32),
@@ -127,10 +122,10 @@ def test_grow_disjoint_appends(device):
     w_sorted, _ = torch.sort(st.weights)
     # Weights painted as -arange, so sorted ascending = [-(n-1), ..., 0, 0, 0]
     assert torch.equal(
-        w_sorted[:n_before - 1].to(torch.float32),
+        w_sorted[: n_before - 1].to(torch.float32),
         torch.arange(-(n_before - 1), 0, device=device, dtype=torch.float32),
     )
-    assert (w_sorted[n_before - 1:] == 0).all()
+    assert (w_sorted[n_before - 1 :] == 0).all()
 
 
 @pytest.mark.parametrize("device", ["cuda"])
@@ -153,23 +148,19 @@ def test_grow_overlap_only_preserves_values(device):
     # Paint a deterministic signature into sidecars so we can verify
     # that the overlap-only grow truly preserves values.
     st.tsdf.copy_(torch.arange(n_before, device=device, dtype=st.tsdf.dtype))
-    st.weights.copy_(torch.arange(n_before, device=device,
-                                  dtype=st.weights.dtype) * -1.0)
+    st.weights.copy_(torch.arange(n_before, device=device, dtype=st.weights.dtype) * -1.0)
     tsdf_snapshot = st.tsdf.clone()
     weights_snapshot = st.weights.clone()
 
-    overlap_ijks = torch.tensor([[0, 0, 0], [1, 1, 1], [3, 3, 3]],
-                                dtype=torch.int32, device=device)
+    overlap_ijks = torch.tensor([[0, 0, 0], [1, 1, 1], [3, 3, 3]], dtype=torch.int32, device=device)
     st.grow(_make_cpp_ijks(overlap_ijks))
 
     assert st.active_voxel_count == n_before
     # Either the fast path kicked in (same tensor, same values) or a
     # realloc + re-inject happened (new tensor, same values). Either
     # way the sorted multiset of values must match the snapshot.
-    assert torch.equal(torch.sort(st.tsdf.flatten())[0],
-                       torch.sort(tsdf_snapshot.flatten())[0])
-    assert torch.equal(torch.sort(st.weights.flatten())[0],
-                       torch.sort(weights_snapshot.flatten())[0])
+    assert torch.equal(torch.sort(st.tsdf.flatten())[0], torch.sort(tsdf_snapshot.flatten())[0])
+    assert torch.equal(torch.sort(st.weights.flatten())[0], torch.sort(weights_snapshot.flatten())[0])
 
 
 @pytest.mark.parametrize("device", ["cuda"])
@@ -189,7 +180,8 @@ def test_grow_many_times_shapes_stay_consistent(device):
         base = 100 + step * 10
         new_ijks = torch.tensor(
             [[base, 0, 0], [base + 1, 0, 0], [base + 2, 0, 0]],
-            dtype=torch.int32, device=device,
+            dtype=torch.int32,
+            device=device,
         )
         st.grow(_make_cpp_ijks(new_ijks))
         assert st.tsdf.shape[0] == st.active_voxel_count
@@ -203,10 +195,7 @@ def test_features_sidecar_survives_grow(device):
     g, st = _seed_state(device=device, with_features=True, feature_dim=4)
     assert st.has_features
     n_before = st.active_voxel_count
-    st.features.copy_(
-        torch.arange(n_before * 4, device=device, dtype=st.features.dtype)
-            .reshape(n_before, 4)
-    )
+    st.features.copy_(torch.arange(n_before * 4, device=device, dtype=st.features.dtype).reshape(n_before, 4))
 
     new_ijks = torch.tensor([[100, 0, 0]], dtype=torch.int32, device=device)
     st.grow(_make_cpp_ijks(new_ijks))

--- a/tests/unit/test_sliced_batch.py
+++ b/tests/unit/test_sliced_batch.py
@@ -81,6 +81,39 @@ class TestSlicedBatchTopology(unittest.TestCase):
                 self.assertEqual(len(got), len(sel), f"{name} sel={sel}: result grid_count")
                 self.assertEqual(got, exp, f"{name} sel={sel}: voxel sets differ")
 
+    @parameterized.expand(all_device_combos)
+    def test_merge_and_inject_on_sliced_views(self, device):
+        coords_a = [
+            torch.tensor([[0, 0, 0], [1, 0, 0]], dtype=torch.int32),
+            torch.tensor([[10, 0, 0], [11, 0, 0]], dtype=torch.int32),
+            torch.tensor([[20, 0, 0], [21, 0, 0]], dtype=torch.int32),
+        ]
+        coords_b = [
+            torch.tensor([[1, 0, 0], [2, 0, 0]], dtype=torch.int32),
+            torch.tensor([[11, 0, 0], [12, 0, 0]], dtype=torch.int32),
+            torch.tensor([[21, 0, 0], [22, 0, 0]], dtype=torch.int32),
+        ]
+        full_a = _build(coords_a, device)
+        full_b = _build(coords_b, device)
+
+        # Reverse and skip items so logical batch indices differ from physical handle indices.
+        sel = [2, 0]
+        view_a = full_a[sel]
+        view_b = full_b[sel]
+        ref_a = _build([coords_a[i] for i in sel], device)
+        ref_b = _build([coords_b[i] for i in sel], device)
+
+        self.assertEqual(_ijk_sets(view_a.merged_grid(view_b)), _ijk_sets(ref_a.merged_grid(ref_b)))
+
+        def coordinate_values(grid):
+            ijk = grid.ijk
+            values = (100 * ijk.jdata[:, 0] + 10 * ijk.jdata[:, 1] + ijk.jdata[:, 2]).float()
+            return grid.jagged_like(values)
+
+        got = view_b.inject_from(view_a, coordinate_values(view_a), default_value=-1)
+        expected = ref_b.inject_from(ref_a, coordinate_values(ref_a), default_value=-1)
+        self.assertTrue(torch.equal(got.jdata, expected.jdata))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Native CUDA kernels and Python wrappers for TSDF and ESDF reconstruction, occupancy mapping, dynamic-scene decay, and a fast sparse-compact marching-cubes variant, sharing a common `PersistentTSDFState` + `BuildPointTruncationShell` substrate.

**This supersedes #656**, rebased onto the upstream-seams allocator work instead of the forked-header approach: it is **stacked on #732** (`feat/nanovdb-torch-resource`), so the diff shown here includes #732's commits until that PR merges — review only the last three commits:

1. **`TSDF + ESDF + Occupancy + Decay + fast marching cubes`** — #655/#656's original feature commit, cherry-picked with authorship preserved. Content is unchanged from #656 apart from one merge-conflict resolution in `tests/unit/test_basic_ops.py` (main's new ray-intersection tests vs. this PR's fp16-expanded `test_marching_cubes` decorator; both kept). The multi-frame integrator paths rely on the `TorchResource` allocator routing from #732 rather than the deleted `nanovdb_overrides/` fork.
2. **`Format fix for the new TSDF / ESDF sources`** — pure clang-format pass over the three sources touched by the adaptation commit, kept separate so the adaptation diff below stays readable.
3. **`Adapt TSDF / ESDF stack to current nanovdb and fvdb APIs`** — the rebase adaptations (46+/35− lines), detailed below.

**Draft until** the upstream NanoVDB memory-resource stack (AcademySoftwareFoundation/openvdb#2268 / #2269 / #2270 / #2272 / #2273, tracking issue [#2232](https://github.com/AcademySoftwareFoundation/openvdb/issues/2232)) merges and #732's temporary nanovdb pin is repointed at `AcademySoftwareFoundation/openvdb`.

For the full feature inventory (topology/state primitives, depth + LiDAR TSDF integrators, occupancy mapping, ESDF, marching cubes, Python surface) see #656's description — the feature set is unchanged.

## Rebase notes (May-era main → current main + memory-resource nanovdb)

Three mechanical adaptations to API drift, no behavioral change (commit 3 above):

- **`fvdb::HDDAVoxelIterator` → `fvdb::HDDALeafVoxelIterator`** in the two point-cloud integrators — the renamed alias whose contract matches their per-leaf-voxel sidecar indexing (`getValue(ijk) - 1`).
- **`buildVoxelBlockManager` raw-pointer overload → direct `BuildVoxelBlockManagerFunctor` launch** in `ComputeESDF.cu`. The overload was removed upstream in favor of a `VoxelBlockManagerHandle` API; the handle can't own `TorchDeviceBuffer`s yet because its accessors `static_cast` from `deviceData()` (upstream issue AcademySoftwareFoundation/openvdb#2274). Keeping the `firstLeafID` / `jumpMap` arrays in torch tensors and launching the public functor directly performs the identical launch while staying in torch's pool; once #2274 lands this can move to the handle.
- **`VoxelBlockManager<BlockWidth>` → `VoxelBlockManager<Log2BlockWidth>`** in the ESDF sweep kernel — the template parameter changed meaning upstream.

## Test plan

On a clean `./build.sh install` against the stacked branch (full CUDA build, `-Werror`):

- `tests/unit/test_persistent_tsdf_state.py` — 7 tests
- `tests/unit/test_compute_esdf.py` — 17 tests (exercise the rewritten VBM build path)
- `tests/unit/test_dirty_mask.py` — 9 tests
- `tests/unit/test_integrate_occupancy.py` — 7 tests
- `tests/unit/test_decay_and_prune.py` — 9 tests
- `tests/unit/test_basic_ops.py` — 286 tests including the new TSDF / marching-cubes fp16 / occupancy additions alongside main's current suite

**335 passed, 1 skipped** locally on the fresh install.

## Followups

- Undraft after the upstream stack merges and the nanovdb pin repoints (tracked on #732).
- Move `ComputeESDF`'s VBM arrays onto `VoxelBlockManagerHandle<TorchDeviceBuffer>` once AcademySoftwareFoundation/openvdb#2274 is fixed.
- Cross-library benchmark drivers (Replica, KITTI, Mai City, 7-Scenes; fvdb vs nvblox / VDBFusion / Open3D) live in a companion PR against openvdb/fvdb-reality-capture, unchanged from #656's plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)