### PR TITLE
Block PRs that drift env pins from fvdb-reality-capture

### DIFF
--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -92,3 +92,54 @@ jobs:
           set +e
           git grep -n "	" -- ':!*/codestyle.yml' ':!*.svg' ':!*.webp' ':!*.cmd' ':!*.png' ':!*.wlt' ':!*.jpg' ':!*.gif' ':!*.mp4' ':!*.pt' ':!*.pth' ':!*.nvdb' ':!*.npz' ':!*.gitmodules' ':!*/wip/*'
           test $? -eq 1
+
+  # The nightly benchmarks in openvdb/fvdb-reality-capture build the fvdb-core
+  # wheel from THIS repo's env/build_environment.yml and install it into their
+  # own benchmark environment. If the pins disagree, that wheel is compiled
+  # against one libtorch and loaded against another, and their nightly dies at
+  # `import fvdb` with an undefined-symbol ImportError. This has happened three
+  # times; a comment in the env file did not prevent the third.
+  #
+  # This gate blocks rather than warns: a GitHub `::warning::` is an annotation,
+  # so a passing (green) check hides it and the drift lands anyway.
+  #
+  # Intentional bumps are expected to fail here, because the companion change
+  # lives in another repository and cannot merge simultaneously. Apply the
+  # 'allow-downstream-drift' label to acknowledge and proceed, then land the
+  # matching update in fvdb-reality-capture.
+  downstream-env-drift:
+    name: Downstream env pins (fvdb-reality-capture)
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      with:
+        persist-credentials: false
+    - name: Compare pins against fvdb-reality-capture benchmark env
+      env:
+        ALLOW_DRIFT: ${{ contains(github.event.pull_request.labels.*.name, 'allow-downstream-drift') }}
+        DOWNSTREAM_URL: https://raw.githubusercontent.com/openvdb/fvdb-reality-capture/main/tests/benchmarks/comparative/docker/benchmark_environment.yml
+      run: |
+        set -euo pipefail
+        curl -fsSL "${DOWNSTREAM_URL}" -o downstream_env.yml
+        rc=0
+        for key in pytorch-gpu cuda-version python; do
+          core=$(grep -oP "^\s*-\s*${key}=\K\S+" env/build_environment.yml || true)
+          downstream=$(grep -oP "^\s*-\s*${key}=\K\S+" downstream_env.yml || true)
+          # An unreadable pin is a failure: a renamed or reformatted line would
+          # otherwise compare empty-to-empty and let this check pass silently.
+          if [ -z "${core}" ] || [ -z "${downstream}" ]; then
+            echo "::error::Could not read '${key}' from both environments (fvdb-core='${core}', downstream='${downstream}'). Update this check if the pin format changed."
+            rc=1
+            continue
+          fi
+          printf '%-14s fvdb-core=%-10s fvdb-reality-capture=%s\n' "${key}" "${core}" "${downstream}"
+          if [ "${core}" != "${downstream}" ]; then
+            echo "::error::${key} drift: this branch pins ${core}, fvdb-reality-capture's benchmark env pins ${downstream}. Merging breaks their nightly benchmarks at 'import fvdb'. Land a companion PR there, or apply the 'allow-downstream-drift' label if this bump is intentional and sequenced."
+            rc=1
+          fi
+        done
+        if [ "${rc}" -ne 0 ] && [ "${ALLOW_DRIFT}" = "true" ]; then
+          echo "::notice::Downstream drift acknowledged via the 'allow-downstream-drift' label."
+          rc=0
+        fi
+        exit "${rc}"

--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -116,30 +116,81 @@ jobs:
         persist-credentials: false
     - name: Compare pins against fvdb-reality-capture benchmark env
       env:
+        GH_TOKEN: ${{ github.token }}
         ALLOW_DRIFT: ${{ contains(github.event.pull_request.labels.*.name, 'allow-downstream-drift') }}
-        DOWNSTREAM_URL: https://raw.githubusercontent.com/openvdb/fvdb-reality-capture/main/tests/benchmarks/comparative/docker/benchmark_environment.yml
+        DOWNSTREAM_REPO: openvdb/fvdb-reality-capture
+        ENV_PATH: tests/benchmarks/comparative/docker/benchmark_environment.yml
+        CORE_ENV: env/build_environment.yml
       run: |
         set -euo pipefail
