### PR TITLE
Fix incorrect channel ordering in FusedSSIM prefetch

### DIFF
--- a/src/fvdb/detail/ops/gsplat/FusedSSIM.cu
+++ b/src/fvdb/detail/ops/gsplat/FusedSSIM.cu
@@ -649,12 +649,13 @@ appendImagePrefetchRanges(std::vector<void *> &prefetchPointers,
             // adjacent devices never issue prefetches for overlapping logical ranges.
             const size_t firstRow = firstTileRow * BLOCK_Y;
             const size_t lastRow  = std::min(lastTileRow * BLOCK_Y, static_cast<size_t>(H));
+            const size_t rowCount = lastRow - firstRow;
 
             for (int channel = 0; channel < CH; ++channel) {
                 const size_t elementOffset = batch * tensor.stride(0) + channel * tensor.stride(1) +
                                              firstRow * tensor.stride(2);
                 auto *pointer          = tensorData + elementOffset * scalarSize;
-                const size_t byteCount = (lastRow - firstRow) * tensor.stride(2) * scalarSize;
+                const size_t byteCount = rowCount * static_cast<size_t>(W) * scalarSize;
 
                 if (prefetchPointers.size() > firstTensorRange) {
                     auto *previousEnd =

--- a/src/fvdb/detail/ops/gsplat/FusedSSIM.cu
+++ b/src/fvdb/detail/ops/gsplat/FusedSSIM.cu
@@ -619,8 +619,7 @@ appendImagePrefetchRanges(std::vector<ImagePrefetchRange> &ranges,
                           int B,
                           int CH,
                           int H,
-                          int W,
-                          int halo) {
+                          int W) {
     if (!tileRowCount) {
         return;
     }
@@ -648,11 +647,10 @@ appendImagePrefetchRanges(std::vector<ImagePrefetchRange> &ranges,
             const size_t lastTileRow =
                 std::min(tileRowEnd, batchTileRowOffset + tileRowsPerImage) - batchTileRowOffset;
 
-            // A chunk owns every x tile in these rows, so only the y extent needs halo expansion.
-            const size_t firstRow = firstTileRow * BLOCK_Y > static_cast<size_t>(halo)
-                                        ? firstTileRow * BLOCK_Y - halo
-                                        : 0;
-            const size_t lastRow  = std::min(lastTileRow * BLOCK_Y + halo, static_cast<size_t>(H));
+            // Prefetch only the rows owned by this device. Halo reads remain demand-driven so
+            // adjacent devices never issue prefetches for overlapping logical ranges.
+            const size_t firstRow     = firstTileRow * BLOCK_Y;
+            const size_t lastRow      = std::min(lastTileRow * BLOCK_Y, static_cast<size_t>(H));
             const size_t elementCount = (lastRow - firstRow) * W;
 
             for (int channel = 0; channel < CH; ++channel) {
@@ -762,7 +760,7 @@ fusedSSIMPrivateUse1(
             std::vector<ImagePrefetchRange> ranges;
             std::vector<torch::Tensor> inputTensors = {img1_, img2_};
             appendImagePrefetchRanges(
-                ranges, inputTensors, chunk.tileRowOffset, chunk.tileRowCount, B, CH, H, W, HALO);
+                ranges, inputTensors, chunk.tileRowOffset, chunk.tileRowCount, B, CH, H, W);
 
             std::vector<torch::Tensor> outputTensors = {ssim_map};
             if (train) {
@@ -771,7 +769,7 @@ fusedSSIMPrivateUse1(
                 outputTensors.emplace_back(dm_dsigma12);
             }
             appendImagePrefetchRanges(
-                ranges, outputTensors, chunk.tileRowOffset, chunk.tileRowCount, B, CH, H, W, 0);
+                ranges, outputTensors, chunk.tileRowOffset, chunk.tileRowCount, B, CH, H, W);
             imagePrefetchBatchAsync(ranges, deviceId, stream);
         }
         C10_CUDA_CHECK(cudaEventRecord(events[deviceId], stream));
@@ -866,23 +864,16 @@ fusedSSIMBackwardPrivateUse1(double C1,
 
             std::vector<torch::Tensor> imageTensors = {img1_, img2_};
             appendImagePrefetchRanges(
-                ranges, imageTensors, chunk.tileRowOffset, chunk.tileRowCount, B, CH, H, W, 0);
+                ranges, imageTensors, chunk.tileRowOffset, chunk.tileRowCount, B, CH, H, W);
 
             std::vector<torch::Tensor> derivativeTensors = {
                 dL_dmap_, dm_dmu1_, dm_dsigma1_sq_, dm_dsigma12_};
-            appendImagePrefetchRanges(ranges,
-                                      derivativeTensors,
-                                      chunk.tileRowOffset,
-                                      chunk.tileRowCount,
-                                      B,
-                                      CH,
-                                      H,
-                                      W,
-                                      HALO);
+            appendImagePrefetchRanges(
+                ranges, derivativeTensors, chunk.tileRowOffset, chunk.tileRowCount, B, CH, H, W);
 
             std::vector<torch::Tensor> outputTensors = {dL_dimg1};
             appendImagePrefetchRanges(
-                ranges, outputTensors, chunk.tileRowOffset, chunk.tileRowCount, B, CH, H, W, 0);
+                ranges, outputTensors, chunk.tileRowOffset, chunk.tileRowCount, B, CH, H, W);
             imagePrefetchBatchAsync(ranges, deviceId, stream);
         }
         C10_CUDA_CHECK(cudaEventRecord(events[deviceId], stream));

--- a/src/fvdb/detail/ops/gsplat/FusedSSIM.cu
+++ b/src/fvdb/detail/ops/gsplat/FusedSSIM.cu
@@ -26,16 +26,17 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 #include <fvdb/detail/ops/gsplat/FusedSSIM.h>
+#include <fvdb/detail/utils/cuda/Prefetch.h>
 #include <fvdb/detail/utils/cuda/Utils.cuh>
 
-#include <nanovdb/util/cuda/Util.h>
-
+#include <c10/core/ScalarType.h>
 #include <c10/cuda/CUDAGuard.h>
 #include <torch/types.h>
 
 #include <cooperative_groups.h>
 
 #include <algorithm>
+#include <cstdint>
 
 namespace fvdb {
 
@@ -589,11 +590,6 @@ struct ImageBlockChunk {
     int blockCount;
 };
 
-struct ImagePrefetchRange {
-    void *pointer;
-    size_t byteCount;
-};
-
 ImageBlockChunk
 imageBlockChunk(int B, int H, int W, int deviceId) {
     // Blocks are flattened with x varying fastest. Split only at full-width tile-row
@@ -612,7 +608,8 @@ imageBlockChunk(int B, int H, int W, int deviceId) {
 }
 
 void
-appendImagePrefetchRanges(std::vector<ImagePrefetchRange> &ranges,
+appendImagePrefetchRanges(std::vector<void *> &prefetchPointers,
+                          std::vector<size_t> &prefetchSizes,
                           const torch::TensorList &tensors,
                           size_t tileRowOffset,
                           size_t tileRowCount,
@@ -635,8 +632,9 @@ appendImagePrefetchRanges(std::vector<ImagePrefetchRange> &ranges,
                         tensor.size(2) == H && tensor.size(3) == W,
                     "Tensor to prefetch does not match the input image shape");
 
-        const size_t firstTensorRange = ranges.size();
-        auto *tensorData              = tensor.data_ptr<float>();
+        const size_t firstTensorRange = prefetchPointers.size();
+        const size_t scalarSize       = c10::elementSize(tensor.scalar_type());
+        auto *tensorData              = static_cast<uint8_t *>(tensor.data_ptr());
 
         const size_t firstBatch = tileRowOffset / tileRowsPerImage;
         const size_t lastBatch  = (tileRowEnd - 1) / tileRowsPerImage;
@@ -649,66 +647,28 @@ appendImagePrefetchRanges(std::vector<ImagePrefetchRange> &ranges,
 
             // Prefetch only the rows owned by this device. Halo reads remain demand-driven so
             // adjacent devices never issue prefetches for overlapping logical ranges.
-            const size_t firstRow     = firstTileRow * BLOCK_Y;
-            const size_t lastRow      = std::min(lastTileRow * BLOCK_Y, static_cast<size_t>(H));
-            const size_t elementCount = (lastRow - firstRow) * W;
+            const size_t firstRow = firstTileRow * BLOCK_Y;
+            const size_t lastRow  = std::min(lastTileRow * BLOCK_Y, static_cast<size_t>(H));
 
             for (int channel = 0; channel < CH; ++channel) {
-                const size_t elementOffset = ((batch * CH + channel) * H + firstRow) * W;
-                auto *pointer              = tensorData + elementOffset;
-                const size_t byteCount     = elementCount * sizeof(float);
+                const size_t elementOffset = batch * tensor.stride(0) + channel * tensor.stride(1) +
+                                             firstRow * tensor.stride(2);
+                auto *pointer          = tensorData + elementOffset * scalarSize;
+                const size_t byteCount = (lastRow - firstRow) * tensor.stride(2) * scalarSize;
 
-                if (ranges.size() > firstTensorRange) {
-                    auto &previousRange = ranges.back();
+                if (prefetchPointers.size() > firstTensorRange) {
                     auto *previousEnd =
-                        static_cast<char *>(previousRange.pointer) + previousRange.byteCount;
-                    if (previousEnd == reinterpret_cast<char *>(pointer)) {
-                        previousRange.byteCount += byteCount;
+                        static_cast<uint8_t *>(prefetchPointers.back()) + prefetchSizes.back();
+                    if (previousEnd == pointer) {
+                        prefetchSizes.back() += byteCount;
                         continue;
                     }
                 }
-                ranges.emplace_back(ImagePrefetchRange{pointer, byteCount});
+                prefetchPointers.emplace_back(pointer);
+                prefetchSizes.emplace_back(byteCount);
             }
         }
     }
-}
-
-void
-imagePrefetchBatchAsync(const std::vector<ImagePrefetchRange> &ranges,
-                        int deviceId,
-                        cudaStream_t stream) {
-    if (ranges.empty()) {
-        return;
-    }
-
-    TORCH_CHECK(stream, "cudaMemPrefetchBatchAsync does not support the default stream");
-#if (CUDART_VERSION < 13000)
-    for (const auto &range: ranges) {
-        C10_CUDA_CHECK(nanovdb::util::cuda::memPrefetchAsync(
-            range.pointer, range.byteCount, deviceId, stream));
-    }
-#else
-    std::vector<void *> prefetchPointers;
-    std::vector<size_t> prefetchSizes;
-    cudaMemLocation location                       = {cudaMemLocationTypeDevice, deviceId};
-    std::vector<cudaMemLocation> prefetchLocations = {location};
-    std::vector<size_t> prefetchLocationIndices    = {0};
-
-    prefetchPointers.reserve(ranges.size());
-    prefetchSizes.reserve(ranges.size());
-    for (const auto &range: ranges) {
-        prefetchPointers.emplace_back(range.pointer);
-        prefetchSizes.emplace_back(range.byteCount);
-    }
-    C10_CUDA_CHECK(cudaMemPrefetchBatchAsync(prefetchPointers.data(),
-                                             prefetchSizes.data(),
-                                             prefetchPointers.size(),
-                                             prefetchLocations.data(),
-                                             prefetchLocationIndices.data(),
-                                             prefetchLocations.size(),
-                                             0,
-                                             stream));
-#endif
 }
 
 } // namespace
@@ -742,6 +702,13 @@ fusedSSIMPrivateUse1(
     auto img1_ = img1.contiguous();
     auto img2_ = img2.contiguous();
 
+    std::vector<torch::Tensor> imageTensors = {img1_, img2_, ssim_map};
+    if (train) {
+        imageTensors.emplace_back(dm_dmu1);
+        imageTensors.emplace_back(dm_dsigma1_sq);
+        imageTensors.emplace_back(dm_dsigma12);
+    }
+
     std::vector<cudaEvent_t> events(c10::cuda::device_count());
     for (const auto deviceId: c10::irange(c10::cuda::device_count())) {
         C10_CUDA_CHECK(cudaSetDevice(deviceId));
@@ -757,20 +724,18 @@ fusedSSIMPrivateUse1(
 
         const auto chunk = imageBlockChunk(B, H, W, deviceId);
         if (chunk.blockCount) {
-            std::vector<ImagePrefetchRange> ranges;
-            std::vector<torch::Tensor> inputTensors = {img1_, img2_};
-            appendImagePrefetchRanges(
-                ranges, inputTensors, chunk.tileRowOffset, chunk.tileRowCount, B, CH, H, W);
-
-            std::vector<torch::Tensor> outputTensors = {ssim_map};
-            if (train) {
-                outputTensors.emplace_back(dm_dmu1);
-                outputTensors.emplace_back(dm_dsigma1_sq);
-                outputTensors.emplace_back(dm_dsigma12);
-            }
-            appendImagePrefetchRanges(
-                ranges, outputTensors, chunk.tileRowOffset, chunk.tileRowCount, B, CH, H, W);
-            imagePrefetchBatchAsync(ranges, deviceId, stream);
+            std::vector<void *> prefetchPointers;
+            std::vector<size_t> prefetchSizes;
+            appendImagePrefetchRanges(prefetchPointers,
+                                      prefetchSizes,
+                                      imageTensors,
+                                      chunk.tileRowOffset,
+                                      chunk.tileRowCount,
+                                      B,
+                                      CH,
+                                      H,
+                                      W);
+            memPrefetchBatchAsync(prefetchPointers, prefetchSizes, deviceId, stream);
         }
         C10_CUDA_CHECK(cudaEventRecord(events[deviceId], stream));
     }
@@ -845,6 +810,9 @@ fusedSSIMBackwardPrivateUse1(double C1,
     auto dm_dsigma1_sq_ = dm_dsigma1_sq.contiguous();
     auto dm_dsigma12_   = dm_dsigma12.contiguous();
 
+    std::vector<torch::Tensor> imageTensors = {
+        img1_, img2_, dL_dmap_, dm_dmu1_, dm_dsigma1_sq_, dm_dsigma12_, dL_dimg1};
+
     std::vector<cudaEvent_t> events(c10::cuda::device_count());
     for (const auto deviceId: c10::irange(c10::cuda::device_count())) {
         C10_CUDA_CHECK(cudaSetDevice(deviceId));
@@ -860,21 +828,18 @@ fusedSSIMBackwardPrivateUse1(double C1,
 
         const auto chunk = imageBlockChunk(B, H, W, deviceId);
         if (chunk.blockCount) {
-            std::vector<ImagePrefetchRange> ranges;
-
-            std::vector<torch::Tensor> imageTensors = {img1_, img2_};
-            appendImagePrefetchRanges(
-                ranges, imageTensors, chunk.tileRowOffset, chunk.tileRowCount, B, CH, H, W);
-
-            std::vector<torch::Tensor> derivativeTensors = {
-                dL_dmap_, dm_dmu1_, dm_dsigma1_sq_, dm_dsigma12_};
-            appendImagePrefetchRanges(
-                ranges, derivativeTensors, chunk.tileRowOffset, chunk.tileRowCount, B, CH, H, W);
-
-            std::vector<torch::Tensor> outputTensors = {dL_dimg1};
-            appendImagePrefetchRanges(
-                ranges, outputTensors, chunk.tileRowOffset, chunk.tileRowCount, B, CH, H, W);
-            imagePrefetchBatchAsync(ranges, deviceId, stream);
+            std::vector<void *> prefetchPointers;
+            std::vector<size_t> prefetchSizes;
+            appendImagePrefetchRanges(prefetchPointers,
+                                      prefetchSizes,
+                                      imageTensors,
+                                      chunk.tileRowOffset,
+                                      chunk.tileRowCount,
+                                      B,
+                                      CH,
+                                      H,
+                                      W);
+            memPrefetchBatchAsync(prefetchPointers, prefetchSizes, deviceId, stream);
         }
         C10_CUDA_CHECK(cudaEventRecord(events[deviceId], stream));
     }

--- a/src/fvdb/detail/ops/gsplat/FusedSSIM.cu
+++ b/src/fvdb/detail/ops/gsplat/FusedSSIM.cu
@@ -582,22 +582,112 @@ fusedSSIMBackwardCUDA(double C1,
 
 namespace {
 
+struct ImageBlockChunk {
+    size_t tileRowOffset;
+    size_t tileRowCount;
+    int blockOffset;
+    int blockCount;
+};
+
+struct ImagePrefetchRange {
+    void *pointer;
+    size_t byteCount;
+};
+
+ImageBlockChunk
+imageBlockChunk(int B, int H, int W, int deviceId) {
+    // Blocks are flattened with x varying fastest. Split only at full-width tile-row
+    // boundaries so each device's NCHW working set can be expressed as compact row ranges.
+    const size_t blocksPerTileRow = (W + BLOCK_X - 1) / BLOCK_X;
+    const size_t tileRowsPerImage = (H + BLOCK_Y - 1) / BLOCK_Y;
+    const size_t globalTileRows   = B * tileRowsPerImage;
+
+    size_t localTileRowOffset, localTileRowCount;
+    std::tie(localTileRowOffset, localTileRowCount) = deviceChunk(globalTileRows, deviceId);
+
+    return {localTileRowOffset,
+            localTileRowCount,
+            static_cast<int>(localTileRowOffset * blocksPerTileRow),
+            static_cast<int>(localTileRowCount * blocksPerTileRow)};
+}
+
 void
-imagePrefetchBatchAsync(const torch::TensorList &tensors,
-                        int localElementOffset,
-                        int localElementCount,
+appendImagePrefetchRanges(std::vector<ImagePrefetchRange> &ranges,
+                          const torch::TensorList &tensors,
+                          size_t tileRowOffset,
+                          size_t tileRowCount,
+                          int B,
+                          int CH,
+                          int H,
+                          int W,
+                          int halo) {
+    if (!tileRowCount) {
+        return;
+    }
+
+    const size_t tileRowsPerImage = (H + BLOCK_Y - 1) / BLOCK_Y;
+    const size_t tileRowEnd       = tileRowOffset + tileRowCount;
+
+    TORCH_CHECK(tileRowEnd <= B * tileRowsPerImage, "Invalid image tile-row range");
+
+    for (const auto &tensor: tensors) {
+        TORCH_CHECK(tensor.is_contiguous(), "Tensor to prefetch is not contiguous");
+        TORCH_CHECK(tensor.dim() == 4 && tensor.size(0) == B && tensor.size(1) == CH &&
+                        tensor.size(2) == H && tensor.size(3) == W,
+                    "Tensor to prefetch does not match the input image shape");
+
+        const size_t firstTensorRange = ranges.size();
+        auto *tensorData              = tensor.data_ptr<float>();
+
+        const size_t firstBatch = tileRowOffset / tileRowsPerImage;
+        const size_t lastBatch  = (tileRowEnd - 1) / tileRowsPerImage;
+        for (size_t batch = firstBatch; batch <= lastBatch; ++batch) {
+            const size_t batchTileRowOffset = batch * tileRowsPerImage;
+            const size_t firstTileRow =
+                std::max(tileRowOffset, batchTileRowOffset) - batchTileRowOffset;
+            const size_t lastTileRow =
+                std::min(tileRowEnd, batchTileRowOffset + tileRowsPerImage) - batchTileRowOffset;
+
+            // A chunk owns every x tile in these rows, so only the y extent needs halo expansion.
+            const size_t firstRow = firstTileRow * BLOCK_Y > static_cast<size_t>(halo)
+                                        ? firstTileRow * BLOCK_Y - halo
+                                        : 0;
+            const size_t lastRow  = std::min(lastTileRow * BLOCK_Y + halo, static_cast<size_t>(H));
+            const size_t elementCount = (lastRow - firstRow) * W;
+
+            for (int channel = 0; channel < CH; ++channel) {
+                const size_t elementOffset = ((batch * CH + channel) * H + firstRow) * W;
+                auto *pointer              = tensorData + elementOffset;
+                const size_t byteCount     = elementCount * sizeof(float);
+
+                if (ranges.size() > firstTensorRange) {
+                    auto &previousRange = ranges.back();
+                    auto *previousEnd =
+                        static_cast<char *>(previousRange.pointer) + previousRange.byteCount;
+                    if (previousEnd == reinterpret_cast<char *>(pointer)) {
+                        previousRange.byteCount += byteCount;
+                        continue;
+                    }
+                }
+                ranges.emplace_back(ImagePrefetchRange{pointer, byteCount});
+            }
+        }
+    }
+}
+
+void
+imagePrefetchBatchAsync(const std::vector<ImagePrefetchRange> &ranges,
                         int deviceId,
                         cudaStream_t stream) {
+    if (ranges.empty()) {
+        return;
+    }
+
     TORCH_CHECK(stream, "cudaMemPrefetchBatchAsync does not support the default stream");
 #if (CUDART_VERSION < 13000)
-    for (size_t i = 0; i < tensors.size(); ++i) {
-        const auto &tensor = tensors[i];
-        TORCH_CHECK(tensor.is_contiguous(), "Tensor to prefetch is not contiguous");
-        C10_CUDA_CHECK(
-            nanovdb::util::cuda::memPrefetchAsync(tensor.data_ptr<float>() + localElementOffset,
-                                                  localElementCount * sizeof(float),
-                                                  deviceId,
-                                                  stream));
+    for (const auto &range: ranges) {
+        C10_CUDA_CHECK(nanovdb::util::cuda::memPrefetchAsync(
+            range.pointer, range.byteCount, deviceId, stream));
     }
 #else
     std::vector<void *> prefetchPointers;
@@ -606,11 +696,11 @@ imagePrefetchBatchAsync(const torch::TensorList &tensors,
     std::vector<cudaMemLocation> prefetchLocations = {location};
     std::vector<size_t> prefetchLocationIndices    = {0};
 
-    for (size_t i = 0; i < tensors.size(); ++i) {
-        const auto &tensor = tensors[i];
-        TORCH_CHECK(tensor.is_contiguous(), "Tensor to prefetch is not contiguous");
-        prefetchPointers.emplace_back(tensor.data_ptr<float>() + localElementOffset);
-        prefetchSizes.emplace_back(localElementCount * sizeof(float));
+    prefetchPointers.reserve(ranges.size());
+    prefetchSizes.reserve(ranges.size());
+    for (const auto &range: ranges) {
+        prefetchPointers.emplace_back(range.pointer);
+        prefetchSizes.emplace_back(range.byteCount);
     }
     C10_CUDA_CHECK(cudaMemPrefetchBatchAsync(prefetchPointers.data(),
                                              prefetchSizes.data(),
@@ -662,34 +752,27 @@ fusedSSIMPrivateUse1(
         C10_CUDA_CHECK(cudaEventRecord(events[deviceId], stream));
     }
 
-    const auto globalBlockCount = ((W + BLOCK_X - 1) / BLOCK_X) * ((H + BLOCK_Y - 1) / BLOCK_Y) * B;
     for (const auto deviceId: c10::irange(c10::cuda::device_count())) {
         C10_CUDA_CHECK(cudaSetDevice(deviceId));
         auto stream = c10::cuda::getStreamFromPool(false, deviceId);
         C10_CUDA_CHECK(cudaStreamWaitEvent(stream, events[deviceId]));
 
-        constexpr size_t kAlignment = kPageSize / (sizeof(float) * BLOCK_X * BLOCK_Y);
-        int localBlockOffset, localBlockCount;
-        std::tie(localBlockOffset, localBlockCount) =
-            deviceAlignedChunk(kAlignment, globalBlockCount, deviceId);
+        const auto chunk = imageBlockChunk(B, H, W, deviceId);
+        if (chunk.blockCount) {
+            std::vector<ImagePrefetchRange> ranges;
+            std::vector<torch::Tensor> inputTensors = {img1_, img2_};
+            appendImagePrefetchRanges(
+                ranges, inputTensors, chunk.tileRowOffset, chunk.tileRowCount, B, CH, H, W, HALO);
 
-        if (localBlockCount) {
-            auto localElementOffset = localBlockOffset * BLOCK_X * BLOCK_Y * CH;
-            auto localElementCount  = localBlockCount * BLOCK_X * BLOCK_Y * CH;
-            if (localElementOffset + localElementCount > img1_.numel()) {
-                localElementOffset = std::min(localElementOffset, static_cast<int>(img1_.numel()));
-                localElementCount  = std::min(localElementCount,
-                                             static_cast<int>(img1_.numel()) - localElementOffset);
-            }
-
-            std::vector<torch::Tensor> tensors = {img1_, img2_, ssim_map};
+            std::vector<torch::Tensor> outputTensors = {ssim_map};
             if (train) {
-                tensors.emplace_back(dm_dmu1);
-                tensors.emplace_back(dm_dsigma1_sq);
-                tensors.emplace_back(dm_dsigma12);
+                outputTensors.emplace_back(dm_dmu1);
+                outputTensors.emplace_back(dm_dsigma1_sq);
+                outputTensors.emplace_back(dm_dsigma12);
             }
-            imagePrefetchBatchAsync(
-                tensors, localElementOffset, localElementCount, deviceId, stream);
+            appendImagePrefetchRanges(
+                ranges, outputTensors, chunk.tileRowOffset, chunk.tileRowCount, B, CH, H, W, 0);
+            imagePrefetchBatchAsync(ranges, deviceId, stream);
         }
         C10_CUDA_CHECK(cudaEventRecord(events[deviceId], stream));
     }
@@ -700,26 +783,14 @@ fusedSSIMPrivateUse1(
         C10_CUDA_CHECK(cudaStreamWaitEvent(stream, events[deviceId]));
         C10_CUDA_CHECK(cudaEventDestroy(events[deviceId]));
 
-        constexpr size_t kAlignment = kPageSize / (sizeof(float) * BLOCK_X * BLOCK_Y);
-        int localBlockOffset, localBlockCount;
-        std::tie(localBlockOffset, localBlockCount) =
-            deviceAlignedChunk(kAlignment, globalBlockCount, deviceId);
-
-        if (localBlockCount) {
-            auto localElementOffset = localBlockOffset * BLOCK_X * BLOCK_Y * CH;
-            auto localElementCount  = localBlockCount * BLOCK_X * BLOCK_Y * CH;
-            if (localElementOffset + localElementCount > img1_.numel()) {
-                localElementOffset = std::min(localElementOffset, static_cast<int>(img1_.numel()));
-                localElementCount  = std::min(localElementCount,
-                                             static_cast<int>(img1_.numel()) - localElementOffset);
-            }
-
+        const auto chunk = imageBlockChunk(B, H, W, deviceId);
+        if (chunk.blockCount) {
             // Launch config
-            dim3 grid(localBlockCount);
+            dim3 grid(chunk.blockCount);
             dim3 block(BLOCK_X, BLOCK_Y);
 
             fusedSSIMKernel<<<grid, block, 0, stream>>>(
-                localBlockOffset,
+                chunk.blockOffset,
                 B,
                 H,
                 W,
@@ -784,29 +855,35 @@ fusedSSIMBackwardPrivateUse1(double C1,
         C10_CUDA_CHECK(cudaEventRecord(events[deviceId], stream));
     }
 
-    const auto globalBlockCount = ((W + BLOCK_X - 1) / BLOCK_X) * ((H + BLOCK_Y - 1) / BLOCK_Y) * B;
     for (const auto deviceId: c10::irange(c10::cuda::device_count())) {
         C10_CUDA_CHECK(cudaSetDevice(deviceId));
         auto stream = c10::cuda::getStreamFromPool(false, deviceId);
         C10_CUDA_CHECK(cudaStreamWaitEvent(stream, events[deviceId]));
 
-        constexpr size_t kAlignment = kPageSize / (sizeof(float) * BLOCK_X * BLOCK_Y);
-        int localBlockOffset, localBlockCount;
-        std::tie(localBlockOffset, localBlockCount) =
-            deviceAlignedChunk(kAlignment, globalBlockCount, deviceId);
+        const auto chunk = imageBlockChunk(B, H, W, deviceId);
+        if (chunk.blockCount) {
+            std::vector<ImagePrefetchRange> ranges;
 
-        if (localBlockCount) {
-            auto localElementOffset = localBlockOffset * BLOCK_X * BLOCK_Y * CH;
-            auto localElementCount  = localBlockCount * BLOCK_X * BLOCK_Y * CH;
-            if (localElementOffset + localElementCount > img1_.numel()) {
-                localElementOffset = std::min(localElementOffset, static_cast<int>(img1_.numel()));
-                localElementCount  = std::min(localElementCount,
-                                             static_cast<int>(img1_.numel()) - localElementOffset);
-            }
+            std::vector<torch::Tensor> imageTensors = {img1_, img2_};
+            appendImagePrefetchRanges(
+                ranges, imageTensors, chunk.tileRowOffset, chunk.tileRowCount, B, CH, H, W, 0);
 
-            std::vector<torch::Tensor> tensors = {dL_dimg1};
-            imagePrefetchBatchAsync(
-                tensors, localElementOffset, localElementCount, deviceId, stream);
+            std::vector<torch::Tensor> derivativeTensors = {
+                dL_dmap_, dm_dmu1_, dm_dsigma1_sq_, dm_dsigma12_};
+            appendImagePrefetchRanges(ranges,
+                                      derivativeTensors,
+                                      chunk.tileRowOffset,
+                                      chunk.tileRowCount,
+                                      B,
+                                      CH,
+                                      H,
+                                      W,
+                                      HALO);
+
+            std::vector<torch::Tensor> outputTensors = {dL_dimg1};
+            appendImagePrefetchRanges(
+                ranges, outputTensors, chunk.tileRowOffset, chunk.tileRowCount, B, CH, H, W, 0);
+            imagePrefetchBatchAsync(ranges, deviceId, stream);
         }
         C10_CUDA_CHECK(cudaEventRecord(events[deviceId], stream));
     }
@@ -817,26 +894,14 @@ fusedSSIMBackwardPrivateUse1(double C1,
         C10_CUDA_CHECK(cudaStreamWaitEvent(stream, events[deviceId]));
         C10_CUDA_CHECK(cudaEventDestroy(events[deviceId]));
 
-        constexpr size_t kAlignment = kPageSize / (sizeof(float) * BLOCK_X * BLOCK_Y);
-        int localBlockOffset, localBlockCount;
-        std::tie(localBlockOffset, localBlockCount) =
-            deviceAlignedChunk(kAlignment, globalBlockCount, deviceId);
-
-        if (localBlockCount) {
-            auto localElementOffset = localBlockOffset * BLOCK_X * BLOCK_Y * CH;
-            auto localElementCount  = localBlockCount * BLOCK_X * BLOCK_Y * CH;
-            if (localElementOffset + localElementCount > img1_.numel()) {
-                localElementOffset = std::min(localElementOffset, static_cast<int>(img1_.numel()));
-                localElementCount  = std::min(localElementCount,
-                                             static_cast<int>(img1_.numel()) - localElementOffset);
-            }
-
+        const auto chunk = imageBlockChunk(B, H, W, deviceId);
+        if (chunk.blockCount) {
             // Launch config
-            dim3 grid(localBlockCount);
+            dim3 grid(chunk.blockCount);
             dim3 block(BLOCK_X, BLOCK_Y);
 
             fusedSSIMBackwardKernel<<<grid, block, 0, stream>>>(
-                localBlockOffset,
+                chunk.blockOffset,
                 B,
                 H,
                 W,


### PR DESCRIPTION
Previously, prefetching in FusedSSIM assumed a NHWC ordering which matches the storage ordering of the image on disk. However, the image is permuted during the training pipeline to NCHW in order to leverage the fused SSIM kernels. This incorrect prefetching led to a significantly amount of unnecessary UVM traffic and fixing it improves fused SSIM scalability dramatically. Measured on 2x RTX 3090s:

| Resolution | Inference: before | Inference: after | Improvement | Training: before | Training: after | Improvement | Backward: before | Backward: after | Improvement |
|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| 1920x1080 | 1.110 ms | 0.559 ms | 1.99x / 49.7% | 1.707 ms | 0.971 ms | 1.76x / 43.1% | 2.353 ms | 1.108 ms | 2.12x / 52.9% |
| 3840x2160 | 4.077 ms | 1.227 ms | 3.32x / 69.9% | 6.143 ms | 2.084 ms | 2.95x / 66.1% | 7.802 ms | 2.222 ms | 3.51x / 71.5% |
| 7680x4320 | 17.089 ms | 3.942 ms | 4.33x / 76.9% | 24.976 ms | 6.078 ms | 4.11x / 75.7% | 31.815 ms | 6.818 ms | 4.67x / 78.6% |