### PR TITLE
CI: retry EC2 runner start with backoff on capacity failures

### DIFF
--- a/.github/workflows/cu130.yml
+++ b/.github/workflows/cu130.yml
@@ -40,22 +40,58 @@ jobs:
       needs.check-changes.outputs.should_test == 'true'
       && (github.event.pull_request.draft == false || github.event_name != 'pull_request_target')
     outputs:
-      label: ${{ steps.start-build-runner.outputs.label }}
-      ec2-instance-id: ${{ steps.start-build-runner.outputs.ec2-instance-id }}
+      label: ${{ steps.start-build-runner-a1.outputs.label || steps.start-build-runner-a2.outputs.label || steps.start-build-runner-a3.outputs.label }}
+      ec2-instance-id: ${{ steps.start-build-runner-a1.outputs.ec2-instance-id || steps.start-build-runner-a2.outputs.ec2-instance-id || steps.start-build-runner-a3.outputs.ec2-instance-id }}
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
           role-to-assume: ${{ needs.versions.outputs.aws-role }}
           aws-region: ${{ needs.versions.outputs.aws-region }}
-      - name: Start EC2 runner
-        id: start-build-runner
+      - name: Start EC2 runner (attempt 1)
+        id: start-build-runner-a1
+        continue-on-error: true
         uses: machulav/ec2-github-runner@343a1b2ae682e681c3cec9a235d882da17ff04ef # v2.6.1
         with:
           mode: start
           github-token: ${{ secrets.EC2_RUNNER_TOKEN }}
           ec2-instance-type: m6a.8xlarge
           availability-zones-config: ${{ needs.versions.outputs.aws-cpu-az-config }}
+      - name: Back off before attempt 2
+        if: steps.start-build-runner-a1.outcome == 'failure'
+        run: |
+          echo "::warning::Runner start attempt 1 found no capacity; retrying in 90s."
+          sleep 90
+      - name: Start EC2 runner (attempt 2)
+        id: start-build-runner-a2
+        if: steps.start-build-runner-a1.outcome == 'failure'
+        continue-on-error: true
+        uses: machulav/ec2-github-runner@343a1b2ae682e681c3cec9a235d882da17ff04ef # v2.6.1
+        with:
+          mode: start
+          github-token: ${{ secrets.EC2_RUNNER_TOKEN }}
+          ec2-instance-type: m6a.8xlarge
+          availability-zones-config: ${{ needs.versions.outputs.aws-cpu-az-config }}
+      - name: Back off before attempt 3
+        if: steps.start-build-runner-a1.outcome == 'failure' && steps.start-build-runner-a2.outcome == 'failure'
+        run: |
+          echo "::warning::Runner start attempt 2 found no capacity; retrying in 180s."
+          sleep 180
+      - name: Start EC2 runner (attempt 3)
+        id: start-build-runner-a3
+        if: steps.start-build-runner-a1.outcome == 'failure' && steps.start-build-runner-a2.outcome == 'failure'
+        continue-on-error: true
+        uses: machulav/ec2-github-runner@343a1b2ae682e681c3cec9a235d882da17ff04ef # v2.6.1
+        with:
+          mode: start
+          github-token: ${{ secrets.EC2_RUNNER_TOKEN }}
+          ec2-instance-type: m6a.8xlarge
+          availability-zones-config: ${{ needs.versions.outputs.aws-cpu-az-config }}
+      - name: Fail if no attempt obtained capacity
+        if: steps.start-build-runner-a1.outcome == 'failure' && steps.start-build-runner-a2.outcome == 'failure' && steps.start-build-runner-a3.outcome == 'failure'
+        run: |
+          echo "::error::Could not obtain an instance after 3 attempts across every configured availability zone; the region is likely out of this instance type."
+          exit 1
 
   ##############################################################################
   # BUILD FVDB
@@ -235,22 +271,58 @@ jobs:
     permissions:
       id-token: write  # Required for AWS OIDC
     outputs:
-      label: ${{ steps.start-tests-gpu-runner.outputs.label }}
-      ec2-instance-id: ${{ steps.start-tests-gpu-runner.outputs.ec2-instance-id }}
+      label: ${{ steps.start-tests-gpu-runner-a1.outputs.label || steps.start-tests-gpu-runner-a2.outputs.label || steps.start-tests-gpu-runner-a3.outputs.label }}
+      ec2-instance-id: ${{ steps.start-tests-gpu-runner-a1.outputs.ec2-instance-id || steps.start-tests-gpu-runner-a2.outputs.ec2-instance-id || steps.start-tests-gpu-runner-a3.outputs.ec2-instance-id }}
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
           role-to-assume: ${{ needs.versions.outputs.aws-role }}
           aws-region: ${{ needs.versions.outputs.aws-region }}