-        curl -fsSL "${DOWNSTREAM_URL}" -o downstream_env.yml
-        rc=0
+
+        read_pin() { grep -oP "^\\s*-\\s*${2}=\\K\\S+" "$1" || true; }
+
+        curl -fsSL "https://raw.githubusercontent.com/${DOWNSTREAM_REPO}/main/${ENV_PATH}" \
+          -o downstream_main.yml
+
+        unreadable=0
+        : > drifted.txt
         for key in pytorch-gpu cuda-version python; do
-          core=$(grep -oP "^\s*-\s*${key}=\K\S+" env/build_environment.yml || true)
-          downstream=$(grep -oP "^\s*-\s*${key}=\K\S+" downstream_env.yml || true)
+          core=$(read_pin "${CORE_ENV}" "${key}")
+          down=$(read_pin downstream_main.yml "${key}")
           # An unreadable pin is a failure: a renamed or reformatted line would
           # otherwise compare empty-to-empty and let this check pass silently.
-          if [ -z "${core}" ] || [ -z "${downstream}" ]; then
-            echo "::error::Could not read '${key}' from both environments (fvdb-core='${core}', downstream='${downstream}'). Update this check if the pin format changed."
-            rc=1
+          if [ -z "${core}" ] || [ -z "${down}" ]; then
+            echo "::error::Could not read '${key}' from both environments (fvdb-core='${core}', downstream='${down}'). Update this check if the pin format changed."
+            unreadable=1
             continue
           fi
-          printf '%-14s fvdb-core=%-10s fvdb-reality-capture=%s\n' "${key}" "${core}" "${downstream}"
-          if [ "${core}" != "${downstream}" ]; then
-            echo "::error::${key} drift: this branch pins ${core}, fvdb-reality-capture's benchmark env pins ${downstream}. Merging breaks their nightly benchmarks at 'import fvdb'. Land a companion PR there, or apply the 'allow-downstream-drift' label if this bump is intentional and sequenced."
-            rc=1
-          fi
+          printf '%-14s fvdb-core=%-10s downstream@main=%s\n' "${key}" "${core}" "${down}"
+          [ "${core}" = "${down}" ] || printf '%s=%s\n' "${key}" "${core}" >> drifted.txt
         done
-        if [ "${rc}" -ne 0 ] && [ "${ALLOW_DRIFT}" = "true" ]; then
-          echo "::notice::Downstream drift acknowledged via the 'allow-downstream-drift' label."
-          rc=0
+        [ "${unreadable}" -eq 0 ] || { echo "::error::Refusing to pass with an unreadable pin."; exit 1; }
+
+        if [ ! -s drifted.txt ]; then
+          echo "All pins match ${DOWNSTREAM_REPO}@main."
+          exit 0
         fi
