### PR TITLE
build: add 'format' subcommand and fix run_clang_format.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -13,6 +13,8 @@ usage() {
   echo "                   wheel      - Build the Python wheel."
   echo "                   ctest      - Run tests (requires tests to be built)."
   echo "                   docstest   - Run pytest markdown documentation tests."
+  echo "                   format     - Run clang-format and black over the repo (matches CI)."
+  echo "                                Pass 'check' to report violations without rewriting files."
   echo ""
   echo "Options:"
   echo "  -h, --help     Display this help message and exit."
@@ -235,7 +237,7 @@ _first_arg_val="$1"
 BUILD_TYPE="install" # Default build type
 
 if [[ -n "$_first_arg_val" ]]; then
-  if [[ "$_first_arg_val" == "install" || "$_first_arg_val" == "wheel" || "$_first_arg_val" == "ctest" || "$_first_arg_val" == "docstest" ]]; then
+  if [[ "$_first_arg_val" == "install" || "$_first_arg_val" == "wheel" || "$_first_arg_val" == "ctest" || "$_first_arg_val" == "docstest" || "$_first_arg_val" == "format" ]]; then
     BUILD_TYPE="$_first_arg_val"
     shift # Consume the build_type argument
   else
@@ -367,6 +369,33 @@ fi
 # Construct PIP_ARGS with potential CMake args and other pass-through args
 export PIP_ARGS="--no-build-isolation$CONFIG_SETTINGS$PASS_THROUGH_ARGS"
 
+if [ "$BUILD_TYPE" == "format" ]; then
+    # Formatting needs no CUDA or build-job setup. Black reads its
+    # settings from pyproject.toml, so no flags are duplicated here.
+    FORMAT_MODE="${PASS_THROUGH_ARGS# }"
+    FORMAT_MODE="${FORMAT_MODE:-format}"
+    if [[ "$FORMAT_MODE" != "format" && "$FORMAT_MODE" != "check" ]]; then
+        echo "Error: 'format' accepts an optional 'check' argument, got: $FORMAT_MODE"
+        exit 1
+    fi
+    FORMAT_EXIT_CODE=0
+
+    echo "Running clang-format ($FORMAT_MODE)"
+    ./src/scripts/run_clang_format.sh "$FORMAT_MODE" || FORMAT_EXIT_CODE=$?
+
+    echo "Running black ($FORMAT_MODE)"
+    if ! python -c "import black" >/dev/null 2>&1; then
+        echo "Error: black is not installed. Install with: python -m pip install \"black~=24.0\""
+        exit 127
+    fi
+    if [ "$FORMAT_MODE" == "check" ]; then
+        python -m black --check --diff . || FORMAT_EXIT_CODE=$?
+    else
+        python -m black . || FORMAT_EXIT_CODE=$?
+    fi
+    exit $FORMAT_EXIT_CODE
+fi
+
 # Detect and export CUDA architectures early so builds pick it up
 set_cuda_arch_list "$CUDA_ARCH_LIST_ARG"
 
@@ -468,6 +497,6 @@ elif [ "$BUILD_TYPE" == "docstest" ]; then
 
 else
     echo "Invalid build/run type: $BUILD_TYPE"
-    echo "Valid build/run types are: wheel, install, ctest, docstest"
+    echo "Valid build/run types are: wheel, install, ctest, docstest, format"
     exit 1
 fi

--- a/src/scripts/run_clang_format.sh
+++ b/src/scripts/run_clang_format.sh
@@ -1,30 +1,51 @@
+#!/bin/bash
 # Copyright Contributors to the OpenVDB Project
 # SPDX-License-Identifier: Apache-2.0
 
-#!/bin/bash
+# Formats C++/CUDA sources under src/ the same way CI checks them
+# (.github/workflows/codestyle.yml: clang-format 18, style=file).
+#
+# Usage: run_clang_format.sh [format|check]
+#   format  rewrite files in place (default)
+#   check   exit non-zero if any file would change
 
-format_files() {
-    find . -type f \( -name "*.cpp" -o -name "*.h" -o -name "*.hpp" -o -name "*.cu" -o -name "*.cuh" \) -exec clang-format -i {} +
-}
+set -euo pipefail
 
-pushd ../benchmarks
-format_files
-popd
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SRC_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+MODE="${1:-format}"
 
-pushd ../dispatch
-format_files
-popd
+CLANG_FORMAT_BIN="${CLANG_FORMAT_BIN:-}"
+if [[ -z "${CLANG_FORMAT_BIN}" ]]; then
+    if command -v clang-format-18 >/dev/null 2>&1; then
+        CLANG_FORMAT_BIN="clang-format-18"
+    elif command -v clang-format >/dev/null 2>&1; then
+        CLANG_FORMAT_BIN="clang-format"
+    else
+        echo "Error: clang-format not found in PATH."
+        echo "CI uses clang-format 18. Install it or set CLANG_FORMAT_BIN=/path/to/clang-format."
+        exit 127
+    fi
+elif ! command -v "${CLANG_FORMAT_BIN}" >/dev/null 2>&1; then
+    echo "Error: CLANG_FORMAT_BIN='${CLANG_FORMAT_BIN}' not found in PATH."
+    exit 127
+fi
 
-pushd ../fvdb
-format_files
-popd
+case "${MODE}" in
+    format) CLANG_FORMAT_ARGS=(-i) ;;
+    check)  CLANG_FORMAT_ARGS=(--dry-run --Werror) ;;
+    *)
+        echo "Error: unknown mode '${MODE}'. Expected 'format' or 'check'."
+        exit 2
+        ;;
+esac
 
-pushd ../python
-format_files
-popd
+CLANG_FORMAT_VERSION="$(${CLANG_FORMAT_BIN} --version | head -n 1)"
+echo "Using ${CLANG_FORMAT_BIN} (${CLANG_FORMAT_VERSION})"
+if [[ "${CLANG_FORMAT_VERSION}" != *"version 18."* ]]; then
+    echo "Warning: CI uses clang-format 18. Other versions may format differently."
+fi
 
-pushd ../tests
-format_files
-popd
-
-
+find "${SRC_DIR}" -type f \
+    \( -name "*.h" -o -name "*.cpp" -o -name "*.cc" -o -name "*.cu" -o -name "*.cuh" \) -print0 \
+    | xargs -0 "${CLANG_FORMAT_BIN}" -style=file "${CLANG_FORMAT_ARGS[@]}"


### PR DESCRIPTION
## Summary

Adds `./build.sh format`, a single command that formats the repo the way CI checks it, and fixes the existing clang-format script.

- `./build.sh format` runs clang-format over `src/` and then black over the repo. `./build.sh format check` reports violations without rewriting files and exits non-zero, matching the CI codestyle jobs.
- Black reads its settings from the `[tool.black]` section in `pyproject.toml` added in #592, so this PR duplicates no black flags.
- `src/scripts/run_clang_format.sh` previously had its shebang after the license header, only worked when invoked from `src/scripts`, and did not pass `-style=file`. It now walks `src/` with the same extensions CI uses, prefers `clang-format-18` (which `env/dev_environment.yml` provides), warns when another version is used, and supports `check` mode.

Supersedes #449. Per the discussion there, the standalone black script is dropped in favor of the pyproject config.

## Testing

- `./build.sh format bogus` and `./build.sh format check extra` reject the arguments.
- `./build.sh format check` runs clang-format in dry-run mode and reports violations, then runs black in check mode. Exit code is non-zero if either reports a problem.
- `./build.sh format` rewrites files in place. With a local clang-format 21 the version warning fires and the reformat differs from CI, which is why the warning exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