-      - name: Start EC2 GPU runner
-        id: start-tests-gpu-runner
+      - name: Start EC2 GPU runner (attempt 1)
+        id: start-tests-gpu-runner-a1
+        continue-on-error: true
         uses: machulav/ec2-github-runner@343a1b2ae682e681c3cec9a235d882da17ff04ef # v2.6.1
         with:
           mode: start
           github-token: ${{ secrets.EC2_RUNNER_TOKEN }}
           ec2-instance-type: g6.xlarge # 4 CPU-core, L4 GPU
           availability-zones-config: ${{ needs.versions.outputs.aws-gpu-az-config }}
+      - name: Back off before attempt 2
+        if: steps.start-tests-gpu-runner-a1.outcome == 'failure'
+        run: |
+          echo "::warning::Runner start attempt 1 found no capacity; retrying in 90s."
+          sleep 90
+      - name: Start EC2 GPU runner (attempt 2)
+        id: start-tests-gpu-runner-a2
+        if: steps.start-tests-gpu-runner-a1.outcome == 'failure'
+        continue-on-error: true
+        uses: machulav/ec2-github-runner@343a1b2ae682e681c3cec9a235d882da17ff04ef # v2.6.1
+        with:
+          mode: start
+          github-token: ${{ secrets.EC2_RUNNER_TOKEN }}
+          ec2-instance-type: g6.xlarge # 4 CPU-core, L4 GPU
+          availability-zones-config: ${{ needs.versions.outputs.aws-gpu-az-config }}
+      - name: Back off before attempt 3
+        if: steps.start-tests-gpu-runner-a1.outcome == 'failure' && steps.start-tests-gpu-runner-a2.outcome == 'failure'
+        run: |
+          echo "::warning::Runner start attempt 2 found no capacity; retrying in 180s."
+          sleep 180
+      - name: Start EC2 GPU runner (attempt 3)
+        id: start-tests-gpu-runner-a3
+        if: steps.start-tests-gpu-runner-a1.outcome == 'failure' && steps.start-tests-gpu-runner-a2.outcome == 'failure'
+        continue-on-error: true
+        uses: machulav/ec2-github-runner@343a1b2ae682e681c3cec9a235d882da17ff04ef # v2.6.1
+        with:
+          mode: start
+          github-token: ${{ secrets.EC2_RUNNER_TOKEN }}
+          ec2-instance-type: g6.xlarge # 4 CPU-core, L4 GPU
+          availability-zones-config: ${{ needs.versions.outputs.aws-gpu-az-config }}
+      - name: Fail if no attempt obtained capacity
+        if: steps.start-tests-gpu-runner-a1.outcome == 'failure' && steps.start-tests-gpu-runner-a2.outcome == 'failure' && steps.start-tests-gpu-runner-a3.outcome == 'failure'
+        run: |
+          echo "::error::Could not obtain an instance after 3 attempts across every configured availability zone; the region is likely out of this instance type."
+          exit 1
 
   ##############################################################################
   # RUN FVDB GTESTS

--- a/.github/workflows/cu132.yml
+++ b/.github/workflows/cu132.yml
@@ -40,22 +40,58 @@ jobs:
       needs.check-changes.outputs.should_test == 'true'
       && (github.event.pull_request.draft == false || github.event_name != 'pull_request_target')
     outputs:
-      label: ${{ steps.start-build-runner.outputs.label }}
-      ec2-instance-id: ${{ steps.start-build-runner.outputs.ec2-instance-id }}
+      label: ${{ steps.start-build-runner-a1.outputs.label || steps.start-build-runner-a2.outputs.label || steps.start-build-runner-a3.outputs.label }}
+      ec2-instance-id: ${{ steps.start-build-runner-a1.outputs.ec2-instance-id || steps.start-build-runner-a2.outputs.ec2-instance-id || steps.start-build-runner-a3.outputs.ec2-instance-id }}
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
           role-to-assume: ${{ needs.versions.outputs.aws-role }}
           aws-region: ${{ needs.versions.outputs.aws-region }}
-      - name: Start EC2 runner
-        id: start-build-runner
+      - name: Start EC2 runner (attempt 1)
+        id: start-build-runner-a1
+        continue-on-error: true
         uses: machulav/ec2-github-runner@343a1b2ae682e681c3cec9a235d882da17ff04ef # v2.6.1
         with:
           mode: start
           github-token: ${{ secrets.EC2_RUNNER_TOKEN }}
           ec2-instance-type: m6a.8xlarge
           availability-zones-config: ${{ needs.versions.outputs.aws-cpu-az-config }}
