### PR TITLE
Use fused NanoVDB `ReadAccessor::getDimAndActive` in the HDDA iterators

### DIFF
--- a/src/cmake/get_nanovdb.cmake
+++ b/src/cmake/get_nanovdb.cmake
@@ -4,7 +4,7 @@
 CPMAddPackage(
     NAME nanovdb
     GITHUB_REPOSITORY AcademySoftwareFoundation/openvdb
-    GIT_TAG 7946f17edb443fe46076a22ea933e52a23453c24
+    GIT_TAG 9df9ec060dd6a982073c06931c5e93cbb208393e
     SOURCE_SUBDIR nanovdb/nanovdb
     DOWNLOAD_ONLY YES
 )

--- a/src/fvdb/detail/utils/nanovdb/HDDAIterators.h
+++ b/src/fvdb/detail/utils/nanovdb/HDDAIterators.h
@@ -11,6 +11,7 @@
 #include <c10/util/Half.h>
 
 #include <iostream>
+#include <type_traits>
 
 namespace nanovdb {
 
@@ -94,16 +95,27 @@ template <typename AccT, typename ScalarT> struct HDDASegmentIterator {
         mTimespan.t0 = mRay.t1() + static_cast<ScalarT>(5.0);
         mTimespan.t1 = mRay.t1();
         do {
-            // Re-align the HDDA to the correct level if mHdda's current dim disagrees with the
-            // tree's dim at the current voxel. After HDDA::update snaps mVoxel to the new grid
-            // level we have to query isActive at the snapped voxel, so we always do the isActive
-            // lookup *after* the dim check.
-            const int dim = mAcc.getDim(mHdda.voxel(), mRay);
-            if (mHdda.dim() != dim) {
+            // Fused getDim + isActive: a single Root->Internal->Leaf descent (or single
+            // accessor-cache lookup) produces both the HDDA step size and the active state of the
+            // current voxel — see ReadAccessor::getDimAndActive in NanoVDB.h. In the common case
+            // where mHdda is already at the right level this saves one full tree walk per
+            // iteration. The default ActiveExact policy is required here: this iterator reads
+            // `active` unconditionally, including at coarse-tile levels, so a skip-flag
+            // short-circuit that leaves `active` unspecified (ActiveOnLeafOnly) would be wrong.
+            //
+            // If we do need to re-align the HDDA to a different level, HDDA::update snaps mVoxel
+            // to the new grid (mVoxel = RoundDown & ~(dim-1)), so the pre-update active bit may no
+            // longer refer to the current voxel. Re-query after update so `active` is always
+            // consistent with the voxel we'll read in the TimeSpan logic below. This restores the
+            // two-descent cost only on level-change iterations (which are rare compared to
+            // same-level stepping).
+            auto dimActive = mAcc.getDimAndActive(mHdda.voxel(), mRay);
+            if (mHdda.dim() != static_cast<int>(dimActive.dim())) {
                 mRay.setMinTime(mHdda.time());
-                mHdda.update(mRay, dim);
+                mHdda.update(mRay, static_cast<int>(dimActive.dim()));
+                dimActive = mAcc.getDimAndActive(mHdda.voxel(), mRay);
             }
-            const bool active = mAcc.isActive(mHdda.voxel());
+            const bool active = dimActive.active();
 
             // Predicated TimeSpan writes: only the `leaving` break is a real branch. The entering
             // and leaving t0/t1 updates are expressed as selects so rays in the same warp whose
@@ -208,31 +220,49 @@ template <typename AccT, typename ScalarT, bool LeafOnly> struct HDDAValueIterat
     __hostdev__ bool
     nextVoxel() {
         do {
+            // Fused getDim + isActive convergence: ReadAccessor::getDimAndActive collapses the
+            // per-pass getDim and the post-convergence isActive into a single
+            // Root->Internal->Leaf descent per iteration — `active` comes "for free" along with
+            // the dim that drives the convergence check.
+            //
+            // Policy choice: when LeafOnly the gate below only consults `active` after checking
+            // dim == 1, which is exactly the ActiveOnLeafOnly contract — on a skip-flag
+            // short-circuit the returned dim exceeds 1, the gate rejects on dim alone, and the
+            // (unspecified) active bit is never read. That preserves getDim's skip-flag fast path.
+            // When !LeafOnly the gate reads `active` at every level (active coarse tiles must be
+            // yielded), so ActiveExact is required — it matches separate getDim + isActive
+            // byte-for-byte.
+            using PolicyT =
+                std::conditional_t<LeafOnly, nanovdb::ActiveOnLeafOnly, nanovdb::ActiveExact>;
+
             // Re-align the HDDA to the tree level at the current voxel. A single update can leave
             // the HDDA one level short when a step crosses several node levels at once, so we retry
-            // up to three passes (root -> upper -> lower -> leaf is the deepest transition). The
-            // `#pragma unroll` is load-bearing: without it ptxas keeps this bounded loop rolled
-            // (the body is two getDim tree-walks plus an update, too big to auto-unroll) and emits
-            // a data-dependent backedge that adds warp divergence at level transitions. Forcing the
-            // unroll turns the <=3 passes into predicated straight-line code with no backedge.
-            int dim = mAcc.getDim(mHdda.voxel(), mRay);
+            // up to three passes (root -> upper -> lower -> leaf is the deepest transition). Each
+            // re-query runs at the voxel HDDA::update just snapped to, so on loop exit `dimActive`
+            // always describes the current mHdda.voxel(). The `#pragma unroll` is load-bearing:
+            // without it ptxas keeps this bounded loop rolled (the body is a fused tree-walk plus
+            // an update, too big to auto-unroll) and emits a data-dependent backedge that adds
+            // warp divergence at level transitions. Forcing the unroll turns the <=3 passes into
+            // predicated straight-line code with no backedge.
+            auto dimActive = mAcc.template getDimAndActive<PolicyT>(mHdda.voxel(), mRay);
             // Emit the pragma only in the CUDA device pass: it's meaningless on the host and the
             // host compiler treats unknown pragmas as errors (-Werror=unknown-pragmas).
 #if defined(__CUDA_ARCH__)
 #pragma unroll
 #endif
-            for (int pass = 0; pass < 3 && mHdda.dim() != dim; ++pass) {
+            for (int pass = 0; pass < 3 && mHdda.dim() != static_cast<int>(dimActive.dim());
+                 ++pass) {
                 mRay.setMinTime(mHdda.time());
-                mHdda.update(mRay, dim);
-                dim = mAcc.getDim(mHdda.voxel(), mRay);
+                mHdda.update(mRay, static_cast<int>(dimActive.dim()));
+                dimActive = mAcc.template getDimAndActive<PolicyT>(mHdda.voxel(), mRay);
             }
 
-            // dim == 1 is a leaf voxel, dim > 1 a coarse tile; isActive is true for both. When
-            // LeafOnly, skip tiles so we yield only leaf voxels (the trailing mHdda.step() jumps
-            // the whole tile in one coarse step); when !LeafOnly the gate collapses to the original
-            // isActive check.
-            const bool isLeaf = (dim == 1);
-            if ((!LeafOnly || isLeaf) && mAcc.isActive(mHdda.voxel())) {
+            // dim == 1 is a leaf voxel, dim > 1 a coarse tile; active is true for both under
+            // ActiveExact. When LeafOnly, skip tiles so we yield only leaf voxels (the trailing
+            // mHdda.step() jumps the whole tile in one coarse step); when !LeafOnly the gate
+            // collapses to the original isActive check.
+            const bool isLeaf = (static_cast<int>(dimActive.dim()) == 1);
+            if ((!LeafOnly || isLeaf) && dimActive.active()) {
                 mData = {mHdda.voxel(), TimespanT(mHdda.time(), mHdda.next())};
                 mHdda.step();
                 return true;


### PR DESCRIPTION
## Summary

OpenVDB PR [#2220](https://github.com/AcademySoftwareFoundation/openvdb/pull/2220) added the fused `ReadAccessor::getDimAndActive` API to NanoVDB: a single Root→Internal→Leaf descent (or accessor-cache lookup) that returns both the HDDA step size and the active state of a voxel, packed into one register. This PR bumps the NanoVDB pin to that merge commit (`9df9ec06`) and adopts the fused call in both HDDA iterators, replacing the separate `getDim` + `isActive` pair that previously cost two tree walks per iteration.

This restores the methodology originally prototyped alongside #663, which had to be reverted before merge because the fused accessor only existed in a fork at the time.

## Changes

**`HDDASegmentIterator::nextSegment`**
- One `getDimAndActive` call per iteration under the default `ActiveExact` policy, which is byte-for-byte equivalent to the separate calls. `ActiveExact` is required here because the iterator reads `active` unconditionally, including at coarse-tile levels.
- When the HDDA re-aligns to a different level, `HDDA::update` snaps `mVoxel` to the new grid, so the result is re-queried after the update to keep `active` consistent with the voxel the TimeSpan logic reads. The two-descent cost is thus only paid on (rare) level-change iterations.

**`HDDAValueIteratorImpl::nextVoxel`**
- The realign-loop `getDim` queries and the post-convergence `isActive` fuse into one `getDimAndActive` per pass; each re-query runs at the voxel `HDDA::update` just snapped to, so on loop exit the result always describes the current voxel. The force-unrolled ≤3-pass structure is unchanged.
- Policy is selected per instantiation: `HDDALeafVoxelIterator` (`LeafOnly=true`) gates on `dim == 1` before consulting `active`, which is exactly the `ActiveOnLeafOnly` contract, so it keeps `getDim`'s skip-flag fast path. `HDDAActiveValueIterator` (`LeafOnly=false`) must yield active coarse tiles, so it uses `ActiveExact`.

No callers change — `ray_implicit_intersection`, `uniform_ray_samples`, `voxels_along_rays`, and `segments_along_rays` consume the iterators through their public API.

## Benchmarks

RTX PRO 6000 Blackwell, 512×512 pinhole-camera rays, fp32, median of 20 CUDA-event-timed iterations (top/bottom-2 trimmed), NanoVDB example grids. Output checksums are bit-identical to main across all workloads — this is a pure performance change.

| Op | Dataset | main (ms) | fused (ms) | Speedup |
|---|---|---|---|---|
| `voxels_along_rays` | dragon | 4.902 | 2.911 | **1.68×** |
| `voxels_along_rays` | emu | 8.343 | 5.031 | **1.66×** |
| `voxels_along_rays` | wdas_cloud | 24.140 | 16.970 | **1.42×** |
| `voxels_along_rays` | crawler | 18.920 | 13.939 | **1.36×** |
| `segments_along_rays` | crawler | 7.544 | 5.795 | **1.30×** |
| `segments_along_rays` | emu | 3.703 | 2.900 | **1.28×** |
| `segments_along_rays` | wdas_cloud | 12.676 | 9.945 | **1.27×** |
| `segments_along_rays` | dragon | 1.634 | 1.351 | **1.21×** |
| `uniform_ray_samples` | wdas_cloud | 12.798 | 10.033 | **1.28×** |
| `uniform_ray_samples` | dragon | 1.669 | 1.385 | **1.21×** |
| `ray_implicit_intersection` | emu | 0.587 | 0.478 | **1.23×** |
| `ray_implicit_intersection` | crawler | 1.901 | 1.630 | **1.17×** |
| `ray_implicit_intersection` | dragon | 0.384 | 0.374 | **1.03×** |

`ray_implicit_intersection` gains the least because its leaf-only iterator already skips coarse tiles cheaply (and now additionally benefits from `ActiveOnLeafOnly` keeping the skip-flag fast path).

## Test plan

- `pytest tests/unit/test_ray_marching.py tests/unit/test_sample.py` — 455 passed, 4 skipped.
- `pytest tests/unit/test_basic_ops.py -k "ray or implicit or voxels_along or segments"` — 56 passed, 1 skipped, including the #692 zero-prefix regression test.
- Benchmark outputs checksum-identical to main on all 13 workloads above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
