### PR TITLE
from_dense on CUDA: build one member, replicate the buffer B times

### DIFF
--- a/src/fvdb/detail/ops/BuildDenseGrid.cu
+++ b/src/fvdb/detail/ops/BuildDenseGrid.cu
@@ -22,6 +22,9 @@
 #include <c10/cuda/CUDAMathCompat.h>
 #include <torch/types.h>
 
+#include <algorithm>
+#include <limits>
+
 namespace fvdb {
 namespace detail {
 namespace ops {
@@ -81,6 +84,63 @@ checkInputs(const torch::Device device,
     }
 }
 
+// Header fix-up for a buffer holding `gridCount` back-to-back copies of the same single grid:
+// copy i becomes grid i of the batch. Every copy has the same mGridSize, so no offset table is
+// needed. The checksum is disabled like ConcatenateGrids does (the source grid from PointsToGrid
+// carries a disabled checksum anyway, so this is consistent rather than a downgrade).
+__global__ void
+fixupReplicatedGridHeaders(uint8_t *base, uint64_t gridSize, uint32_t gridCount) {
+    const uint32_t i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= gridCount) {
+        return;
+    }
+    auto *data = reinterpret_cast<nanovdb::GridData *>(base + static_cast<uint64_t>(i) * gridSize);
+    data->mGridIndex = i;
+    data->mGridCount = gridCount;
+    data->mChecksum.disable();
+}
+
+// Replicate a single-grid device handle `count` times into one buffer laid out the way
+// nanovdb::cuda::mergeGridHandles lays out a multi-grid handle (grids back-to-back, each header's
+// mGridIndex / mGridCount naming its slot), without the per-member allocation, host readback and
+// stream synchronization that mergeGridHandles performs for every grid.
+nanovdb::GridHandle<TorchDeviceBuffer>
+replicateGridHandle(const nanovdb::GridHandle<TorchDeviceBuffer> &single,
+                    int64_t count,
+                    torch::Device device,
+                    cudaStream_t stream) {
+    TORCH_CHECK(single.gridCount() == 1, "replicateGridHandle expects a single-grid handle");
+    TORCH_CHECK(count > 1, "replicateGridHandle expects count > 1");
+    TORCH_CHECK(count <= std::numeric_limits<uint32_t>::max(), "too many grids to replicate");
+    const uint8_t *src = single.buffer().deviceData();
+    TORCH_CHECK(src != nullptr, "replicateGridHandle expects a device-resident handle");
+    const uint64_t gridSize = single.gridSize(0);
+
+    TorchDeviceBuffer buffer(gridSize * static_cast<uint64_t>(count), device);
+    uint8_t *dst = buffer.deviceData();
+
+    // Seed copy 0 from the source, then double the filled prefix: log2(count) device-to-device
+    // memcpys instead of one per member.
+    C10_CUDA_CHECK(cudaMemcpyAsync(dst, src, gridSize, cudaMemcpyDeviceToDevice, stream));
+    for (int64_t filled = 1; filled < count; filled *= 2) {
+        const int64_t n = std::min(filled, count - filled);
+        C10_CUDA_CHECK(cudaMemcpyAsync(dst + static_cast<uint64_t>(filled) * gridSize,
+                                       dst,
+                                       static_cast<uint64_t>(n) * gridSize,
+                                       cudaMemcpyDeviceToDevice,
+                                       stream));
+    }
+
+    const int64_t numBlocks = GET_BLOCKS(count, DEFAULT_BLOCK_DIM);
+    fixupReplicatedGridHeaders<<<numBlocks, DEFAULT_BLOCK_DIM, 0, stream>>>(
+        dst, gridSize, static_cast<uint32_t>(count));
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+
+    // The GridHandle constructor reads grid 0's header and builds the per-grid metadata table
+    // (offset = i * gridSize) from the device buffer.
+    return nanovdb::GridHandle<TorchDeviceBuffer>(std::move(buffer));
+}
+
 } // namespace
 
 template <torch::DeviceType>
