### PR TITLE
Batched Erode passes for exclude_border / negative padded_grid on CUDA (issue 775 item 7)

### DIFF
--- a/src/fvdb/detail/ops/BuildPaddedGrid.cu
+++ b/src/fvdb/detail/ops/BuildPaddedGrid.cu
@@ -1,7 +1,6 @@
 // Copyright Contributors to the OpenVDB Project
 // SPDX-License-Identifier: Apache-2.0
 //
-#include <fvdb/BuilderResource.h>
 #include <fvdb/GridBatchData.h>
 #include <fvdb/TorchDeviceBuffer.h>
 #include <fvdb/detail/GridBatchDataFactory.h>
@@ -15,14 +14,9 @@
 #include <fvdb/detail/utils/cuda/ForEachPrivateUse1.cuh>
 #include <fvdb/detail/utils/cuda/GridDim.h>
 #include <fvdb/detail/utils/nanovdb/BatchedTopologyBuilder.cuh>
-#include <fvdb/detail/utils/nanovdb/CreateEmptyGridHandle.h>
-#include <fvdb/detail/utils/nanovdb/PadGrid.cuh>
 
 #include <nanovdb/NanoVDB.h>
 #include <nanovdb/tools/CreateNanoGrid.h>
-#include <nanovdb/tools/cuda/PruneGrid.cuh>
-#include <nanovdb/util/cuda/DeviceGridTraits.cuh>
-#include <nanovdb/util/cuda/Util.h>
 
 #include <c10/cuda/CUDACachingAllocator.h>
 #include <c10/cuda/CUDAGuard.h>
@@ -243,76 +237,6 @@ buildPaddedGridFromGridCPU(const GridBatchData &baseBatchHdl, int BMIN, int BMAX
     }
 }
 