+      - name: Back off before attempt 2
+        if: steps.start-build-runner-a1.outcome == 'failure'
+        run: |
+          echo "::warning::Runner start attempt 1 found no capacity; retrying in 90s."
+          sleep 90
+      - name: Start EC2 runner (attempt 2)
+        id: start-build-runner-a2
+        if: steps.start-build-runner-a1.outcome == 'failure'
+        continue-on-error: true
+        uses: machulav/ec2-github-runner@343a1b2ae682e681c3cec9a235d882da17ff04ef # v2.6.1
+        with:
+          mode: start
+          github-token: ${{ secrets.EC2_RUNNER_TOKEN }}
+          ec2-instance-type: m6a.8xlarge
+          availability-zones-config: ${{ needs.versions.outputs.aws-cpu-az-config }}
+      - name: Back off before attempt 3
+        if: steps.start-build-runner-a1.outcome == 'failure' && steps.start-build-runner-a2.outcome == 'failure'
+        run: |
+          echo "::warning::Runner start attempt 2 found no capacity; retrying in 180s."
+          sleep 180
+      - name: Start EC2 runner (attempt 3)
+        id: start-build-runner-a3
+        if: steps.start-build-runner-a1.outcome == 'failure' && steps.start-build-runner-a2.outcome == 'failure'
+        continue-on-error: true
+        uses: machulav/ec2-github-runner@343a1b2ae682e681c3cec9a235d882da17ff04ef # v2.6.1
+        with:
+          mode: start
+          github-token: ${{ secrets.EC2_RUNNER_TOKEN }}
+          ec2-instance-type: m6a.8xlarge
+          availability-zones-config: ${{ needs.versions.outputs.aws-cpu-az-config }}
+      - name: Fail if no attempt obtained capacity
+        if: steps.start-build-runner-a1.outcome == 'failure' && steps.start-build-runner-a2.outcome == 'failure' && steps.start-build-runner-a3.outcome == 'failure'
+        run: |
+          echo "::error::Could not obtain an instance after 3 attempts across every configured availability zone; the region is likely out of this instance type."
+          exit 1
 
   ##############################################################################
   # BUILD FVDB
@@ -235,22 +271,58 @@ jobs:
     permissions:
       id-token: write  # Required for AWS OIDC
     outputs:
-      label: ${{ steps.start-tests-gpu-runner.outputs.label }}
-      ec2-instance-id: ${{ steps.start-tests-gpu-runner.outputs.ec2-instance-id }}
+      label: ${{ steps.start-tests-gpu-runner-a1.outputs.label || steps.start-tests-gpu-runner-a2.outputs.label || steps.start-tests-gpu-runner-a3.outputs.label }}
+      ec2-instance-id: ${{ steps.start-tests-gpu-runner-a1.outputs.ec2-instance-id || steps.start-tests-gpu-runner-a2.outputs.ec2-instance-id || steps.start-tests-gpu-runner-a3.outputs.ec2-instance-id }}
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
           role-to-assume: ${{ needs.versions.outputs.aws-role }}
           aws-region: ${{ needs.versions.outputs.aws-region }}
-      - name: Start EC2 GPU runner
-        id: start-tests-gpu-runner
+      - name: Start EC2 GPU runner (attempt 1)
+        id: start-tests-gpu-runner-a1
+        continue-on-error: true
         uses: machulav/ec2-github-runner@343a1b2ae682e681c3cec9a235d882da17ff04ef # v2.6.1
         with:
           mode: start
           github-token: ${{ secrets.EC2_RUNNER_TOKEN }}
           ec2-instance-type: g6.xlarge # 4 CPU-core, L4 GPU
           availability-zones-config: ${{ needs.versions.outputs.aws-gpu-az-config }}
+      - name: Back off before attempt 2
+        if: steps.start-tests-gpu-runner-a1.outcome == 'failure'
+        run: |
+          echo "::warning::Runner start attempt 1 found no capacity; retrying in 90s."
+          sleep 90
+      - name: Start EC2 GPU runner (attempt 2)
+        id: start-tests-gpu-runner-a2
+        if: steps.start-tests-gpu-runner-a1.outcome == 'failure'
+        continue-on-error: true
+        uses: machulav/ec2-github-runner@343a1b2ae682e681c3cec9a235d882da17ff04ef # v2.6.1
+        with:
+          mode: start
+          github-token: ${{ secrets.EC2_RUNNER_TOKEN }}
+          ec2-instance-type: g6.xlarge # 4 CPU-core, L4 GPU
+          availability-zones-config: ${{ needs.versions.outputs.aws-gpu-az-config }}
+      - name: Back off before attempt 3
+        if: steps.start-tests-gpu-runner-a1.outcome == 'failure' && steps.start-tests-gpu-runner-a2.outcome == 'failure'
+        run: |
+          echo "::warning::Runner start attempt 2 found no capacity; retrying in 180s."
+          sleep 180
+      - name: Start EC2 GPU runner (attempt 3)
+        id: start-tests-gpu-runner-a3
+        if: steps.start-tests-gpu-runner-a1.outcome == 'failure' && steps.start-tests-gpu-runner-a2.outcome == 'failure'
+        continue-on-error: true
+        uses: machulav/ec2-github-runner@343a1b2ae682e681c3cec9a235d882da17ff04ef # v2.6.1
+        with:
+          mode: start
+          github-token: ${{ secrets.EC2_RUNNER_TOKEN }}
+          ec2-instance-type: g6.xlarge # 4 CPU-core, L4 GPU
+          availability-zones-config: ${{ needs.versions.outputs.aws-gpu-az-config }}
+      - name: Fail if no attempt obtained capacity
+        if: steps.start-tests-gpu-runner-a1.outcome == 'failure' && steps.start-tests-gpu-runner-a2.outcome == 'failure' && steps.start-tests-gpu-runner-a3.outcome == 'failure'
+        run: |
+          echo "::error::Could not obtain an instance after 3 attempts across every configured availability zone; the region is likely out of this instance type."
+          exit 1
 
   ##############################################################################
   # RUN FVDB GTESTS

