### PR TITLE
Use the batch bbox min for the default morton/hilbert encoding offset

### DIFF
--- a/fvdb/functional/_topology.py
+++ b/fvdb/functional/_topology.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 """Functional API for grid topology operations (coarsen, refine, dual, dilate, etc.)."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
@@ -554,7 +555,8 @@ def morton_batch(grid: GridBatch, offset: torch.Tensor | NumericMaxRank1 | None 
     """
     grid_data = grid.data
     if offset is None:
-        offset = -torch.min(_fvdb_cpp.active_grid_coords(grid_data).jdata, dim=0).values
+        # bbox min == componentwise min over active voxel coords; host metadata, no kernel/sync
+        offset = -grid_data.total_bbox[0]
     elif not isinstance(offset, torch.Tensor):
         offset = to_Vec3i(offset)
     return JaggedTensor(impl=_fvdb_cpp.serialize_encode(grid_data, "morton", offset.tolist()))
@@ -574,7 +576,8 @@ def morton_single(grid: Grid, offset: torch.Tensor | NumericMaxRank1 | None = No
     """
     grid_data = grid.data
     if offset is None:
-        offset = -torch.min(_fvdb_cpp.active_grid_coords(grid_data).jdata, dim=0).values
+        # bbox min == componentwise min over active voxel coords; host metadata, no kernel/sync
+        offset = -grid_data.total_bbox[0]
     elif not isinstance(offset, torch.Tensor):
         offset = to_Vec3i(offset)
     return JaggedTensor(impl=_fvdb_cpp.serialize_encode(grid_data, "morton", offset.tolist())).jdata
@@ -594,7 +597,8 @@ def morton_zyx_batch(grid: GridBatch, offset: torch.Tensor | NumericMaxRank1 | N
     """
     grid_data = grid.data
     if offset is None:
-        offset = -torch.min(_fvdb_cpp.active_grid_coords(grid_data).jdata, dim=0).values
+        # bbox min == componentwise min over active voxel coords; host metadata, no kernel/sync
+        offset = -grid_data.total_bbox[0]
     elif not isinstance(offset, torch.Tensor):
         offset = to_Vec3i(offset)
     return JaggedTensor(impl=_fvdb_cpp.serialize_encode(grid_data, "morton_zyx", offset.tolist()))
@@ -614,7 +618,8 @@ def morton_zyx_single(grid: Grid, offset: torch.Tensor | NumericMaxRank1 | None 
     """
     grid_data = grid.data
     if offset is None:
-        offset = -torch.min(_fvdb_cpp.active_grid_coords(grid_data).jdata, dim=0).values
+        # bbox min == componentwise min over active voxel coords; host metadata, no kernel/sync
+        offset = -grid_data.total_bbox[0]
     elif not isinstance(offset, torch.Tensor):
         offset = to_Vec3i(offset)
     return JaggedTensor(impl=_fvdb_cpp.serialize_encode(grid_data, "morton_zyx", offset.tolist())).jdata
@@ -634,7 +639,8 @@ def hilbert_batch(grid: GridBatch, offset: torch.Tensor | NumericMaxRank1 | None
     """
     grid_data = grid.data
     if offset is None:
-        offset = -torch.min(_fvdb_cpp.active_grid_coords(grid_data).jdata, dim=0).values
+        # bbox min == componentwise min over active voxel coords; host metadata, no kernel/sync
+        offset = -grid_data.total_bbox[0]
     elif not isinstance(offset, torch.Tensor):
         offset = to_Vec3i(offset)
     return JaggedTensor(impl=_fvdb_cpp.serialize_encode(grid_data, "hilbert", offset.tolist()))
@@ -654,7 +660,8 @@ def hilbert_single(grid: Grid, offset: torch.Tensor | NumericMaxRank1 | None = N
     """
     grid_data = grid.data
     if offset is None:
-        offset = -torch.min(_fvdb_cpp.active_grid_coords(grid_data).jdata, dim=0).values
+        # bbox min == componentwise min over active voxel coords; host metadata, no kernel/sync
+        offset = -grid_data.total_bbox[0]
     elif not isinstance(offset, torch.Tensor):
         offset = to_Vec3i(offset)
     return JaggedTensor(impl=_fvdb_cpp.serialize_encode(grid_data, "hilbert", offset.tolist())).jdata
@@ -674,7 +681,8 @@ def hilbert_zyx_batch(grid: GridBatch, offset: torch.Tensor | NumericMaxRank1 | 
     """
     grid_data = grid.data
     if offset is None:
-        offset = -torch.min(_fvdb_cpp.active_grid_coords(grid_data).jdata, dim=0).values
+        # bbox min == componentwise min over active voxel coords; host metadata, no kernel/sync
+        offset = -grid_data.total_bbox[0]
     elif not isinstance(offset, torch.Tensor):
         offset = to_Vec3i(offset)
     return JaggedTensor(impl=_fvdb_cpp.serialize_encode(grid_data, "hilbert_zyx", offset.tolist()))
@@ -694,7 +702,8 @@ def hilbert_zyx_single(grid: Grid, offset: torch.Tensor | NumericMaxRank1 | None
     """
     grid_data = grid.data
     if offset is None:
-        offset = -torch.min(_fvdb_cpp.active_grid_coords(grid_data).jdata, dim=0).values
+        # bbox min == componentwise min over active voxel coords; host metadata, no kernel/sync
+        offset = -grid_data.total_bbox[0]
     elif not isinstance(offset, torch.Tensor):
         offset = to_Vec3i(offset)
     return JaggedTensor(impl=_fvdb_cpp.serialize_encode(grid_data, "hilbert_zyx", offset.tolist())).jdata

--- a/tests/unit/test_morton_hilbert.py
+++ b/tests/unit/test_morton_hilbert.py
@@ -300,5 +300,33 @@ class TestMortonHilbert(unittest.TestCase):
         self.assertEqual(len(ijks_flat), len(hilbert_codes))
 
 
+class TestDefaultOffsetUsesBBoxMin(unittest.TestCase):
+    """The default (offset=None) encoding offset comes from the batch bbox min, which must be
+    exactly equivalent to the componentwise min over all active voxel coordinates (the previous
+    implementation materialized every coordinate just to take that min)."""
+
+    def setUp(self):
+        torch.manual_seed(42)
+
+    @parameterized.expand(all_device_combos)
+    def test_default_offset_matches_explicit_coord_min(self, device):
+        device = resolve_device(device)
+        import fvdb.functional as F
+        from fvdb import Grid
+
+        ijks = [torch.randint(-20, 32, (n, 3), dtype=torch.int32, device=device) for n in (4000, 3000, 2000)]
+        gb = GridBatch.from_ijk(JaggedTensor(ijks))
+
+        for batch in (gb, gb[1:3]):  # sliced views must recompute their bbox
+            offset = -torch.min(batch.ijk.jdata, dim=0).values
+            for fn in (F.morton_batch, F.morton_zyx_batch, F.hilbert_batch, F.hilbert_zyx_batch):
+                self.assertTrue(torch.equal(fn(batch).jdata, fn(batch, offset=offset).jdata))
+
+        g = Grid.from_ijk(ijks[0])
+        offset = -torch.min(g.ijk, dim=0).values
+        for fn in (F.morton_single, F.morton_zyx_single, F.hilbert_single, F.hilbert_zyx_single):
+            self.assertTrue(torch.equal(fn(g), fn(g, offset=offset)))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

The default (`offset=None`) path of the eight morton/hilbert encoding functions in `fvdb/functional/_topology.py` computed its coordinate offset by materializing every active voxel coordinate as an `(N, 3)` tensor (`active_grid_coords`), running a device-wide min reduction, and syncing the result to the host — all to produce a 3-element offset. The batch bbox min is the same componentwise minimum and is already tracked as host-side metadata (`GridBatchData::mTotalBBox`), so the default offset now costs nothing: no kernel launch, no `(N, 3)` allocation, no device sync.

One-line change per site (×8: `morton`/`morton_zyx`/`hilbert`/`hilbert_zyx`, batch and single variants):

```python
offset = -torch.min(_fvdb_cpp.active_grid_coords(grid_data).jdata, dim=0).values   # before
offset = -grid_data.total_bbox[0]                                                  # after
```

### Performance

`GridBatch.morton()` wall time (RTX sm_120, median of 30):

| grid size | before | after | speedup |
|---|---|---|---|
| 400k voxels | 87 µs | 52 µs | 1.67× |
| 5M voxels | 290 µs | 162 µs | 1.79× |

The eliminated work scales with voxel count while the bbox read is O(1), so the win grows with grid size. Removing the device→host sync also makes the encoders launch-async-friendly.

### Correctness

A new regression test (`TestDefaultOffsetUsesBBoxMin`) pins the equivalence: default-offset codes are bitwise identical to explicitly passing `-min(active coords)` for all eight encoders, on CPU and CUDA, including sliced `GridBatch` views (whose bbox metadata is recomputed per view — verified). Full `test_morton_hilbert`, `test_basic_ops`, and `test_basic_ops_single` suites pass (444 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
