### PR TITLE
Batched BoxDilate passes for GridBatch.dilated_grid on CUDA (issue 775 item 3)

### DIFF
--- a/src/fvdb/detail/ops/BuildDilatedGrid.cu
+++ b/src/fvdb/detail/ops/BuildDilatedGrid.cu
@@ -8,6 +8,7 @@
 #include <fvdb/detail/ops/CloneGrid.h>
 #include <fvdb/detail/ops/MakeContiguous.h>
 #include <fvdb/detail/utils/Utils.h>
+#include <fvdb/detail/utils/nanovdb/BatchedTopologyBuilder.cuh>
 
 #include <nanovdb/NanoVDB.h>
 #include <nanovdb/tools/CreateNanoGrid.h>
@@ -26,24 +27,18 @@ template <torch::DeviceType>
 nanovdb::GridHandle<TorchDeviceBuffer>
 dispatchDilateGrid(const GridBatchData &gridBatch, const std::vector<int64_t> &dilationAmount);
 
-template <>
-nanovdb::GridHandle<TorchDeviceBuffer>
-dispatchDilateGrid<torch::kCUDA>(const GridBatchData &gridBatch,
-                                 const std::vector<int64_t> &dilationAmount) {
-    c10::cuda::CUDAGuard deviceGuard(gridBatch.device());
-
-    at::cuda::CUDAStream stream = at::cuda::getCurrentCUDAStream(gridBatch.device().index());
-
-    // This guide buffer is a hack to pass in a device with an index to the cudaCreateNanoGrid
-    // function. We can't pass in a device directly but we can pass in a buffer which gets
-    // passed to TorchDeviceBuffer::create. The guide buffer holds the device and effectively
-    // passes it to the created buffer.
-    TorchDeviceBuffer guide(0, gridBatch.device());
-
-    // Create a grid for each batch item and store the handles. (An all-zero dilation is handled
-    // upstream in dilateGrid() via cloneGrid, so the 0-branch below only fires for a mixed batch.)
+// Per-member fallback for a NON-uniform dilation vector (reachable only from C++ callers such as
+// IntegrateTSDF, whose per-member pad count derives from each member's voxel size; the Python
+// dilated_grid API broadcasts one scalar). Each member runs nanovdb's DilateGrid dilationAmount[i]
+// times and the single-grid handles are merged -- several stream syncs per member.
+static nanovdb::GridHandle<TorchDeviceBuffer>
+dilatePerMemberCUDA(const GridBatchData &gridBatch,
+                    const std::vector<int64_t> &dilationAmount,
+                    const TorchDeviceBuffer &guide,
+                    cudaStream_t stream) {
     std::vector<nanovdb::GridHandle<TorchDeviceBuffer>> handles;
-    for (int i = 0; i < gridBatch.batchSize(); i += 1) {
+    handles.reserve(gridBatch.batchSize());
+    for (int64_t i = 0; i < gridBatch.batchSize(); i += 1) {
         nanovdb::GridHandle<TorchDeviceBuffer> handle;
 
         if (dilationAmount[i] == 0) {
@@ -54,7 +49,7 @@ dispatchDilateGrid<torch::kCUDA>(const GridBatchData &gridBatch,
             nanovdb::OnIndexGrid *grid = gridBatch.deviceGridPtrAt(i);
             TORCH_CHECK(grid, "Grid is null");
 
-            for (auto j = 0; j < dilationAmount[i]; j += 1) {
+            for (int64_t j = 0; j < dilationAmount[i]; j += 1) {
                 nanovdb::tools::cuda::DilateGrid<nanovdb::ValueOnIndex, BuilderResource> dilateOp(
                     grid, stream);
                 dilateOp.setOperation(nanovdb::tools::morphology::NN_FACE_EDGE_VERTEX);
@@ -72,13 +67,52 @@ dispatchDilateGrid<torch::kCUDA>(const GridBatchData &gridBatch,
     }
 
     if (handles.size() == 1) {
-        // If there's only one handle, just return it
         return std::move(handles[0]);
-    } else {
-        // This copies all the handles into a single handle -- only do it if there are multiple
-        // grids
-        return nanovdb::cuda::mergeGridHandles(handles, &guide);
     }
+    return nanovdb::cuda::mergeGridHandles(handles, &guide);
+}
+
+template <>
+nanovdb::GridHandle<TorchDeviceBuffer>
+dispatchDilateGrid<torch::kCUDA>(const GridBatchData &gridBatch,
+                                 const std::vector<int64_t> &dilationAmount) {
+    c10::cuda::CUDAGuard deviceGuard(gridBatch.device());
+
+    at::cuda::CUDAStream stream = at::cuda::getCurrentCUDAStream(gridBatch.device().index());
+
+    // This guide buffer is a hack to pass in a device with an index to the cudaCreateNanoGrid
+    // function. We can't pass in a device directly but we can pass in a buffer which gets
+    // passed to TorchDeviceBuffer::create. The guide buffer holds the device and effectively
+    // passes it to the created buffer.
+    TorchDeviceBuffer guide(0, gridBatch.device());
+
+    TORCH_CHECK(!dilationAmount.empty(), "dilationAmount must have one entry per batch member");
+    const int64_t dilation = dilationAmount[0];
+    const bool uniform     = std::all_of(dilationAmount.begin(),
+                                     dilationAmount.end(),
+                                     [dilation](int64_t amount) { return amount == dilation; });
+    if (!uniform) {
+        return dilatePerMemberCUDA(gridBatch, dilationAmount, guide, stream.stream());
+    }
+
+    // Identity (all members dilate by 0). dilateGrid() already short-circuits this via cloneGrid,
+    // so this is defensive: compact the (possibly sliced) selected grids into a fresh contiguous
+    // handle, as BuildPaddedGrid.cu does for its zero-pass case.
+    if (dilation == 0) {
+        if (gridBatch.isContiguous()) {
+            return gridBatch.nanoGridHandle().copy<TorchDeviceBuffer>(guide);
+        }
+        return ops::contiguousGridHandle(gridBatch);
+    }
+
+    // Uniform dilation (the only case the Python API produces): dilating by radius d with the
+    // full 26-neighbor (face+edge+vertex) stencil equals d chained Minkowski sums with [-1,1]^3,
+    // so run d batched BoxDilate(-1,+1) passes over the WHOLE batch -- one output buffer, one
+    // stream synchronization per pass, no per-member builds or handle merging (issue #775).
+    // Empty members become valid empty grids inline.
+    const std::vector<batched::TopologyPassSpec> passes(
+        dilation, batched::TopologyPassSpec::boxDilate(nanovdb::Coord(-1), nanovdb::Coord(1)));
+    return batched::batchedTopologyHandle(gridBatch, passes, stream.stream());
 }
 
 template <>

--- a/tests/unit/test_batched_topology_builder.py
+++ b/tests/unit/test_batched_topology_builder.py
@@ -4,8 +4,8 @@
 """Equivalence tests for the batched leaf-mask topology builder (issue #755).
 
 On CUDA, ``refined_grid`` / ``coarsened_grid`` (and through them ``conv_grid`` /
-``conv_transpose_grid`` for K == S) build all batch members in a single batched pass instead of
-one NanoVDB build + merge per member. These tests pin the batched results against:
+``conv_transpose_grid`` for K == S) and ``dilated_grid`` build all batch members in a single
+batched pass instead of one NanoVDB build + merge per member. These tests pin the batched results against:
 
 - ``from_ijk`` (PointsToGrid) grids built from independently computed expected coordinates,
   compared **elementwise** (``torch.equal`` on ``ijk.jdata``), which pins the canonical NanoVDB
@@ -50,6 +50,25 @@ def _expected_coarsen_ijk(ijk: torch.Tensor, factor: int) -> torch.Tensor:
         return ijk.reshape(0, 3)
     coarse = torch.div(ijk.to(torch.int64), factor, rounding_mode="floor")
     return torch.unique(coarse, dim=0).to(torch.int32)
+
+
+def _expected_dilate_ijk(ijk: torch.Tensor, dilation: int) -> torch.Tensor:
+    """Unique coordinates of ``ijk`` dilated ``dilation`` times by the 26-neighbor stencil.
+
+    Each application is the Minkowski sum with {-1,0,1}^3; ``dilation`` chained applications
+    equal the sum with [-d, d]^3, which is what the CPU implementation computes in one shot.
+    """
+    if ijk.numel() == 0:
+        return ijk.reshape(0, 3)
+    offsets = torch.stack(
+        torch.meshgrid(torch.arange(-1, 2), torch.arange(-1, 2), torch.arange(-1, 2), indexing="ij"),
+        dim=-1,
+    ).reshape(-1, 3)
+    out = ijk.to(torch.int64)
+    for _ in range(dilation):
+        out = (out[:, None, :] + offsets[None, :, :].to(out.device)).reshape(-1, 3)
+        out = torch.unique(out, dim=0)
+    return out.to(torch.int32)
 
 
 def _ijk_sets(grid: GridBatch):
@@ -146,6 +165,28 @@ class TestBatchedTopologyBuilder(unittest.TestCase):
             self._check_against_expected(result, expected, f"{name} coarsen x{factor}")
             cpu_result = _build(coords, "cpu").coarsened_grid(factor)
             self._check_against_cpu(result, cpu_result, f"{name} coarsen x{factor} vs CPU")
+
+    @parameterized.expand([(name,) for name in _tricky_batches().keys()])
+    def test_dilated_grid_matches_expected_and_cpu(self, name):
+        # dilated_grid(d) on CUDA runs d chained batched BoxDilate(-1, +1) passes over the whole
+        # batch (issue #775 item 3). Pin against a from_ijk build of the 26-neighbor Minkowski sum
+        # applied d times (elementwise: canonical node order) and against the CPU implementation.
+        coords = _tricky_batches()[name]
+        for dilation in (1, 2):
+            grid = _build(coords, "cuda")
+            result = grid.dilated_grid(dilation)
+            expected = [_expected_dilate_ijk(c, dilation) for c in coords]
+            self._check_against_expected(result, expected, f"{name} dilate {dilation}")
+            cpu_result = _build(coords, "cpu").dilated_grid(dilation)
+            self._check_against_cpu(result, cpu_result, f"{name} dilate {dilation} vs CPU")
+
+    def test_dilated_grid_sliced_view_matches_full(self):
+        # A sliced (non-contiguous) view dilates the same as the equivalent standalone batch.
+        coords = _tricky_batches()["mixed_sizes"]
+        full = _build(coords, "cuda")
+        view = full[1:]
+        standalone = _build(coords[1:], "cuda")
+        self.assertTrue(torch.equal(view.dilated_grid(1).ijk.jdata, standalone.dilated_grid(1).ijk.jdata))
 
     def test_conv_grid_k2s2_multi_grid_matches_per_member(self):
         coords = _tricky_batches()["mixed_sizes"]


### PR DESCRIPTION
## Summary

`GridBatch.dilated_grid` on CUDA built each batch member separately: `nanovdb::tools::cuda::DilateGrid` (`NN_FACE_EDGE_VERTEX`, the full 26-neighbor stencil) run `dilation` times per member, several stream syncs per `getHandle`, then `nanovdb::cuda::mergeGridHandles`. Cost was ~0.9 ms per member per pass regardless of size, so wall clock grew linearly in batch size.

The CUDA path now runs `dilation` chained `batched::TopologyPassSpec::boxDilate(Coord(-1), Coord(1))` passes over the whole batch via `batched::batchedTopologyHandle` (the builder from #757): one output buffer, one stream sync per pass, no per-member builds, no handle merge. Empty members become valid empty grids inline.

## Approach

- `src/fvdb/detail/ops/BuildDilatedGrid.cu`, `dispatchDilateGrid<torch::kCUDA>`:
  - Uniform dilation vector (everything `GridBatch.dilated_grid(dilation: int)` produces): dilating by radius `d` with the 26-neighbor stencil is `d` Minkowski sums with `[-1, 1]^3`, so build `d` BoxDilate(-1, +1) passes and return `batchedTopologyHandle`.
  - `dilation == 0`: identity, compacted to a contiguous copy (same shape as `BuildPaddedGrid.cu`'s zero-pass branch). Defensive only; `dilateGrid()` already short-circuits an all-zero vector via `cloneGrid`.
  - Non-uniform vector: kept on the previous per-member `DilateGrid` loop (`dilatePerMemberCUDA`). This is reachable from `IntegrateTSDF.cu::buildPointGrid`, which derives a pad count from each member's voxel size, so a batch with heterogeneous voxel sizes can legitimately arrive here; a hard `TORCH_CHECK` would have regressed `integrate_tsdf` for that case. The batched builder has no per-member pass count.
- CPU and PrivateUse1 paths unchanged. The CPU implementation dilates with the full `(2d+1)^3` cube in one shot, which equals `d` chained 26-neighbor passes, so the expected coordinates in the tests are computed the same way.

## Benchmark

`dilated_grid(d)` on `GridBatch.from_ijk` of B members with ~97.6k random voxels each in `[-64, 64)^3`, 20 iterations after one warmup, `torch.cuda.synchronize()` before/after, single shared GPU under `flock`. Before = installed env (per-member `DilateGrid` + merge); after = this branch.

| B | dilation | before (ms) | after (ms) | speedup |
|---:|---:|---:|---:|---:|
| 1 | 1 | 1.16 | 2.27 | 0.5x |
| 1 | 2 | 1.81 | 4.83 | 0.4x |
| 4 | 1 | 3.92 | 2.40 | 1.6x |
| 4 | 2 | 6.88 | 5.16 | 1.3x |
| 16 | 1 | 14.28 | 2.91 | 4.9x |
| 16 | 2 | 27.53 | 6.36 | 4.3x |
| 64 | 1 | 55.28 | 5.46 | 10.1x |
| 64 | 2 | 120.75 | 13.66 | 8.8x |

Time is now roughly flat in B. The B=1 number at this size is slower than the single-grid `DilateGrid` builder: the batched pass emits 27 candidate slots per source leaf and sorts them, and this input produces 1.5M output voxels. It is a property of the batched BoxDilate pass, not this change: in the same measurement `conv_grid(kernel_size=3, stride=1)`, which has run the identical BoxDilate(-1, +1) pass since #757, takes 2.35 ms before and 2.41 ms after on the same B=1 grid, and at ~19k voxels/member `dilated_grid(1)` ties at 0.85 ms both before and after. Reducing the B=1 constant would be a builder-level change (shared with item 1 and the stride-1 conv paths).

## Tests

Added to `tests/unit/test_batched_topology_builder.py`:
- `test_dilated_grid_matches_expected_and_cpu` (parameterized over `_tricky_batches()`: mixed sizes, empty members, all-empty, +-4096 tile boundaries, single grid, 16-member batch) for `dilation` in (1, 2): elementwise `ijk.jdata` pin (`_check_against_expected`) against a `from_ijk` build of the 26-neighbor Minkowski sum applied `d` times (torch, `unique(dim=0)`), plus `num_voxels`/bbox, and `_check_against_cpu`.
- `test_dilated_grid_sliced_view_matches_full`: a sliced (non-contiguous) view dilates identically to the equivalent standalone batch.

Results with the wheel from this branch installed in an override directory:
- `tests/unit/test_batched_topology_builder.py`: 28 passed.
- Existing suites exercising `dilated_grid` / `integrate_tsdf` (`test_basic_ops.py`, `test_basic_ops_single.py`, `test_sliced_batch.py`, `test_inject.py`, `test_dual.py`, `test_ray_marching.py`): 740 passed, 5 skipped, 44 subtests passed.
- `clang-format --dry-run --Werror` and `black --line-length 120` clean on the changed files.

Part of #775 (item 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