--- a/.github/workflows/nightly-publish.yml
+++ b/.github/workflows/nightly-publish.yml
@@ -78,8 +78,9 @@ jobs:
         with:
           role-to-assume: ${{ needs.versions.outputs.aws-role }}
           aws-region: ${{ needs.versions.outputs.aws-region }}
-      - name: Start EC2 runner
-        id: start-build-runner
+      - name: Start EC2 runner (attempt 1)
+        id: start-build-runner-a1
+        continue-on-error: true
         uses: machulav/ec2-github-runner@343a1b2ae682e681c3cec9a235d882da17ff04ef # v2.6.1
         with:
           mode: start
@@ -95,6 +96,59 @@ jobs:
               {"Key": "CudaVersion", "Value": "${{ matrix.cuda-version }}"},
               {"Key": "GitHubRunId", "Value": "${{ github.run_id }}"}
             ]
+      - name: Back off before attempt 2
+        if: steps.start-build-runner-a1.outcome == 'failure'
+        run: |
+          echo "::warning::Runner start attempt 1 found no capacity; retrying in 90s."
+          sleep 90
+      - name: Start EC2 runner (attempt 2)
+        id: start-build-runner-a2
+        if: steps.start-build-runner-a1.outcome == 'failure'
+        continue-on-error: true
+        uses: machulav/ec2-github-runner@343a1b2ae682e681c3cec9a235d882da17ff04ef # v2.6.1
+        with:
+          mode: start
+          github-token: ${{ secrets.EC2_RUNNER_TOKEN }}
+          ec2-instance-type: m6a.xlarge
+          availability-zones-config: ${{ needs.versions.outputs.aws-cpu-az-config }}
+          label: nightly-${{ matrix.python-version }}-pt${{ matrix.torch-version }}-cu${{ matrix.cuda-version }}-${{ github.run_id }}
+          aws-resource-tags: >
+            [
+              {"Key": "RunnerLabel", "Value": "nightly-${{ matrix.python-version }}-pt${{ matrix.torch-version }}-cu${{ matrix.cuda-version }}-${{ github.run_id }}"},
+              {"Key": "PythonVersion", "Value": "${{ matrix.python-version }}"},
+              {"Key": "TorchVersion", "Value": "${{ matrix.torch-version }}"},
+              {"Key": "CudaVersion", "Value": "${{ matrix.cuda-version }}"},
+              {"Key": "GitHubRunId", "Value": "${{ github.run_id }}"}
+            ]
+      - name: Back off before attempt 3
+        if: steps.start-build-runner-a1.outcome == 'failure' && steps.start-build-runner-a2.outcome == 'failure'
+        run: |
+          echo "::warning::Runner start attempt 2 found no capacity; retrying in 180s."
+          sleep 180
+      - name: Start EC2 runner (attempt 3)
+        id: start-build-runner-a3
+        if: steps.start-build-runner-a1.outcome == 'failure' && steps.start-build-runner-a2.outcome == 'failure'
+        continue-on-error: true
+        uses: machulav/ec2-github-runner@343a1b2ae682e681c3cec9a235d882da17ff04ef # v2.6.1
+        with:
+          mode: start
+          github-token: ${{ secrets.EC2_RUNNER_TOKEN }}
+          ec2-instance-type: m6a.xlarge
+          availability-zones-config: ${{ needs.versions.outputs.aws-cpu-az-config }}
+          label: nightly-${{ matrix.python-version }}-pt${{ matrix.torch-version }}-cu${{ matrix.cuda-version }}-${{ github.run_id }}
+          aws-resource-tags: >
+            [
+              {"Key": "RunnerLabel", "Value": "nightly-${{ matrix.python-version }}-pt${{ matrix.torch-version }}-cu${{ matrix.cuda-version }}-${{ github.run_id }}"},
+              {"Key": "PythonVersion", "Value": "${{ matrix.python-version }}"},
+              {"Key": "TorchVersion", "Value": "${{ matrix.torch-version }}"},
+              {"Key": "CudaVersion", "Value": "${{ matrix.cuda-version }}"},
+              {"Key": "GitHubRunId", "Value": "${{ github.run_id }}"}
+            ]
+      - name: Fail if no attempt obtained capacity
+        if: steps.start-build-runner-a1.outcome == 'failure' && steps.start-build-runner-a2.outcome == 'failure' && steps.start-build-runner-a3.outcome == 'failure'
+        run: |
+          echo "::error::Could not obtain an instance after 3 attempts across every configured availability zone; the region is likely out of this instance type."
+          exit 1
 
   ##############################################################################
   # BUILD NIGHTLY WHEELS

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -140,8 +140,9 @@ jobs:
         with:
           role-to-assume: ${{ needs.versions.outputs.aws-role }}
           aws-region: ${{ needs.versions.outputs.aws-region }}
