### PR TITLE
Fix reinitialize_sdf inactive-interior bug; rename retopologize_sdf to rebuild_narrow_band

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,16 @@ fVDB Version History
 ## Version 0.6.0 - In Development
 
 - **PyTorch 2.13** fVDB updated to build, test and publish with PyTorch 2.13, CUDA 13.0/13.2 and Python 3.10-3.15 support.
+- **Breaking:** `retopologize_sdf` is renamed `rebuild_narrow_band` (`Grid`, `GridBatch`, and
+  `fvdb.functional.rebuild_narrow_band_{single,batch}`); no alias is kept. The old name was mesh-remeshing jargon
+  and did not say that the op produces a *narrow-band* SDF on a rebuilt grid.
+- Fixed `reinitialize_sdf` treating every inactive voxel as exterior. An `IndexGrid` has a single background slot,
+  so a narrow band whose interior is inactive (a pruned level set, an imported OpenVDB grid, or
+  `rebuild_narrow_band`'s own output) grew a phantom interface one voxel inside the true surface; the zero crossing
+  survived, but the inner half of the band was wrong and `rebuild_narrow_band` was not idempotent. Inactive
+  neighbours now continue the sign of the adjacent active voxel, and `pad=True` seeds new voxels from their
+  neighbours' sign instead of as exterior. `reinitialize_sdf` also now raises `ValueError` for anisotropic voxels
+  instead of silently using only `voxel_size[0]`.
 - **Breaking:** Unified sparse convolution and transposed-convolution geometry around the componentwise Torch-phase
   relation ``fine_ijk = stride * coarse_ijk + tap_ijk - padding_before``, where
   ``padding_before = floor((kernel_size - 1) / 2)`` and each zero-based tap component satisfies

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,10 @@ fVDB Version History
   neighbours now continue the sign of the adjacent active voxel, and `pad=True` seeds new voxels from their
   neighbours' sign instead of as exterior. `reinitialize_sdf` also now raises `ValueError` for anisotropic voxels
   instead of silently using only `voxel_size[0]`.
+  Occupancy inputs must include an explicit positive exterior layer around negative occupied voxels:
+  the active-region boundary no longer implicitly defines a surface, so rebuilding an all-negative
+  occupancy field yields an empty narrow band. Both SDF operations now require finite scalar values
+  with shape `(N,)` or `(N, 1)` and reject other shapes and NaN/Inf values with `ValueError`.
 - **Breaking:** Unified sparse convolution and transposed-convolution geometry around the componentwise Torch-phase
   relation ``fine_ijk = stride * coarse_ijk + tap_ijk - padding_before``, where
   ``padding_before = floor((kernel_size - 1) / 2)`` and each zero-based tap component satisfies

--- a/fvdb/enums.py
+++ b/fvdb/enums.py
@@ -46,7 +46,7 @@ class ConvolutionPhasePolicy(StrEnum):
 class SmoothingMode(IntEnum):
     """
     Laplacian smoothing mode used to de-staircase a signed distance field in
-    :meth:`fvdb.Grid.reinitialize_sdf` / :meth:`fvdb.Grid.retopologize_sdf` (and their
+    :meth:`fvdb.Grid.reinitialize_sdf` / :meth:`fvdb.Grid.rebuild_narrow_band` (and their
     :class:`fvdb.GridBatch` counterparts).
 
     The number of smoothing passes is controlled separately by the ``smooth`` argument; this enum

--- a/fvdb/enums.py
+++ b/fvdb/enums.py
@@ -50,7 +50,11 @@ class SmoothingMode(IntEnum):
     :class:`fvdb.GridBatch` counterparts).
 
     The number of smoothing passes is controlled separately by the ``smooth`` argument; this enum
-    selects *which* umbrella-Laplacian flow each pass applies. Values mirror the C++
+    selects *which* umbrella-Laplacian flow each pass applies. Smoothing runs after the redistance
+    and is followed by a short second redistance (with a freshly computed sign) so ``|grad phi| = 1``
+    is restored; unlike a pure redistance it therefore *moves* the zero crossing to the smoothed
+    surface. Thin (about one voxel) features can be eroded by :attr:`MEAN_CURVATURE`; prefer
+    :attr:`TAUBIN` or ``smooth=0`` for them. Values mirror the C++
     ``fvdb::detail::ops::SmoothingMode`` enum.
     """
 

--- a/fvdb/functional/__init__.py
+++ b/fvdb/functional/__init__.py
@@ -97,8 +97,8 @@ from ._meshing import (
 from ._sdf import (
     reinitialize_sdf_batch,
     reinitialize_sdf_single,
-    retopologize_sdf_batch,
-    retopologize_sdf_single,
+    rebuild_narrow_band_batch,
+    rebuild_narrow_band_single,
 )
 
 # Pooling / refinement
@@ -271,8 +271,8 @@ __all__ = [
     # Signed distance fields
     "reinitialize_sdf_batch",
     "reinitialize_sdf_single",
-    "retopologize_sdf_batch",
-    "retopologize_sdf_single",
+    "rebuild_narrow_band_batch",
+    "rebuild_narrow_band_single",
     # Topology
     "clip_batch",
     "clip_single",

--- a/fvdb/functional/__init__.py
+++ b/fvdb/functional/__init__.py
@@ -269,10 +269,10 @@ __all__ = [
     "integrate_tsdf_with_features_batch",
     "integrate_tsdf_with_features_single",
     # Signed distance fields
-    "reinitialize_sdf_batch",
-    "reinitialize_sdf_single",
     "rebuild_narrow_band_batch",
     "rebuild_narrow_band_single",
+    "reinitialize_sdf_batch",
+    "reinitialize_sdf_single",
     # Topology
     "clip_batch",
     "clip_single",

--- a/fvdb/functional/_sdf.py
+++ b/fvdb/functional/_sdf.py
@@ -113,6 +113,21 @@ def reinitialize_sdf_batch(
     Returns:
         sdf (JaggedTensor): The re-initialized SDF, same per-voxel ordering as ``field``.
 
+    Note:
+        * Only the **sign** of ``field`` is trusted; magnitudes are rebuilt. With ``smooth=0`` the
+          input's zero crossing is preserved (to sub-voxel accuracy); smoothing moves the surface to
+          its de-staircased position and then re-redistances.
+        * Inactive neighbours read as ``+/-band*vx`` with the sign of the adjacent active voxel, so
+          both filled solids (interior active) and narrow bands whose interior is inactive are valid
+          inputs. Voxels with no data are best left *inactive* rather than given a value.
+        * Voxels whose value is exactly ``0`` have a zero frozen sign and are left at ``0`` by the
+          redistance (a no-data pass-through relied on by the ray-implicit-intersection op, which
+          treats exact ``0`` as a gap). Their signed neighbours, however, see them as an interface and
+          are redistanced toward them, and smoothing blends them -- prune such voxels first when you
+          can.
+        * Each grid is assumed isotropic (only ``voxel_sizes[:, 0]`` is used). CUDA only;
+          ``float32`` or ``float64``.
+
     .. seealso:: :func:`reinitialize_sdf_single`, :func:`retopologize_sdf_batch`
     """
     result = _fvdb_cpp.reinitialize_sdf(
@@ -145,6 +160,12 @@ def reinitialize_sdf_single(
 
     Returns:
         sdf (torch.Tensor): The re-initialized SDF, shape ``(num_voxels,)``.
+
+    Note:
+        See :func:`reinitialize_sdf_batch` for the input contract: only the sign of ``field`` is
+        trusted, inactive neighbours continue the sign of the adjacent voxel (filled solids and
+        narrow bands with an inactive interior are both valid), exact-``0`` voxels are a no-data
+        pass-through that neighbours see as an interface, and voxels are assumed isotropic.
 
     .. seealso:: :func:`reinitialize_sdf_batch`, :func:`retopologize_sdf_single`
     """
@@ -202,6 +223,10 @@ def retopologize_sdf_batch(
         out_grid (GridBatch): The pruned (or, with ``prune=False``, the padded/original) grid batch.
         sdf (JaggedTensor): The narrow-band SDF, aligned with ``out_grid``.
 
+    Note:
+        Applying this to its own output reproduces it (up to a voxel layer at the band edge). See
+        :func:`reinitialize_sdf_batch` for the input contract.
+
     .. seealso:: :func:`retopologize_sdf_single`, :func:`reinitialize_sdf_batch`
     """
     # per-grid narrow-band half-width; voxel size may vary across the batch
@@ -255,6 +280,10 @@ def retopologize_sdf_single(
     Returns:
         out_grid (Grid): The pruned (or, with ``prune=False``, the padded/original) grid.
         sdf (torch.Tensor): The narrow-band SDF, aligned with ``out_grid``.
+
+    Note:
+        Applying this to its own output reproduces it (up to a voxel layer at the band edge). See
+        :func:`reinitialize_sdf_batch` for the input contract.
 
     .. seealso:: :func:`retopologize_sdf_batch`, :func:`reinitialize_sdf_single`
     """

--- a/fvdb/functional/_sdf.py
+++ b/fvdb/functional/_sdf.py
@@ -121,9 +121,8 @@ def reinitialize_sdf_batch(
           each sign across the crossing is sufficient (two or more per side gives the best sub-voxel
           accuracy). A grid whose active values are all one sign has no surface: the result is the
           constant ``-/+band*vx`` and :func:`rebuild_narrow_band_batch` returns an empty band, which
-          is correct for e.g. a tile that lies entirely inside an object. An occupancy mask must
-          therefore be given a positive exterior layer first (``dilated_grid(1)`` + ``inject`` with
-          ``default_value=+1``) -- its boundary is not treated as a surface.
+          is correct for e.g. a tile that lies entirely inside an object. The boundary of the active
+          region is not itself a surface.
         * Inactive neighbours read as ``+/-band*vx`` with the sign of the adjacent active voxel, so
           both filled solids (interior active) and narrow bands whose interior is inactive are valid
           inputs. Voxels with no data are best left *inactive* rather than given a value.

--- a/fvdb/functional/_sdf.py
+++ b/fvdb/functional/_sdf.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 """Functional API for signed-distance-field (SDF) re-initialization and narrow-band rebuild."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
@@ -21,6 +22,17 @@ if TYPE_CHECKING:
 def _to_cpp_smoothing(smoothing: SmoothingMode) -> "_fvdb_cpp.SmoothingMode":
     """Convert a public :class:`fvdb.SmoothingMode` to the bound C++ enum (matched by member name)."""
     return getattr(_fvdb_cpp.SmoothingMode, smoothing.name)
+
+
+def _validated_scalar_field(field: torch.Tensor, num_voxels: int) -> torch.Tensor:
+    """Validate before padding, where NaN is reserved for newly activated voxels."""
+    if field.dim() not in (1, 2) or (field.dim() == 2 and field.shape[1] != 1):
+        raise ValueError(f"field must be a scalar field with shape (N,) or (N, 1), got {tuple(field.shape)}")
+    if field.shape[0] != num_voxels:
+        raise ValueError(f"field must have one value per voxel, got {field.shape[0]} values for {num_voxels} voxels")
+    if not torch.isfinite(field).all().item():
+        raise ValueError("field must contain only finite values; leave no-data voxels inactive")
+    return field.reshape(-1)
 
 
 # ---------------------------------------------------------------------------
@@ -114,17 +126,21 @@ def reinitialize_sdf_batch(
         sdf (JaggedTensor): The re-initialized SDF, same per-voxel ordering as ``field``.
 
     Note:
-        * Only the **sign** of ``field`` is trusted; magnitudes are rebuilt. With ``smooth=0`` the
-          input's zero crossing is preserved (to sub-voxel accuracy); smoothing moves the surface to
-          its de-staircased position and then re-redistances.
+        * ``field`` must represent the intended inside/outside regions and zero crossings. Its
+          magnitudes need not be accurate distances, but affect convergence, accuracy, and sub-voxel
+          surface location. With ``smooth=0`` redistancing aims to preserve the input surface, subject
+          to discretization error; smoothing moves the surface and then re-redistances.
+        * Values must be finite, with shape ``(N,)`` or ``(N, 1)`` (for a batch, the shape of
+          ``field.jdata``). Invalid shapes and NaN/Inf values raise ``ValueError``.
         * The surface is where the field changes sign between *active* voxels; one active voxel of
           each sign across the crossing is sufficient (two or more per side gives the best sub-voxel
           accuracy). A grid whose active values are all one sign has no surface: the result is the
           constant ``-/+band*vx`` and :func:`rebuild_narrow_band_batch` returns an empty band, which
           is correct for e.g. a tile that lies entirely inside an object.
-        * Inactive neighbours read as ``+/-band*vx`` with the sign of the adjacent active voxel, so
-          both filled solids (interior active) and narrow bands whose interior is inactive are valid
-          inputs. Voxels with no data are best left *inactive* rather than given a value.
+        * Inactive neighbours read as ``+/-band*vx`` using the adjacent voxel's frozen sign during
+          redistancing and its current sign during smoothing. Both filled solids (interior active)
+          and narrow bands whose interior is inactive are valid inputs. Leave no-data voxels
+          *inactive* rather than assigning them NaN/Inf values.
         * Voxels whose value is exactly ``0`` have a zero frozen sign and are left at ``0`` by the
           redistance (a no-data pass-through relied on by the ray-implicit-intersection op, which
           treats exact ``0`` as a gap). Their signed neighbours, however, see them as an interface and
@@ -154,7 +170,7 @@ def reinitialize_sdf_single(
 
     Args:
         grid (Grid): The single grid defining the sparse topology.
-        field (torch.Tensor): Per-voxel signed field values, shape ``(num_voxels,)``.
+        field (torch.Tensor): Per-voxel signed field values, shape ``(num_voxels,)`` or ``(num_voxels, 1)``.
         band (int): Narrow-band half-width in voxels.
         smooth (int): Number of smoothing passes (``0`` disables smoothing).
         order (int): TVD-RK order, one of ``1``, ``2``, or ``3``.
@@ -233,10 +249,7 @@ def rebuild_narrow_band_batch(
     """
     # per-grid narrow-band half-width; voxel size may vary across the batch
     band_width = band * grid.voxel_sizes[:, 0]
-    # Canonicalize scalar fields to flat per-voxel storage: reinitialize_sdf accepts (N, 1) (and
-    # returns (N,)), and the padding masks below must be one-dimensional.
-    if field.jdata.dim() != 1:
-        field = field.jagged_like(field.jdata.reshape(-1))
+    field = field.jagged_like(_validated_scalar_field(field.jdata, grid.total_voxels))
     if pad:
         grid, field = _pad_with_sign_batch(grid, field, band, band_width)
     phi = reinitialize_sdf_batch(grid, field, band, smooth, order, smoothing, redistance_iters)
@@ -266,7 +279,7 @@ def rebuild_narrow_band_single(
 
     Args:
         grid (Grid): The single grid defining the sparse topology.
-        field (torch.Tensor): Per-voxel signed field values, shape ``(num_voxels,)``.
+        field (torch.Tensor): Per-voxel signed field values, shape ``(num_voxels,)`` or ``(num_voxels, 1)``.
         band (int): Narrow-band half-width in voxels.
         smooth (int): Number of smoothing passes (``0`` disables smoothing).
         order (int): TVD-RK order, one of ``1``, ``2``, or ``3``.
@@ -295,10 +308,7 @@ def rebuild_narrow_band_single(
     """
     # narrow-band half-width
     band_width = band * float(grid.voxel_size[0])
-    # Canonicalize scalar fields to flat per-voxel storage: reinitialize_sdf accepts (N, 1) (and
-    # returns (N,)), and the padding masks below must be one-dimensional.
-    if field.dim() != 1:
-        field = field.reshape(-1)
+    field = _validated_scalar_field(field, grid.num_voxels)
     if pad:
         grid, field = _pad_with_sign_single(grid, field, band, band_width)
     phi = reinitialize_sdf_single(grid, field, band, smooth, order, smoothing, redistance_iters)

--- a/fvdb/functional/_sdf.py
+++ b/fvdb/functional/_sdf.py
@@ -121,8 +121,7 @@ def reinitialize_sdf_batch(
           each sign across the crossing is sufficient (two or more per side gives the best sub-voxel
           accuracy). A grid whose active values are all one sign has no surface: the result is the
           constant ``-/+band*vx`` and :func:`rebuild_narrow_band_batch` returns an empty band, which
-          is correct for e.g. a tile that lies entirely inside an object. The boundary of the active
-          region is not itself a surface.
+          is correct for e.g. a tile that lies entirely inside an object.
         * Inactive neighbours read as ``+/-band*vx`` with the sign of the adjacent active voxel, so
           both filled solids (interior active) and narrow bands whose interior is inactive are valid
           inputs. Voxels with no data are best left *inactive* rather than given a value.

--- a/fvdb/functional/_sdf.py
+++ b/fvdb/functional/_sdf.py
@@ -117,6 +117,13 @@ def reinitialize_sdf_batch(
         * Only the **sign** of ``field`` is trusted; magnitudes are rebuilt. With ``smooth=0`` the
           input's zero crossing is preserved (to sub-voxel accuracy); smoothing moves the surface to
           its de-staircased position and then re-redistances.
+        * The surface is where the field changes sign between *active* voxels; one active voxel of
+          each sign across the crossing is sufficient (two or more per side gives the best sub-voxel
+          accuracy). A grid whose active values are all one sign has no surface: the result is the
+          constant ``-/+band*vx`` and :func:`rebuild_narrow_band_batch` returns an empty band, which
+          is correct for e.g. a tile that lies entirely inside an object. An occupancy mask must
+          therefore be given a positive exterior layer first (``dilated_grid(1)`` + ``inject`` with
+          ``default_value=+1``) -- its boundary is not treated as a surface.
         * Inactive neighbours read as ``+/-band*vx`` with the sign of the adjacent active voxel, so
           both filled solids (interior active) and narrow bands whose interior is inactive are valid
           inputs. Voxels with no data are best left *inactive* rather than given a value.

--- a/fvdb/functional/_sdf.py
+++ b/fvdb/functional/_sdf.py
@@ -125,8 +125,8 @@ def reinitialize_sdf_batch(
           treats exact ``0`` as a gap). Their signed neighbours, however, see them as an interface and
           are redistanced toward them, and smoothing blends them -- prune such voxels first when you
           can.
-        * Each grid is assumed isotropic (only ``voxel_sizes[:, 0]`` is used). CUDA only;
-          ``float32`` or ``float64``.
+        * Each grid must have isotropic voxels (``ValueError`` otherwise); grids in the batch may
+          differ from one another. CUDA only; ``float32`` or ``float64``.
 
     .. seealso:: :func:`reinitialize_sdf_single`, :func:`retopologize_sdf_batch`
     """
@@ -165,7 +165,7 @@ def reinitialize_sdf_single(
         See :func:`reinitialize_sdf_batch` for the input contract: only the sign of ``field`` is
         trusted, inactive neighbours continue the sign of the adjacent voxel (filled solids and
         narrow bands with an inactive interior are both valid), exact-``0`` voxels are a no-data
-        pass-through that neighbours see as an interface, and voxels are assumed isotropic.
+        pass-through that neighbours see as an interface, and voxels must be isotropic.
 
     .. seealso:: :func:`reinitialize_sdf_batch`, :func:`retopologize_sdf_single`
     """

--- a/fvdb/functional/_sdf.py
+++ b/fvdb/functional/_sdf.py
@@ -231,6 +231,10 @@ def rebuild_narrow_band_batch(
     """
     # per-grid narrow-band half-width; voxel size may vary across the batch
     band_width = band * grid.voxel_sizes[:, 0]
+    # Canonicalize scalar fields to flat per-voxel storage: reinitialize_sdf accepts (N, 1) (and
+    # returns (N,)), and the padding masks below must be one-dimensional.
+    if field.jdata.dim() != 1:
+        field = field.jagged_like(field.jdata.reshape(-1))
     if pad:
         grid, field = _pad_with_sign_batch(grid, field, band, band_width)
     phi = reinitialize_sdf_batch(grid, field, band, smooth, order, smoothing, redistance_iters)
@@ -289,6 +293,10 @@ def rebuild_narrow_band_single(
     """
     # narrow-band half-width
     band_width = band * float(grid.voxel_size[0])
+    # Canonicalize scalar fields to flat per-voxel storage: reinitialize_sdf accepts (N, 1) (and
+    # returns (N,)), and the padding masks below must be one-dimensional.
+    if field.dim() != 1:
+        field = field.reshape(-1)
     if pad:
         grid, field = _pad_with_sign_single(grid, field, band, band_width)
     phi = reinitialize_sdf_single(grid, field, band, smooth, order, smoothing, redistance_iters)

--- a/fvdb/functional/_sdf.py
+++ b/fvdb/functional/_sdf.py
@@ -1,7 +1,7 @@
 # Copyright Contributors to the OpenVDB Project
 # SPDX-License-Identifier: Apache-2.0
 #
-"""Functional API for signed-distance-field (SDF) re-initialization and narrow-band retopologization."""
+"""Functional API for signed-distance-field (SDF) re-initialization and narrow-band rebuild."""
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
@@ -24,7 +24,7 @@ def _to_cpp_smoothing(smoothing: SmoothingMode) -> "_fvdb_cpp.SmoothingMode":
 
 
 # ---------------------------------------------------------------------------
-#  sign-aware padding (shared by retopologize_sdf_{single,batch})
+#  sign-aware padding (shared by rebuild_narrow_band_{single,batch})
 # ---------------------------------------------------------------------------
 
 
@@ -128,7 +128,7 @@ def reinitialize_sdf_batch(
         * Each grid must have isotropic voxels (``ValueError`` otherwise); grids in the batch may
           differ from one another. CUDA only; ``float32`` or ``float64``.
 
-    .. seealso:: :func:`reinitialize_sdf_single`, :func:`retopologize_sdf_batch`
+    .. seealso:: :func:`reinitialize_sdf_single`, :func:`rebuild_narrow_band_batch`
     """
     result = _fvdb_cpp.reinitialize_sdf(
         grid.data, field._impl, band, redistance_iters, order, smooth, _to_cpp_smoothing(smoothing)
@@ -167,7 +167,7 @@ def reinitialize_sdf_single(
         narrow bands with an inactive interior are both valid), exact-``0`` voxels are a no-data
         pass-through that neighbours see as an interface, and voxels must be isotropic.
 
-    .. seealso:: :func:`reinitialize_sdf_batch`, :func:`retopologize_sdf_single`
+    .. seealso:: :func:`reinitialize_sdf_batch`, :func:`rebuild_narrow_band_single`
     """
     field_jt = JaggedTensor(field)
     result = _fvdb_cpp.reinitialize_sdf(
@@ -177,11 +177,11 @@ def reinitialize_sdf_single(
 
 
 # ---------------------------------------------------------------------------
-#  retopologize_sdf  (reinitialize + narrow-band prune)
+#  rebuild_narrow_band  (pad + reinitialize + narrow-band prune)
 # ---------------------------------------------------------------------------
 
 
-def retopologize_sdf_batch(
+def rebuild_narrow_band_batch(
     grid: GridBatch,
     field: JaggedTensor,
     band: int = 3,
@@ -192,7 +192,7 @@ def retopologize_sdf_batch(
     pad: bool = True,
     prune: bool = True,
 ) -> tuple[GridBatch, JaggedTensor]:
-    """Retopologize a signed field into a clean narrow-band SDF on a (possibly pruned) grid batch.
+    """Rebuild a signed field into a clean narrow-band SDF on a (possibly pruned) grid batch.
 
     If ``pad`` is ``True`` the grid is first dilated by ``band`` voxels (so the eikonal solve has room
     to propagate a full-width band), then :func:`reinitialize_sdf_batch` is run, and finally, if
@@ -227,7 +227,7 @@ def retopologize_sdf_batch(
         Applying this to its own output reproduces it (up to a voxel layer at the band edge). See
         :func:`reinitialize_sdf_batch` for the input contract.
 
-    .. seealso:: :func:`retopologize_sdf_single`, :func:`reinitialize_sdf_batch`
+    .. seealso:: :func:`rebuild_narrow_band_single`, :func:`reinitialize_sdf_batch`
     """
     # per-grid narrow-band half-width; voxel size may vary across the batch
     band_width = band * grid.voxel_sizes[:, 0]
@@ -240,7 +240,7 @@ def retopologize_sdf_batch(
     return grid.pruned_grid(phi.jagged_like(mask)), phi.rmask(mask)
 
 
-def retopologize_sdf_single(
+def rebuild_narrow_band_single(
     grid: Grid,
     field: torch.Tensor,
     band: int = 3,
@@ -251,7 +251,7 @@ def retopologize_sdf_single(
     pad: bool = True,
     prune: bool = True,
 ) -> tuple[Grid, torch.Tensor]:
-    """Retopologize a signed field into a clean narrow-band SDF on a (possibly pruned) single grid.
+    """Rebuild a signed field into a clean narrow-band SDF on a (possibly pruned) single grid.
 
     If ``pad`` is ``True`` the grid is first dilated by ``band`` voxels (so the eikonal solve has room
     to propagate a full-width band), then :func:`reinitialize_sdf_single` is run, and finally, if
@@ -285,7 +285,7 @@ def retopologize_sdf_single(
         Applying this to its own output reproduces it (up to a voxel layer at the band edge). See
         :func:`reinitialize_sdf_batch` for the input contract.
 
-    .. seealso:: :func:`retopologize_sdf_batch`, :func:`reinitialize_sdf_single`
+    .. seealso:: :func:`rebuild_narrow_band_batch`, :func:`reinitialize_sdf_single`
     """
     # narrow-band half-width
     band_width = band * float(grid.voxel_size[0])

--- a/fvdb/functional/_sdf.py
+++ b/fvdb/functional/_sdf.py
@@ -24,6 +24,61 @@ def _to_cpp_smoothing(smoothing: SmoothingMode) -> "_fvdb_cpp.SmoothingMode":
 
 
 # ---------------------------------------------------------------------------
+#  sign-aware padding (shared by retopologize_sdf_{single,batch})
+# ---------------------------------------------------------------------------
+
+
+def _seed_sign(neighbor_values_sum: torch.Tensor, band_width: torch.Tensor | float) -> torch.Tensor:
+    """``-band_width`` where the summed neighbour values are negative, else ``+band_width``."""
+    return torch.where(neighbor_values_sum < 0, -band_width, band_width)
+
+
+def _pad_with_sign_single(grid: Grid, field: torch.Tensor, band: int, band_width: float) -> tuple[Grid, torch.Tensor]:
+    """Dilate ``grid`` by ``band`` voxels, one layer at a time, seeding each fresh voxel with
+    ``+/-band_width`` according to the sign of its already-present 26-neighbours.
+
+    An IndexGrid cannot mark inactive space as interior or exterior, so a constant exterior seed
+    would turn the inside of a hollow narrow band into "outside". Growing one layer at a time and
+    copying the sign of the neighbours lets the padding continue the field inward and outward.
+    """
+    for _ in range(band):
+        dilated = grid.dilated_grid(1)
+        padded = inject_single(dilated, grid, field, default_value=float("nan"))
+        is_new = torch.isnan(padded)
+        if is_new.any():
+            nbr = grid.neighbor_indexes(dilated.ijk[is_new], 1).reshape(int(is_new.sum()), -1)
+            zero = torch.zeros((), dtype=field.dtype, device=field.device)
+            nbr_sum = torch.where(nbr >= 0, field[nbr.clamp(min=0)], zero).sum(dim=1)
+            padded[is_new] = _seed_sign(nbr_sum, band_width).to(field.dtype)
+        grid, field = dilated, padded
+    return grid, field
+
+
+def _pad_with_sign_batch(
+    grid: GridBatch, field: JaggedTensor, band: int, band_width: torch.Tensor
+) -> tuple[GridBatch, JaggedTensor]:
+    """Batched :func:`_pad_with_sign_single`; ``band_width`` holds one half-width per grid."""
+    for _ in range(band):
+        dilated = grid.dilated_grid(1)
+        padded = inject_batch(dilated, grid, field, default_value=float("nan"))
+        is_new = torch.isnan(padded.jdata)
+        if is_new.any():
+            new_ijk = dilated.ijk.rmask(is_new)
+            # neighbor_indexes returns per-grid indices; shift them into the flat jdata.
+            nbr = grid.neighbor_indexes(new_ijk, 1).jdata.reshape(int(is_new.sum()), -1)
+            grid_of_new = new_ijk.jidx.long()
+            flat = nbr + field.joffsets[grid_of_new, None].to(nbr.device)
+            zero = torch.zeros((), dtype=field.jdata.dtype, device=field.jdata.device)
+            nbr_sum = torch.where(nbr >= 0, field.jdata[flat.clamp(min=0)], zero).sum(dim=1)
+            bw = band_width.to(field.jdata.device, field.jdata.dtype)[grid_of_new]
+            data = padded.jdata.clone()
+            data[is_new] = _seed_sign(nbr_sum, bw)
+            padded = padded.jagged_like(data)
+        grid, field = dilated, padded
+    return grid, field
+
+
+# ---------------------------------------------------------------------------
 #  reinitialize_sdf  (fixed-topology redistance + de-staircase)
 # ---------------------------------------------------------------------------
 
@@ -136,11 +191,10 @@ def retopologize_sdf_batch(
         redistance_iters (int): Number of redistancing sweeps. ``<= 0`` uses the default.
         pad (bool): If ``True`` (default) dilate the grid by ``band`` voxels before redistancing so
             the output narrow band is a full ``band`` voxels wide even if the input grid had a
-            thinner active region. Newly added voxels are seeded as *exterior* (``+band*vx``), which
-            is correct when the dilation extends outward -- i.e. when the grid's interior (the
-            ``phi < 0`` region) is already represented (the usual case for occupancy/TSDF/mesh-derived
-            fields). For a thin shell that does not fill its interior, pass ``pad=False`` and supply a
-            grid that already has an adequate band.
+            thinner active region. The dilation grows one layer at a time and seeds each new voxel
+            with ``+/-band*vx`` according to the sign of its existing neighbours, so padding
+            continues a narrow band both outward (exterior) and inward (interior) and works for
+            filled solids as well as narrow bands whose interior is inactive.
         prune (bool): If ``True`` prune to the narrow band; if ``False`` return the (possibly
             padded) grid and the re-initialized field unchanged.
 
@@ -153,11 +207,7 @@ def retopologize_sdf_batch(
     # per-grid narrow-band half-width; voxel size may vary across the batch
     band_width = band * grid.voxel_sizes[:, 0]
     if pad:
-        # Seed fresh voxels as exterior. A positive seed >= every grid's band width is fine:
-        # reinitialize_sdf re-clamps it to that grid's +band*vx, so only its (positive) sign matters.
-        dilated = grid.dilated_grid(band)
-        field = inject_batch(dilated, grid, field, default_value=float(band_width.max()))
-        grid = dilated
+        grid, field = _pad_with_sign_batch(grid, field, band, band_width)
     phi = reinitialize_sdf_batch(grid, field, band, smooth, order, smoothing, redistance_iters)
     if not prune:
         return grid, phi
@@ -195,11 +245,10 @@ def retopologize_sdf_single(
         redistance_iters (int): Number of redistancing sweeps. ``<= 0`` uses the default.
         pad (bool): If ``True`` (default) dilate the grid by ``band`` voxels before redistancing so
             the output narrow band is a full ``band`` voxels wide even if the input grid had a
-            thinner active region. Newly added voxels are seeded as *exterior* (``+band*vx``), which
-            is correct when the dilation extends outward -- i.e. when the grid's interior (the
-            ``phi < 0`` region) is already represented (the usual case for occupancy/TSDF/mesh-derived
-            fields). For a thin shell that does not fill its interior, pass ``pad=False`` and supply a
-            grid that already has an adequate band.
+            thinner active region. The dilation grows one layer at a time and seeds each new voxel
+            with ``+/-band*vx`` according to the sign of its existing neighbours, so padding
+            continues a narrow band both outward (exterior) and inward (interior) and works for
+            filled solids as well as narrow bands whose interior is inactive.
         prune (bool): If ``True`` prune to the narrow band; if ``False`` return the (possibly padded)
             grid and the re-initialized field unchanged.
 
@@ -212,11 +261,7 @@ def retopologize_sdf_single(
     # narrow-band half-width
     band_width = band * float(grid.voxel_size[0])
     if pad:
-        # Seed fresh voxels as exterior. A positive seed >= the grid's band width is fine:
-        # reinitialize_sdf re-clamps it to +band*vx, so only its (positive) sign matters.
-        dilated = grid.dilated_grid(band)
-        field = inject_single(dilated, grid, field, default_value=band_width)
-        grid = dilated
+        grid, field = _pad_with_sign_single(grid, field, band, band_width)
     phi = reinitialize_sdf_single(grid, field, band, smooth, order, smoothing, redistance_iters)
     if not prune:
         return grid, phi

--- a/fvdb/functional/_sdf.py
+++ b/fvdb/functional/_sdf.py
@@ -167,10 +167,7 @@ def reinitialize_sdf_single(
         sdf (torch.Tensor): The re-initialized SDF, shape ``(num_voxels,)``.
 
     Note:
-        See :func:`reinitialize_sdf_batch` for the input contract: only the sign of ``field`` is
-        trusted, inactive neighbours continue the sign of the adjacent voxel (filled solids and
-        narrow bands with an inactive interior are both valid), exact-``0`` voxels are a no-data
-        pass-through that neighbours see as an interface, and voxels must be isotropic.
+        See :func:`reinitialize_sdf_batch` for the input contract.
 
     .. seealso:: :func:`reinitialize_sdf_batch`, :func:`rebuild_narrow_band_single`
     """

--- a/fvdb/grid.py
+++ b/fvdb/grid.py
@@ -1539,8 +1539,8 @@ class Grid:
               ``0`` as a gap). Their signed neighbours, however, see them as an interface and are
               redistanced toward them, and smoothing blends them -- prune such voxels first when you
               can.
-            * Voxels are assumed isotropic (only ``voxel_size[0]`` is used). CUDA only; ``float32``
-              or ``float64``.
+            * Voxels must be isotropic (``ValueError`` otherwise). CUDA only; ``float32`` or
+              ``float64``.
         """
         from . import functional
 

--- a/fvdb/grid.py
+++ b/fvdb/grid.py
@@ -1521,10 +1521,26 @@ class Grid:
             smoothing (SmoothingMode): Which Laplacian flow each smoothing pass applies --
                 :attr:`~fvdb.SmoothingMode.MEAN_CURVATURE` (default) or
                 :attr:`~fvdb.SmoothingMode.TAUBIN` (volume-preserving). Only used when ``smooth > 0``.
-            redistance_iters (int): Number of redistancing sweeps; ``<= 0`` uses the default.
+            redistance_iters (int): Number of redistancing sweeps; ``<= 0`` uses the default
+                ``max(6, round(2.5*band) + 2)``.
 
         Returns:
             sdf (torch.Tensor): The re-initialized SDF, shape ``(num_voxels,)``.
+
+        Note:
+            * Only the **sign** of ``field`` is trusted; magnitudes are rebuilt. With ``smooth=0``
+              the input's zero crossing is preserved (to sub-voxel accuracy); smoothing moves the
+              surface to its de-staircased position and then re-redistances.
+            * Inactive neighbours read as ``+/-band*vx`` with the sign of the adjacent active voxel,
+              so both filled solids (interior active) and narrow bands whose interior is inactive are
+              valid inputs. Voxels with no data are best left *inactive* rather than given a value.
+            * Voxels whose value is exactly ``0`` have a zero frozen sign and are left at ``0`` by the
+              redistance (a no-data pass-through; :meth:`ray_implicit_intersection` treats exact
+              ``0`` as a gap). Their signed neighbours, however, see them as an interface and are
+              redistanced toward them, and smoothing blends them -- prune such voxels first when you
+              can.
+            * Voxels are assumed isotropic (only ``voxel_size[0]`` is used). CUDA only; ``float32``
+              or ``float64``.
         """
         from . import functional
 
@@ -1558,14 +1574,20 @@ class Grid:
                 :attr:`~fvdb.SmoothingMode.TAUBIN` (volume-preserving). Only used when ``smooth > 0``.
             redistance_iters (int): Number of redistancing sweeps; ``<= 0`` uses the default.
             pad (bool): If ``True`` (default) dilate by ``band`` first so the output band is a full
-                ``band`` voxels wide even if the input grid was thinner. New voxels are seeded as
-                exterior (``+band*vx``), which is correct when the interior (``phi < 0``) is already
-                represented; for a hollow thin shell, pass ``pad=False`` with a pre-banded grid.
+                ``band`` voxels wide even if the input grid was thinner. The dilation grows one layer
+                at a time and seeds each new voxel with ``+/-band*vx`` according to the sign of its
+                existing neighbours, so it continues the band inward (interior) as well as outward and
+                works for filled solids and for narrow bands whose interior is inactive.
             prune (bool): If ``True`` prune to the narrow band, else return the (padded) grid.
 
         Returns:
             out_grid (Grid): The pruned (or padded/original) grid.
             sdf (torch.Tensor): The narrow-band SDF, aligned with ``out_grid``.
+
+        Note:
+            Applying this to its own output reproduces it (up to a voxel layer at the band edge).
+            See :meth:`reinitialize_sdf` for the input contract (sign trusted, inactive neighbours
+            continue the adjacent sign, exact-``0`` voxels are no-data pass-through).
         """
         from . import functional
 

--- a/fvdb/grid.py
+++ b/fvdb/grid.py
@@ -1514,7 +1514,7 @@ class Grid:
         Peng sign), then optionally de-staircases it with curvature-based smoothing.
 
         Args:
-            field (torch.Tensor): Per-voxel signed field, shape ``(num_voxels,)``.
+            field (torch.Tensor): Per-voxel signed field, shape ``(num_voxels,)`` or ``(num_voxels, 1)``.
             band (int): Narrow-band half-width in voxels (clamps the field to ``[-band*vx, band*vx]``).
             smooth (int): Number of smoothing passes (``0`` disables smoothing).
             order (int): TVD-RK order, one of ``1``, ``2``, or ``3``.
@@ -1528,17 +1528,21 @@ class Grid:
             sdf (torch.Tensor): The re-initialized SDF, shape ``(num_voxels,)``.
 
         Note:
-            * Only the **sign** of ``field`` is trusted; magnitudes are rebuilt. With ``smooth=0``
-              the input's zero crossing is preserved (to sub-voxel accuracy); smoothing moves the
-              surface to its de-staircased position and then re-redistances.
+            * ``field`` must represent the intended inside/outside regions and zero crossings. Its
+              magnitudes need not be accurate distances, but affect convergence, accuracy, and
+              sub-voxel surface location. With ``smooth=0`` redistancing aims to preserve the input
+              surface, subject to discretization error; smoothing moves it and then re-redistances.
+            * Values must be finite, with shape ``(N,)`` or ``(N, 1)``. Invalid shapes and NaN/Inf
+              values raise ``ValueError``.
             * The surface is where the field changes sign between *active* voxels; one active voxel
               of each sign across the crossing is sufficient (two or more per side gives the best
               sub-voxel accuracy). A grid whose active values are all one sign has no surface: the
               result is the constant ``-/+band*vx`` and :meth:`rebuild_narrow_band` returns an empty
               band, which is correct for e.g. a tile that lies entirely inside an object.
-            * Inactive neighbours read as ``+/-band*vx`` with the sign of the adjacent active voxel,
-              so both filled solids (interior active) and narrow bands whose interior is inactive are
-              valid inputs. Voxels with no data are best left *inactive* rather than given a value.
+            * Inactive neighbours read as ``+/-band*vx`` using the adjacent voxel's frozen sign during
+              redistancing and its current sign during smoothing. Both filled solids (interior active)
+              and narrow bands whose interior is inactive are valid inputs. Leave no-data voxels
+              *inactive* rather than assigning them NaN/Inf values.
             * Voxels whose value is exactly ``0`` have a zero frozen sign and are left at ``0`` by the
               redistance (a no-data pass-through; :meth:`ray_implicit_intersection` treats exact
               ``0`` as a gap). Their signed neighbours, however, see them as an interface and are
@@ -1570,7 +1574,7 @@ class Grid:
         (``|phi| < band*vx*0.999``).
 
         Args:
-            field (torch.Tensor): Per-voxel signed field, shape ``(num_voxels,)``.
+            field (torch.Tensor): Per-voxel signed field, shape ``(num_voxels,)`` or ``(num_voxels, 1)``.
             band (int): Narrow-band half-width in voxels.
             smooth (int): Number of smoothing passes (``0`` disables smoothing).
             order (int): TVD-RK order, one of ``1``, ``2``, or ``3``.

--- a/fvdb/grid.py
+++ b/fvdb/grid.py
@@ -1546,7 +1546,7 @@ class Grid:
 
         return functional.reinitialize_sdf_single(self, field, band, smooth, order, smoothing, redistance_iters)
 
-    def retopologize_sdf(
+    def rebuild_narrow_band(
         self,
         field: torch.Tensor,
         band: int = 3,
@@ -1557,7 +1557,7 @@ class Grid:
         pad: bool = True,
         prune: bool = True,
     ) -> tuple[Grid, torch.Tensor]:
-        """Retopologize a signed field into a clean narrow-band SDF on a (possibly pruned) grid.
+        """Rebuild a signed field into a clean narrow-band SDF on a (possibly pruned) grid.
 
         If ``pad`` is ``True`` this grid is first dilated by ``band`` voxels so the redistance has
         room to build a full-width band, then :meth:`reinitialize_sdf` is run, and finally, if
@@ -1591,7 +1591,7 @@ class Grid:
         """
         from . import functional
 
-        return functional.retopologize_sdf_single(
+        return functional.rebuild_narrow_band_single(
             self, field, band, smooth, order, smoothing, redistance_iters, pad, prune
         )
 

--- a/fvdb/grid.py
+++ b/fvdb/grid.py
@@ -1535,8 +1535,7 @@ class Grid:
               of each sign across the crossing is sufficient (two or more per side gives the best
               sub-voxel accuracy). A grid whose active values are all one sign has no surface: the
               result is the constant ``-/+band*vx`` and :meth:`rebuild_narrow_band` returns an empty
-              band, which is correct for e.g. a tile that lies entirely inside an object. The
-              boundary of the active region is not itself a surface.
+              band, which is correct for e.g. a tile that lies entirely inside an object.
             * Inactive neighbours read as ``+/-band*vx`` with the sign of the adjacent active voxel,
               so both filled solids (interior active) and narrow bands whose interior is inactive are
               valid inputs. Voxels with no data are best left *inactive* rather than given a value.

--- a/fvdb/grid.py
+++ b/fvdb/grid.py
@@ -1531,6 +1531,14 @@ class Grid:
             * Only the **sign** of ``field`` is trusted; magnitudes are rebuilt. With ``smooth=0``
               the input's zero crossing is preserved (to sub-voxel accuracy); smoothing moves the
               surface to its de-staircased position and then re-redistances.
+            * The surface is where the field changes sign between *active* voxels; one active voxel
+              of each sign across the crossing is sufficient (two or more per side gives the best
+              sub-voxel accuracy). A grid whose active values are all one sign has no surface: the
+              result is the constant ``-/+band*vx`` and :meth:`rebuild_narrow_band` returns an empty
+              band, which is correct for e.g. a tile that lies entirely inside an object. An
+              occupancy mask must therefore be given a positive exterior layer first
+              (``dilated_grid(1)`` + ``inject_from`` with a positive default) -- its boundary is not
+              treated as a surface.
             * Inactive neighbours read as ``+/-band*vx`` with the sign of the adjacent active voxel,
               so both filled solids (interior active) and narrow bands whose interior is inactive are
               valid inputs. Voxels with no data are best left *inactive* rather than given a value.

--- a/fvdb/grid.py
+++ b/fvdb/grid.py
@@ -1535,10 +1535,8 @@ class Grid:
               of each sign across the crossing is sufficient (two or more per side gives the best
               sub-voxel accuracy). A grid whose active values are all one sign has no surface: the
               result is the constant ``-/+band*vx`` and :meth:`rebuild_narrow_band` returns an empty
-              band, which is correct for e.g. a tile that lies entirely inside an object. An
-              occupancy mask must therefore be given a positive exterior layer first
-              (``dilated_grid(1)`` + ``inject_from`` with a positive default) -- its boundary is not
-              treated as a surface.
+              band, which is correct for e.g. a tile that lies entirely inside an object. The
+              boundary of the active region is not itself a surface.
             * Inactive neighbours read as ``+/-band*vx`` with the sign of the adjacent active voxel,
               so both filled solids (interior active) and narrow bands whose interior is inactive are
               valid inputs. Voxels with no data are best left *inactive* rather than given a value.

--- a/fvdb/grid_batch.py
+++ b/fvdb/grid_batch.py
@@ -1095,7 +1095,7 @@ class GridBatch:
               sub-voxel accuracy). A grid whose active values are all one sign has no surface: the
               result is the constant ``-/+band*vx`` and :meth:`rebuild_narrow_band` returns an empty
               band for that grid, which is correct for e.g. a tile that lies entirely inside an
-              object. The boundary of the active region is not itself a surface.
+              object.
             * Inactive neighbours read as ``+/-band*vx`` with the sign of the adjacent active voxel,
               so both filled solids (interior active) and narrow bands whose interior is inactive are
               valid inputs. Voxels with no data are best left *inactive* rather than given a value.

--- a/fvdb/grid_batch.py
+++ b/fvdb/grid_batch.py
@@ -1095,9 +1095,7 @@ class GridBatch:
               sub-voxel accuracy). A grid whose active values are all one sign has no surface: the
               result is the constant ``-/+band*vx`` and :meth:`rebuild_narrow_band` returns an empty
               band for that grid, which is correct for e.g. a tile that lies entirely inside an
-              object. An occupancy mask must therefore be given a positive exterior layer first
-              (``dilated_grid(1)`` + ``inject_from`` with a positive default) -- its boundary is not
-              treated as a surface.
+              object. The boundary of the active region is not itself a surface.
             * Inactive neighbours read as ``+/-band*vx`` with the sign of the adjacent active voxel,
               so both filled solids (interior active) and narrow bands whose interior is inactive are
               valid inputs. Voxels with no data are best left *inactive* rather than given a value.

--- a/fvdb/grid_batch.py
+++ b/fvdb/grid_batch.py
@@ -1090,6 +1090,14 @@ class GridBatch:
             * Only the **sign** of ``field`` is trusted; magnitudes are rebuilt. With ``smooth=0``
               the input's zero crossing is preserved (to sub-voxel accuracy); smoothing moves the
               surface to its de-staircased position and then re-redistances.
+            * The surface is where the field changes sign between *active* voxels; one active voxel
+              of each sign across the crossing is sufficient (two or more per side gives the best
+              sub-voxel accuracy). A grid whose active values are all one sign has no surface: the
+              result is the constant ``-/+band*vx`` and :meth:`rebuild_narrow_band` returns an empty
+              band for that grid, which is correct for e.g. a tile that lies entirely inside an
+              object. An occupancy mask must therefore be given a positive exterior layer first
+              (``dilated_grid(1)`` + ``inject_from`` with a positive default) -- its boundary is not
+              treated as a surface.
             * Inactive neighbours read as ``+/-band*vx`` with the sign of the adjacent active voxel,
               so both filled solids (interior active) and narrow bands whose interior is inactive are
               valid inputs. Voxels with no data are best left *inactive* rather than given a value.

--- a/fvdb/grid_batch.py
+++ b/fvdb/grid_batch.py
@@ -1080,10 +1080,26 @@ class GridBatch:
             smoothing (SmoothingMode): Which Laplacian flow each smoothing pass applies --
                 :attr:`~fvdb.SmoothingMode.MEAN_CURVATURE` (default) or
                 :attr:`~fvdb.SmoothingMode.TAUBIN` (volume-preserving). Only used when ``smooth > 0``.
-            redistance_iters (int): Number of redistancing sweeps; ``<= 0`` uses the default.
+            redistance_iters (int): Number of redistancing sweeps; ``<= 0`` uses the default
+                ``max(6, round(2.5*band) + 2)``.
 
         Returns:
             sdf (JaggedTensor): The re-initialized SDF, same per-voxel ordering as ``field``.
+
+        Note:
+            * Only the **sign** of ``field`` is trusted; magnitudes are rebuilt. With ``smooth=0``
+              the input's zero crossing is preserved (to sub-voxel accuracy); smoothing moves the
+              surface to its de-staircased position and then re-redistances.
+            * Inactive neighbours read as ``+/-band*vx`` with the sign of the adjacent active voxel,
+              so both filled solids (interior active) and narrow bands whose interior is inactive are
+              valid inputs. Voxels with no data are best left *inactive* rather than given a value.
+            * Voxels whose value is exactly ``0`` have a zero frozen sign and are left at ``0`` by the
+              redistance (a no-data pass-through; :meth:`ray_implicit_intersection` treats exact
+              ``0`` as a gap). Their signed neighbours, however, see them as an interface and are
+              redistanced toward them, and smoothing blends them -- prune such voxels first when you
+              can.
+            * Each grid is assumed isotropic (only ``voxel_sizes[:, 0]`` is used); grids in the
+              batch may have different voxel sizes. CUDA only; ``float32`` or ``float64``.
 
         .. seealso:: :meth:`Grid.reinitialize_sdf`
         """
@@ -1119,14 +1135,20 @@ class GridBatch:
                 :attr:`~fvdb.SmoothingMode.TAUBIN` (volume-preserving). Only used when ``smooth > 0``.
             redistance_iters (int): Number of redistancing sweeps; ``<= 0`` uses the default.
             pad (bool): If ``True`` (default) dilate by ``band`` first so the output band is a full
-                ``band`` voxels wide even if the input grid was thinner. New voxels are seeded as
-                exterior (``+band*vx``), which is correct when the interior (``phi < 0``) is already
-                represented; for a hollow thin shell, pass ``pad=False`` with a pre-banded grid.
+                ``band`` voxels wide even if the input grid was thinner. The dilation grows one layer
+                at a time and seeds each new voxel with ``+/-band*vx`` according to the sign of its
+                existing neighbours, so it continues the band inward (interior) as well as outward and
+                works for filled solids and for narrow bands whose interior is inactive.
             prune (bool): If ``True`` prune to the narrow band, else return the (padded) grid batch.
 
         Returns:
             out_grid (GridBatch): The pruned (or padded/original) grid batch.
             sdf (JaggedTensor): The narrow-band SDF, aligned with ``out_grid``.
+
+        Note:
+            Applying this to its own output reproduces it (up to a voxel layer at the band edge).
+            See :meth:`reinitialize_sdf` for the input contract (sign trusted, inactive neighbours
+            continue the adjacent sign, exact-``0`` voxels are no-data pass-through).
 
         .. seealso:: :meth:`Grid.retopologize_sdf`
         """

--- a/fvdb/grid_batch.py
+++ b/fvdb/grid_batch.py
@@ -1087,18 +1087,22 @@ class GridBatch:
             sdf (JaggedTensor): The re-initialized SDF, same per-voxel ordering as ``field``.
 
         Note:
-            * Only the **sign** of ``field`` is trusted; magnitudes are rebuilt. With ``smooth=0``
-              the input's zero crossing is preserved (to sub-voxel accuracy); smoothing moves the
-              surface to its de-staircased position and then re-redistances.
+            * ``field`` must represent the intended inside/outside regions and zero crossings. Its
+              magnitudes need not be accurate distances, but affect convergence, accuracy, and
+              sub-voxel surface location. With ``smooth=0`` redistancing aims to preserve the input
+              surface, subject to discretization error; smoothing moves it and then re-redistances.
+            * Values must be finite, with shape ``(N,)`` or ``(N, 1)`` (for a batch, the shape of
+              ``field.jdata``). Invalid shapes and NaN/Inf values raise ``ValueError``.
             * The surface is where the field changes sign between *active* voxels; one active voxel
               of each sign across the crossing is sufficient (two or more per side gives the best
               sub-voxel accuracy). A grid whose active values are all one sign has no surface: the
               result is the constant ``-/+band*vx`` and :meth:`rebuild_narrow_band` returns an empty
               band for that grid, which is correct for e.g. a tile that lies entirely inside an
               object.
-            * Inactive neighbours read as ``+/-band*vx`` with the sign of the adjacent active voxel,
-              so both filled solids (interior active) and narrow bands whose interior is inactive are
-              valid inputs. Voxels with no data are best left *inactive* rather than given a value.
+            * Inactive neighbours read as ``+/-band*vx`` using the adjacent voxel's frozen sign during
+              redistancing and its current sign during smoothing. Both filled solids (interior active)
+              and narrow bands whose interior is inactive are valid inputs. Leave no-data voxels
+              *inactive* rather than assigning them NaN/Inf values.
             * Voxels whose value is exactly ``0`` have a zero frozen sign and are left at ``0`` by the
               redistance (a no-data pass-through; :meth:`ray_implicit_intersection` treats exact
               ``0`` as a gap). Their signed neighbours, however, see them as an interface and are

--- a/fvdb/grid_batch.py
+++ b/fvdb/grid_batch.py
@@ -1098,8 +1098,8 @@ class GridBatch:
               ``0`` as a gap). Their signed neighbours, however, see them as an interface and are
               redistanced toward them, and smoothing blends them -- prune such voxels first when you
               can.
-            * Each grid is assumed isotropic (only ``voxel_sizes[:, 0]`` is used); grids in the
-              batch may have different voxel sizes. CUDA only; ``float32`` or ``float64``.
+            * Each grid must have isotropic voxels (``ValueError`` otherwise); grids in the batch
+              may differ from one another. CUDA only; ``float32`` or ``float64``.
 
         .. seealso:: :meth:`Grid.reinitialize_sdf`
         """

--- a/fvdb/grid_batch.py
+++ b/fvdb/grid_batch.py
@@ -1107,7 +1107,7 @@ class GridBatch:
 
         return functional.reinitialize_sdf_batch(self, field, band, smooth, order, smoothing, redistance_iters)
 
-    def retopologize_sdf(
+    def rebuild_narrow_band(
         self,
         field: JaggedTensor,
         band: int = 3,
@@ -1118,7 +1118,7 @@ class GridBatch:
         pad: bool = True,
         prune: bool = True,
     ) -> tuple["GridBatch", JaggedTensor]:
-        """Retopologize a signed field into a clean narrow-band SDF on a (possibly pruned) grid batch.
+        """Rebuild a signed field into a clean narrow-band SDF on a (possibly pruned) grid batch.
 
         If ``pad`` is ``True`` the grid is first dilated by ``band`` voxels so the redistance has
         room to build a full-width band, then :meth:`reinitialize_sdf` is run, and finally, if
@@ -1150,11 +1150,11 @@ class GridBatch:
             See :meth:`reinitialize_sdf` for the input contract (sign trusted, inactive neighbours
             continue the adjacent sign, exact-``0`` voxels are no-data pass-through).
 
-        .. seealso:: :meth:`Grid.retopologize_sdf`
+        .. seealso:: :meth:`Grid.rebuild_narrow_band`
         """
         from . import functional
 
-        return functional.retopologize_sdf_batch(
+        return functional.rebuild_narrow_band_batch(
             self, field, band, smooth, order, smoothing, redistance_iters, pad, prune
         )
 

--- a/src/fvdb/detail/ops/RayImplicitIntersection.cu
+++ b/src/fvdb/detail/ops/RayImplicitIntersection.cu
@@ -22,11 +22,12 @@ constexpr int INVALID_SIGN = 10;
 //
 // Both NaN and *exactly* zero map to INVALID_SIGN, i.e. they are treated as gaps that neither seed
 // the sign reference nor trigger a crossing. NaN is an explicit gap marker. Exact zero is the
-// background/no-data fill of a sparse narrow band: ops like `reinitialize_sdf` leave every active
-// voxel outside the reinitialised band at 0, so a ray that starts far from the surface walks a long
-// prefix of active-but-uncomputed 0 voxels before reaching real signed data. Mapping 0 to a real
-// sign (the mathematical `sgn(0) == 0`) would let that background seed a bogus reference and report
-// a spurious crossing the instant the ray touched the first genuine +/- voxel (issue #692). A true
+// background/no-data fill of a sparse narrow band: `reinitialize_sdf` gives an exactly-0 input
+// voxel a zero frozen sign and leaves it at 0 (e.g. the unobserved fill from integrate_tsdf), so a
+// ray that starts far from the surface walks a long prefix of active-but-no-data 0 voxels before
+// reaching real signed data. Mapping 0 to a real sign (the mathematical `sgn(0) == 0`) would let
+// that background seed a bogus reference and report a spurious crossing the instant the ray touched
+// the first genuine +/- voxel (issue #692). A true
 // on-surface voxel is still bracketed by its signed neighbours, so this only costs bracket-entry
 // (rather than interpolated) precision on the vanishingly rare exactly-0 sample.
 template <typename T>

--- a/src/fvdb/detail/ops/ReinitializeSdf.cu
+++ b/src/fvdb/detail/ops/ReinitializeSdf.cu
@@ -99,8 +99,9 @@ signFusedKernel(const OnIndexGridT *grid,
     VBM_FACES_BEGIN();
     const ScalarT phiCenter = field[centerIndex];
     VBM_FACE_VALUES(field, phiCenter, bandWidth);
-    ScalarT gradX = (xp - xm) / (2 * voxelSize), gradY = (yp - ym) / (2 * voxelSize),
-            gradZ = (zp - zm) / (2 * voxelSize);
+    ScalarT gradX = (xp - xm) / (2 * voxelSize);
+    ScalarT gradY = (yp - ym) / (2 * voxelSize);
+    ScalarT gradZ = (zp - zm) / (2 * voxelSize);
     sign[centerIndex] =
         phiCenter / nanovdb::math::Sqrt(phiCenter * phiCenter +
                                         (gradX * gradX + gradY * gradY + gradZ * gradZ) *

--- a/src/fvdb/detail/ops/ReinitializeSdf.cu
+++ b/src/fvdb/detail/ops/ReinitializeSdf.cu
@@ -83,7 +83,9 @@ faceValue(const ScalarT *field, uint64_t index, ScalarT center, ScalarT bandWidt
                   zp = faceValue<ScalarT>(field, faceIndex[5], centerValue, bandWidth)
 
 // =====================  fused stencil kernels ====================================================
-// frozen Peng smoothed sign from a field's value + central-difference gradient.
+// frozen Peng smoothed sign from a field's value + central-difference gradient. An exactly-0 centre
+// yields sign 0, so the Godunov RHS vanishes there and such (no-data) voxels are never moved by the
+// redistance; the ray-implicit-intersection op relies on exact 0 surviving as a gap marker.
 template <typename ScalarT>
 __global__ void
 signFusedKernel(const OnIndexGridT *grid,

--- a/src/fvdb/detail/ops/ReinitializeSdf.cu
+++ b/src/fvdb/detail/ops/ReinitializeSdf.cu
@@ -34,7 +34,8 @@ static constexpr int kLog2BlockWidth = 9;
 // neighbours through a cached ReadAccessor. Yields `centerIndex` (the centre voxel's value index)
 // and `faceIndex[6]` (the 6 face-neighbour value indices, -x,+x,-y,+y,-z,+z; 0 =
 // inactive/background). Kernels using it take the grid/firstLeafID/jumpMap/firstOffset parameters
-// by these exact names.
+// by these exact names. Neighbour VALUES must be read through `faceValue` (below), never
+// `field[faceIndex[k]]` directly, so that inactive neighbours get a sign-aware boundary value.
 #define VBM_FACES_BEGIN()                                                                        \
     constexpr int blockWidth = 1 << kLog2BlockWidth, jumpMapWordCount = blockWidth / 64;         \
     using VoxelBlockManagerT = nanovdb::tools::cuda::VoxelBlockManager<kLog2BlockWidth>;         \
@@ -60,6 +61,27 @@ static constexpr int kLog2BlockWidth = 9;
                                         accessor.getValue(centerCoord.offsetBy(0, 0, -1)),       \
                                         accessor.getValue(centerCoord.offsetBy(0, 0, 1))};
 
+// Sign-aware read of a face neighbour. An IndexGrid has a single background slot (value index 0),
+// so it cannot carry OpenVDB's two-signed inactive tiles (-background inside, +background outside).
+// Instead, an inactive neighbour continues the sign of the centre voxel: beside a negative voxel it
+// is deep interior (-bandWidth), beside a positive voxel deep exterior (+bandWidth). Without this
+// the inner edge of a narrow band sees +bandWidth across the face and a phantom interface forms
+// one voxel inside the true surface. Active neighbours are read from the value-indexed buffer.
+template <typename ScalarT>
+__device__ inline ScalarT
+faceValue(const ScalarT *field, uint64_t index, ScalarT center, ScalarT bandWidth) {
+    return index ? field[index] : (center < ScalarT(0) ? -bandWidth : bandWidth);
+}
+
+// Reads the 6 face neighbours of `field` around `centerValue` into xm,xp,ym,yp,zm,zp.
+#define VBM_FACE_VALUES(field, centerValue, bandWidth)                                  \
+    const ScalarT xm = faceValue<ScalarT>(field, faceIndex[0], centerValue, bandWidth), \
+                  xp = faceValue<ScalarT>(field, faceIndex[1], centerValue, bandWidth), \
+                  ym = faceValue<ScalarT>(field, faceIndex[2], centerValue, bandWidth), \
+                  yp = faceValue<ScalarT>(field, faceIndex[3], centerValue, bandWidth), \
+                  zm = faceValue<ScalarT>(field, faceIndex[4], centerValue, bandWidth), \
+                  zp = faceValue<ScalarT>(field, faceIndex[5], centerValue, bandWidth)
+
 // =====================  fused stencil kernels ====================================================
 // frozen Peng smoothed sign from a field's value + central-difference gradient.
 template <typename ScalarT>
@@ -70,12 +92,13 @@ signFusedKernel(const OnIndexGridT *grid,
                 uint64_t firstOffset,
                 const ScalarT *field,
                 ScalarT voxelSize,
+                ScalarT bandWidth,
                 ScalarT *sign) {
     VBM_FACES_BEGIN();
-    ScalarT xm = field[faceIndex[0]], xp = field[faceIndex[1]], ym = field[faceIndex[2]],
-            yp = field[faceIndex[3]], zm = field[faceIndex[4]], zp = field[faceIndex[5]];
+    const ScalarT phiCenter = field[centerIndex];
+    VBM_FACE_VALUES(field, phiCenter, bandWidth);
     ScalarT gradX = (xp - xm) / (2 * voxelSize), gradY = (yp - ym) / (2 * voxelSize),
-            gradZ = (zp - zm) / (2 * voxelSize), phiCenter = field[centerIndex];
+            gradZ = (zp - zm) / (2 * voxelSize);
     sign[centerIndex] =
         phiCenter / nanovdb::math::Sqrt(phiCenter * phiCenter +
                                         (gradX * gradX + gradY * gradY + gradZ * gradZ) *
@@ -108,11 +131,11 @@ godunovFusedKernel(const OnIndexGridT *grid,
                    const ScalarT *field,
                    const ScalarT *sign,
                    ScalarT voxelSize,
+                   ScalarT bandWidth,
                    ScalarT *rhs) {
     VBM_FACES_BEGIN();
-    ScalarT center = field[centerIndex], sgn = sign[centerIndex];
-    ScalarT xm = field[faceIndex[0]], xp = field[faceIndex[1]], ym = field[faceIndex[2]],
-            yp = field[faceIndex[3]], zm = field[faceIndex[4]], zp = field[faceIndex[5]];
+    const ScalarT center = field[centerIndex], sgn = sign[centerIndex];
+    VBM_FACE_VALUES(field, center, bandWidth);
     ScalarT gradMag = nanovdb::math::Sqrt(
         upwind<ScalarT>((center - xm) / voxelSize, (xp - center) / voxelSize, sgn) +
         upwind<ScalarT>((center - ym) / voxelSize, (yp - center) / voxelSize, sgn) +
@@ -130,12 +153,12 @@ smoothFusedKernel(const OnIndexGridT *grid,
                   uint64_t firstOffset,
                   const ScalarT *in,
                   ScalarT weight,
+                  ScalarT bandWidth,
                   ScalarT *out) {
     VBM_FACES_BEGIN();
-    ScalarT center   = in[centerIndex];
-    ScalarT faceMean = (in[faceIndex[0]] + in[faceIndex[1]] + in[faceIndex[2]] + in[faceIndex[3]] +
-                        in[faceIndex[4]] + in[faceIndex[5]]) *
-                       (ScalarT(1) / ScalarT(6));
+    const ScalarT center = in[centerIndex];
+    VBM_FACE_VALUES(in, center, bandWidth);
+    ScalarT faceMean = (xm + xp + ym + yp + zm + zp) * (ScalarT(1) / ScalarT(6));
     out[centerIndex] = center + weight * (faceMean - center);
 }
 
@@ -212,9 +235,10 @@ struct VBMHelper {
 };
 
 // Redistance (|grad phi| = 1) + optional de-staircase one grid's value-indexed buffer, in place.
-// `phi`/scratch are length `valueCount` with slot 0 holding the +bandWidth background; the
-// stencil/combiner kernels never write slot 0 (so inactive-neighbour reads always see the boundary
-// value).
+// `phi`/scratch are length `valueCount`; slot 0 is the (never written) background slot. Stencil
+// kernels do not read slot 0: inactive neighbours are resolved by `faceValue` to
+// +/-bandWidth with the sign of the centre voxel, so a narrow band with an inactive interior is
+// treated as continuing inward, not as exterior.
 template <typename ScalarT>
 void
 runReinit(OnIndexGridT *grid,
@@ -244,14 +268,14 @@ runReinit(OnIndexGridT *grid,
     auto godunov = [&](const ScalarT *field, ScalarT *out) {
         if (blockCount) {
             godunovFusedKernel<ScalarT><<<blockCount, blockWidth, 0, stream>>>(
-                grid, firstLeafID, jumpMap, firstOffset, field, sign, voxelSize, out);
+                grid, firstLeafID, jumpMap, firstOffset, field, sign, voxelSize, bandWidth, out);
             C10_CUDA_KERNEL_LAUNCH_CHECK();
         }
     };
     auto redistance = [&](int iters) {
         if (blockCount) {
             signFusedKernel<ScalarT><<<blockCount, blockWidth, 0, stream>>>(
-                grid, firstLeafID, jumpMap, firstOffset, phi, voxelSize, sign);
+                grid, firstLeafID, jumpMap, firstOffset, phi, voxelSize, bandWidth, sign);
             C10_CUDA_KERNEL_LAUNCH_CHECK();
         }
         for (int it = 0; it < iters; ++it) {
@@ -320,7 +344,7 @@ runReinit(OnIndexGridT *grid,
         auto pass = [&](ScalarT weight) {
             if (blockCount) {
                 smoothFusedKernel<ScalarT><<<blockCount, blockWidth, 0, stream>>>(
-                    grid, firstLeafID, jumpMap, firstOffset, cur, weight, other);
+                    grid, firstLeafID, jumpMap, firstOffset, cur, weight, bandWidth, other);
                 C10_CUDA_KERNEL_LAUNCH_CHECK();
             }
             std::swap(cur, other);
@@ -383,8 +407,8 @@ reinitializeSdfCuda(const GridBatchData &batchHdl,
         ScalarT *rhs0         = rhs0Buf.data_ptr<ScalarT>();
         ScalarT *rhs1         = (order == 2) ? rhs1Buf.data_ptr<ScalarT>() : nullptr;
 
-        // gather: phi[0] = bandWidth (outside BC), phi[1..] = field; stage[0] = bandWidth (RK slot
-        // 0)
+        // gather: phi[1..] = field. Slot 0 of phi/stage is the background slot: filled with
+        // bandWidth for hygiene but never read by the stencil kernels (see faceValue) nor written.
         fillKernel<ScalarT>
             <<<GET_BLOCKS(valueCount, DEFAULT_BLOCK_DIM), DEFAULT_BLOCK_DIM, 0, stream>>>(
                 phi, valueCount, bandWidth);

--- a/src/fvdb/detail/ops/ReinitializeSdf.cu
+++ b/src/fvdb/detail/ops/ReinitializeSdf.cu
@@ -63,24 +63,25 @@ static constexpr int kLog2BlockWidth = 9;
 
 // Sign-aware read of a face neighbour. An IndexGrid has a single background slot (value index 0),
 // so it cannot carry OpenVDB's two-signed inactive tiles (-background inside, +background outside).
-// Instead, an inactive neighbour continues the sign of the centre voxel: beside a negative voxel it
+// Instead, an inactive neighbour continues the supplied sign: beside a negative voxel it
 // is deep interior (-bandWidth), beside a positive voxel deep exterior (+bandWidth). Without this
 // the inner edge of a narrow band sees +bandWidth across the face and a phantom interface forms
-// one voxel inside the true surface. Active neighbours are read from the value-indexed buffer.
+// one voxel inside the true surface. Godunov updates supply the frozen sign; sign computation and
+// smoothing supply the current centre value. Active neighbours use the value-indexed buffer.
 template <typename ScalarT>
 __device__ inline ScalarT
-faceValue(const ScalarT *field, uint64_t index, ScalarT center, ScalarT bandWidth) {
-    return index ? field[index] : (center < ScalarT(0) ? -bandWidth : bandWidth);
+faceValue(const ScalarT *field, uint64_t index, ScalarT signSource, ScalarT bandWidth) {
+    return index ? field[index] : (signSource < ScalarT(0) ? -bandWidth : bandWidth);
 }
 
-// Reads the 6 face neighbours of `field` around `centerValue` into xm,xp,ym,yp,zm,zp.
-#define VBM_FACE_VALUES(field, centerValue, bandWidth)                                  \
-    const ScalarT xm = faceValue<ScalarT>(field, faceIndex[0], centerValue, bandWidth), \
-                  xp = faceValue<ScalarT>(field, faceIndex[1], centerValue, bandWidth), \
-                  ym = faceValue<ScalarT>(field, faceIndex[2], centerValue, bandWidth), \
-                  yp = faceValue<ScalarT>(field, faceIndex[3], centerValue, bandWidth), \
-                  zm = faceValue<ScalarT>(field, faceIndex[4], centerValue, bandWidth), \
-                  zp = faceValue<ScalarT>(field, faceIndex[5], centerValue, bandWidth)
+// Reads the 6 face neighbours, using `signSource` for inactive values.
+#define VBM_FACE_VALUES(field, signSource, bandWidth)                                  \
+    const ScalarT xm = faceValue<ScalarT>(field, faceIndex[0], signSource, bandWidth), \
+                  xp = faceValue<ScalarT>(field, faceIndex[1], signSource, bandWidth), \
+                  ym = faceValue<ScalarT>(field, faceIndex[2], signSource, bandWidth), \
+                  yp = faceValue<ScalarT>(field, faceIndex[3], signSource, bandWidth), \
+                  zm = faceValue<ScalarT>(field, faceIndex[4], signSource, bandWidth), \
+                  zp = faceValue<ScalarT>(field, faceIndex[5], signSource, bandWidth)
 
 // =====================  fused stencil kernels ====================================================
 // frozen Peng smoothed sign from a field's value + central-difference gradient. An exactly-0 centre
@@ -138,7 +139,9 @@ godunovFusedKernel(const OnIndexGridT *grid,
                    ScalarT *rhs) {
     VBM_FACES_BEGIN();
     const ScalarT center = field[centerIndex], sgn = sign[centerIndex];
-    VBM_FACE_VALUES(field, center, bandWidth);
+    // Match upwind's frozen sign even if an RK stage crosses zero. For clamped stage values,
+    // inactive faces then remain downwind instead of introducing a spurious boundary slope.
+    VBM_FACE_VALUES(field, sgn, bandWidth);
     ScalarT gradMag = nanovdb::math::Sqrt(
         upwind<ScalarT>((center - xm) / voxelSize, (xp - center) / voxelSize, sgn) +
         upwind<ScalarT>((center - ym) / voxelSize, (yp - center) / voxelSize, sgn) +
@@ -240,8 +243,8 @@ struct VBMHelper {
 // Redistance (|grad phi| = 1) + optional de-staircase one grid's value-indexed buffer, in place.
 // `phi`/scratch are length `valueCount`; slot 0 is the (never written) background slot. Stencil
 // kernels do not read slot 0: inactive neighbours are resolved by `faceValue` to
-// +/-bandWidth with the sign of the centre voxel, so a narrow band with an inactive interior is
-// treated as continuing inward, not as exterior.
+// +/-bandWidth using the frozen sign for Godunov updates and the current centre sign otherwise,
+// so a narrow band with an inactive interior is treated as continuing inward, not as exterior.
 template <typename ScalarT>
 void
 runReinit(OnIndexGridT *grid,
@@ -343,7 +346,7 @@ runReinit(OnIndexGridT *grid,
     redistance(redistanceIters > 0 ? redistanceIters : defaultIters);
 
     if (smooth) {
-        ScalarT *cur = phi, *other = stage; // ping-pong (stage[0] already = bandWidth)
+        ScalarT *cur = phi, *other = stage; // ping-pong; stencil reads do not use slot 0
         auto pass = [&](ScalarT weight) {
             if (blockCount) {
                 smoothFusedKernel<ScalarT><<<blockCount, blockWidth, 0, stream>>>(
@@ -485,6 +488,10 @@ reinitializeSdf(const GridBatchData &batchHdl,
         field.ldim() == 1,
         "Expected field to have 1 list dimension (a single list of per-voxel values)");
     TORCH_CHECK_TYPE(field.is_floating_point(), "field must have a floating point type");
+    const auto &data = field.jdata();
+    TORCH_CHECK_VALUE(data.dim() == 1 || (data.dim() == 2 && data.size(1) == 1),
+                      "field must be a scalar field with shape (N,) or (N, 1), got ",
+                      data.sizes());
     TORCH_CHECK_VALUE(field.numel() == batchHdl.totalVoxels(),
                       "field value count does not match the number of voxels in the grid");
     TORCH_CHECK_VALUE(field.num_outer_lists() == batchHdl.batchSize(),
@@ -500,6 +507,8 @@ reinitializeSdf(const GridBatchData &batchHdl,
                      "reinitialize_sdf supports float32 or float64 fields");
 
     torch::Tensor fieldJdata = field.jdata().contiguous();
+    TORCH_CHECK_VALUE(torch::isfinite(fieldJdata).all().item<bool>(),
+                      "field must contain only finite values; leave no-data voxels inactive");
     if (fieldJdata.dim() != 1)
         fieldJdata = fieldJdata.view({-1});
 

--- a/src/fvdb/detail/ops/ReinitializeSdf.cu
+++ b/src/fvdb/detail/ops/ReinitializeSdf.cu
@@ -390,7 +390,23 @@ reinitializeSdfCuda(const GridBatchData &batchHdl,
         OnIndexGridT *grid =
             batchHdl.mGridHdl->deviceGrid<nanovdb::ValueOnIndex>((uint32_t)batchIdx);
         const int64_t voxelOffset = batchHdl.cumVoxelsAt(batchIdx);
-        const ScalarT voxelSize   = (ScalarT)batchHdl.voxelSizeAt(batchIdx)[0];
+        const nanovdb::Vec3d &vs  = batchHdl.voxelSizeAt(batchIdx);
+        // The eikonal solve uses one voxel size for all three axes; an anisotropic grid would get
+        // distances silently scaled by the aspect ratio along y/z. Relative tolerance absorbs
+        // float32 -> double round-off in voxel sizes that arrive from Python.
+        TORCH_CHECK_VALUE(std::abs(vs[1] - vs[0]) <= 1e-6 * vs[0] &&
+                              std::abs(vs[2] - vs[0]) <= 1e-6 * vs[0],
+                          "reinitialize_sdf requires isotropic voxels (the eikonal solve uses a "
+                          "single voxel size), but grid ",
+                          batchIdx,
+                          " has voxel_size (",
+                          vs[0],
+                          ", ",
+                          vs[1],
+                          ", ",
+                          vs[2],
+                          ")");
+        const ScalarT voxelSize = (ScalarT)vs[0];
         const ScalarT bandWidth = (ScalarT)band * voxelSize; // narrow-band half-width, world units
 
         VBMHelper vbm(grid, stream);

--- a/src/fvdb/detail/ops/ReinitializeSdf.h
+++ b/src/fvdb/detail/ops/ReinitializeSdf.h
@@ -30,8 +30,11 @@ enum class SmoothingMode : int32_t {
 /// same per-voxel ordering as the input.
 ///
 /// @param batchHdl    Grid batch defining the sparse topology.
-/// @param field       Per-voxel signed field (a single list of scalar values, numel ==
-///                    totalVoxels). Only its sign is trusted; magnitudes are rebuilt. A voxel whose
+/// @param field       Per-voxel signed field with finite values and shape (N,) or (N, 1),
+///                    N == totalVoxels. It must represent the intended inside/outside regions and
+///                    zero crossings. Magnitudes need not be accurate distances, but affect
+///                    convergence, accuracy, and sub-voxel surface location. Invalid shapes and
+///                    NaN/Inf values raise ValueError. Leave no-data voxels inactive. A voxel whose
 ///                    value is exactly 0 has a zero frozen sign and is left at 0 by the redistance
 ///                    (no-data pass-through), though its signed neighbours see it as an interface.
 ///                    The surface is where the field changes sign between ACTIVE voxels; a grid
@@ -40,11 +43,11 @@ enum class SmoothingMode : int32_t {
 ///                    otherwise).
 /// @param band        Narrow-band half-width in voxels. The field is clamped to [-band*vx, band*vx]
 ///                    each sweep. Inactive neighbours act as a Dirichlet boundary whose value
-///                    continues the sign of the adjacent active voxel: -band*vx beside a negative
-///                    (interior) voxel, +band*vx beside a positive (exterior) one. An IndexGrid has
-///                    a single background slot, so this is how a narrow band with an inactive
-///                    interior (e.g. the output of rebuild_narrow_band) is kept solid rather than
-///                    hollow.
+///                    uses the adjacent voxel's frozen sign during redistancing and its current
+///                    sign during smoothing: -band*vx for negative, +band*vx otherwise. An
+///                    IndexGrid has a single background slot, so this is how a narrow band with an
+///                    inactive interior (e.g. the output of rebuild_narrow_band) is kept solid
+///                    rather than hollow.
 /// @param redistanceIters  Number of TVD-RK redistancing sweeps. Pass <= 0 to use the default
 ///                         max(6, round(2.5*band) + 2).
 /// @param order       TVD-RK order: 1 (forward Euler), 2 (Heun), or 3 (Shu-Osher).

--- a/src/fvdb/detail/ops/ReinitializeSdf.h
+++ b/src/fvdb/detail/ops/ReinitializeSdf.h
@@ -40,7 +40,7 @@ enum class SmoothingMode : int32_t {
 ///                    continues the sign of the adjacent active voxel: -band*vx beside a negative
 ///                    (interior) voxel, +band*vx beside a positive (exterior) one. An IndexGrid has
 ///                    a single background slot, so this is how a narrow band with an inactive
-///                    interior (e.g. the output of retopologize_sdf) is kept solid rather than
+///                    interior (e.g. the output of rebuild_narrow_band) is kept solid rather than
 ///                    hollow.
 /// @param redistanceIters  Number of TVD-RK redistancing sweeps. Pass <= 0 to use the default
 ///                         max(6, round(2.5*band) + 2).

--- a/src/fvdb/detail/ops/ReinitializeSdf.h
+++ b/src/fvdb/detail/ops/ReinitializeSdf.h
@@ -36,8 +36,8 @@ enum class SmoothingMode : int32_t {
 ///                    (no-data pass-through), though its signed neighbours see it as an interface.
 ///                    The surface is where the field changes sign between ACTIVE voxels; a grid
 ///                    whose active values are all one sign has no surface and comes back as the
-///                    constant -/+band*vx (the active-region boundary is not a surface).
-///                    Voxels must be isotropic (a ValueError is raised otherwise).
+///                    constant -/+band*vx. Voxels must be isotropic (a ValueError is raised
+///                    otherwise).
 /// @param band        Narrow-band half-width in voxels. The field is clamped to [-band*vx, band*vx]
 ///                    each sweep. Inactive neighbours act as a Dirichlet boundary whose value
 ///                    continues the sign of the adjacent active voxel: -band*vx beside a negative

--- a/src/fvdb/detail/ops/ReinitializeSdf.h
+++ b/src/fvdb/detail/ops/ReinitializeSdf.h
@@ -31,7 +31,10 @@ enum class SmoothingMode : int32_t {
 ///
 /// @param batchHdl    Grid batch defining the sparse topology.
 /// @param field       Per-voxel signed field (a single list of scalar values, numel ==
-/// totalVoxels).
+///                    totalVoxels). Only its sign is trusted; magnitudes are rebuilt. A voxel whose
+///                    value is exactly 0 has a zero frozen sign and is left at 0 by the redistance
+///                    (no-data pass-through), though its signed neighbours see it as an interface.
+///                    Only voxelSize[0] is used (isotropic voxels assumed).
 /// @param band        Narrow-band half-width in voxels. The field is clamped to [-band*vx, band*vx]
 ///                    each sweep. Inactive neighbours act as a Dirichlet boundary whose value
 ///                    continues the sign of the adjacent active voxel: -band*vx beside a negative

--- a/src/fvdb/detail/ops/ReinitializeSdf.h
+++ b/src/fvdb/detail/ops/ReinitializeSdf.h
@@ -34,7 +34,7 @@ enum class SmoothingMode : int32_t {
 ///                    totalVoxels). Only its sign is trusted; magnitudes are rebuilt. A voxel whose
 ///                    value is exactly 0 has a zero frozen sign and is left at 0 by the redistance
 ///                    (no-data pass-through), though its signed neighbours see it as an interface.
-///                    Only voxelSize[0] is used (isotropic voxels assumed).
+///                    Voxels must be isotropic (a ValueError is raised otherwise).
 /// @param band        Narrow-band half-width in voxels. The field is clamped to [-band*vx, band*vx]
 ///                    each sweep. Inactive neighbours act as a Dirichlet boundary whose value
 ///                    continues the sign of the adjacent active voxel: -band*vx beside a negative

--- a/src/fvdb/detail/ops/ReinitializeSdf.h
+++ b/src/fvdb/detail/ops/ReinitializeSdf.h
@@ -34,6 +34,9 @@ enum class SmoothingMode : int32_t {
 ///                    totalVoxels). Only its sign is trusted; magnitudes are rebuilt. A voxel whose
 ///                    value is exactly 0 has a zero frozen sign and is left at 0 by the redistance
 ///                    (no-data pass-through), though its signed neighbours see it as an interface.
+///                    The surface is where the field changes sign between ACTIVE voxels; a grid
+///                    whose active values are all one sign has no surface and comes back as the
+///                    constant -/+band*vx (the active-region boundary is not a surface).
 ///                    Voxels must be isotropic (a ValueError is raised otherwise).
 /// @param band        Narrow-band half-width in voxels. The field is clamped to [-band*vx, band*vx]
 ///                    each sweep. Inactive neighbours act as a Dirichlet boundary whose value

--- a/src/fvdb/detail/ops/ReinitializeSdf.h
+++ b/src/fvdb/detail/ops/ReinitializeSdf.h
@@ -33,8 +33,12 @@ enum class SmoothingMode : int32_t {
 /// @param field       Per-voxel signed field (a single list of scalar values, numel ==
 /// totalVoxels).
 /// @param band        Narrow-band half-width in voxels. The field is clamped to [-band*vx, band*vx]
-///                    each sweep and the "outside" Dirichlet value for inactive neighbours is
-///                    +band*vx.
+///                    each sweep. Inactive neighbours act as a Dirichlet boundary whose value
+///                    continues the sign of the adjacent active voxel: -band*vx beside a negative
+///                    (interior) voxel, +band*vx beside a positive (exterior) one. An IndexGrid has
+///                    a single background slot, so this is how a narrow band with an inactive
+///                    interior (e.g. the output of retopologize_sdf) is kept solid rather than
+///                    hollow.
 /// @param redistanceIters  Number of TVD-RK redistancing sweeps. Pass <= 0 to use the default
 ///                         max(6, round(2.5*band) + 2).
 /// @param order       TVD-RK order: 1 (forward Euler), 2 (Heun), or 3 (Shu-Osher).

--- a/tests/unit/test_basic_ops.py
+++ b/tests/unit/test_basic_ops.py
@@ -2148,8 +2148,9 @@ class TestBasicOps(unittest.TestCase):
         # spurious crossing seeded by the no-data prefix.
         #
         # Sparse fvdb SDFs (e.g. integrate_tsdf + reinitialize_sdf) leave
-        # active-but-unobserved voxels outside the narrow band at exactly
-        # 0. Mathematically sgn(0) == 0, so if the kernel treated 0 as a
+        # active-but-unobserved voxels at exactly 0: reinitialize_sdf gives
+        # an exactly-0 voxel a zero frozen sign and never moves it.
+        # Mathematically sgn(0) == 0, so if the kernel treated 0 as a
         # real sign it would latch the very first 0 voxel as its reference
         # and flag a "sign change" the instant the ray reached the first
         # signed (+/-) voxel — collapsing the hit to ~a voxel from the

--- a/tests/unit/test_sdf.py
+++ b/tests/unit/test_sdf.py
@@ -159,6 +159,29 @@ class ReinitializeSdfTests(unittest.TestCase):
         # the deepest interior voxels still reach the band clamp
         self.assertLess(phi.min().item(), -(self.band - 1.25) * self.vx)
 
+    def test_rk_boundary_uses_frozen_sign(self):
+        """A stage sign flip must not turn an inactive face into an upwind contribution."""
+        ijk = torch.tensor(
+            [[0, 0, 0], [1, 0, 0], [0, -1, 0], [0, 1, 0], [0, 0, -1], [0, 0, 1]],
+            device=self.device,
+            dtype=torch.int32,
+        )
+        g = fvdb.Grid.from_ijk(ijk, voxel_size=1.0, origin=0.0)
+        center = (g.ijk == 0).all(dim=1)
+        plus_x = (g.ijk == ijk[1]).all(dim=1)
+        # All inputs are within [-B, B]. Opposing faces cancel in the central gradient,
+        # giving the centre a frozen sign near +1 despite its small value of +0.1.
+        field = torch.full((g.num_voxels,), -3.0, device=self.device, dtype=torch.float64)
+        field[center] = 0.1
+        field[plus_x] = 3.0
+        for polarity in (1.0, -1.0):
+            with self.subTest(polarity=polarity):
+                phi = g.reinitialize_sdf(polarity * field, band=3, order=3, redistance_iters=1)
+                # Evaluating RK3 with the missing faces excluded from the upwind gradient
+                # gives centre stages -1.253625, -0.279841, -0.842034 for positive polarity.
+                # The live-sign boundary instead flips to -B after stage 1 and ends at -1.103265.
+                self.assertAlmostEqual(phi[center].item(), polarity * -0.842034, delta=1e-6)
+
     def test_rebuild_idempotent(self):
         """rebuild_narrow_band applied to its own (interior-pruned) output must reproduce that output."""
         field = self.analytic.clamp(-self.bw, self.bw)
@@ -215,6 +238,46 @@ class ReinitializeSdfTests(unittest.TestCase):
         for i in range(2):
             self.assertTrue(torch.equal(gb_out[i].ijk.jdata, g_flat.ijk))
             self.assertTrue(torch.allclose(phib[i].jdata, phi_flat, atol=1e-5))
+
+    def test_sdf_rejects_non_scalar_shapes(self):
+        """Validate scalar layout before flattening, including shapes whose numel happens to fit."""
+        n = self.grid.num_voxels
+        gb = fvdb.GridBatch.from_ijk(fvdb.JaggedTensor([self.grid.ijk]), voxel_sizes=self.vx, origins=0.0)
+        for shape in ((n, 3), (1, n), (n, 1, 1)):
+            field = torch.ones(shape, device=self.device)
+            # Construct directly so malformed leading dimensions also reach the op's validation.
+            batched = fvdb.JaggedTensor(field)
+            for grid, values in ((self.grid, field), (gb, batched)):
+                with self.subTest(shape=shape, batch=isinstance(grid, fvdb.GridBatch)):
+                    with self.assertRaisesRegex(ValueError, "scalar field with shape"):
+                        grid.reinitialize_sdf(values)
+                    for pad in (False, True):
+                        with self.assertRaisesRegex(ValueError, "scalar field with shape"):
+                            grid.rebuild_narrow_band(values, pad=pad)
+
+    def test_rebuild_rejects_wrong_voxel_count(self):
+        n = self.grid.num_voxels
+        gb = fvdb.GridBatch.from_ijk(fvdb.JaggedTensor([self.grid.ijk]), voxel_sizes=self.vx, origins=0.0)
+        for count in (n - 1, n + 1):
+            field = torch.ones(count, device=self.device)
+            for grid, values in ((self.grid, field), (gb, fvdb.JaggedTensor(field))):
+                with self.subTest(count=count, batch=isinstance(grid, fvdb.GridBatch)):
+                    with self.assertRaisesRegex(ValueError, "one value per voxel"):
+                        grid.rebuild_narrow_band(values)
+
+    def test_sdf_rejects_nonfinite_values(self):
+        """NaN must not be treated as new padding; neither solver accepts NaN or infinity."""
+        gb = fvdb.GridBatch.from_ijk(fvdb.JaggedTensor([self.grid.ijk]), voxel_sizes=self.vx, origins=0.0)
+        for invalid in (float("nan"), float("inf"), -float("inf")):
+            field = self.analytic.clamp(-self.bw, self.bw).clone()
+            field[0] = invalid
+            for grid, values in ((self.grid, field), (gb, gb.jagged_like(field))):
+                with self.subTest(invalid=invalid, batch=isinstance(grid, fvdb.GridBatch)):
+                    with self.assertRaisesRegex(ValueError, "finite values"):
+                        grid.reinitialize_sdf(values)
+                    for pad in (False, True):
+                        with self.assertRaisesRegex(ValueError, "finite values"):
+                            grid.rebuild_narrow_band(values, pad=pad)
 
     def test_single_sign_field_has_no_surface(self):
         """The surface is a sign change between ACTIVE voxels. An all-negative field (a raw occupancy

--- a/tests/unit/test_sdf.py
+++ b/tests/unit/test_sdf.py
@@ -196,6 +196,18 @@ class ReinitializeSdfTests(unittest.TestCase):
             self.assertTrue(torch.equal(gb2[i].ijk.jdata, g2.ijk))
             self.assertTrue(torch.allclose(phib[i].jdata, phi, atol=1e-5))
 
+    def test_anisotropic_voxels_rejected(self):
+        """The eikonal solve uses a single voxel size, so anisotropic grids must raise, not
+        silently return distances scaled along y/z."""
+        g = fvdb.Grid.from_ijk(self.grid.ijk, voxel_size=[self.vx, self.vx, 2 * self.vx], origin=0.0)
+        field = self.analytic.clamp(-self.bw, self.bw)
+        with self.assertRaisesRegex(ValueError, "isotropic"):
+            g.reinitialize_sdf(field, band=self.band)
+        # float32 round-off in an isotropic size must NOT trip the check
+        g_iso = fvdb.Grid.from_ijk(self.grid.ijk, voxel_size=torch.tensor([0.1, 0.1, 0.1]), origin=0.0)
+        phi = g_iso.reinitialize_sdf(field, band=self.band)
+        self.assertEqual(phi.shape[0], g_iso.num_voxels)
+
     # ------------------------------------------------------------------ batch
     def test_batch_matches_single(self):
         vx = self.vx

--- a/tests/unit/test_sdf.py
+++ b/tests/unit/test_sdf.py
@@ -80,10 +80,10 @@ class ReinitializeSdfTests(unittest.TestCase):
         err = (phi[m] - self.analytic[m].double()).abs()
         self.assertLess(err.mean().item(), 0.25 * self.vx)
 
-    # ------------------------------------------------------------------ retopo
-    def test_retopologize_prune(self):
+    # ------------------------------------------------------------------ rebuild_narrow_band
+    def test_rebuild_prune(self):
         field = self.analytic.clamp(-self.bw, self.bw)
-        pruned, phi = self.grid.retopologize_sdf(field, band=self.band, prune=True)
+        pruned, phi = self.grid.rebuild_narrow_band(field, band=self.band, prune=True)
         self.assertEqual(phi.shape[0], pruned.num_voxels)
         self.assertLessEqual(pruned.num_voxels, self.grid.num_voxels)
         self.assertLess(phi.abs().max().item(), self.bw)  # strictly inside the band
@@ -95,13 +95,13 @@ class ReinitializeSdfTests(unittest.TestCase):
         field = self.analytic.clamp(-self.bw, self.bw)
         phi_full = self.grid.reinitialize_sdf(field, band=self.band)
         mask = phi_full.abs() < self.bw * 0.999
-        pruned, phi = self.grid.retopologize_sdf(field, band=self.band, prune=True)
+        pruned, phi = self.grid.rebuild_narrow_band(field, band=self.band, prune=True)
         self.assertTrue(torch.equal(self.grid.ijk[mask], pruned.ijk))
         self.assertTrue(torch.allclose(phi, phi_full[mask]))
 
     def test_no_prune_no_pad_returns_same_grid(self):
         field = self.analytic.clamp(-self.bw, self.bw)
-        grid_out, phi = self.grid.retopologize_sdf(field, band=self.band, pad=False, prune=False)
+        grid_out, phi = self.grid.rebuild_narrow_band(field, band=self.band, pad=False, prune=False)
         self.assertEqual(grid_out.num_voxels, self.grid.num_voxels)
         self.assertEqual(phi.shape[0], self.grid.num_voxels)
 
@@ -117,8 +117,8 @@ class ReinitializeSdfTests(unittest.TestCase):
         analytic = (g.ijk.float() * self.vx).norm(dim=1) - self.R
         field = analytic.clamp(-self.bw, self.bw)
 
-        g0, phi0 = g.retopologize_sdf(field, band=self.band, pad=False, prune=True)
-        g1, phi1 = g.retopologize_sdf(field, band=self.band, pad=True, prune=True)
+        g0, phi0 = g.rebuild_narrow_band(field, band=self.band, pad=False, prune=True)
+        g1, phi1 = g.rebuild_narrow_band(field, band=self.band, pad=True, prune=True)
 
         # padding produces a genuine multi-voxel exterior band; without it the band is truncated
         self.assertGreater((phi1 > 0.5 * self.vx).sum().item(), (phi0 > 0.5 * self.vx).sum().item())
@@ -159,12 +159,12 @@ class ReinitializeSdfTests(unittest.TestCase):
         # the deepest interior voxels still reach the band clamp
         self.assertLess(phi.min().item(), -(self.band - 1.25) * self.vx)
 
-    def test_retopologize_idempotent(self):
-        """retopologize_sdf applied to its own (interior-pruned) output must reproduce that output."""
+    def test_rebuild_idempotent(self):
+        """rebuild_narrow_band applied to its own (interior-pruned) output must reproduce that output."""
         field = self.analytic.clamp(-self.bw, self.bw)
-        g1, phi1 = self.grid.retopologize_sdf(field, band=self.band)
+        g1, phi1 = self.grid.rebuild_narrow_band(field, band=self.band)
         for pad in (False, True):
-            g2, phi2 = g1.retopologize_sdf(phi1, band=self.band, pad=pad)
+            g2, phi2 = g1.rebuild_narrow_band(phi1, band=self.band, pad=pad)
             a2 = (g2.ijk.float() * self.vx).norm(dim=1) - self.R
             err = (phi2 - a2).abs()
             self.assertLess(err.mean().item(), 0.25 * self.vx, f"pad={pad}")
@@ -176,7 +176,7 @@ class ReinitializeSdfTests(unittest.TestCase):
         """Padding a narrow band with an inactive interior must seed the inward layers negative."""
         g, analytic = self._narrow_band_grid()
         field = analytic.clamp(-self.bw, self.bw)
-        padded, phi = g.retopologize_sdf(field, band=self.band, pad=True, prune=False)
+        padded, phi = g.rebuild_narrow_band(field, band=self.band, pad=True, prune=False)
         a = (padded.ijk.float() * self.vx).norm(dim=1) - self.R
         interior_new = a < -self.bw  # voxels the padding added on the inside
         self.assertGreater(interior_new.sum().item(), 0)
@@ -190,8 +190,8 @@ class ReinitializeSdfTests(unittest.TestCase):
         field = analytic.clamp(-self.bw, self.bw)
         gb = fvdb.GridBatch.from_ijk(fvdb.JaggedTensor([g.ijk, g.ijk]), voxel_sizes=self.vx, origins=0.0)
         fb = gb.jagged_like(torch.cat([field, field]))
-        gb2, phib = gb.retopologize_sdf(fb, band=self.band, pad=True)
-        g2, phi = g.retopologize_sdf(field, band=self.band, pad=True)
+        gb2, phib = gb.rebuild_narrow_band(fb, band=self.band, pad=True)
+        g2, phi = g.rebuild_narrow_band(field, band=self.band, pad=True)
         for i in range(2):
             self.assertTrue(torch.equal(gb2[i].ijk.jdata, g2.ijk))
             self.assertTrue(torch.allclose(phib[i].jdata, phi, atol=1e-5))

--- a/tests/unit/test_sdf.py
+++ b/tests/unit/test_sdf.py
@@ -196,6 +196,26 @@ class ReinitializeSdfTests(unittest.TestCase):
             self.assertTrue(torch.equal(gb2[i].ijk.jdata, g2.ijk))
             self.assertTrue(torch.allclose(phib[i].jdata, phi, atol=1e-5))
 
+    def test_rebuild_accepts_column_field(self):
+        """(N, 1) scalar fields (the usual TSDF layout) must work with the default pad=True, single and
+        batched, and match the flat (N,) result."""
+        field = self.analytic.clamp(-self.bw, self.bw)
+        g_flat, phi_flat = self.grid.rebuild_narrow_band(field, band=self.band)
+        g_col, phi_col = self.grid.rebuild_narrow_band(field[:, None], band=self.band)
+        self.assertEqual(phi_col.dim(), 1)
+        self.assertTrue(torch.equal(g_col.ijk, g_flat.ijk))
+        self.assertTrue(torch.allclose(phi_col, phi_flat))
+
+        gb = fvdb.GridBatch.from_ijk(
+            fvdb.JaggedTensor([self.grid.ijk, self.grid.ijk]), voxel_sizes=self.vx, origins=0.0
+        )
+        fb_col = gb.jagged_like(torch.cat([field, field])[:, None])
+        gb_out, phib = gb.rebuild_narrow_band(fb_col, band=self.band)
+        self.assertEqual(phib.jdata.dim(), 1)
+        for i in range(2):
+            self.assertTrue(torch.equal(gb_out[i].ijk.jdata, g_flat.ijk))
+            self.assertTrue(torch.allclose(phib[i].jdata, phi_flat, atol=1e-5))
+
     def test_anisotropic_voxels_rejected(self):
         """The eikonal solve uses a single voxel size, so anisotropic grids must raise, not
         silently return distances scaled along y/z."""

--- a/tests/unit/test_sdf.py
+++ b/tests/unit/test_sdf.py
@@ -216,6 +216,32 @@ class ReinitializeSdfTests(unittest.TestCase):
             self.assertTrue(torch.equal(gb_out[i].ijk.jdata, g_flat.ijk))
             self.assertTrue(torch.allclose(phib[i].jdata, phi_flat, atol=1e-5))
 
+    def test_single_sign_field_has_no_surface(self):
+        """The surface is a sign change between ACTIVE voxels. An all-negative field (a raw occupancy
+        mask) has none: reinitialize_sdf returns the constant -band*vx and rebuild_narrow_band an empty
+        band. The active-region boundary is deliberately NOT a surface -- a tile lying entirely inside
+        an object must come back empty. Adding one positive exterior layer restores the surface."""
+        solid = fvdb.Grid.from_ijk(self.grid.ijk[self.analytic < 0], voxel_size=self.vx, origin=0.0)
+        occupancy = -torch.ones(solid.num_voxels, device=self.device)
+        phi = solid.reinitialize_sdf(occupancy, band=self.band)
+        self.assertTrue(torch.allclose(phi, torch.full_like(phi, -self.bw)))
+        empty, phi_empty = solid.rebuild_narrow_band(occupancy, band=self.band)
+        self.assertEqual(empty.num_voxels, 0)
+        self.assertEqual(phi_empty.shape[0], 0)
+
+        # occupancy recipe: one exterior layer seeded positive -> the boundary becomes the surface
+        shell = solid.dilated_grid(1)
+        signed = shell.inject_from(solid, occupancy, default_value=1.0)
+        g, sdf = shell.rebuild_narrow_band(signed, band=self.band)
+        self.assertGreater(g.num_voxels, 0)
+        self.assertGreater((sdf > 0).sum().item(), 0)
+        self.assertGreater((sdf < 0).sum().item(), 0)
+        # boundary sits ~half a voxel outside the outermost occupied voxel centre; a +/-1 step on a
+        # voxelised boundary carries staircase error, so only check it lands within a voxel
+        analytic = (g.ijk.float() * self.vx).norm(dim=1) - (self.R + 0.5 * self.vx)
+        near = analytic.abs() < 1.5 * self.vx
+        self.assertLess((sdf[near] - analytic[near]).abs().mean().item(), 1.0 * self.vx)
+
     def test_anisotropic_voxels_rejected(self):
         """The eikonal solve uses a single voxel size, so anisotropic grids must raise, not
         silently return distances scaled along y/z."""

--- a/tests/unit/test_sdf.py
+++ b/tests/unit/test_sdf.py
@@ -128,6 +128,74 @@ class ReinitializeSdfTests(unittest.TestCase):
         v, f, n = g1.marching_cubes(phi1, level=0.0)
         self.assertGreater(v.shape[0], 0)
 
+    # ------------------------------------------------------------------ inactive interior
+    def _narrow_band_grid(self):
+        """The sphere restricted to |phi| < band*vx: a narrow band whose INTERIOR is inactive."""
+        keep = self.analytic.abs() < self.bw
+        g = fvdb.Grid.from_ijk(self.grid.ijk[keep], voxel_size=self.vx, origin=0.0)
+        analytic = (g.ijk.float() * self.vx).norm(dim=1) - self.R
+        return g, analytic
+
+    def test_reinitialize_narrow_band_with_inactive_interior(self):
+        """A narrow band with an inactive interior must stay solid: the inner half of the band must
+        match the analytic SDF as closely as the outer half, not grow a phantom inner surface.
+
+        An IndexGrid has a single background slot, so inactive neighbours are resolved per read with
+        the sign of the adjacent voxel (-band*vx inside, +band*vx outside). Before that fix the inner
+        half-band error was ~3.6 vx and the innermost voxels flipped positive."""
+        g, analytic = self._narrow_band_grid()
+        field = analytic.clamp(-self.bw, self.bw)
+        phi = g.reinitialize_sdf(field, band=self.band, order=3)
+        err = (phi - analytic).abs()
+        inner = (analytic <= -0.5 * self.bw) & (analytic > -self.bw)
+        outer = (analytic >= 0.5 * self.bw) & (analytic < self.bw)
+        self.assertLess(err[inner].mean().item(), 0.25 * self.vx)
+        self.assertLess(err[inner].max().item(), 1.0 * self.vx)
+        # inner and outer halves should be comparably accurate
+        self.assertLess(err[inner].mean().item(), 3.0 * err[outer].mean().item() + 0.05 * self.vx)
+        # no sign flips away from the surface
+        away = analytic.abs() > 0.5 * self.vx
+        self.assertEqual(((phi.sign() != analytic.sign()) & away).sum().item(), 0)
+        # the deepest interior voxels still reach the band clamp
+        self.assertLess(phi.min().item(), -(self.band - 1.25) * self.vx)
+
+    def test_retopologize_idempotent(self):
+        """retopologize_sdf applied to its own (interior-pruned) output must reproduce that output."""
+        field = self.analytic.clamp(-self.bw, self.bw)
+        g1, phi1 = self.grid.retopologize_sdf(field, band=self.band)
+        for pad in (False, True):
+            g2, phi2 = g1.retopologize_sdf(phi1, band=self.band, pad=pad)
+            a2 = (g2.ijk.float() * self.vx).norm(dim=1) - self.R
+            err = (phi2 - a2).abs()
+            self.assertLess(err.mean().item(), 0.25 * self.vx, f"pad={pad}")
+            self.assertLess(phi2.min().item(), -(self.band - 1.25) * self.vx, f"pad={pad}")
+            # same band on both passes (within a layer of voxels)
+            self.assertLess(abs(g2.num_voxels - g1.num_voxels) / g1.num_voxels, 0.1, f"pad={pad}")
+
+    def test_pad_seeds_interior_of_hollow_band(self):
+        """Padding a narrow band with an inactive interior must seed the inward layers negative."""
+        g, analytic = self._narrow_band_grid()
+        field = analytic.clamp(-self.bw, self.bw)
+        padded, phi = g.retopologize_sdf(field, band=self.band, pad=True, prune=False)
+        a = (padded.ijk.float() * self.vx).norm(dim=1) - self.R
+        interior_new = a < -self.bw  # voxels the padding added on the inside
+        self.assertGreater(interior_new.sum().item(), 0)
+        self.assertTrue((phi[interior_new] < 0).all().item())
+        exterior_new = a > self.bw
+        self.assertTrue((phi[exterior_new] > 0).all().item())
+
+    def test_batch_pad_matches_single(self):
+        """Batched sign-aware padding must agree with the single-grid path for each grid."""
+        g, analytic = self._narrow_band_grid()
+        field = analytic.clamp(-self.bw, self.bw)
+        gb = fvdb.GridBatch.from_ijk(fvdb.JaggedTensor([g.ijk, g.ijk]), voxel_sizes=self.vx, origins=0.0)
+        fb = gb.jagged_like(torch.cat([field, field]))
+        gb2, phib = gb.retopologize_sdf(fb, band=self.band, pad=True)
+        g2, phi = g.retopologize_sdf(field, band=self.band, pad=True)
+        for i in range(2):
+            self.assertTrue(torch.equal(gb2[i].ijk.jdata, g2.ijk))
+            self.assertTrue(torch.allclose(phib[i].jdata, phi, atol=1e-5))
+
     # ------------------------------------------------------------------ batch
     def test_batch_matches_single(self):
         vx = self.vx


### PR DESCRIPTION
Fixes a correctness bug in `reinitialize_sdf` / `retopologize_sdf` (introduced in #669) for any input whose interior is inactive, documents the op's actual input contract, rejects anisotropic voxels instead of silently mis-scaling, and **renames `retopologize_sdf` → `rebuild_narrow_band`** (breaking, no alias).

## Bug

An `IndexGrid` has a single background slot (value-index 0). The eikonal solver filled it with `+band*vx`, so **every inactive neighbour read as "outside"**. That is correct for a filled solid (the occupancy → SDF pipeline the op was written for), but wrong for a narrow band whose interior is inactive — a pruned level set, an imported OpenVDB grid, or **the op's own narrow-band output**. The innermost active voxels saw `+band*vx` across the face, `|∇φ|` blew up to ~`2·band`, and a phantom interface grew inward from the band edge.

The zero crossing survives (the frozen Peng sign pins it), so meshes looked right and this went unnoticed. But the inner half of the band was wrong and the rebuild was not idempotent.

Measured on a sphere (R = 12 vx, band = 3), before the fix:

| input | inner-half-band mean \|err\| | min(φ) | sign flips (\|truth\| > 0.5 vx) |
|---|---|---|---|
| solid (interior active) | 0.076 vx | −2.92 | 0 |
| narrow band (interior inactive) | **3.579 vx** | **+0.29** (truth −2.94) | **2120** |
| rebuild applied to its own output | 0.767 vx | **−0.95** (was −2.99) | |

## Fix

**`ReinitializeSdf.cu`** — resolve inactive neighbours per read instead of via slot 0: `faceValue()` returns `copysign(band*vx, φ_center)`, so inactive space continues the sign of the adjacent active voxel (−B beside interior, +B beside exterior). All three stencil kernels (sign, Godunov, smoothing) go through it. No-op for filled solids, whose inactive neighbours only ever touch positive voxels.

**`_sdf.py`** — `pad=True` had the same flaw one level up: it injected a constant `+band*vx` into every freshly dilated voxel, so padding a hollow band seeded its interior as exterior. It now pads one layer at a time and seeds each new voxel with the sign of its 26-neighbours (batched path applies per-grid `joffsets`, since `GridBatch.neighbor_indexes` returns per-grid indices).

After the fix the narrow-band case matches the solid case exactly (0.076 vx, no flips) and a second pass reproduces `min(φ) = −2.99`.

## Rename: `retopologize_sdf` → `rebuild_narrow_band`

"Retopologize" is mesh-remeshing jargon and says nothing about what the op produces — a *narrow-band* SDF on a rebuilt grid — so it's neither discoverable nor descriptive. The new name follows OpenVDB's `levelSetRebuild`. Affected: `Grid.rebuild_narrow_band`, `GridBatch.rebuild_narrow_band`, `fvdb.functional.rebuild_narrow_band_{single,batch}`. Signature and return type are unchanged. **No deprecation alias is kept** (the op shipped in 0.5.x); `CHANGES.md` records it under 0.6.0 as breaking. `reinitialize_sdf` keeps its name — "reinitialization" is the standard level-set term for exactly this PDE.

## Documentation audit

Every docstring/comment describing this functionality was checked against the (fixed) behaviour:

- `Grid.rebuild_narrow_band` / `GridBatch.rebuild_narrow_band` still said new voxels are "seeded as exterior … for a hollow shell pass `pad=False`". That advice was already incorrect (`pad` never governed the in-kernel read); replaced.
- All `reinitialize_sdf` docstrings + the C++ header now state the input contract: only the **sign** of `field` is trusted; the surface is a sign change between *active* voxels (one voxel of each sign across the crossing suffices; a single-sign grid has no surface, so an occupancy mask needs a positive exterior layer first); inactive neighbours continue the adjacent sign (solids and hollow bands both valid); voxels that are **exactly 0** have a zero frozen sign and are left untouched (a no-data pass-through that `ray_implicit_intersection` relies on — #692), but their signed neighbours see them as an interface and smoothing blends them, so prune them first when possible; voxels must be isotropic; CUDA only, float32/float64.
- `SmoothingMode` now says smoothing is followed by a re-redistance and therefore *moves* the zero crossing, and that `MEAN_CURVATURE` erodes ~1-voxel features.
- `RayImplicitIntersection.cu` / `test_basic_ops.py` said `reinitialize_sdf` "leaves every active voxel outside the band at 0" — overstated; only exactly-0 input voxels stay 0 (verified: 150/150 with `smooth=0`, 2/150 with `smooth=2`).

## Isotropy check

The solve uses one voxel size but read only `voxelSizeAt(b)[0]`, so an anisotropic grid returned distances scaled by the aspect ratio along y/z. Now a per-grid `TORCH_CHECK_VALUE` (1e-6 relative tolerance, so float32 `0.1` → double round-off is accepted) raises `ValueError` naming the grid and its `voxel_size` before any GPU work. This is a behaviour change: callers feeding anisotropic grids were getting wrong answers and will now get an exception.

## Test plan

Built in the `fvdb` conda env (CUDA), `cd tests && pytest unit/test_sdf.py -v`:

- [x] 10 pre-existing tests unchanged (modulo the rename) and passing
- [x] `test_reinitialize_narrow_band_with_inactive_interior` — inner half-band error < 0.25 vx, comparable to outer half, no sign flips, deepest voxels reach the clamp
- [x] `test_rebuild_idempotent` — second pass with `pad=False` and `pad=True` reproduces the band
- [x] `test_pad_seeds_interior_of_hollow_band` — padded interior layers negative, exterior positive
- [x] `test_batch_pad_matches_single` — batched sign-aware padding matches the single-grid path
- [x] `test_rebuild_accepts_column_field` — `(N, 1)` scalar fields with the default `pad=True`, single and batched, match the flat `(N,)` result (review finding: the padding mask kept the trailing singleton dim; the field is now canonicalized to flat storage first)
- [x] `test_single_sign_field_has_no_surface` — an all-negative (occupancy) field has no surface: `reinitialize_sdf` returns the constant `-band*vx` and `rebuild_narrow_band` an empty band (correct for a fully-interior tile; the active-region boundary is not a surface). The occupancy recipe — one exterior layer seeded positive, then rebuild — recovers the boundary surface.
- [x] `test_anisotropic_voxels_rejected` — anisotropic raises `ValueError`; float32-round-off isotropic does not
- [x] API surface check: `retopologize_sdf*` absent from `Grid`, `GridBatch`, `fvdb.functional`; `rebuild_narrow_band*` present
- [x] `pytest unit/test_basic_ops.py -k ray_implicit_intersection` — 56 passed (comments touched there)
- [x] `clang-format --Werror` clean on the touched CUDA lines

## Notes

- The `feature/prune-layer-generative-examples` branch carries a rewrite of this kernel onto the register VBM decode; `faceValue` and the isotropy check will need re-applying there when it rebases.
- `_fvdb_cpp.pyi` / pybind registration needed no change (the C++ entry point `reinitialize_sdf` is unchanged; the rename is Python-side only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