-// One unit padding pass (Minkowski sum by {0,1}^3 if positive, else {-1,0}^3), building the
-// padded topology directly from the source leaf masks via TopologyBuilder (no coordinate list).
-static nanovdb::GridHandle<TorchDeviceBuffer>
-padOncePass(nanovdb::OnIndexGrid *grid,
-            bool positive,
-            const TorchDeviceBuffer &guide,
-            cudaStream_t stream) {
-    fvdb::detail::morphology::PadGrid<nanovdb::ValueOnIndex, BuilderResource> op(
-        grid, positive, stream);
-    op.setChecksum(nanovdb::CheckMode::Default);
-    auto handle = op.getHandle(guide);
-    C10_CUDA_KERNEL_LAUNCH_CHECK();
-    return handle;
-}
-
-// One unit erosion pass (exclude-border padding). Computes a per-leaf "keep" mask sidecar
-// (voxel survives iff its whole octant neighborhood is active) then prunes the source grid to
-// it via PruneGrid. The keep mask is a subset of the source, so the result is exact.
-static nanovdb::GridHandle<TorchDeviceBuffer>
-erodeOncePass(nanovdb::OnIndexGrid *grid,
-              uint32_t leafCount,
-              bool positive,
-              const torch::Device &device,
-              const TorchDeviceBuffer &guide,
-              cudaStream_t stream) {
-    // Allocate the per-leaf keep-mask sidecar as a torch CUDA tensor so its emptiness can be
-    // tested reliably with a torch reduction below (a raw device buffer viewed via from_blob does
-    // not reduce correctly).
-    // Use a uint64 tensor (not uint8) so its data pointer is guaranteed 8-byte aligned for
-    // Mask<3> -- which is 8 uint64_t words -- since the kernels dereference it as Mask<3>*.
-    // (A uint8 tensor's data_ptr alignment isn't guaranteed by the tensor API, even though
-    // torch's allocators over-align in practice.)
-    const int64_t maskWords =
-        static_cast<int64_t>(sizeof(nanovdb::Mask<3>) / sizeof(uint64_t)) * leafCount;
-    torch::Tensor keepTensor =
-        torch::empty({maskWords}, torch::TensorOptions().dtype(torch::kUInt64).device(device));
-    auto *keepMasks = reinterpret_cast<nanovdb::Mask<3> *>(keepTensor.data_ptr());
-    if (positive) {
-        nanovdb::util::cuda::lambdaKernel<<<(leafCount + 127) / 128, 128, 0, stream>>>(
-            leafCount,
-            fvdb::detail::morphology::ErodeKeepMaskFunctor<nanovdb::ValueOnIndex, true>(),
-            grid,
-            keepMasks);
-    } else {
-        nanovdb::util::cuda::lambdaKernel<<<(leafCount + 127) / 128, 128, 0, stream>>>(
-            leafCount,
-            fvdb::detail::morphology::ErodeKeepMaskFunctor<nanovdb::ValueOnIndex, false>(),
-            grid,
-            keepMasks);
-    }
-    C10_CUDA_KERNEL_LAUNCH_CHECK();
-
-    // PruneGrid (via TopologyBuilder) dereferences a null d_upperOffsets when the result has no
-    // nodes, so it cannot build an empty grid. Detect an all-empty keep mask (erosion removed
-    // everything) and return an explicit empty grid instead -- same guard as BuildPrunedGrid.cu.
-    // Reduce via (!= 0).any(): any() alone (an `or` reduction) is not implemented for uint64 on
-    // CUDA, but the `!=` yields a bool tensor whose reduction is.
-    if (!(keepTensor != 0).any().item<bool>()) {
-        return createEmptyGridHandle(device);
-    }
-
-    nanovdb::tools::cuda::PruneGrid<nanovdb::ValueOnIndex, BuilderResource> pruneOp(
-        grid, keepMasks, stream);
-    pruneOp.setChecksum(nanovdb::CheckMode::Default);
-    pruneOp.setVerbose(0);
-    auto handle = pruneOp.getHandle(guide);
-    C10_CUDA_KERNEL_LAUNCH_CHECK();
-    return handle;
-}
-
 template <>
 nanovdb::GridHandle<TorchDeviceBuffer>
 dispatchBuildPaddedGrid<torch::kCUDA>(const GridBatchData &baseBatchHdl,
@@ -321,11 +245,6 @@ dispatchBuildPaddedGrid<torch::kCUDA>(const GridBatchData &baseBatchHdl,
                                       bool excludeBorder) {
     c10::cuda::CUDAGuard deviceGuard(baseBatchHdl.device());
     at::cuda::CUDAStream stream = at::cuda::getCurrentCUDAStream(baseBatchHdl.device().index());
-
-    // This guide buffer is a hack to pass a device (with index) into the TopologyBuilder buffer
-    // allocation (see BuildDilatedGrid.cu). The created grid buffers inherit the guide's
-    // device.
-    TorchDeviceBuffer guide(0, baseBatchHdl.device());
 
     // Pad by [bmin, bmax]^3 = (bmax positive unit passes) followed by (-bmin negative unit
     // passes). Minkowski sums / erosions by boxes compose, so the order is immaterial.
@@ -343,72 +262,39 @@ dispatchBuildPaddedGrid<torch::kCUDA>(const GridBatchData &baseBatchHdl,
     // fix-up (dual swap or verbatim copy, per `dualTransform`).
     if (totalPasses == 0) {
         if (baseBatchHdl.isContiguous()) {
+            // The guide buffer carries the device (with index) into the copy's allocation; the
+            // copied buffer inherits it.
+            const TorchDeviceBuffer guide(0, baseBatchHdl.device());
             return baseBatchHdl.nanoGridHandle().copy<TorchDeviceBuffer>(guide);
         }
         return ops::contiguousGridHandle(baseBatchHdl);
     }
 
-    // Pure positive padding without erosion (dual_grid, build_padded_grid(0, k)): the whole batch
-    // is built in `bmax` chained batched BoxDilate passes, each a Minkowski sum with the octant
-    // {0,1}^3 (issue #775). One output buffer, one stream synchronization per pass, no per-member
-    // builds or handle merging; empty members become valid empty grids inline. Sliced /
-    // non-contiguous batches are handled by the view-aware source pointers.
-    if (numNegative == 0 && !excludeBorder) {
-        const std::vector<batched::TopologyPassSpec> passes(
-            numPositive,
-            batched::TopologyPassSpec::boxDilate(nanovdb::Coord(0), nanovdb::Coord(1)));
-        return batched::batchedTopologyHandle(baseBatchHdl, passes, stream.stream());
+    // The whole batch is built in `totalPasses` chained batched passes via
+    // batched::batchedTopologyHandle (issue #775): one output buffer, one stream synchronization
+    // per pass, no per-member builds or handle merging; members that end up empty (including
+    // members eroded to nothing) become valid empty grids inline. Sliced / non-contiguous batches
+    // are handled by the view-aware source pointers.
+    //
+    //   plain padding   : bmax BoxDilate({0,1}^3) passes, then -bmin BoxDilate({-1,0}^3) passes
+    //                     (Minkowski sum with [bmin, bmax]^3);
+    //   exclude_border  : the same octants as Erode passes (a voxel survives iff its whole
+    //                     [bmin, bmax]^3 neighborhood is active), matching
+    //                     buildPaddedGridFromGridWithoutBorderCPU.
+    //
+    // dual_grid is exactly one {0,1}^3 pass.
+    const nanovdb::Coord zero(0), one(1), minusOne(-1);
+    std::vector<batched::TopologyPassSpec> passes;
+    passes.reserve(totalPasses);
+    for (int p = 0; p < numPositive; ++p) {
+        passes.push_back(excludeBorder ? batched::TopologyPassSpec::erode(zero, one)
+                                       : batched::TopologyPassSpec::boxDilate(zero, one));
     }
-
-    // Negative padding and/or erosion (exclude_border) stay on the per-member path.
-    std::vector<nanovdb::GridHandle<TorchDeviceBuffer>> handles;
-    handles.reserve(baseBatchHdl.batchSize());
-    for (int64_t i = 0; i < baseBatchHdl.batchSize(); ++i) {
-        if (baseBatchHdl.numVoxelsAt(i) == 0) {
-            handles.push_back(createEmptyGridHandle(baseBatchHdl.device()));
-            continue;
-        }
-
-        // View-aware byte-offset accessor: the i-th *logical* grid (correct for sliced/
-        // non-contiguous batches, unlike mGridHdl->deviceGrid(i) which indexes physically).
-        nanovdb::OnIndexGrid *grid = baseBatchHdl.deviceGridPtrAt(i);
-
-        nanovdb::GridHandle<TorchDeviceBuffer> handle;
-        bool haveHandle = false;
-        for (int p = 0; p < totalPasses; ++p) {
-            const bool positive = (p < numPositive);
-            if (!excludeBorder) {
-                handle = padOncePass(grid, positive, guide, stream.stream());
-            } else {
-                const uint32_t leafCount =
-                    haveHandle
-                        ? nanovdb::util::cuda::DeviceGridTraits<nanovdb::ValueOnIndex>::getTreeData(
-                              grid)
-                              .mNodeCount[0]
-                        : baseBatchHdl.numLeavesAt(i);
-                if (leafCount == 0) {
-                    // No leaves to erode -- already eroded to empty, or (defensively) a
-                    // leaf-free tile grid. Ensure `handle` is a valid empty grid rather than
-                    // the default-constructed one before breaking.
-                    if (!haveHandle) {
-                        handle = createEmptyGridHandle(baseBatchHdl.device());
-                    }
-                    break;
-                }
-                handle = erodeOncePass(
-                    grid, leafCount, positive, baseBatchHdl.device(), guide, stream.stream());
-            }
-            haveHandle = true;
-            grid       = handle.deviceGrid<nanovdb::ValueOnIndex>();
-        }
-
-        handles.push_back(std::move(handle));
+    for (int p = 0; p < numNegative; ++p) {
+        passes.push_back(excludeBorder ? batched::TopologyPassSpec::erode(minusOne, zero)
+                                       : batched::TopologyPassSpec::boxDilate(minusOne, zero));
     }
-
-    if (handles.size() == 1) {
-        return std::move(handles[0]);
-    }
-    return nanovdb::cuda::mergeGridHandles(handles, &guide);
+    return batched::batchedTopologyHandle(baseBatchHdl, passes, stream.stream());
 }
 
 template <>

--- a/src/fvdb/detail/ops/BuildPaddedGrid.cu
+++ b/src/fvdb/detail/ops/BuildPaddedGrid.cu
@@ -14,6 +14,7 @@
 #include <fvdb/detail/utils/cuda/ForEachCUDA.cuh>
 #include <fvdb/detail/utils/cuda/ForEachPrivateUse1.cuh>
 #include <fvdb/detail/utils/cuda/GridDim.h>
+#include <fvdb/detail/utils/nanovdb/BatchedTopologyBuilder.cuh>
 #include <fvdb/detail/utils/nanovdb/CreateEmptyGridHandle.h>
 #include <fvdb/detail/utils/nanovdb/PadGrid.cuh>
 
@@ -347,6 +348,19 @@ dispatchBuildPaddedGrid<torch::kCUDA>(const GridBatchData &baseBatchHdl,
         return ops::contiguousGridHandle(baseBatchHdl);
     }
 
+    // Pure positive padding without erosion (dual_grid, build_padded_grid(0, k)): the whole batch
+    // is built in `bmax` chained batched BoxDilate passes, each a Minkowski sum with the octant
+    // {0,1}^3 (issue #775). One output buffer, one stream synchronization per pass, no per-member
+    // builds or handle merging; empty members become valid empty grids inline. Sliced /
+    // non-contiguous batches are handled by the view-aware source pointers.
+    if (numNegative == 0 && !excludeBorder) {
+        const std::vector<batched::TopologyPassSpec> passes(
+            numPositive,
+            batched::TopologyPassSpec::boxDilate(nanovdb::Coord(0), nanovdb::Coord(1)));
+        return batched::batchedTopologyHandle(baseBatchHdl, passes, stream.stream());
+    }
+
+    // Negative padding and/or erosion (exclude_border) stay on the per-member path.
     std::vector<nanovdb::GridHandle<TorchDeviceBuffer>> handles;
     handles.reserve(baseBatchHdl.batchSize());
     for (int64_t i = 0; i < baseBatchHdl.batchSize(); ++i) {

--- a/src/fvdb/detail/utils/nanovdb/BatchedTopologyBuilder.cuh
+++ b/src/fvdb/detail/utils/nanovdb/BatchedTopologyBuilder.cuh
@@ -72,12 +72,14 @@ using LeafT  = nanovdb::NanoLeaf<BuildT>;
 /// One batched topology pass over the whole batch. `Refine` and `Coarsen` are the factor-2
 /// subdivision / coarsening passes; `BoxDilate` is a Minkowski sum with the axis-aligned box
 /// [boxLo, boxHi] (components in {-1,0,1}), covering NanoVDB's 26-neighbor DilateGrid
-/// (boxLo=-1, boxHi=1) and fvdb's one-sided PadGrid octants ({-1,0}^3 and {0,1}^3). Larger
-/// boxes compose from multiple passes (Minkowski sums by boxes compose).
+/// (boxLo=-1, boxHi=1) and fvdb's one-sided PadGrid octants ({-1,0}^3 and {0,1}^3). `Erode` is
+/// the Minkowski dual with the same box: a voxel survives iff every box offset of it is active
+/// (fvdb's exclude_border padding). Larger boxes compose from multiple passes (Minkowski sums
+/// and erosions by boxes compose).
 struct TopologyPassSpec {
-    enum class Op { Refine, Coarsen, BoxDilate };
+    enum class Op { Refine, Coarsen, BoxDilate, Erode };
     Op op;
-    nanovdb::Coord boxLo{0}, boxHi{0}; // BoxDilate only
+    nanovdb::Coord boxLo{0}, boxHi{0}; // BoxDilate / Erode only
 
     static TopologyPassSpec
     refine() {
@@ -90,6 +92,10 @@ struct TopologyPassSpec {
     static TopologyPassSpec
     boxDilate(const nanovdb::Coord &lo, const nanovdb::Coord &hi) {
         return {Op::BoxDilate, lo, hi};
+    }
+    static TopologyPassSpec
+    erode(const nanovdb::Coord &lo, const nanovdb::Coord &hi) {
+        return {Op::Erode, lo, hi};
     }
 };
 
@@ -433,6 +439,135 @@ emitBoxDilatedLeaves(EmissionArrays em, nanovdb::Coord boxLo, nanovdb::Coord box
     }
 }
 
+/// Erode: slot = source leaf. out(v) = AND_{o in [boxLo,boxHi]} src(v + o), the Minkowski dual
+/// of BoxDilate. The result is a subset of the source leaf, so the source-to-output mapping is
+/// injective (no deduplication); leaves eroded to nothing become dead slots, and members eroded to
+/// nothing become empty grids downstream.
+///
+/// The AND factorizes per axis, so the mask is eroded along z, then y, then x. At a leaf border a
+/// shift pulls the voxel just outside the leaf from the neighbor leaf on that side (a missing
+/// neighbor leaf contributes zeros and so erodes the border voxels away). Because the y-stage reads
+/// the z-eroded words of the +-y neighbor leaves, and the x-stage the (z,y)-eroded words of the
+/// +-x neighbor leaves, the earlier stages run on every neighbor leaf the box reaches: up to 2^3
+/// leaves for a one-sided octant, 3^3 for the full box. Neighbors are fetched through the source
+/// grid's root (tree traversal from the root tile).
+static __global__ void
+emitErodedLeaves(EmissionArrays em, nanovdb::Coord boxLo, nanovdb::Coord boxHi) {
+    // Per-axis neighbor-leaf offset ranges reached by the box.
+    int dbLo[3], dbHi[3];
+    for (int a = 0; a < 3; ++a) {
+        dbLo[a] = boxLo[a] < 0 ? -1 : 0;
+        dbHi[a] = boxHi[a] > 0 ? 1 : 0;
+    }
+
+    for (int32_t s = blockIdx.x * blockDim.x + threadIdx.x; s < em.numSlots;
+         s += gridDim.x * blockDim.x) {
+        const int32_t g         = findSegment(em.segOffsets, em.numSegments, s);
+        const int32_t leafLocal = s - em.segOffsets[g];
+
+        const GridT *grid              = em.srcGrids[g];
+        const LeafT &srcLeaf           = grid->tree().template getFirstNode<0>()[leafLocal];
+        const nanovdb::Coord srcOrigin = srcLeaf.origin();
+
+        // Source words of the neighbor leaves the box reaches, indexed [dbx+1][dby+1][dbz+1];
+        // entries outside the box's ranges are never read.
+        uint64_t nb[3][3][3][8];
+        for (int dbx = dbLo[0]; dbx <= dbHi[0]; ++dbx) {
+            for (int dby = dbLo[1]; dby <= dbHi[1]; ++dby) {
+                for (int dbz = dbLo[2]; dbz <= dbHi[2]; ++dbz) {
+                    const uint64_t *words = nullptr;
+                    if (dbx == 0 && dby == 0 && dbz == 0) {
+                        words = srcLeaf.valueMask().words();
+                    } else if (const LeafT *nbr = grid->tree().root().probeLeaf(
+                                   srcOrigin.offsetBy(8 * dbx, 8 * dby, 8 * dbz))) {
+                        words = nbr->valueMask().words();
+                    }
+                    uint64_t *dst = nb[dbx + 1][dby + 1][dbz + 1];
+                    for (int i = 0; i < 8; ++i) {
+                        dst[i] = words ? words[i] : uint64_t(0);
+                    }
+                }
+            }
+        }
+
+        // z-stage on every (dbx, dby) block: bit z of the result is AND over oz of bit z+oz, taken
+        // from the +-z neighbor block when z+oz leaves [0,7].
+        uint64_t wz[3][3][8];
+        for (int dbx = dbLo[0]; dbx <= dbHi[0]; ++dbx) {
+            for (int dby = dbLo[1]; dby <= dbHi[1]; ++dby) {
+                const uint64_t(*blk)[8] = nb[dbx + 1][dby + 1];
+                for (int i = 0; i < 8; ++i) {
+                    uint64_t acc = ~uint64_t(0);
+                    for (int oz = boxLo[2]; oz <= boxHi[2]; ++oz) {
+                        uint64_t v = shiftWordZ(blk[1][i], -oz);
+                        if (oz > 0) {
+                            v |= shiftWordZ(blk[2][i], 8 - oz);
+                        } else if (oz < 0) {
+                            v |= shiftWordZ(blk[0][i], -8 - oz);
+                        }
+                        acc &= v;
+                    }
+                    wz[dbx + 1][dby + 1][i] = acc;
+                }
+            }
+        }
+
+        // y-stage on every dbx block: byte y of the result is AND over oy of byte y+oy, from the
+        // +-y neighbor block when y+oy leaves [0,7].
+        uint64_t wy[3][8];
+        for (int dbx = dbLo[0]; dbx <= dbHi[0]; ++dbx) {
+            const uint64_t(*blk)[8] = wz[dbx + 1];
+            for (int i = 0; i < 8; ++i) {
+                uint64_t acc = ~uint64_t(0);
+                for (int oy = boxLo[1]; oy <= boxHi[1]; ++oy) {
+                    uint64_t v = shiftWordY(blk[1][i], -oy);
+                    if (oy > 0) {
+                        v |= shiftWordY(blk[2][i], 8 - oy);
+                    } else if (oy < 0) {
+                        v |= shiftWordY(blk[0][i], -8 - oy);
+                    }
+                    acc &= v;
+                }
+                wy[dbx + 1][i] = acc;
+            }
+        }
+
+        // x-stage (word permutation): word x of the result is AND over ox of word x+ox, from the
+        // +-x neighbor block when x+ox leaves [0,7].
+        uint64_t out[8];
+        uint64_t occupied = 0;
+        for (int x = 0; x < 8; ++x) {
+            uint64_t acc = ~uint64_t(0);
+            for (int ox = boxLo[0]; ox <= boxHi[0]; ++ox) {
+                const int xs = x + ox;
+                if (xs < 0) {
+                    acc &= wy[0][7];
+                } else if (xs > 7) {
+                    acc &= wy[2][0];
+                } else {
+                    acc &= wy[1][xs];
+                }
+            }
+            out[x] = acc;
+            occupied |= acc;
+        }
+        if (!occupied) {
+            em.tileKey[s] = kInvalidTileKey;
+            em.nodeKey[s] = 0; // sort pass 1 reads every slot's node key
+            continue;
+        }
+
+        em.tileKey[s]                 = tileSortKey(srcOrigin);
+        em.nodeKey[s]                 = nodeSortKey(srcOrigin);
+        em.origin[originIndex(s)]     = srcOrigin[0];
+        em.origin[originIndex(s) + 1] = srcOrigin[1];
+        em.origin[originIndex(s) + 2] = srcOrigin[2];
+        for (int i = 0; i < 8; ++i) {
+            em.mask[maskIndex(s) + i] = out[i];
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------------------------
 // Sort / dedup kernels
 // ---------------------------------------------------------------------------------------------
@@ -559,7 +694,7 @@ scatterNodeTables(const uint32_t *__restrict__ leafFlag,
 }
 
 /// Coarsen and BoxDilate: OR every duplicate slot's mask contribution into its unique leaf's head
-/// slot. Refine is excluded because its source-to-output leaf mapping is injective.
+/// slot. Refine and Erode are excluded because their source-to-output leaf mappings are injective.
 static __global__ void
 combineDuplicateMasks(const uint64_t *__restrict__ tileKey,
                       const uint32_t *__restrict__ leafFlag,
@@ -870,6 +1005,14 @@ runBatchedTopologyPass(const BatchedTopologySource &src,
             fanout *= (pass.boxHi[a] > 0 ? 1 : 0) - (pass.boxLo[a] < 0 ? -1 : 0) + 1;
         }
         break;
+    case TopologyPassSpec::Op::Erode:
+        for (int a = 0; a < 3; ++a) {
+            TORCH_CHECK(pass.boxLo[a] >= -1 && pass.boxLo[a] <= 0 && pass.boxHi[a] >= 0 &&
+                            pass.boxHi[a] <= 1,
+                        "Erode pass components must be in {-1,0} / {0,1}");
+        }
+        fanout = 1; // the eroded leaf is a subset of the source leaf
+        break;
     }
 
     // Per-grid emission slot ranges (host-known: leaf counts x fanout; no sync needed).
@@ -951,6 +1094,10 @@ runBatchedTopologyPass(const BatchedTopologySource &src,
             break;
         case TopologyPassSpec::Op::BoxDilate:
             emitBoxDilatedLeaves<<<numBlocks(numSlots), kThreads, 0, stream>>>(
+                em, pass.boxLo, pass.boxHi);
+            break;
+        case TopologyPassSpec::Op::Erode:
+            emitErodedLeaves<<<numBlocks(numSlots), kThreads, 0, stream>>>(
                 em, pass.boxLo, pass.boxHi);
             break;
         }
@@ -1069,7 +1216,9 @@ runBatchedTopologyPass(const BatchedTopologySource &src,
                                                                         u32(upperHeadSlot));
         C10_CUDA_KERNEL_LAUNCH_CHECK();
 
-        if (pass.op != TopologyPassSpec::Op::Refine) { // coarsen/dilate have duplicate producers
+        const bool injective =
+            pass.op == TopologyPassSpec::Op::Refine || pass.op == TopologyPassSpec::Op::Erode;
+        if (!injective) { // coarsen/dilate have duplicate producers
             combineDuplicateMasks<<<numBlocks(numSlots), kThreads, 0, stream>>>(sorted.tileKey,
                                                                                 u32(leafFlag),
                                                                                 u32(leafRank),

--- a/tests/unit/test_batched_topology_builder.py
+++ b/tests/unit/test_batched_topology_builder.py
@@ -4,9 +4,10 @@
 """Equivalence tests for the batched leaf-mask topology builder (issue #755).
 
 On CUDA, ``refined_grid`` / ``coarsened_grid`` (and through them ``conv_grid`` /
-``conv_transpose_grid`` for K == S), and the positive-padding ops ``dual_grid`` /
-``build_padded_grid(0, k)`` (issue #775), build all batch members in a single batched pass instead
-of one NanoVDB build + merge per member. These tests pin the batched results against:
+``conv_transpose_grid`` for K == S), and the padding ops ``dual_grid`` / ``build_padded_grid``
+(box dilation for plain padding, erosion for ``exclude_border``; issue #775), build all batch
+members in a single batched pass instead of one NanoVDB build + merge per member. These tests pin
+the batched results against:
 
 - ``from_ijk`` (PointsToGrid) grids built from independently computed expected coordinates,
   compared **elementwise** (``torch.equal`` on ``ijk.jdata``), which pins the canonical NanoVDB
@@ -53,19 +54,45 @@ def _expected_coarsen_ijk(ijk: torch.Tensor, factor: int) -> torch.Tensor:
     return torch.unique(coarse, dim=0).to(torch.int32)
 
 
-def _expected_pad_ijk(ijk: torch.Tensor, bmax: int) -> torch.Tensor:
-    """Unique coordinates of the Minkowski sum of ``ijk`` with the box {0, ..., bmax}^3.
+def _box_offsets(bmin: int, bmax: int) -> torch.Tensor:
+    r = torch.arange(bmin, bmax + 1)
+    return torch.stack(torch.meshgrid(r, r, r, indexing="ij"), dim=-1).reshape(-1, 3)
 
-    ``bmax`` chained unit pads by the octant {0,1}^3 compose to exactly this box (Minkowski sums
-    of axis-aligned boxes compose), so this is the expected result of ``build_padded_grid(0, bmax)``
-    and, for ``bmax == 1``, of ``dual_grid()``.
+
+def _expected_pad_ijk(ijk: torch.Tensor, bmax: int, bmin: int = 0) -> torch.Tensor:
+    """Unique coordinates of the Minkowski sum of ``ijk`` with the box {bmin, ..., bmax}^3.
+
+    ``bmax`` chained unit pads by the octant {0,1}^3 and ``-bmin`` by {-1,0}^3 compose to exactly
+    this box (Minkowski sums of axis-aligned boxes compose), so this is the expected result of
+    ``build_padded_grid(bmin, bmax)`` and, for ``(0, 1)``, of ``dual_grid()``.
     """
     if ijk.numel() == 0:
         return ijk.reshape(0, 3)
-    r = torch.arange(bmax + 1)
-    offsets = torch.stack(torch.meshgrid(r, r, r, indexing="ij"), dim=-1).reshape(-1, 3)
+    offsets = _box_offsets(bmin, bmax)
     padded = ijk.to(torch.int64)[:, None, :] + offsets[None, :, :].to(ijk.device)
     return torch.unique(padded.reshape(-1, 3), dim=0).to(torch.int32)
+
+
+def _coord_keys(ijk: torch.Tensor) -> torch.Tensor:
+    """Injective int64 key per coordinate (components must lie within +-2^20)."""
+    shifted = ijk.to(torch.int64) + (1 << 20)
+    return (shifted[:, 0] << 42) | (shifted[:, 1] << 21) | shifted[:, 2]
+
+
+def _expected_erode_ijk(ijk: torch.Tensor, bmin: int, bmax: int) -> torch.Tensor:
+    """Voxels of ``ijk`` whose whole {bmin, ..., bmax}^3 neighborhood lies in ``ijk``.
+
+    Erosion by the box, i.e. the ``exclude_border=True`` semantics of ``build_padded_grid`` /
+    ``dual_grid``: a voxel survives iff every box offset of it is active. Chained unit erosions by
+    the octants compose to this box like the Minkowski sums do.
+    """
+    if ijk.numel() == 0:
+        return ijk.reshape(0, 3)
+    voxels = torch.unique(ijk.to(torch.int64), dim=0)
+    offsets = _box_offsets(bmin, bmax).to(ijk.device)
+    neighbors = (voxels[:, None, :] + offsets[None, :, :]).reshape(-1, 3)
+    present = torch.isin(_coord_keys(neighbors), _coord_keys(voxels)).reshape(voxels.shape[0], -1)
+    return voxels[present.all(dim=1)].to(torch.int32)
 
 
 def _build_padded_grid(grid: GridBatch, bmin: int, bmax: int, exclude_border: bool = False) -> GridBatch:
@@ -122,6 +149,45 @@ def _tricky_batches():
         ],
         "larger_batch": [torch.randint(-32, 32, (50 + 37 * i, 3), dtype=torch.int32) for i in range(16)],
     }
+
+
+# Dense coordinate batches for the erosion tests: the sparse random members of _tricky_batches()
+# mostly erode to nothing, so these add members dense enough that interior voxels survive, with
+# leaves straddling leaf (multiples of 8) and root-tile (+-4096) boundaries and negative octants.
+def _dense_batches():
+    torch.manual_seed(7)
+    return {
+        "dense_blobs": [
+            torch.randint(-6, 10, (12000, 3), dtype=torch.int32),
+            torch.empty((0, 3), dtype=torch.int32),
+            torch.randint(4090, 4102, (6000, 3), dtype=torch.int32),
+            torch.randint(-4102, -4090, (6000, 3), dtype=torch.int32),
+        ],
+        "dense_slabs": [
+            # Thin slabs: everything erodes away along the thin axis unless the box is one-sided.
+            torch.stack(
+                torch.meshgrid(torch.arange(-4, 12), torch.arange(-4, 12), torch.arange(0, 2), indexing="ij"), -1
+            )
+            .reshape(-1, 3)
+            .to(torch.int32),
+            torch.stack(torch.meshgrid(torch.arange(0, 3), torch.arange(-9, 9), torch.arange(-9, 9), indexing="ij"), -1)
+            .reshape(-1, 3)
+            .to(torch.int32),
+        ],
+    }
+
+
+def _solid_block(lo, hi):
+    """All coordinates of the half-open box [lo, hi)^3."""
+    r = torch.arange(lo, hi)
+    return torch.stack(torch.meshgrid(r, r, r, indexing="ij"), -1).reshape(-1, 3).to(torch.int32)
+
+
+def _shell(lo, hi):
+    """One-voxel-thick surface of the half-open box [lo, hi)^3."""
+    block = _solid_block(lo, hi)
+    on_surface = ((block == lo) | (block == hi - 1)).any(dim=1)
+    return block[on_surface]
 
 
 @unittest.skipIf(not torch.cuda.is_available(), "CUDA is required for the batched builder")
@@ -200,6 +266,74 @@ class TestBatchedTopologyBuilder(unittest.TestCase):
             cpu_result = _build_padded_grid(cpu_grid, 0, bmax)
             self._check_against_cpu(result, cpu_result, f"{name} padded_grid(0, {bmax}) vs CPU")
             self.assertTrue(torch.allclose(result.origins, grid.origins), f"{name} padded_grid(0, {bmax}) origin")
+
+    @parameterized.expand([(name,) for name in list(_tricky_batches().keys()) + list(_dense_batches().keys())])
+    def test_dual_grid_exclude_border_matches_expected_and_cpu(self, name):
+        # dual_grid(exclude_border=True) is one batched Erode({0,1}^3) pass: a voxel survives iff
+        # its whole positive octant is active. Members eroded to nothing must come out as empty
+        # grids (no host-side emptiness check).
+        coords = {**_tricky_batches(), **_dense_batches()}[name]
+        grid = _build(coords, "cuda")
+        result = grid.dual_grid(exclude_border=True)
+        expected = [_expected_erode_ijk(c, 0, 1) for c in coords]
+        self._check_against_expected(result, expected, f"{name} dual_grid(exclude_border)")
+        cpu_result = _build(coords, "cpu").dual_grid(exclude_border=True)
+        self._check_against_cpu(result, cpu_result, f"{name} dual_grid(exclude_border) vs CPU")
+        self.assertTrue(
+            torch.allclose(result.origins, grid.origins - 0.5 * grid.voxel_sizes),
+            f"{name} dual_grid(exclude_border) origin",
+        )
+
+    @parameterized.expand([(name,) for name in list(_tricky_batches().keys()) + list(_dense_batches().keys())])
+    def test_padded_grid_negative_bounds_match_expected_and_cpu(self, name):
+        # A general [bmin, bmax] box is bmax {0,1}^3 passes followed by -bmin {-1,0}^3 passes:
+        # BoxDilate passes for plain padding (Minkowski sum), Erode passes for exclude_border.
+        coords = {**_tricky_batches(), **_dense_batches()}[name]
+        grid = _build(coords, "cuda")
+        cpu_grid = _build(coords, "cpu")
+        for bmin, bmax in ((-1, 0), (-1, 1), (-2, 0)):
+            msg = f"{name} padded_grid({bmin}, {bmax})"
+            result = _build_padded_grid(grid, bmin, bmax)
+            expected = [_expected_pad_ijk(c, bmax, bmin) for c in coords]
+            self._check_against_expected(result, expected, msg)
+            self._check_against_cpu(result, _build_padded_grid(cpu_grid, bmin, bmax), f"{msg} vs CPU")
+
+            msg = f"{name} padded_grid({bmin}, {bmax}, exclude_border)"
+            result = _build_padded_grid(grid, bmin, bmax, exclude_border=True)
+            expected = [_expected_erode_ijk(c, bmin, bmax) for c in coords]
+            self._check_against_expected(result, expected, msg)
+            cpu_result = _build_padded_grid(cpu_grid, bmin, bmax, exclude_border=True)
+            self._check_against_cpu(result, cpu_result, f"{msg} vs CPU")
+            self.assertTrue(torch.allclose(result.origins, grid.origins), f"{msg} origin")
+
+    def test_erode_shell_to_empty_and_solid_block_interior(self):
+        # A one-voxel-thick shell has no voxel with a fully active octant, so every erosion
+        # empties it (grid_count preserved, member empty inline). A solid block keeps its interior:
+        # [lo, hi)^3 eroded by {0,1}^3 is [lo, hi-1)^3, by [-1,1]^3 is [lo+1, hi-1)^3, by {-1,0}^3
+        # twice is [lo+2, hi)^3. Blocks straddle leaf (multiples of 8) and root-tile (4096)
+        # boundaries so border bits cross into neighbor leaves under different parents.
+        shells = [_shell(0, 10), _shell(-5, 11), _shell(4090, 4100)]
+        shell_grid = _build(shells, "cuda")
+        eroded = shell_grid.dual_grid(exclude_border=True)
+        self.assertEqual(eroded.grid_count, 3)
+        self.assertTrue(torch.equal(eroded.num_voxels.cpu(), torch.zeros(3, dtype=torch.int64)))
+        self.assertEqual(eroded.ijk.jdata.shape[0], 0)
+        eroded = _build_padded_grid(shell_grid, -1, 1, exclude_border=True)
+        self.assertTrue(torch.equal(eroded.num_voxels.cpu(), torch.zeros(3, dtype=torch.int64)))
+
+        bounds = [(0, 10), (-5, 11), (4090, 4100), (-4100, -4090)]
+        blocks = [_solid_block(lo, hi) for lo, hi in bounds]
+        block_grid = _build(blocks + [torch.empty((0, 3), dtype=torch.int32)], "cuda")
+        for (bmin, bmax), shrink in (((0, 1), (0, -1)), ((-1, 1), (1, -1)), ((-2, 0), (2, 0))):
+            result = _build_padded_grid(block_grid, bmin, bmax, exclude_border=True)
+            expected = [_solid_block(lo + shrink[0], hi + shrink[1]) for lo, hi in bounds]
+            expected.append(torch.empty((0, 3), dtype=torch.int32))
+            self._check_against_expected(result, expected, f"solid block erode({bmin}, {bmax})")
+            for b, (lo, hi) in enumerate(bounds):
+                bbox = result.bbox_at(b).cpu()
+                self.assertTrue(torch.equal(bbox[0], torch.full((3,), lo + shrink[0], dtype=bbox.dtype)))
+                self.assertTrue(torch.equal(bbox[1], torch.full((3,), hi + shrink[1] - 1, dtype=bbox.dtype)))
+            self.assertEqual(int(result.num_voxels[-1].item()), 0)
 
     def test_dual_grid_of_sliced_batch(self):
         # A sliced (non-contiguous) view shares a handle holding more grids than batchSize(); the

--- a/tests/unit/test_batched_topology_builder.py
+++ b/tests/unit/test_batched_topology_builder.py
@@ -4,8 +4,9 @@
 """Equivalence tests for the batched leaf-mask topology builder (issue #755).
 
 On CUDA, ``refined_grid`` / ``coarsened_grid`` (and through them ``conv_grid`` /
-``conv_transpose_grid`` for K == S) build all batch members in a single batched pass instead of
-one NanoVDB build + merge per member. These tests pin the batched results against:
+``conv_transpose_grid`` for K == S), and the positive-padding ops ``dual_grid`` /
+``build_padded_grid(0, k)`` (issue #775), build all batch members in a single batched pass instead
+of one NanoVDB build + merge per member. These tests pin the batched results against:
 
 - ``from_ijk`` (PointsToGrid) grids built from independently computed expected coordinates,
   compared **elementwise** (``torch.equal`` on ``ijk.jdata``), which pins the canonical NanoVDB
@@ -50,6 +51,26 @@ def _expected_coarsen_ijk(ijk: torch.Tensor, factor: int) -> torch.Tensor:
         return ijk.reshape(0, 3)
     coarse = torch.div(ijk.to(torch.int64), factor, rounding_mode="floor")
     return torch.unique(coarse, dim=0).to(torch.int32)
+
+
+def _expected_pad_ijk(ijk: torch.Tensor, bmax: int) -> torch.Tensor:
+    """Unique coordinates of the Minkowski sum of ``ijk`` with the box {0, ..., bmax}^3.
+
+    ``bmax`` chained unit pads by the octant {0,1}^3 compose to exactly this box (Minkowski sums
+    of axis-aligned boxes compose), so this is the expected result of ``build_padded_grid(0, bmax)``
+    and, for ``bmax == 1``, of ``dual_grid()``.
+    """
+    if ijk.numel() == 0:
+        return ijk.reshape(0, 3)
+    r = torch.arange(bmax + 1)
+    offsets = torch.stack(torch.meshgrid(r, r, r, indexing="ij"), dim=-1).reshape(-1, 3)
+    padded = ijk.to(torch.int64)[:, None, :] + offsets[None, :, :].to(ijk.device)
+    return torch.unique(padded.reshape(-1, 3), dim=0).to(torch.int32)
+
+
+def _build_padded_grid(grid: GridBatch, bmin: int, bmax: int, exclude_border: bool = False) -> GridBatch:
+    """Wrapper around the low-level ``build_padded_grid`` binding (generic [bmin, bmax] box)."""
+    return GridBatch(data=fvdb._fvdb_cpp.build_padded_grid(grid.data, bmin, bmax, exclude_border))
 
 
 def _ijk_sets(grid: GridBatch):
@@ -146,6 +167,53 @@ class TestBatchedTopologyBuilder(unittest.TestCase):
             self._check_against_expected(result, expected, f"{name} coarsen x{factor}")
             cpu_result = _build(coords, "cpu").coarsened_grid(factor)
             self._check_against_cpu(result, cpu_result, f"{name} coarsen x{factor} vs CPU")
+
+    @parameterized.expand([(name,) for name in _tricky_batches().keys()])
+    def test_dual_grid_matches_expected_and_cpu(self, name):
+        # dual_grid is one batched BoxDilate({0,1}^3) pass: the Minkowski sum of the primal
+        # voxels with the unit octant (voxels at the corners of the primal voxels).
+        coords = _tricky_batches()[name]
+        grid = _build(coords, "cuda")
+        result = grid.dual_grid()
+        expected = [_expected_pad_ijk(c, 1) for c in coords]
+        self._check_against_expected(result, expected, f"{name} dual_grid")
+        cpu_result = _build(coords, "cpu").dual_grid()
+        self._check_against_cpu(result, cpu_result, f"{name} dual_grid vs CPU")
+        # The dual transform fix-up must survive the batched build: result voxel centers sit on
+        # the source's corner (dual) lattice, i.e. the origin shifts by half a voxel.
+        self.assertTrue(torch.allclose(result.voxel_sizes, grid.voxel_sizes), f"{name} dual_grid voxel size")
+        self.assertTrue(
+            torch.allclose(result.origins, grid.origins - 0.5 * grid.voxel_sizes), f"{name} dual_grid origin"
+        )
+
+    @parameterized.expand([(name,) for name in _tricky_batches().keys()])
+    def test_padded_grid_positive_matches_expected_and_cpu(self, name):
+        # build_padded_grid(0, k) is k chained batched BoxDilate({0,1}^3) passes; the result lies
+        # on the source lattice (transforms unchanged).
+        coords = _tricky_batches()[name]
+        grid = _build(coords, "cuda")
+        cpu_grid = _build(coords, "cpu")
+        for bmax in (1, 2):
+            result = _build_padded_grid(grid, 0, bmax)
+            expected = [_expected_pad_ijk(c, bmax) for c in coords]
+            self._check_against_expected(result, expected, f"{name} padded_grid(0, {bmax})")
+            cpu_result = _build_padded_grid(cpu_grid, 0, bmax)
+            self._check_against_cpu(result, cpu_result, f"{name} padded_grid(0, {bmax}) vs CPU")
+            self.assertTrue(torch.allclose(result.origins, grid.origins), f"{name} padded_grid(0, {bmax}) origin")
+
+    def test_dual_grid_of_sliced_batch(self):
+        # A sliced (non-contiguous) view shares a handle holding more grids than batchSize(); the
+        # batched builder must read the *logical* members via the view-aware grid pointers.
+        coords = _tricky_batches()["mixed_sizes"] + _tricky_batches()["empty_members"]
+        full = _build(coords, "cuda")
+        view = full[1:6]
+        self.assertEqual(view.grid_count, 5)
+        result = view.dual_grid()
+        expected = [_expected_pad_ijk(c, 1) for c in coords[1:6]]
+        self._check_against_expected(result, expected, "sliced dual_grid")
+        for b in range(5):
+            single = _build([coords[1 + b]], "cuda").dual_grid()
+            self.assertTrue(torch.equal(result.ijk.unbind()[b], single.ijk.jdata), f"sliced dual_grid member {b}")
 
     def test_conv_grid_k2s2_multi_grid_matches_per_member(self):
         coords = _tricky_batches()["mixed_sizes"]


### PR DESCRIPTION
## Summary

Stacked on PR #776 (item 1); only the second commit is new.

After PR #776, `dispatchBuildPaddedGrid<torch::kCUDA>` still looped over batch members for erosion (`dual_grid(exclude_border=True)`, `build_padded_grid` with `exclude_border`) and for negative padding: `erodeOncePass` computed a per-leaf keep-mask sidecar, tested it for emptiness with a `(keepTensor != 0).any().item<bool>()` host sync, ran NanoVDB `PruneGrid` per member, and `padOncePass` ran one `PadGrid` per member per unit of padding, all merged with `nanovdb::cuda::mergeGridHandles`. Wall clock grew linearly with batch size regardless of topology size.

The whole `[bmin, bmax]` family is now one chain of batched passes through `batched::batchedTopologyHandle`: `bmax` positive-octant passes followed by `-bmin` negative-octant passes, `BoxDilate` for plain padding (Minkowski sum) and the new `Erode` op for `exclude_border`. One output buffer, one stream synchronization per pass, no per-member builds, no handle merging, no host-side emptiness check: members eroded to nothing come out as valid empty grids inline. The identity branch (`bmin == bmax == 0`) is unchanged; CPU and PrivateUse1 paths are untouched.

## Approach

`TopologyPassSpec::Op::Erode` in `BatchedTopologyBuilder.cuh` carries the same `boxLo`/`boxHi` (components in {-1,0} / {0,1}) as `BoxDilate`, with the dual semantics: an output voxel is active iff every box offset of it is active in the source. Emission (`emitErodedLeaves`) is injective -- slot = source leaf, the eroded leaf is a subset of the source leaf -- so `combineDuplicateMasks` is skipped like for Refine. The AND over the box factorizes per axis, so the kernel erodes along z, then y, then x with the existing `shiftWordZ` / `shiftWordY` helpers and the x-stage word permutation from `emitBoxDilatedLeaves`, combining with AND from all-ones instead of OR from zero. Bits that cross a leaf border come from the neighbor leaf on that side (fetched through the source grid's root; a missing neighbor contributes zeros and erodes the border voxels away). Because the y-stage reads z-eroded words of the +-y neighbors and the x-stage reads (z,y)-eroded words of the +-x neighbors, the earlier stages run on every neighbor leaf the box reaches (up to 2^3 for a one-sided octant, 3^3 for the full box). Leaves eroded to nothing are dead slots.

One correction to the item-7 wording: negative padding *without* `exclude_border` is a Minkowski sum with `{-1,0}^3` (the old `padOncePass(positive=false)`, and the CPU `buildPaddedGridFromGridCPU`), not an erosion, so it is wired as `BoxDilate(-1, 0)` passes; only `exclude_border` uses `Erode`. The new tests pin both against the CPU path.

The dead `padOncePass` / `erodeOncePass` helpers and their includes (`PadGrid.cuh`, `PruneGrid.cuh`, `DeviceGridTraits.cuh`, `CreateEmptyGridHandle.h`, `BuilderResource.h`) are removed from `BuildPaddedGrid.cu`. `ErodeKeepMaskFunctor` in `PadGrid.cuh` is now unused but left in place (library helper, still documented alongside `PadLeafNodesFunctor`).

## Benchmark

~83k voxels per member (`from_ijk` of 100k random ints in [0,64)^3), 20 iterations after one warmup, `torch.cuda.synchronize()` around the loop, RTX PRO 6000 Blackwell. Before = the installed env (per-member erode / pad + merge); after = this branch.

| op | B | before (ms) | after (ms) |
|---|---|---|---|
| `dual_grid(exclude_border=True)` | 1 | 0.59 | 0.56 |
| | 4 | 2.45 | 0.60 |
| | 16 | 9.96 | 0.73 |
| | 64 | 38.55 | 1.20 |
| `build_padded_grid(-1, 0)` | 1 | 0.66 | 0.56 |
| | 4 | 2.80 | 0.60 |
| | 16 | 10.42 | 0.73 |
| | 64 | 39.34 | 1.34 |

## Tests

New in `tests/unit/test_batched_topology_builder.py`, over `_tricky_batches()` (empty members, all-empty, +-4096 tile boundaries, 16 members) plus new dense batches (`_dense_batches()`: near-solid blobs straddling leaf and +-4096 tile boundaries in both octants, thin slabs) so that interior voxels actually survive erosion:

- `test_dual_grid_exclude_border_matches_expected_and_cpu`: `dual_grid(exclude_border=True)` pinned elementwise (`ijk.jdata`, `num_voxels`, per-member bbox) against a `from_ijk` build of the expected erosion computed in torch (a voxel survives iff all its box neighbors are in the set, via `torch.isin` on packed coordinate keys), as coordinate sets against CPU, plus the dual-transform origin fix-up.
- `test_padded_grid_negative_bounds_match_expected_and_cpu`: `build_padded_grid` for `(bmin, bmax)` in `(-1,0), (-1,1), (-2,0)`, plain (expected Minkowski sum with `[bmin,bmax]^3`) and `exclude_border` (expected erosion), vs expected and vs CPU.
- `test_erode_shell_to_empty_and_solid_block_interior`: one-voxel-thick shells (including one straddling 4096) erode to empty members with `grid_count` preserved; solid blocks `[lo,hi)^3` straddling leaf and tile boundaries in both octants erode to `[lo, hi-1)`, `[lo+1, hi-1)`, `[lo+2, hi)` for the three boxes, with the bbox checked per member and an empty member alongside.

The torch reference itself was cross-checked against the (unchanged) CPU implementation for every batch and box before pinning the CUDA path to it.

Results with the wheel from this branch: `test_batched_topology_builder.py` 51 passed; `test_dual.py` + `test_batching.py` + `test_sliced_batch.py` 74 passed; `test_basic_ops.py` + `test_basic_ops_single.py` 430 passed, 1 skipped.

Part of #775 (item 7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