-      - name: Start EC2 runner
-        id: start-build-runner
+      - name: Start EC2 runner (attempt 1)
+        id: start-build-runner-a1
+        continue-on-error: true
         uses: machulav/ec2-github-runner@343a1b2ae682e681c3cec9a235d882da17ff04ef # v2.6.1
         with:
           mode: start
@@ -157,6 +158,59 @@ jobs:
               {"Key": "CudaVersion", "Value": "${{ matrix.cuda-version }}"},
               {"Key": "GitHubRunId", "Value": "${{ github.run_id }}"}
             ]
+      - name: Back off before attempt 2
+        if: steps.start-build-runner-a1.outcome == 'failure'
+        run: |
+          echo "::warning::Runner start attempt 1 found no capacity; retrying in 90s."
+          sleep 90
+      - name: Start EC2 runner (attempt 2)
+        id: start-build-runner-a2
+        if: steps.start-build-runner-a1.outcome == 'failure'
+        continue-on-error: true
+        uses: machulav/ec2-github-runner@343a1b2ae682e681c3cec9a235d882da17ff04ef # v2.6.1
+        with:
+          mode: start
+          github-token: ${{ secrets.EC2_RUNNER_TOKEN }}
+          ec2-instance-type: m6a.8xlarge
+          availability-zones-config: ${{ needs.versions.outputs.aws-cpu-az-config }}
+          label: ec2-${{ matrix.python-version }}-pt${{ matrix.torch-version }}-cu${{ matrix.cuda-version }}-${{ github.run_id }}
+          aws-resource-tags: >
+            [
+              {"Key": "RunnerLabel", "Value": "ec2-${{ matrix.python-version }}-pt${{ matrix.torch-version }}-cu${{ matrix.cuda-version }}-${{ github.run_id }}"},
+              {"Key": "PythonVersion", "Value": "${{ matrix.python-version }}"},
+              {"Key": "TorchVersion", "Value": "${{ matrix.torch-version }}"},
+              {"Key": "CudaVersion", "Value": "${{ matrix.cuda-version }}"},
+              {"Key": "GitHubRunId", "Value": "${{ github.run_id }}"}
+            ]
+      - name: Back off before attempt 3
+        if: steps.start-build-runner-a1.outcome == 'failure' && steps.start-build-runner-a2.outcome == 'failure'
+        run: |
+          echo "::warning::Runner start attempt 2 found no capacity; retrying in 180s."
+          sleep 180
+      - name: Start EC2 runner (attempt 3)
+        id: start-build-runner-a3
+        if: steps.start-build-runner-a1.outcome == 'failure' && steps.start-build-runner-a2.outcome == 'failure'
+        continue-on-error: true
+        uses: machulav/ec2-github-runner@343a1b2ae682e681c3cec9a235d882da17ff04ef # v2.6.1
+        with:
+          mode: start
+          github-token: ${{ secrets.EC2_RUNNER_TOKEN }}
+          ec2-instance-type: m6a.8xlarge
+          availability-zones-config: ${{ needs.versions.outputs.aws-cpu-az-config }}
+          label: ec2-${{ matrix.python-version }}-pt${{ matrix.torch-version }}-cu${{ matrix.cuda-version }}-${{ github.run_id }}
+          aws-resource-tags: >
+            [
+              {"Key": "RunnerLabel", "Value": "ec2-${{ matrix.python-version }}-pt${{ matrix.torch-version }}-cu${{ matrix.cuda-version }}-${{ github.run_id }}"},
+              {"Key": "PythonVersion", "Value": "${{ matrix.python-version }}"},
+              {"Key": "TorchVersion", "Value": "${{ matrix.torch-version }}"},
+              {"Key": "CudaVersion", "Value": "${{ matrix.cuda-version }}"},
+              {"Key": "GitHubRunId", "Value": "${{ github.run_id }}"}
+            ]
+      - name: Fail if no attempt obtained capacity
+        if: steps.start-build-runner-a1.outcome == 'failure' && steps.start-build-runner-a2.outcome == 'failure' && steps.start-build-runner-a3.outcome == 'failure'
+        run: |
+          echo "::error::Could not obtain an instance after 3 attempts across every configured availability zone; the region is likely out of this instance type."
+          exit 1
 
   fvdb-build:
     name: fVDB Build