-        exit "${rc}"
+        echo "Pin drift vs ${DOWNSTREAM_REPO}@main:"; sed 's/^/  /' drifted.txt
+
+        # A companion PR that already sets every drifted pin to this branch's
+        # value is a valid unblock: it is self-service (fork contributors cannot
+        # apply labels) and it is the change they must make anyway. The hard
+        # backstop stays downstream, where their nightly refuses to run on drift.
+        companion=""; drafts=""; checked=""
+        if ! gh api "repos/${DOWNSTREAM_REPO}/pulls?state=open&per_page=100" \
+              --jq '.[] | [.number, .draft, .head.sha, .title] | @tsv' > open_prs.tsv 2> api_err.txt; then
+          # Fail closed: an API hiccup must not look like an acknowledged bump.
+          echo "::warning::Could not list open PRs in ${DOWNSTREAM_REPO}; not treating that as an unblock. $(tr '\n' ' ' < api_err.txt)"
+        else
+          while IFS=$'\t' read -r num draft sha title; do
+            [ -n "${num:-}" ] || continue
+            checked="${checked} #${num}"
+            if ! gh api "repos/${DOWNSTREAM_REPO}/contents/${ENV_PATH}?ref=${sha}" --jq '.content' 2>/dev/null \
+                 | base64 -d > pr_env.yml 2>/dev/null; then
+              continue
+            fi
+            ok=1
+            while IFS='=' read -r key want; do
+              [ "$(read_pin pr_env.yml "${key}")" = "${want}" ] || ok=0
+            done < drifted.txt
+            [ "${ok}" -eq 1 ] || continue
+            if [ "${draft}" = "true" ]; then
+              drafts="${drafts} #${num}"
+            else
+              companion="#${num} ${title}"
+              break
+            fi
+          done < open_prs.tsv
+        fi
+
+        if [ -n "${companion}" ]; then
+          echo "::notice::Companion PR in ${DOWNSTREAM_REPO} sets the drifted pins to match this branch: ${companion}. Merge it alongside this PR."
+          exit 0
+        fi
+        [ -z "${drafts}" ] || echo "::warning::Draft PR(s) match the drifted pins, but a draft is not accepted as a companion:${drafts}. Mark it ready for review."
+        if [ "${ALLOW_DRIFT}" = "true" ]; then
+          echo "::notice::Drift acknowledged via the 'allow-downstream-drift' label."
+          exit 0
+        fi
+        echo "::error::Pin drift vs ${DOWNSTREAM_REPO}@main with no companion PR. Merging breaks their nightly benchmarks at 'import fvdb'. Open a PR there updating ${ENV_PATH} to match, or apply the 'allow-downstream-drift' label. Open PRs checked:${checked:- none}"
+        exit 1

--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -3,6 +3,11 @@ on:
     pull_request:
       branches:
         - '**'
+      # labeled/unlabeled are needed by downstream-env-drift: its
+      # 'allow-downstream-drift' escape hatch is only honoured on a fresh run,
+      # so without these the label would neither unblock a red check nor
+      # re-block a green one when removed.
+      types: [opened, synchronize, reopened, labeled, unlabeled]
 
 # Allow subsequent pushes to the same PR or REF to cancel any previous jobs.
 concurrency:
@@ -131,6 +136,7 @@ jobs:
 
         unreadable=0
         : > drifted.txt
+        : > core_pins.txt
         for key in pytorch-gpu cuda-version python; do
           core=$(read_pin "${CORE_ENV}" "${key}")
           down=$(read_pin downstream_main.yml "${key}")
@@ -142,6 +148,7 @@ jobs:
             continue
           fi
           printf '%-14s fvdb-core=%-10s downstream@main=%s\n' "${key}" "${core}" "${down}"
+          printf '%s=%s\n' "${key}" "${core}" >> core_pins.txt
           [ "${core}" = "${down}" ] || printf '%s=%s\n' "${key}" "${core}" >> drifted.txt
         done
         [ "${unreadable}" -eq 0 ] || { echo "::error::Refusing to pass with an unreadable pin."; exit 1; }
@@ -157,22 +164,30 @@ jobs:
         # apply labels) and it is the change they must make anyway. The hard
         # backstop stays downstream, where their nightly refuses to run on drift.
         companion=""; drafts=""; checked=""
-        if ! gh api "repos/${DOWNSTREAM_REPO}/pulls?state=open&per_page=100" \
-              --jq '.[] | [.number, .draft, .head.sha, .title] | @tsv' > open_prs.tsv 2> api_err.txt; then
+        # base=main so a PR onto some temporary branch cannot unblock this gate;
+        # --paginate so a companion beyond the first page is not missed.
+        if ! gh api --paginate "repos/${DOWNSTREAM_REPO}/pulls?state=open&base=main&per_page=100" \
+              --jq '.[] | [.number, .draft, .head.sha, .base.ref, .title] | @tsv' > open_prs.tsv 2> api_err.txt; then
           # Fail closed: an API hiccup must not look like an acknowledged bump.
           echo "::warning::Could not list open PRs in ${DOWNSTREAM_REPO}; not treating that as an unblock. $(tr '\n' ' ' < api_err.txt)"
         else
