### PR TITLE
Bound world-space rasterization channel loop unrolling to improve compile times

### DIFF
--- a/src/fvdb/detail/ops/gsplat/RasterizeWorldSpaceGaussiansBackward.cu
+++ b/src/fvdb/detail/ops/gsplat/RasterizeWorldSpaceGaussiansBackward.cu
@@ -60,6 +60,11 @@ template <uint32_t NUM_CHANNELS, typename Camera>
 __global__ void
 rasterizeFromWorld3DGSBackwardKernel(
     const RasterizeFromWorldBackwardArgs<NUM_CHANNELS, Camera> args) {
+    // Fully expanding every channel operation makes the 512/513-channel kernels prohibitively
+    // expensive for ptxas to optimize, especially for SM 120. Preserve full unrolling for the
+    // smaller kernels while keeping the generated code bounded for larger channel counts.
+    constexpr uint32_t CHANNEL_UNROLL = NUM_CHANNELS <= 32 ? 32 : 4;
+
     auto block               = cg::this_thread_block();
     const uint32_t blockSize = blockDim.x * blockDim.y;
     const auto &common       = args.commonArgs;
@@ -107,7 +112,7 @@ rasterizeFromWorld3DGSBackwardKernel(
     float T                        = 1.0f;
 
     float v_render_c[NUM_CHANNELS];
-#pragma unroll
+#pragma unroll CHANNEL_UNROLL
     for (uint32_t k = 0; k < NUM_CHANNELS; ++k) {
         v_render_c[k] = 0.f;
     }
@@ -120,7 +125,7 @@ rasterizeFromWorld3DGSBackwardKernel(
         T_final                = 1.0f - alphaFinal;
         T                      = T_final;
 
-#pragma unroll
+#pragma unroll CHANNEL_UNROLL
         for (uint32_t k = 0; k < NUM_CHANNELS; ++k) {
             v_render_c[k] = args.dLossDRenderedFeatures[camId][row][col][k];
         }
@@ -128,7 +133,7 @@ rasterizeFromWorld3DGSBackwardKernel(
     }
 
     float buffer[NUM_CHANNELS];
-#pragma unroll
+#pragma unroll CHANNEL_UNROLL
     for (uint32_t k = 0; k < NUM_CHANNELS; ++k) {
         buffer[k] = 0.f;
     }
@@ -237,7 +242,7 @@ rasterizeFromWorld3DGSBackwardKernel(
             }
 
             float v_feat_local[NUM_CHANNELS];
-#pragma unroll
+#pragma unroll CHANNEL_UNROLL
             for (uint32_t k = 0; k < NUM_CHANNELS; ++k) {
                 v_feat_local[k] = 0.f;
             }
@@ -252,7 +257,7 @@ rasterizeFromWorld3DGSBackwardKernel(
                 T *= ra;
 
                 const float fac = alpha * T;
-#pragma unroll
+#pragma unroll CHANNEL_UNROLL
                 for (uint32_t k = 0; k < NUM_CHANNELS; ++k) {
                     v_feat_local[k] = fac * v_render_c[k];
                 }
@@ -263,7 +268,7 @@ rasterizeFromWorld3DGSBackwardKernel(
                 const int32_t cid    = flatId / (int32_t)common.means.size(0);
                 const int32_t gid    = flatId % (int32_t)common.means.size(0);
 
-#pragma unroll
+#pragma unroll CHANNEL_UNROLL
                 for (uint32_t k = 0; k < NUM_CHANNELS; ++k) {
                     const float c = common.features[cid][gid][k];
                     v_alpha += (c * T - buffer[k] * ra) * v_render_c[k];
@@ -273,7 +278,7 @@ rasterizeFromWorld3DGSBackwardKernel(
 
                 if (common.backgrounds != nullptr) {
                     float accum = 0.f;
-#pragma unroll
+#pragma unroll CHANNEL_UNROLL
                     for (uint32_t k = 0; k < NUM_CHANNELS; ++k) {
                         accum += common.backgroundValue(camId, k) * v_render_c[k];
                     }
@@ -327,7 +332,7 @@ rasterizeFromWorld3DGSBackwardKernel(
                 }
 
                 // buffer update
-#pragma unroll
+#pragma unroll CHANNEL_UNROLL
                 for (uint32_t k = 0; k < NUM_CHANNELS; ++k) {
                     const int32_t flatId = idBatch[t];
                     const int32_t cid    = flatId / (int32_t)common.means.size(0);
@@ -341,7 +346,11 @@ rasterizeFromWorld3DGSBackwardKernel(
             warpSumMut(v_mean_local, warp);
             warpSumMut<4>(v_quat_local, warp);
             warpSumMut(v_logscale_local, warp);
-            warpSumMut<NUM_CHANNELS>(v_feat_local, warp);
+            if constexpr (NUM_CHANNELS <= 32) {
+                warpSumMut<NUM_CHANNELS>(v_feat_local, warp);
+            } else {
+                warpSumMut(v_feat_local, NUM_CHANNELS, warp);
+            }
 
             if (warp.thread_rank() == 0) {
                 const int32_t flatId = idBatch[t];
@@ -352,7 +361,7 @@ rasterizeFromWorld3DGSBackwardKernel(
                 float *dFeaturesGaussianPtr = args.dFeatures.data() +
                                               cid * args.dFeatures.stride(0) +
                                               gid * args.dFeatures.stride(1);
-#pragma unroll
+#pragma unroll CHANNEL_UNROLL
                 for (uint32_t k = 0; k < NUM_CHANNELS; ++k) {
                     atomicAdd(dFeaturesGaussianPtr + k * args.dFeatures.stride(2), v_feat_local[k]);
                 }

--- a/src/fvdb/detail/ops/gsplat/RasterizeWorldSpaceGaussiansForward.cu
+++ b/src/fvdb/detail/ops/gsplat/RasterizeWorldSpaceGaussiansForward.cu
@@ -40,6 +40,11 @@ template <uint32_t NUM_CHANNELS, typename Camera> struct RasterizeFromWorldForwa
 
     inline __device__ void
     volumeRenderTileForward() const {
+        // Fully expanding every channel operation makes the 512/513-channel kernels prohibitively
+        // expensive for ptxas to optimize, especially for SM 120. Preserve full unrolling for the
+        // smaller kernels while keeping the generated code bounded for larger channel counts.
+        constexpr uint32_t CHANNEL_UNROLL = NUM_CHANNELS <= 32 ? 32 : 4;
+
         const uint32_t blockSize = blockDim.x * blockDim.y;
         auto block               = cg::this_thread_block();
         const auto &common       = commonArgs;
@@ -65,7 +70,7 @@ template <uint32_t NUM_CHANNELS, typename Camera> struct RasterizeFromWorldForwa
             if (inside) {
                 outAlphaPtr[0]  = 0.0f;
                 outLastIdPtr[0] = -1;
-#pragma unroll
+#pragma unroll CHANNEL_UNROLL
                 for (uint32_t k = 0; k < NUM_CHANNELS; ++k) {
                     outFeaturesPtr[k * outFeatures.stride(3)] = common.backgroundValue(camId, k);
                 }
@@ -96,7 +101,7 @@ template <uint32_t NUM_CHANNELS, typename Camera> struct RasterizeFromWorldForwa
                 // alpha=0, output background if provided else 0.
                 outAlphaPtr[0]  = 0.0f;
                 outLastIdPtr[0] = -1;
-#pragma unroll
+#pragma unroll CHANNEL_UNROLL
                 for (uint32_t k = 0; k < NUM_CHANNELS; ++k) {
                     outFeaturesPtr[k * outFeatures.stride(3)] = common.backgroundValue(camId, k);
                 }
@@ -116,7 +121,7 @@ template <uint32_t NUM_CHANNELS, typename Camera> struct RasterizeFromWorldForwa
         float transmittance            = 1.0f;
         int32_t lastIntersectionOffset = -1;
         float pixOut[NUM_CHANNELS];
-#pragma unroll
+#pragma unroll CHANNEL_UNROLL
         for (uint32_t k = 0; k < NUM_CHANNELS; ++k) {
             pixOut[k] = 0.f;
         }
@@ -186,7 +191,7 @@ template <uint32_t NUM_CHANNELS, typename Camera> struct RasterizeFromWorldForwa
                 const float contrib = alpha * transmittance;
                 const int32_t cid   = g.id / (int32_t)common.means.size(0);
                 const int32_t gid   = g.id % (int32_t)common.means.size(0);
-#pragma unroll
+#pragma unroll CHANNEL_UNROLL
                 for (uint32_t k = 0; k < NUM_CHANNELS; ++k) {
                     pixOut[k] += common.features[cid][gid][k] * contrib;
                 }
@@ -201,7 +206,7 @@ template <uint32_t NUM_CHANNELS, typename Camera> struct RasterizeFromWorldForwa
 
         outAlphaPtr[0]  = 1.0f - transmittance;
         outLastIdPtr[0] = lastIntersectionOffset;
-#pragma unroll
+#pragma unroll CHANNEL_UNROLL
         for (uint32_t k = 0; k < NUM_CHANNELS; ++k) {
             outFeaturesPtr[k * outFeatures.stride(3)] =
                 pixOut[k] + transmittance * common.backgroundValue(camId, k);

--- a/src/tests/GaussianRasterizeWorldSpaceTest.cpp
+++ b/src/tests/GaussianRasterizeWorldSpaceTest.cpp
@@ -186,6 +186,27 @@ TEST(GaussianRasterizeWorldSpaceTest, BackwardMatchesFiniteDifference) {
     EXPECT_TRUE(torch::isfinite(std::get<4>(backward)).all().item<bool>());
 }
 
+TEST(GaussianRasterizeWorldSpaceTest, BackwardSupportsLargeChannelCounts) {
+    const WorldSpaceInputs inputs = makeInputs();
+
+    for (const int64_t channels: {33, 513}) {
+        const auto features = torch::full({1, 1, channels}, 0.25f, inputs.means.options());
+        for (const DistortionModel cameraModel:
+             {DistortionModel::PINHOLE, DistortionModel::ORTHOGRAPHIC}) {
+            const auto forward  = rasterize(inputs, features, cameraModel);
+            const auto backward = rasterizeBackward(inputs, features, forward, cameraModel);
+
+            EXPECT_TRUE(std::get<3>(backward).sizes() == features.sizes());
+            EXPECT_TRUE(torch::isfinite(std::get<0>(backward)).all().item<bool>());
+            EXPECT_TRUE(torch::isfinite(std::get<1>(backward)).all().item<bool>());
+            EXPECT_TRUE(torch::isfinite(std::get<2>(backward)).all().item<bool>());
+            EXPECT_TRUE(torch::isfinite(std::get<3>(backward)).all().item<bool>());
+            EXPECT_TRUE(torch::isfinite(std::get<4>(backward)).all().item<bool>());
+            EXPECT_GT(std::get<3>(backward).abs().sum().item<float>(), 0.0f);
+        }
+    }
+}
+
 TEST(GaussianRasterizeWorldSpaceTest, MasksBackgroundsAndNoIntersections) {
     const WorldSpaceInputs inputs = makeInputs();
     const auto background         = torch::tensor({{0.1f, -0.2f, 0.3f}}, inputs.means.options());


### PR DESCRIPTION
Limit full channel-loop unrolling to kernels with at most 32 channels and use four-way unrolling for larger specializations. Keep the templated warp reduction for small kernels while using the runtime-sized reduction for larger backward kernels.

For CUDA 13.2 targeting sm_120, this reduces forward compile wall time from 165.50s to 71.02s (57.1%, 2.33x) and backward compile wall time from 301.05s to 82.72s (72.5%, 3.64x).