@@ -552,8 +606,9 @@ jobs:
         with:
           role-to-assume: ${{ needs.versions.outputs.aws-role }}
           aws-region: ${{ needs.versions.outputs.aws-region }}
-      - name: Start EC2 GPU runner
-        id: start-validation-runner
+      - name: Start EC2 GPU runner (attempt 1)
+        id: start-validation-runner-a1
+        continue-on-error: true
         uses: machulav/ec2-github-runner@343a1b2ae682e681c3cec9a235d882da17ff04ef # v2.6.1
         with:
           mode: start
@@ -569,6 +624,59 @@ jobs:
               {"Key": "CudaVersion", "Value": "${{ matrix.cuda-version }}"},
               {"Key": "GitHubRunId", "Value": "${{ github.run_id }}"}
             ]
+      - name: Back off before attempt 2
+        if: steps.start-validation-runner-a1.outcome == 'failure'
+        run: |
+          echo "::warning::Runner start attempt 1 found no capacity; retrying in 90s."
+          sleep 90
+      - name: Start EC2 GPU runner (attempt 2)
+        id: start-validation-runner-a2
+        if: steps.start-validation-runner-a1.outcome == 'failure'
+        continue-on-error: true
+        uses: machulav/ec2-github-runner@343a1b2ae682e681c3cec9a235d882da17ff04ef # v2.6.1
+        with:
+          mode: start
+          github-token: ${{ secrets.EC2_RUNNER_TOKEN }}
+          ec2-instance-type: g6.xlarge
+          availability-zones-config: ${{ needs.versions.outputs.aws-gpu-az-config }}
+          label: val-${{ matrix.python-version }}-pt${{ matrix.torch-version }}-cu${{ matrix.cuda-version }}-${{ github.run_id }}
+          aws-resource-tags: >
+            [
+              {"Key": "RunnerLabel", "Value": "val-${{ matrix.python-version }}-pt${{ matrix.torch-version }}-cu${{ matrix.cuda-version }}-${{ github.run_id }}"},
+              {"Key": "PythonVersion", "Value": "${{ matrix.python-version }}"},
+              {"Key": "TorchVersion", "Value": "${{ matrix.torch-version }}"},
+              {"Key": "CudaVersion", "Value": "${{ matrix.cuda-version }}"},
+              {"Key": "GitHubRunId", "Value": "${{ github.run_id }}"}
+            ]
+      - name: Back off before attempt 3
+        if: steps.start-validation-runner-a1.outcome == 'failure' && steps.start-validation-runner-a2.outcome == 'failure'
+        run: |
+          echo "::warning::Runner start attempt 2 found no capacity; retrying in 180s."
+          sleep 180
+      - name: Start EC2 GPU runner (attempt 3)
+        id: start-validation-runner-a3
+        if: steps.start-validation-runner-a1.outcome == 'failure' && steps.start-validation-runner-a2.outcome == 'failure'
+        continue-on-error: true
+        uses: machulav/ec2-github-runner@343a1b2ae682e681c3cec9a235d882da17ff04ef # v2.6.1
+        with:
+          mode: start
+          github-token: ${{ secrets.EC2_RUNNER_TOKEN }}
+          ec2-instance-type: g6.xlarge
+          availability-zones-config: ${{ needs.versions.outputs.aws-gpu-az-config }}
+          label: val-${{ matrix.python-version }}-pt${{ matrix.torch-version }}-cu${{ matrix.cuda-version }}-${{ github.run_id }}
+          aws-resource-tags: >
+            [
+              {"Key": "RunnerLabel", "Value": "val-${{ matrix.python-version }}-pt${{ matrix.torch-version }}-cu${{ matrix.cuda-version }}-${{ github.run_id }}"},
+              {"Key": "PythonVersion", "Value": "${{ matrix.python-version }}"},
+              {"Key": "TorchVersion", "Value": "${{ matrix.torch-version }}"},
+              {"Key": "CudaVersion", "Value": "${{ matrix.cuda-version }}"},
+              {"Key": "GitHubRunId", "Value": "${{ github.run_id }}"}
+            ]
+      - name: Fail if no attempt obtained capacity
+        if: steps.start-validation-runner-a1.outcome == 'failure' && steps.start-validation-runner-a2.outcome == 'failure' && steps.start-validation-runner-a3.outcome == 'failure'
+        run: |
+          echo "::error::Could not obtain an instance after 3 attempts across every configured availability zone; the region is likely out of this instance type."
+          exit 1
 
   validate-smoke-test:
     name: Smoke test built wheel

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,22 +46,58 @@ jobs:
       needs.check-changes.outputs.should_test == 'true'
       && (github.event.pull_request.draft == false || github.event_name != 'pull_request_target')
     outputs:
