### PR TITLE
Batched BoxDilate passes for positive padded_grid / dual_grid on CUDA

### DIFF
--- a/src/fvdb/detail/ops/BuildPaddedGrid.cu
+++ b/src/fvdb/detail/ops/BuildPaddedGrid.cu
@@ -14,6 +14,7 @@
 #include <fvdb/detail/utils/cuda/ForEachCUDA.cuh>
 #include <fvdb/detail/utils/cuda/ForEachPrivateUse1.cuh>
 #include <fvdb/detail/utils/cuda/GridDim.h>
+#include <fvdb/detail/utils/nanovdb/BatchedTopologyBuilder.cuh>
 #include <fvdb/detail/utils/nanovdb/CreateEmptyGridHandle.h>
 #include <fvdb/detail/utils/nanovdb/PadGrid.cuh>
 
@@ -347,6 +348,19 @@ dispatchBuildPaddedGrid<torch::kCUDA>(const GridBatchData &baseBatchHdl,
         return ops::contiguousGridHandle(baseBatchHdl);
     }
 
+    // Pure positive padding without erosion (dual_grid, build_padded_grid(0, k)): the whole batch
+    // is built in `bmax` chained batched BoxDilate passes, each a Minkowski sum with the octant
+    // {0,1}^3 (issue #775). One output buffer, one stream synchronization per pass, no per-member
+    // builds or handle merging; empty members become valid empty grids inline. Sliced /
+    // non-contiguous batches are handled by the view-aware source pointers.
+    if (numNegative == 0 && !excludeBorder) {
+        const std::vector<batched::TopologyPassSpec> passes(
+            numPositive,
+            batched::TopologyPassSpec::boxDilate(nanovdb::Coord(0), nanovdb::Coord(1)));
+        return batched::batchedTopologyHandle(baseBatchHdl, passes, stream.stream());
+    }
+
+    // Negative padding and/or erosion (exclude_border) stay on the per-member path.
     std::vector<nanovdb::GridHandle<TorchDeviceBuffer>> handles;
     handles.reserve(baseBatchHdl.batchSize());
     for (int64_t i = 0; i < baseBatchHdl.batchSize(); ++i) {

--- a/tests/unit/test_batched_topology_builder.py
+++ b/tests/unit/test_batched_topology_builder.py
@@ -4,8 +4,9 @@
 """Equivalence tests for the batched leaf-mask topology builder (issue #755).
 
 On CUDA, ``refined_grid`` / ``coarsened_grid`` (and through them ``conv_grid`` /
-``conv_transpose_grid`` for K == S) build all batch members in a single batched pass instead of
-one NanoVDB build + merge per member. These tests pin the batched results against:
+``conv_transpose_grid`` for K == S), and the positive-padding ops ``dual_grid`` /
+``build_padded_grid(0, k)`` (issue #775), build all batch members in a single batched pass instead
+of one NanoVDB build + merge per member. These tests pin the batched results against:
 
 - ``from_ijk`` (PointsToGrid) grids built from independently computed expected coordinates,
   compared **elementwise** (``torch.equal`` on ``ijk.jdata``), which pins the canonical NanoVDB
@@ -50,6 +51,26 @@ def _expected_coarsen_ijk(ijk: torch.Tensor, factor: int) -> torch.Tensor:
         return ijk.reshape(0, 3)
     coarse = torch.div(ijk.to(torch.int64), factor, rounding_mode="floor")
     return torch.unique(coarse, dim=0).to(torch.int32)
+
+
+def _expected_pad_ijk(ijk: torch.Tensor, bmax: int) -> torch.Tensor:
+    """Unique coordinates of the Minkowski sum of ``ijk`` with the box {0, ..., bmax}^3.
+
+    ``bmax`` chained unit pads by the octant {0,1}^3 compose to exactly this box (Minkowski sums
+    of axis-aligned boxes compose), so this is the expected result of ``build_padded_grid(0, bmax)``
+    and, for ``bmax == 1``, of ``dual_grid()``.
+    """
+    if ijk.numel() == 0:
+        return ijk.reshape(0, 3)
+    r = torch.arange(bmax + 1)
+    offsets = torch.stack(torch.meshgrid(r, r, r, indexing="ij"), dim=-1).reshape(-1, 3)
+    padded = ijk.to(torch.int64)[:, None, :] + offsets[None, :, :].to(ijk.device)
+    return torch.unique(padded.reshape(-1, 3), dim=0).to(torch.int32)
+
+
+def _build_padded_grid(grid: GridBatch, bmin: int, bmax: int, exclude_border: bool = False) -> GridBatch:
+    """Wrapper around the low-level ``build_padded_grid`` binding (generic [bmin, bmax] box)."""
+    return GridBatch(data=fvdb._fvdb_cpp.build_padded_grid(grid.data, bmin, bmax, exclude_border))
 
 
 def _ijk_sets(grid: GridBatch):
@@ -146,6 +167,53 @@ class TestBatchedTopologyBuilder(unittest.TestCase):
             self._check_against_expected(result, expected, f"{name} coarsen x{factor}")
             cpu_result = _build(coords, "cpu").coarsened_grid(factor)
             self._check_against_cpu(result, cpu_result, f"{name} coarsen x{factor} vs CPU")
+
+    @parameterized.expand([(name,) for name in _tricky_batches().keys()])
+    def test_dual_grid_matches_expected_and_cpu(self, name):
+        # dual_grid is one batched BoxDilate({0,1}^3) pass: the Minkowski sum of the primal
+        # voxels with the unit octant (voxels at the corners of the primal voxels).
+        coords = _tricky_batches()[name]
+        grid = _build(coords, "cuda")
+        result = grid.dual_grid()
+        expected = [_expected_pad_ijk(c, 1) for c in coords]
+        self._check_against_expected(result, expected, f"{name} dual_grid")
+        cpu_result = _build(coords, "cpu").dual_grid()
+        self._check_against_cpu(result, cpu_result, f"{name} dual_grid vs CPU")
+        # The dual transform fix-up must survive the batched build: result voxel centers sit on
+        # the source's corner (dual) lattice, i.e. the origin shifts by half a voxel.
+        self.assertTrue(torch.allclose(result.voxel_sizes, grid.voxel_sizes), f"{name} dual_grid voxel size")
+        self.assertTrue(
+            torch.allclose(result.origins, grid.origins - 0.5 * grid.voxel_sizes), f"{name} dual_grid origin"
+        )
+
+    @parameterized.expand([(name,) for name in _tricky_batches().keys()])
+    def test_padded_grid_positive_matches_expected_and_cpu(self, name):
+        # build_padded_grid(0, k) is k chained batched BoxDilate({0,1}^3) passes; the result lies
+        # on the source lattice (transforms unchanged).
+        coords = _tricky_batches()[name]
+        grid = _build(coords, "cuda")
+        cpu_grid = _build(coords, "cpu")
+        for bmax in (1, 2):
+            result = _build_padded_grid(grid, 0, bmax)
+            expected = [_expected_pad_ijk(c, bmax) for c in coords]
+            self._check_against_expected(result, expected, f"{name} padded_grid(0, {bmax})")
+            cpu_result = _build_padded_grid(cpu_grid, 0, bmax)
+            self._check_against_cpu(result, cpu_result, f"{name} padded_grid(0, {bmax}) vs CPU")
+            self.assertTrue(torch.allclose(result.origins, grid.origins), f"{name} padded_grid(0, {bmax}) origin")
+
+    def test_dual_grid_of_sliced_batch(self):
+        # A sliced (non-contiguous) view shares a handle holding more grids than batchSize(); the
+        # batched builder must read the *logical* members via the view-aware grid pointers.
+        coords = _tricky_batches()["mixed_sizes"] + _tricky_batches()["empty_members"]
+        full = _build(coords, "cuda")
+        view = full[1:6]
+        self.assertEqual(view.grid_count, 5)
+        result = view.dual_grid()
+        expected = [_expected_pad_ijk(c, 1) for c in coords[1:6]]
+        self._check_against_expected(result, expected, "sliced dual_grid")
+        for b in range(5):
+            single = _build([coords[1 + b]], "cuda").dual_grid()
+            self.assertTrue(torch.equal(result.ijk.unbind()[b], single.ijk.jdata), f"sliced dual_grid member {b}")
 
     def test_conv_grid_k2s2_multi_grid_matches_per_member(self):
         coords = _tricky_batches()["mixed_sizes"]


### PR DESCRIPTION
## Summary

`dispatchBuildPaddedGrid<torch::kCUDA>` (behind `GridBatch.dual_grid()` and the `build_padded_grid` binding) looped over batch members, running one TopologyBuilder-based `PadGrid` pass per member per unit of padding and then merging the per-member handles with `nanovdb::cuda::mergeGridHandles`. Each `getHandle` performs several stream synchronizations, so wall clock grew linearly with batch size regardless of topology size.

For the pure positive-padding case (`bmin == 0`, `exclude_border == False`, i.e. `dual_grid()` and `build_padded_grid(0, k)`) the whole batch is now built in `k` chained `batched::TopologyPassSpec::boxDilate(Coord(0), Coord(1))` passes through `batched::batchedTopologyHandle` (the `BoxDilate` pass in `BatchedTopologyBuilder.cuh` already covered the one-sided `{0,1}^3` octant; this file just never called it). One output buffer, one host synchronization per pass, empty members become valid empty grids inline, sliced/non-contiguous views are read through the view-aware member pointers.

## Approach

- `src/fvdb/detail/ops/BuildPaddedGrid.cu`: include `BatchedTopologyBuilder.cuh`; after the existing `totalPasses == 0` identity branch, when `numNegative == 0 && !excludeBorder` build a `std::vector<TopologyPassSpec>` of `bmax` `boxDilate(0, +1)` passes and return `batchedTopologyHandle(baseBatchHdl, passes, stream)`.
- Semantics check: `bmax` chained Minkowski sums with `{0,1}^3` equal the Minkowski sum with `{0..bmax}^3`, which is exactly what `buildPaddedGridFromGridCPU` computes for `[0, bmax]^3`.
- Unchanged: the identity branch, the negative-pad / `exclude_border` erosion branch (still per-member; that is item 7), the dual-transform fix-up in `buildPaddedGrid`, and the CPU / PrivateUse1 dispatches.

## Benchmark

`GridBatch.dual_grid()`, `from_ijk` members of 100k random int coordinates in `[-64, 64)^3` (~97.5k unique voxels each), 20 iterations after one warmup, `torch.cuda.synchronize()` around the loop, RTX PRO 6000 Blackwell. Before = installed env (per-member path), after = this branch.

| B | voxels | before (ms) | after (ms) | speedup |
|---|---|---|---|---|
| 1 | 97,559 | 1.369 | 1.008 | 1.4x |
| 4 | 390,545 | 4.683 | 1.070 | 4.4x |
| 16 | 1,562,624 | 14.458 | 1.323 | 10.9x |
| 64 | 6,249,689 | 55.191 | 2.776 | 19.9x |

Time is now roughly flat in B (the remaining growth at B=64 is the 6.2M-voxel sort, not per-member overhead).

## Tests

Added to `tests/unit/test_batched_topology_builder.py` (15 new cases):
- `test_dual_grid_matches_expected_and_cpu` over `_tricky_batches()`: elementwise `ijk.jdata` pin (`_check_against_expected`) against a `from_ijk` build of `unique(ijk + {0,1}^3)` computed in torch, coordinate-set / `num_voxels` comparison against the CPU `dual_grid`, and the dual-transform fix-up (voxel size preserved, origin shifted by half a voxel).
- `test_padded_grid_positive_matches_expected_and_cpu` for `build_padded_grid(0, k)`, `k in (1, 2)`: same pins against `unique(ijk + {0..k}^3)` and CPU, plus origin unchanged.
- `test_dual_grid_of_sliced_batch`: `dual_grid` on a `[1:6]` slice of an 8-member batch (with empty members) equals per-member builds and the expected coordinates.

Results with this build: `test_batched_topology_builder.py` 34 passed; `test_dual.py` + `test_batching.py` + `test_ray_marching.py` 192 passed / 4 skipped; `test_basic_ops.py` + `test_basic_ops_single.py` 430 passed / 1 skipped; `test_sdf.py` 21 passed.

Part of #775 (item 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