-          while IFS=$'\t' read -r num draft sha title; do
+          while IFS=$'\t' read -r num draft sha baseref title; do
             [ -n "${num:-}" ] || continue
+            # Defensive: the query already filters base=main.
+            [ "${baseref}" = "main" ] || continue
             checked="${checked} #${num}"
             if ! gh api "repos/${DOWNSTREAM_REPO}/contents/${ENV_PATH}?ref=${sha}" --jq '.content' 2>/dev/null \
                  | base64 -d > pr_env.yml 2>/dev/null; then
               continue
             fi
+            # Compare every pin, not just the drifted ones: a PR that fixes the
+            # drifted key while moving an already-aligned key away from fvdb-core
+            # would otherwise be accepted and simply relocate the drift.
             ok=1
             while IFS='=' read -r key want; do
-              [ "$(read_pin pr_env.yml "${key}")" = "${want}" ] || ok=0
-            done < drifted.txt
+              got=$(read_pin pr_env.yml "${key}")
+              [ -n "${got}" ] && [ "${got}" = "${want}" ] || ok=0
+            done < core_pins.txt
             [ "${ok}" -eq 1 ] || continue
             if [ "${draft}" = "true" ]; then
               drafts="${drafts} #${num}"


### PR DESCRIPTION
## Problem

The nightly benchmarks in [openvdb/fvdb-reality-capture](https://github.com/openvdb/fvdb-reality-capture) build the fvdb-core wheel from **this repo's** `env/build_environment.yml`, then install it into their own benchmark environment. When those pins disagree, the wheel is compiled against one libtorch and loaded against another, and their nightly dies at `import fvdb`:

```
ImportError: .../site-packages/fvdb/libfvdb.so: undefined symbol:
  _ZN3c1010ValueErrorC1ENS_14SourceLocationENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE
```

This has happened three times. Most recently #738 (PyTorch 2.13) bumped `pytorch-gpu` from 2.11.0 to 2.13.0 while their benchmark env still pinned 2.11.0, breaking their nightly the same day. The two previous occurrences were fixed downstream in their `1b6956f` (2.8→2.10) and `6c2ede6` (2.10→2.11). A comment in the env file did not prevent the third.

## Change

Add a `downstream-env-drift` job to the code style workflow comparing `pytorch-gpu`, `cuda-version` and `python` against their benchmark env on `main`.

## Design notes

**It blocks rather than warns.** A GitHub `::warning::` is an annotation — it does not post to the PR conversation, and the check still reports green. A warning buried under passing CI is exactly the failure mode this is meant to prevent, so the check fails instead.

**Intentional bumps are expected to fail, and there is an escape hatch.** The companion change lives in another repository and cannot merge in the same commit, so a hard gate with no override would deadlock a legitimate PyTorch bump. Applying the **`allow-downstream-drift`** label acknowledges the drift and lets the PR proceed; the matching update then lands in fvdb-reality-capture. *(That label needs to be created in this repo before the escape hatch works.)*

**An unreadable pin fails.** Without that, renaming or reformatting a pin line would make both `grep -oP` results empty, compare equal, and pass — a guard that quietly stops guarding.

**Hosted in `codestyle.yml`** because it needs only `pull_request` and `contents: read`, so it works for fork PRs with no elevated permissions and no `pull_request_target`.

## Testing

Dry-ran all four paths against the real environment files from both repos:

| Case | Result |
|---|---|
| Real drift (2.13.0 vs 2.11.0), no label | exit 1, error annotation naming both versions |
| Real drift, with `allow-downstream-drift` | exit 0, notice annotation |
| Pins synced | exit 0 |
| Pin line renamed/reformatted | exit 1, "could not read" error |

## Sequencing

This check fails against fvdb-reality-capture `main` today, because the 2.11→2.13 drift is real and present. It goes green once their [#318](https://github.com/openvdb/fvdb-reality-capture/pull/318) merges — **that should land first**, otherwise this red-Xes every fvdb-core PR.

Companion PR adding the mirror-image fail-fast gate to their nightly: [fvdb-reality-capture#319](https://github.com/openvdb/fvdb-reality-capture/pull/319).

🤖 Generated with [Claude Code](https://claude.com/claude-code)