-      label: ${{ steps.start-build-runner.outputs.label }}
-      ec2-instance-id: ${{ steps.start-build-runner.outputs.ec2-instance-id }}
+      label: ${{ steps.start-build-runner-a1.outputs.label || steps.start-build-runner-a2.outputs.label || steps.start-build-runner-a3.outputs.label }}
+      ec2-instance-id: ${{ steps.start-build-runner-a1.outputs.ec2-instance-id || steps.start-build-runner-a2.outputs.ec2-instance-id || steps.start-build-runner-a3.outputs.ec2-instance-id }}
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
           role-to-assume: ${{ needs.versions.outputs.aws-role }}
           aws-region: ${{ needs.versions.outputs.aws-region }}
-      - name: Start EC2 runner
-        id: start-build-runner
+      - name: Start EC2 runner (attempt 1)
+        id: start-build-runner-a1
+        continue-on-error: true
         uses: machulav/ec2-github-runner@343a1b2ae682e681c3cec9a235d882da17ff04ef # v2.6.1
         with:
           mode: start
           github-token: ${{ secrets.EC2_RUNNER_TOKEN }}
           ec2-instance-type: m6a.8xlarge
           availability-zones-config: ${{ needs.versions.outputs.aws-cpu-az-config }}
+      - name: Back off before attempt 2
+        if: steps.start-build-runner-a1.outcome == 'failure'
+        run: |
+          echo "::warning::Runner start attempt 1 found no capacity; retrying in 90s."
+          sleep 90
+      - name: Start EC2 runner (attempt 2)
+        id: start-build-runner-a2
+        if: steps.start-build-runner-a1.outcome == 'failure'
+        continue-on-error: true
+        uses: machulav/ec2-github-runner@343a1b2ae682e681c3cec9a235d882da17ff04ef # v2.6.1
+        with:
+          mode: start
+          github-token: ${{ secrets.EC2_RUNNER_TOKEN }}
+          ec2-instance-type: m6a.8xlarge
+          availability-zones-config: ${{ needs.versions.outputs.aws-cpu-az-config }}
+      - name: Back off before attempt 3
+        if: steps.start-build-runner-a1.outcome == 'failure' && steps.start-build-runner-a2.outcome == 'failure'
+        run: |
+          echo "::warning::Runner start attempt 2 found no capacity; retrying in 180s."
+          sleep 180
+      - name: Start EC2 runner (attempt 3)
+        id: start-build-runner-a3
+        if: steps.start-build-runner-a1.outcome == 'failure' && steps.start-build-runner-a2.outcome == 'failure'
+        continue-on-error: true
+        uses: machulav/ec2-github-runner@343a1b2ae682e681c3cec9a235d882da17ff04ef # v2.6.1
+        with:
+          mode: start
+          github-token: ${{ secrets.EC2_RUNNER_TOKEN }}
+          ec2-instance-type: m6a.8xlarge
+          availability-zones-config: ${{ needs.versions.outputs.aws-cpu-az-config }}
+      - name: Fail if no attempt obtained capacity
+        if: steps.start-build-runner-a1.outcome == 'failure' && steps.start-build-runner-a2.outcome == 'failure' && steps.start-build-runner-a3.outcome == 'failure'
+        run: |
+          echo "::error::Could not obtain an instance after 3 attempts across every configured availability zone; the region is likely out of this instance type."
+          exit 1
   fvdb-build:
     name: fVDB Build (Conda)
     needs: [start-build-runner, versions] # required to start the main job when the runner is ready
@@ -190,22 +226,58 @@ jobs:
     permissions:
       id-token: write  # Required for AWS OIDC
     outputs:
-      label: ${{ steps.start-tests-gpu-runner.outputs.label }}
-      ec2-instance-id: ${{ steps.start-tests-gpu-runner.outputs.ec2-instance-id }}
+      label: ${{ steps.start-tests-gpu-runner-a1.outputs.label || steps.start-tests-gpu-runner-a2.outputs.label || steps.start-tests-gpu-runner-a3.outputs.label }}
+      ec2-instance-id: ${{ steps.start-tests-gpu-runner-a1.outputs.ec2-instance-id || steps.start-tests-gpu-runner-a2.outputs.ec2-instance-id || steps.start-tests-gpu-runner-a3.outputs.ec2-instance-id }}
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
           role-to-assume: ${{ needs.versions.outputs.aws-role }}
           aws-region: ${{ needs.versions.outputs.aws-region }}
-      - name: Start EC2 GPU runner
-        id: start-tests-gpu-runner
+      - name: Start EC2 GPU runner (attempt 1)
+        id: start-tests-gpu-runner-a1
+        continue-on-error: true
         uses: machulav/ec2-github-runner@343a1b2ae682e681c3cec9a235d882da17ff04ef # v2.6.1
         with:
           mode: start
           github-token: ${{ secrets.EC2_RUNNER_TOKEN }}
           ec2-instance-type: g6.xlarge # 4 CPU-core, L4 GPU
           availability-zones-config: ${{ needs.versions.outputs.aws-gpu-az-config }}