@@ -133,34 +193,30 @@ dispatchCreateNanoGridFromDense<torch::kCUDA>(int64_t batchSize,
 
     TORCH_CHECK(ijkData.is_contiguous(), "ijkData must be contiguous");
 
-    // Every batch item is the same dense box (a mask, if given, is shared across the batch), so
-    // build the grid once and copy it for the remaining items instead of re-running the radix sort
-    // over the identical coordinate list batchSize times.
-    const int64_t nVoxels = ijkData.size(0);
-    std::vector<nanovdb::GridHandle<TorchDeviceBuffer>> handles;
-    handles.reserve(batchSize);
-    for (int64_t i = 0; i < batchSize; i += 1) {
-        if (nVoxels == 0) {
-            handles.push_back(createEmptyGridHandle(guide.device()));
-        } else if (i == 0) {
-            handles.push_back(
-                nanovdb::tools::cuda::
-                    voxelsToGrid<GridT, nanovdb::Coord *, TorchDeviceBuffer, BuilderResource>(
-                        (nanovdb::Coord *)ijkData.data_ptr(), nVoxels, 1.0, guide));
-            C10_CUDA_KERNEL_LAUNCH_CHECK();
-        } else {
-            handles.push_back(handles[0].copy(guide));
-        }
+    if (batchSize == 0) {
+        // Same result as merging zero handles: an empty handle, which makeGridBatchData rejects.
+        return nanovdb::GridHandle<TorchDeviceBuffer>(TorchDeviceBuffer(0, device));
     }
 
-    if (handles.size() == 1) {
-        // If there's only one handle, just return it
-        return std::move(handles[0]);
-    } else {
-        // This copies all the handles into a single handle -- only do it if there are multie
-        // grids
-        return nanovdb::cuda::mergeGridHandles(handles, &guide);
+    // Every batch item is the same dense box (a mask, if given, is shared across the batch), so
+    // build ONE grid and replicate its buffer batchSize times with a header fix-up per copy,
+    // instead of one PointsToGrid (or one handle copy) per member followed by mergeGridHandles,
+    // which allocates, synchronizes and reads back the host once per member.
+    const int64_t nVoxels = ijkData.size(0);
+    if (nVoxels == 0) {
+        // Mask selected nothing: batchSize valid empty grids (built on host, moved to device).
+        return createEmptyGridHandle(device, batchSize);
     }
+
+    nanovdb::GridHandle<TorchDeviceBuffer> single = nanovdb::tools::cuda::
+        voxelsToGrid<GridT, nanovdb::Coord *, TorchDeviceBuffer, BuilderResource>(
+            (nanovdb::Coord *)ijkData.data_ptr(), nVoxels, 1.0, guide);
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+
+    if (batchSize == 1) {
+        return single;
+    }
+    return replicateGridHandle(single, batchSize, device, stream);
 }
 
 template <>

--- a/tests/unit/test_batched_topology_builder.py
+++ b/tests/unit/test_batched_topology_builder.py
@@ -213,6 +213,97 @@ class TestBatchedTopologyBuilder(unittest.TestCase):
         self.assertEqual(_ijk_sets(back), _ijk_sets(grid))
         self.assertTrue(torch.equal(back.num_voxels, grid.num_voxels))
 
+    # -- from_dense: build one member, replicate the buffer B times (issue #775 item 4) --------
+
+    def _check_from_dense_matches_per_member(self, num_grids, dims, ijk_min, mask, msg):
+        """Multi-member from_dense equals B independent single-member builds, elementwise."""
+        batched = GridBatch.from_dense(num_grids, dims, ijk_min, 1.0, 0.0, mask=mask, device="cuda")
+        single = GridBatch.from_dense(1, dims, ijk_min, 1.0, 0.0, mask=mask, device="cuda")
+        self.assertEqual(batched.grid_count, num_grids, msg)
+        self.assertEqual(single.grid_count, 1, msg)
+        self.assertTrue(torch.equal(batched.num_voxels, single.num_voxels.repeat(num_grids)), msg)
+        self.assertEqual(batched.total_voxels, num_grids * single.total_voxels, msg)
+        self.assertTrue(
+            torch.equal(batched.ijk.jdata, single.ijk.jdata.repeat(num_grids, 1)),
+            f"{msg}: voxel enumeration of replicated members differs from a single-member build",
+        )
+        self.assertTrue(torch.equal(batched.ijk.joffsets.cpu(), torch.arange(num_grids + 1) * single.total_voxels), msg)
+        for b in range(num_grids):
+            self.assertTrue(
+                torch.equal(batched.bbox_at(b).cpu(), single.bbox_at(0).cpu()), f"{msg}: bbox of member {b}"
+            )
+            self.assertTrue(torch.equal(batched.ijk[b].jdata, single.ijk.jdata), f"{msg}: ijk of member {b}")
+        # Member b of the batch is addressable as its own grid (header mGridIndex / mGridCount and
+        # the handle's per-grid offset table must agree).
+        idx = torch.tensor([num_grids - 1, 0], device="cuda")
+        sliced = batched[idx]
+        self.assertEqual(sliced.grid_count, 2, msg)
+        self.assertTrue(torch.equal(sliced.ijk.jdata, single.ijk.jdata.repeat(2, 1)), msg)
+        # And the whole thing matches the CPU implementation as coordinate sets.
+        cpu_mask = None if mask is None else mask.cpu()
+        cpu = GridBatch.from_dense(num_grids, dims, ijk_min, 1.0, 0.0, mask=cpu_mask, device="cpu")
+        self._check_against_cpu(batched, cpu, f"{msg}: vs CPU")
+        return batched, single
+
+    @parameterized.expand([(b,) for b in (1, 3, 16)])
+    def test_from_dense_unmasked_matches_per_member(self, num_grids):
+        # Non-cubic box, negative / tile-straddling ijk_min (crosses the 8-voxel leaf boundary and
+        # a 128-voxel upper-node boundary), so leaf origins are not aligned to the box corner.
+        for dims, ijk_min in (([8, 8, 8], [0, 0, 0]), ([5, 12, 7], [-3, 125, 4]), ([17, 4, 33], [-4100, 0, 4090])):
+            batched, single = self._check_from_dense_matches_per_member(
+                num_grids, dims, ijk_min, None, f"from_dense B={num_grids} dims={dims} ijk_min={ijk_min}"
+            )
+            self.assertEqual(single.total_voxels, dims[0] * dims[1] * dims[2])
+            lo = torch.tensor(ijk_min, dtype=torch.int32)
+            hi = lo + torch.tensor(dims, dtype=torch.int32) - 1
+            for b in range(num_grids):
+                self.assertTrue(torch.equal(batched.bbox_at(b).cpu(), torch.stack([lo, hi])))
+
+    @parameterized.expand([(b,) for b in (1, 3, 16)])
+    def test_from_dense_masked_matches_per_member(self, num_grids):
+        torch.manual_seed(775)
+        dims = [9, 6, 14]
+        ijk_min = [-2, 7, -13]
+        mask = torch.rand(*dims, device="cuda") < 0.3
+        batched, single = self._check_from_dense_matches_per_member(
+            num_grids, dims, ijk_min, mask, f"masked from_dense B={num_grids}"
+        )
+        self.assertEqual(single.total_voxels, int(mask.sum().item()))
+        # Selected coordinates are exactly the mask's true cells, shifted by ijk_min.
+        expected = torch.nonzero(mask).to(torch.int32) + torch.tensor(ijk_min, dtype=torch.int32, device="cuda")
+        self.assertEqual(set(map(tuple, expected.tolist())), _ijk_sets(single)[0])
+
+    @parameterized.expand([(b,) for b in (1, 3, 16)])
+    def test_from_dense_mask_selects_nothing(self, num_grids):
+        dims = [4, 5, 6]
+        mask = torch.zeros(*dims, dtype=torch.bool, device="cuda")
+        batched, single = self._check_from_dense_matches_per_member(
+            num_grids, dims, [1, 2, 3], mask, f"all-false mask from_dense B={num_grids}"
+        )
+        self.assertEqual(batched.total_voxels, 0)
+        self.assertEqual(batched.ijk.jdata.shape, (0, 3))
+        self.assertTrue(torch.equal(batched.num_voxels.cpu(), torch.zeros(num_grids, dtype=torch.int64)))
+        # Empty members are still valid grids: topology ops on them work and stay empty.
+        self.assertEqual(batched.dual_grid().total_voxels, 0)
+        self.assertEqual(batched.dual_grid().grid_count, num_grids)
+
+    def test_from_dense_replicated_members_are_independent_grids(self):
+        # Ops that address each member through its own header (voxel lookup, coarsening, and
+        # concatenation with another batch) must see B identical but separate grids.
+        num_grids = 5
+        grid = GridBatch.from_dense(num_grids, [10, 6, 3], [1, -9, 2], 1.0, 0.0, device="cuda")
+        pts = torch.tensor([[1, -9, 2], [10, -4, 4], [11, -4, 4]], dtype=torch.int32, device="cuda")
+        idx = grid.ijk_to_index(JaggedTensor([pts] * num_grids), cumulative=True)
+        for b in range(num_grids):
+            self.assertEqual(idx[b].jdata.tolist(), [b * 180, b * 180 + 179, -1])
+        coarse = grid.coarsened_grid(2)
+        coarse_single = GridBatch.from_dense(1, [10, 6, 3], [1, -9, 2], 1.0, 0.0, device="cuda").coarsened_grid(2)
+        self.assertTrue(torch.equal(coarse.ijk.jdata, coarse_single.ijk.jdata.repeat(num_grids, 1)))
+        other = _build(_tricky_batches()["mixed_sizes"], "cuda")
+        cat = GridBatch.from_cat([grid, other])
+        self.assertEqual(cat.grid_count, num_grids + other.grid_count)
+        self.assertTrue(torch.equal(cat.ijk.jdata, torch.cat([grid.ijk.jdata, other.ijk.jdata])))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

`GridBatch.from_dense` on CUDA built one NanoVDB grid with `PointsToGrid`, then paid per-member cost for every remaining member: a handle copy (allocation + synchronous `cudaMemcpy`) followed by `nanovdb::cuda::mergeGridHandles`, which for each grid allocates, memcpys, launches a header kernel, reads a dirty flag back to the host and synchronizes the stream. Every member of a `from_dense` batch is the same box with the same optional mask, so all of that was per-member work on identical data (~0.25 ms per member on the shared GPU here). Time is now flat in B.

## Approach

`src/fvdb/detail/ops/BuildDenseGrid.cu`, `dispatchCreateNanoGridFromDense<torch::kCUDA>`:

- Build the single grid once (unchanged `voxelsToGrid` / `BuilderResource` path).
- `replicateGridHandle` allocates one `TorchDeviceBuffer` of `gridSize * B` bytes and fills it with `log2(B)` device-to-device `cudaMemcpyAsync` calls (copy the source once, then double the filled prefix) on the current stream.
- One kernel (`fixupReplicatedGridHeaders`) sets `mGridIndex = i`, `mGridCount = B` and disables the checksum on each copy, the same header fix-up `ConcatenateGrids.cu` applies. `PointsToGrid` already emits a disabled checksum, so this is consistent rather than a downgrade. `mGridSize` is identical per copy.
- The `GridHandle<TorchDeviceBuffer>` constructor derives the per-grid metadata table (`offset = i * gridSize`) from grid 0's header exactly as it does for a `mergeGridHandles` result, so `gridCount() == B` and `gridData(i)` resolve as before.
- `batchSize == 1` returns the single handle unchanged. A mask that selects nothing returns `createEmptyGridHandle(device, batchSize)` (B valid empty grids, as before). `batchSize == 0` still yields the empty handle that `makeGridBatchData` rejects (unchanged behaviour).
- The 2^31 unmasked-volume `TORCH_CHECK`s are kept. No change to the batched topology builder, CPU, or PrivateUse1 paths.

## Benchmark

`GridBatch.from_dense(B, dims, 0, 1.0, 0.0, device="cuda")`, 20 iterations after one warmup, `torch.cuda.synchronize()` before/after, shared GPU under `flock`. Baseline is the installed build of `main`; after is this branch.

| dims | B | before (ms) | after (ms) |
|---|---|---|---|
| 32^3 | 1 | 1.035 | 1.205 |
| 32^3 | 4 | 2.115 | 1.271 |
| 32^3 | 16 | 6.037 | 1.278 |
| 32^3 | 64 | 16.755 | 1.664 |
| 64^3 | 1 | 1.010 | 1.015 |
| 64^3 | 4 | 2.242 | 1.256 |
| 64^3 | 16 | 5.318 | 1.381 |
| 64^3 | 64 | 17.912 | 1.635 |

The B = 1 path is code-identical before and after (same `voxelsToGrid`, return the single handle); the 32^3 B = 1 difference is run-to-run noise on the shared GPU.

## Tests

Added to `tests/unit/test_batched_topology_builder.py` (10 new cases, CUDA only):

- `test_from_dense_unmasked_matches_per_member[B]` for B in (1, 3, 16): cubic box at the origin, a non-cubic `[5, 12, 7]` box with `ijk_min = [-3, 125, 4]` (crosses leaf and upper-node boundaries), and `[17, 4, 33]` at `[-4100, 0, 4090]` (straddles the +-4096 root-tile boundary). Pinned elementwise against a single-member build: `grid_count`, `num_voxels`, `total_voxels`, `ijk.jdata` (repeated B times), `ijk.joffsets`, per-member `bbox_at`, per-member `ijk[b]`, fancy indexing `batch[[B-1, 0]]`, plus the CPU path as coordinate sets and the analytic bbox.
- `test_from_dense_masked_matches_per_member[B]`: random 30% mask on a `[9, 6, 14]` box with negative `ijk_min`; same checks plus the selected set equals `nonzero(mask) + ijk_min`.
- `test_from_dense_mask_selects_nothing[B]`: all-false mask; B valid empty grids (`total_voxels == 0`, `ijk.jdata.shape == (0, 3)`, `dual_grid()` on them works and stays empty).
- `test_from_dense_replicated_members_are_independent_grids`: cumulative `ijk_to_index` per member, `coarsened_grid(2)` equals the single-member result repeated, and `GridBatch.from_cat` with an unrelated batch.

Results with the branch build (run as plain `pytest` against the wheel):

- `tests/unit/test_batched_topology_builder.py`: 31 passed
- `tests/unit/test_dense_interface.py`: 124 passed
- `tests/unit/test_basic_ops.py`: 276 passed, 1 skipped
- `tests/unit/test_basic_ops_single.py tests/unit/test_accessors.py -k dense`: 4 passed
- `tests/unit/test_sample.py tests/unit/test_ray_marching.py`: 455 passed, 4 skipped
- `tests/unit/test_nn_modules.py`: 68 passed

`clang-format --dry-run --Werror` and `black --line-length 120 --check` are clean.

Part of #775 (item 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