+      - name: Back off before attempt 2
+        if: steps.start-tests-gpu-runner-a1.outcome == 'failure'
+        run: |
+          echo "::warning::Runner start attempt 1 found no capacity; retrying in 90s."
+          sleep 90
+      - name: Start EC2 GPU runner (attempt 2)
+        id: start-tests-gpu-runner-a2
+        if: steps.start-tests-gpu-runner-a1.outcome == 'failure'
+        continue-on-error: true
+        uses: machulav/ec2-github-runner@343a1b2ae682e681c3cec9a235d882da17ff04ef # v2.6.1
+        with:
+          mode: start
+          github-token: ${{ secrets.EC2_RUNNER_TOKEN }}
+          ec2-instance-type: g6.xlarge # 4 CPU-core, L4 GPU
+          availability-zones-config: ${{ needs.versions.outputs.aws-gpu-az-config }}
+      - name: Back off before attempt 3
+        if: steps.start-tests-gpu-runner-a1.outcome == 'failure' && steps.start-tests-gpu-runner-a2.outcome == 'failure'
+        run: |
+          echo "::warning::Runner start attempt 2 found no capacity; retrying in 180s."
+          sleep 180
+      - name: Start EC2 GPU runner (attempt 3)
+        id: start-tests-gpu-runner-a3
+        if: steps.start-tests-gpu-runner-a1.outcome == 'failure' && steps.start-tests-gpu-runner-a2.outcome == 'failure'
+        continue-on-error: true
+        uses: machulav/ec2-github-runner@343a1b2ae682e681c3cec9a235d882da17ff04ef # v2.6.1
+        with:
+          mode: start
+          github-token: ${{ secrets.EC2_RUNNER_TOKEN }}
+          ec2-instance-type: g6.xlarge # 4 CPU-core, L4 GPU
+          availability-zones-config: ${{ needs.versions.outputs.aws-gpu-az-config }}
+      - name: Fail if no attempt obtained capacity
+        if: steps.start-tests-gpu-runner-a1.outcome == 'failure' && steps.start-tests-gpu-runner-a2.outcome == 'failure' && steps.start-tests-gpu-runner-a3.outcome == 'failure'
+        run: |
+          echo "::error::Could not obtain an instance after 3 attempts across every configured availability zone; the region is likely out of this instance type."
+          exit 1
 
   ##############################################################################
   # RUN FVDB GTESTS


### PR DESCRIPTION
## Problem

Multi-AZ configuration makes the runner action walk every availability zone before giving up — but that walk takes *seconds*. When a whole region is short of an instance type, every zone fails in one burst and the job dies:

```
Attempting to start EC2 instance using 3 availability zone configuration(s)
Trying availability zone configuration 1/3 ... 2/3 ... 3/3
##[error]All availability zone configurations failed
```

`g6.xlarge` is currently unavailable across **all three** us-east-2 zones, so multi-AZ alone doesn't help. Capacity typically frees within minutes.

The action has **no launch retry** of its own — in either `v2.4.3` or `v2.6.1`, `startup-retry-interval-seconds` only governs runner *registration* after an instance already exists.

## Change

Each start step becomes three attempts with **90s then 180s** backoff:

- each attempt is `continue-on-error: true`, so a failure falls through to the next
- each attempt still walks every configured AZ
- a final step fails the job only if all three attempts found no capacity
- jobs exposing the runner label as a job output select it with `||` across the three attempt ids; jobs passing an explicit `label:` input need no change

## Why inline rather than a shared reusable workflow

I first built this as a reusable workflow (much DRYer), then found fvdb-core's `check_runner_token_policy.py` forbids exactly that:

> Rule 2: *"…already forbids putting the token in … a reusable-workflow `secrets:` block"*
> Rule 4: *"A job that references the token must not … no local actions (`uses: ./...`)"*

Calling a local reusable workflow is `uses: ./...` and passes the token via `secrets:` — two violations, and the policy anticipates the pattern by name. Inline expansion keeps every occurrence as the exact `github-token: ${{ secrets.<TOKEN> }}` action input. The same shape is used in both repos for consistency, even though only fvdb-core enforces the policy.

## Testing

CI provisioning can't be fully proven without a capacity failure to retry against, but everything statically checkable was verified:

- all workflows parse; every start job has exactly 3 attempts, all `continue-on-error`
- every attempt carries the exact policy-required token line
- label propagation intact via `||`-joined outputs or an explicit `label:` input
- `mode: stop` steps untouched
- **fvdb-core: `check_runner_token_policy.py` passes** (`✅ EC2 runner token policy: OK`)

Note the failing GPU checks on this PR are the capacity outage itself, not a defect here; and for `pull_request_target` workflows these changes only take effect after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)