### PR TITLE
Batched {0,1}^3 pad for from_nearest_voxels_to_points via a chained BoxDilate pass (issue 775 item 6)

### DIFF
--- a/src/fvdb/detail/ops/BuildGridFromIjk.cu
+++ b/src/fvdb/detail/ops/BuildGridFromIjk.cu
@@ -1,6 +1,7 @@
 // Copyright Contributors to the OpenVDB Project
 // SPDX-License-Identifier: Apache-2.0
 //
+#include <fvdb/BuilderResource.h>
 #include <fvdb/GridBatchData.h>
 #include <fvdb/detail/GridBatchDataFactory.h>
 #include <fvdb/detail/ops/BuildGridFromIjk.h>
@@ -34,7 +35,8 @@ nanovdb::GridHandle<TorchDeviceBuffer> dispatchCreateNanoGridFromIJK(const Jagge
 // NanoVDB's PointsToGrid / DistributedPointsToGrid radix sort casts the per-grid coordinate count
 // to int32 (PointsToGrid.cuh:645), which silently corrupts the grid above 2^31 candidates, and the
 // batched Coords pass indexes its emission slots (one per coordinate) with int32 as well. Reject
-// that here rather than return a garbage grid. Takes an already-on-host joffsets accessor so each
+// that here (on every CUDA path: single-member PointsToGrid and multi-member Coords) rather than
+// return a garbage grid. Takes an already-on-host joffsets accessor so each
 // dispatch reuses the host copy it makes anyway -- no extra device sync.
 static void
 checkCandidateCountsFitInt32(const torch::TensorAccessor<fvdb::JOffsetsType, 1> &joffsetsAcc) {
@@ -51,51 +53,141 @@ checkCandidateCountsFitInt32(const torch::TensorAccessor<fvdb::JOffsetsType, 1> 
     }
 }
 
-template <>
-nanovdb::GridHandle<TorchDeviceBuffer>
-dispatchCreateNanoGridFromIJK<torch::kCUDA>(const JaggedTensor &ijk) {
+// Shared argument validation of `_createNanoGridFromIJK` and `batchedCoordsPassFromIJK`.
+static void
+checkIjkArguments(const JaggedTensor &ijk) {
+    TORCH_CHECK_VALUE(
+        ijk.ldim() == 1,
+        "Expected coords to have 1 list dimension, i.e. be a single list of coordinate values, but got",
+        ijk.ldim(),
+        "list dimensions");
+    TORCH_CHECK_TYPE(at::isIntegralType(ijk.scalar_type(), false), "ijk must have an integer type");
+    TORCH_CHECK_VALUE(ijk.rdim() == 2,
+                      std::string("Expected ijk to have 2 dimensions (shape (n, 3)) but got ") +
+                          std::to_string(ijk.rdim()) + " dimensions");
+    TORCH_CHECK_VALUE(ijk.rsize(1) == 3,
+                      "Expected 3 dimensional coords but got ijk.rshape[1] = " +
+                          std::to_string(ijk.rsize(1)));
+    TORCH_CHECK(ijk.num_tensors() == ijk.num_outer_lists(),
+                "If this happens, Francis' paranoia was justified. File a bug");
+    TORCH_CHECK_VALUE(ijk.num_outer_lists() <= GridBatchData::MAX_GRIDS_PER_BATCH,
+                      "Cannot create a batch of grids with more than ",
+                      GridBatchData::MAX_GRIDS_PER_BATCH,
+                      " grids in it. ",
+                      "You passed in ",
+                      ijk.num_outer_lists(),
+                      " ijk sets.");
+    const int64_t numGrids = ijk.joffsets().size(0) - 1;
+    TORCH_CHECK(numGrids == ijk.num_outer_lists(),
+                "If this happens, Francis' paranoia was justified. File a bug");
+}
+
+namespace {
+
+// Validated CUDA from_ijk input: int32 contiguous (N, 3) coordinates, the device jagged offsets,
+// and the host-side per-member coordinate counts (from the one host copy of joffsets that the
+// int32 candidate-count guard makes anyway).
+struct CudaIjkInput {
+    torch::Tensor ijkData;     // int32, contiguous, (N, 3)
+    torch::Tensor joffsetsDev; // int64, contiguous, (B + 1)
+    std::vector<int64_t> coordCounts;
+    at::cuda::CUDAStream stream;
+};
+
+CudaIjkInput
+prepareCudaIjk(const JaggedTensor &ijk) {
     TORCH_CHECK(ijk.is_contiguous(), "ijk must be contiguous");
     TORCH_CHECK(ijk.device().is_cuda(), "device must be cuda");
     TORCH_CHECK(ijk.device().has_index(), "device must have index");
     TORCH_CHECK(ijk.scalar_type() == torch::kInt32 || ijk.scalar_type() == torch::kInt64,
                 "ijk must be int32 or int64");
 
-    c10::cuda::CUDAGuard deviceGuard(ijk.device());
-    at::cuda::CUDAStream stream = at::cuda::getCurrentCUDAStream(ijk.device().index());
-
     static_assert(sizeof(nanovdb::Coord) == 3 * sizeof(int32_t), "nanovdb::Coord must be 3 ints");
     static_assert(std::is_same_v<fvdb::JOffsetsType, int64_t>,
                   "the batched Coords pass reads int64 jagged offsets");
 
-    // Host copy of the jagged offsets: the per-grid int32 candidate-count guard and the per-grid
-    // emission slot counts of the batched pass both come from it (one device sync).
+    CudaIjkInput in{
+        torch::Tensor(), torch::Tensor(), {}, at::cuda::getCurrentCUDAStream(ijk.device().index())};
+
     torch::Tensor ijkBOffsetTensor = ijk.joffsets().cpu();
     auto ijkBOffset                = ijkBOffsetTensor.accessor<fvdb::JOffsetsType, 1>();
     checkCandidateCountsFitInt32(ijkBOffset);
     const int64_t numGrids = ijkBOffset.size(0) - 1;
-    std::vector<int64_t> coordCounts(numGrids);
+    in.coordCounts.resize(numGrids);
     for (int64_t gi = 0; gi < numGrids; gi += 1) {
-        coordCounts[gi] = ijkBOffset[gi + 1] - ijkBOffset[gi];
+        in.coordCounts[gi] = ijkBOffset[gi + 1] - ijkBOffset[gi];
     }
 
-    torch::Tensor ijkData = ijk.jdata();
-    if (ijkData.scalar_type() != torch::kInt32) {
-        ijkData = ijkData.to(torch::kInt32);
+    in.ijkData = ijk.jdata();
+    if (in.ijkData.scalar_type() != torch::kInt32) {
+        in.ijkData = in.ijkData.to(torch::kInt32);
     }
-    TORCH_CHECK(ijkData.is_contiguous(), "ijk must be contiguous");
-    TORCH_CHECK(ijkData.dim() == 2, "ijk must have shape (N, 3)");
-    TORCH_CHECK(ijkData.size(1) == 3, "ijk must have shape (N, 3)");
-    const torch::Tensor joffsetsDev = ijk.joffsets().contiguous();
+    TORCH_CHECK(in.ijkData.is_contiguous(), "ijk must be contiguous");
+    TORCH_CHECK(in.ijkData.dim() == 2, "ijk must have shape (N, 3)");
+    TORCH_CHECK(in.ijkData.size(1) == 3, "ijk must have shape (N, 3)");
+    in.joffsetsDev = ijk.joffsets().contiguous();
+    return in;
+}
 
-    // All batch members are built together in one batched Coords pass: one emission slot per
-    // coordinate (leaf origin + single-voxel mask bit), duplicates and coordinates sharing a leaf
-    // OR-combined, a single output buffer, one stream synchronization -- no per-member
-    // PointsToGrid builds or handle merging (issue #775). Empty members become valid empty
-    // grids inline.
+// Single-member build: NanoVDB's PointsToGrid, as before the batched pass. It is kept for B == 1
+// because the Coords pass gains almost nothing in time there (there is no per-member overhead to
+// remove) while holding more scratch per coordinate (about 148 MiB vs 88 MiB of torch-visible
+// peak for 2M coordinates).
+nanovdb::GridHandle<TorchDeviceBuffer>
+pointsToGridSingle(const CudaIjkInput &in, const torch::Device &device) {
+    using GridT = nanovdb::ValueOnIndex;
+    TORCH_CHECK(in.coordCounts.size() == 1, "pointsToGridSingle expects exactly one member");
+    const int64_t nVoxels = in.coordCounts[0];
+    if (nVoxels == 0) {
+        return createEmptyGridHandle(device);
+    }
+    // The guide buffer carries the device (with index) into TorchDeviceBuffer::create.
+    TorchDeviceBuffer guide(0, device);
+    auto handle = nanovdb::tools::cuda::
+        voxelsToGrid<GridT, nanovdb::Coord *, TorchDeviceBuffer, BuilderResource>(
+            reinterpret_cast<nanovdb::Coord *>(in.ijkData.data_ptr<int32_t>()),
+            nVoxels,
+            1.0,
+            guide);
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+    return handle;
+}
+
+// Multi-member build: all batch members together in one batched Coords pass -- one emission slot
+// per coordinate (leaf origin + single-voxel mask bit), duplicates and coordinates sharing a leaf
+// OR-combined, a single output buffer, one stream synchronization; no per-member PointsToGrid
+// builds or handle merging (issue #775). Empty members become valid empty grids inline.
+batched::BatchedTopologyResult
+coordsPassMulti(const CudaIjkInput &in, const torch::Device &device) {
     const batched::TopologyPassSpec pass = batched::TopologyPassSpec::coords(
-        ijkData.data_ptr<int32_t>(), joffsetsDev.data_ptr<fvdb::JOffsetsType>());
-    batched::BatchedTopologyResult result = batched::runBatchedTopologyPass(
-        batched::sourceFromCoordCounts(coordCounts, ijk.device()), pass, stream.stream());
+        in.ijkData.data_ptr<int32_t>(), in.joffsetsDev.data_ptr<fvdb::JOffsetsType>());
+    return batched::runBatchedTopologyPass(
+        batched::sourceFromCoordCounts(in.coordCounts, device), pass, in.stream.stream());
+}
+
+} // namespace
+
+batched::BatchedTopologyResult
+batchedCoordsPassFromIJK(const JaggedTensor &ijk) {
+    checkIjkArguments(ijk);
+    c10::cuda::CUDAGuard deviceGuard(ijk.device());
+    const CudaIjkInput in = prepareCudaIjk(ijk);
+    if (in.coordCounts.size() == 1) {
+        return batched::resultFromGridHandle(pointsToGridSingle(in, ijk.device()),
+                                             in.stream.stream());
+    }
+    return coordsPassMulti(in, ijk.device());
+}
+
+template <>
+nanovdb::GridHandle<TorchDeviceBuffer>
+dispatchCreateNanoGridFromIJK<torch::kCUDA>(const JaggedTensor &ijk) {
+    c10::cuda::CUDAGuard deviceGuard(ijk.device());
+    const CudaIjkInput in = prepareCudaIjk(ijk);
+    if (in.coordCounts.size() == 1) {
+        return pointsToGridSingle(in, ijk.device());
+    }
+    batched::BatchedTopologyResult result = coordsPassMulti(in, ijk.device());
     return nanovdb::GridHandle<TorchDeviceBuffer>(std::move(result.buffer));
 }
 
@@ -227,30 +319,7 @@ dispatchCreateNanoGridFromIJK<torch::kCPU>(const JaggedTensor &jaggedCoords) {
 
 nanovdb::GridHandle<TorchDeviceBuffer>
 _createNanoGridFromIJK(const JaggedTensor &ijk) {
-    TORCH_CHECK_VALUE(
-        ijk.ldim() == 1,
-        "Expected coords to have 1 list dimension, i.e. be a single list of coordinate values, but got",
-        ijk.ldim(),
-        "list dimensions");
-    TORCH_CHECK_TYPE(at::isIntegralType(ijk.scalar_type(), false), "ijk must have an integer type");
-    TORCH_CHECK_VALUE(ijk.rdim() == 2,
-                      std::string("Expected ijk to have 2 dimensions (shape (n, 3)) but got ") +
-                          std::to_string(ijk.rdim()) + " dimensions");
-    TORCH_CHECK_VALUE(ijk.rsize(1) == 3,
-                      "Expected 3 dimensional coords but got ijk.rshape[1] = " +
-                          std::to_string(ijk.rsize(1)));
-    TORCH_CHECK(ijk.num_tensors() == ijk.num_outer_lists(),
-                "If this happens, Francis' paranoia was justified. File a bug");
-    TORCH_CHECK_VALUE(ijk.num_outer_lists() <= GridBatchData::MAX_GRIDS_PER_BATCH,
-                      "Cannot create a batch of grids with more than ",
-                      GridBatchData::MAX_GRIDS_PER_BATCH,
-                      " grids in it. ",
-                      "You passed in ",
-                      ijk.num_outer_lists(),
-                      " ijk sets.");
-    const int64_t numGrids = ijk.joffsets().size(0) - 1;
-    TORCH_CHECK(numGrids == ijk.num_outer_lists(),
-                "If this happens, Francis' paranoia was justified. File a bug");
+    checkIjkArguments(ijk);
 
     // The >2^31-candidate overflow guard runs inside each dispatch (checkCandidateCountsFitInt32),
     // reusing the host joffsets copy those paths already make -- no extra device sync here.

--- a/src/fvdb/detail/ops/BuildGridFromIjk.cu
+++ b/src/fvdb/detail/ops/BuildGridFromIjk.cu
@@ -1,13 +1,13 @@
 // Copyright Contributors to the OpenVDB Project
 // SPDX-License-Identifier: Apache-2.0
 //
-#include <fvdb/BuilderResource.h>
 #include <fvdb/GridBatchData.h>
 #include <fvdb/detail/GridBatchDataFactory.h>
 #include <fvdb/detail/ops/BuildGridFromIjk.h>
 #include <fvdb/detail/utils/AccessorHelpers.cuh>
 #include <fvdb/detail/utils/Utils.h>
 #include <fvdb/detail/utils/cuda/Utils.cuh>
+#include <fvdb/detail/utils/nanovdb/BatchedTopologyBuilder.cuh>
 #include <fvdb/detail/utils/nanovdb/CreateEmptyGridHandle.h>
 
 #if CCCL_DEVICE_MERGE_SUPPORTED
@@ -19,6 +19,7 @@
 #include <c10/cuda/CUDACachingAllocator.h>
 #include <c10/cuda/CUDAGuard.h>
 #include <c10/cuda/CUDAMathCompat.h>
+#include <c10/cuda/CUDAStream.h>
 #include <torch/types.h>
 
 #include <limits>
@@ -31,7 +32,8 @@ template <torch::DeviceType>
 nanovdb::GridHandle<TorchDeviceBuffer> dispatchCreateNanoGridFromIJK(const JaggedTensor &ijk);
 
 // NanoVDB's PointsToGrid / DistributedPointsToGrid radix sort casts the per-grid coordinate count
-// to int32 (PointsToGrid.cuh:645), which silently corrupts the grid above 2^31 candidates. Reject
+// to int32 (PointsToGrid.cuh:645), which silently corrupts the grid above 2^31 candidates, and the
+// batched Coords pass indexes its emission slots (one per coordinate) with int32 as well. Reject
 // that here rather than return a garbage grid. Takes an already-on-host joffsets accessor so each
 // dispatch reuses the host copy it makes anyway -- no extra device sync.
 static void
@@ -52,8 +54,6 @@ checkCandidateCountsFitInt32(const torch::TensorAccessor<fvdb::JOffsetsType, 1> 
 template <>
 nanovdb::GridHandle<TorchDeviceBuffer>
 dispatchCreateNanoGridFromIJK<torch::kCUDA>(const JaggedTensor &ijk) {
-    using GridT = nanovdb::ValueOnIndex;
-
     TORCH_CHECK(ijk.is_contiguous(), "ijk must be contiguous");
     TORCH_CHECK(ijk.device().is_cuda(), "device must be cuda");
     TORCH_CHECK(ijk.device().has_index(), "device must have index");
@@ -61,20 +61,23 @@ dispatchCreateNanoGridFromIJK<torch::kCUDA>(const JaggedTensor &ijk) {
                 "ijk must be int32 or int64");
 
     c10::cuda::CUDAGuard deviceGuard(ijk.device());
+    at::cuda::CUDAStream stream = at::cuda::getCurrentCUDAStream(ijk.device().index());
 
     static_assert(sizeof(nanovdb::Coord) == 3 * sizeof(int32_t), "nanovdb::Coord must be 3 ints");
+    static_assert(std::is_same_v<fvdb::JOffsetsType, int64_t>,
+                  "the batched Coords pass reads int64 jagged offsets");
 
-    // This guide buffer is a hack to pass in a device with an index to the cudaCreateNanoGrid
-    // function. We can't pass in a device directly but we can pass in a buffer which gets
-    // passed to TorchDeviceBuffer::create. The guide buffer holds the device and effectively
-    // passes it to the created buffer.
-    TorchDeviceBuffer guide(0, ijk.device());
-
-    // FIXME: This is slow because we have to copy this data to the host and then build the
-    // grids. Ideally we want to do this in a single invocation.
+    // Host copy of the jagged offsets: the per-grid int32 candidate-count guard and the per-grid
+    // emission slot counts of the batched pass both come from it (one device sync).
     torch::Tensor ijkBOffsetTensor = ijk.joffsets().cpu();
     auto ijkBOffset                = ijkBOffsetTensor.accessor<fvdb::JOffsetsType, 1>();
     checkCandidateCountsFitInt32(ijkBOffset);
+    const int64_t numGrids = ijkBOffset.size(0) - 1;
+    std::vector<int64_t> coordCounts(numGrids);
+    for (int64_t gi = 0; gi < numGrids; gi += 1) {
+        coordCounts[gi] = ijkBOffset[gi + 1] - ijkBOffset[gi];
+    }
+
     torch::Tensor ijkData = ijk.jdata();
     if (ijkData.scalar_type() != torch::kInt32) {
         ijkData = ijkData.to(torch::kInt32);
@@ -82,32 +85,18 @@ dispatchCreateNanoGridFromIJK<torch::kCUDA>(const JaggedTensor &ijk) {
     TORCH_CHECK(ijkData.is_contiguous(), "ijk must be contiguous");
     TORCH_CHECK(ijkData.dim() == 2, "ijk must have shape (N, 3)");
     TORCH_CHECK(ijkData.size(1) == 3, "ijk must have shape (N, 3)");
+    const torch::Tensor joffsetsDev = ijk.joffsets().contiguous();
 
-    // Create a grid for each batch item and store the handles
-    std::vector<nanovdb::GridHandle<TorchDeviceBuffer>> handles;
-    for (int i = 0; i < (ijkBOffset.size(0) - 1); i += 1) {
-        const int64_t startIdx = ijkBOffset[i];
-        const int64_t nVoxels  = ijkBOffset[i + 1] - startIdx;
-        // torch::Tensor ijkDataSlice = ijkData.narrow(0, startIdx, nVoxels);
-        const int32_t *dataPtr = ijkData.data_ptr<int32_t>() + 3 * startIdx;
-
-        handles.push_back(
-            nVoxels == 0
-                ? createEmptyGridHandle(guide.device())
-                : nanovdb::tools::cuda::
-                      voxelsToGrid<GridT, nanovdb::Coord *, TorchDeviceBuffer, BuilderResource>(
-                          (nanovdb::Coord *)dataPtr, nVoxels, 1.0, guide));
-        C10_CUDA_KERNEL_LAUNCH_CHECK();
-    }
-
-    if (handles.size() == 1) {
-        // If there's only one handle, just return it
-        return std::move(handles[0]);
-    } else {
-        // This copies all the handles into a single handle -- only do it if there are multie
-        // grids
-        return nanovdb::cuda::mergeGridHandles(handles, &guide);
-    }
+    // All batch members are built together in one batched Coords pass: one emission slot per
+    // coordinate (leaf origin + single-voxel mask bit), duplicates and coordinates sharing a leaf
+    // OR-combined, a single output buffer, one stream synchronization -- no per-member
+    // PointsToGrid builds or handle merging (issue #775). Empty members become valid empty
+    // grids inline.
+    const batched::TopologyPassSpec pass = batched::TopologyPassSpec::coords(
+        ijkData.data_ptr<int32_t>(), joffsetsDev.data_ptr<fvdb::JOffsetsType>());
+    batched::BatchedTopologyResult result = batched::runBatchedTopologyPass(
+        batched::sourceFromCoordCounts(coordCounts, ijk.device()), pass, stream.stream());
+    return nanovdb::GridHandle<TorchDeviceBuffer>(std::move(result.buffer));
 }
 
 template <>

--- a/src/fvdb/detail/ops/BuildGridFromIjk.h
+++ b/src/fvdb/detail/ops/BuildGridFromIjk.h
@@ -11,11 +11,25 @@
 
 namespace fvdb {
 namespace detail {
+namespace batched {
+struct BatchedTopologyResult;
+} // namespace batched
+
 namespace ops {
 
 // Internal helper used by other grid-building ops (BuildCoarseGridFromFine, BuildGridFromPoints,
 // etc.)
 nanovdb::GridHandle<TorchDeviceBuffer> _createNanoGridFromIJK(const JaggedTensor &ijk);
+
+// CUDA only. Builds the from_ijk grid batch and returns the raw batched-pass result (one buffer
+// holding every member, plus the per-member layout) instead of a GridHandle, so callers can chain
+// further batched passes onto it through `batched::sourceFromResult` (e.g. the {0,1}^3 pad of
+// from_nearest_voxels_to_points). Multi-member batches run the batched Coords pass; a
+// single-member batch runs NanoVDB's PointsToGrid (same output, lower peak memory) and is wrapped
+// with `batched::resultFromGridHandle`. Performs the same argument validation as
+// `_createNanoGridFromIJK`; `ijk` must live on a CUDA device (not PrivateUse1). Callers must
+// include BatchedTopologyBuilder.cuh to use the result.
+batched::BatchedTopologyResult batchedCoordsPassFromIJK(const JaggedTensor &ijk);
 
 c10::intrusive_ptr<GridBatchData>
 createNanoGridFromIJK(const JaggedTensor &ijk,

--- a/src/fvdb/detail/ops/BuildGridFromNearestVoxelsToPoints.cu
+++ b/src/fvdb/detail/ops/BuildGridFromNearestVoxelsToPoints.cu
@@ -1,7 +1,6 @@
 // Copyright Contributors to the OpenVDB Project
 // SPDX-License-Identifier: Apache-2.0
 //
-#include <fvdb/BuilderResource.h>
 #include <fvdb/GridBatchData.h>
 #include <fvdb/detail/GridBatchDataFactory.h>
 #include <fvdb/detail/ops/BuildGridFromIjk.h>
@@ -10,15 +9,13 @@
 #include <fvdb/detail/utils/Utils.h>
 #include <fvdb/detail/utils/cuda/ForEachCUDA.cuh>
 #include <fvdb/detail/utils/cuda/RAIIRawDeviceBuffer.h>
-#include <fvdb/detail/utils/nanovdb/CreateEmptyGridHandle.h>
-#include <fvdb/detail/utils/nanovdb/PadGrid.cuh>
+#include <fvdb/detail/utils/nanovdb/BatchedTopologyBuilder.cuh>
 
 #include <nanovdb/tools/CreateNanoGrid.h>
-#include <nanovdb/tools/cuda/PointsToGrid.cuh>
 
-#include <c10/cuda/CUDACachingAllocator.h>
 #include <c10/cuda/CUDAGuard.h>
 #include <c10/cuda/CUDAMathCompat.h>
+#include <c10/cuda/CUDAStream.h>
 #include <torch/types.h>
 
 namespace fvdb {
@@ -94,36 +91,21 @@ dispatchBuildGridFromNearestVoxelsToPoints<torch::kCUDA>(
     c10::cuda::CUDAGuard deviceGuard(points.device());
     at::cuda::CUDAStream stream = at::cuda::getCurrentCUDAStream(points.device().index());
 
-    // Build the base grid from the single voxel containing each point. Points are unstructured, so
-    // one sort is unavoidable.
-    JaggedTensor flooredIjk                        = flooredIjkForPoints(points, txs);
-    nanovdb::GridHandle<TorchDeviceBuffer> baseHdl = ops::_createNanoGridFromIJK(flooredIjk);
+    // Build the base grid batch from the single voxel containing each point: one batched Coords
+    // pass over all members (points are unstructured, so one sort is unavoidable).
+    const JaggedTensor flooredIjk       = flooredIjkForPoints(points, txs);
+    batched::BatchedTopologyResult base = ops::batchedCoordsPassFromIJK(flooredIjk);
 
     // The 8 nearest voxels of a point are floor(p) + {0,1}^3, so the nearest-voxel grid is the base
-    // grid padded by one positive octant (the Minkowski sum distributes over the point union).
-    TorchDeviceBuffer guide(0, points.device());
-    const torch::Tensor joffsetsCpu = points.joffsets().cpu();
-    const auto joffsetsAcc          = joffsetsCpu.accessor<fvdb::JOffsetsType, 1>();
-
-    std::vector<nanovdb::GridHandle<TorchDeviceBuffer>> handles;
-    handles.reserve(baseHdl.gridCount());
-    for (uint32_t i = 0; i < baseHdl.gridCount(); i += 1) {
-        if (joffsetsAcc[i + 1] - joffsetsAcc[i] == 0) {
-            // No points in this batch item -> empty grid (>=1 point always yields >=1 base voxel).
-            handles.push_back(createEmptyGridHandle(points.device()));
-            continue;
-        }
-        nanovdb::OnIndexGrid *grid = baseHdl.deviceGrid<nanovdb::ValueOnIndex>(i);
-        TORCH_CHECK(grid, "Grid is null");
-        morphology::PadGrid<nanovdb::ValueOnIndex, BuilderResource> op(
-            grid, /*positiveOctant=*/true, stream.stream());
-        op.setChecksum(nanovdb::CheckMode::Default);
-        handles.push_back(op.getHandle(guide));
-        C10_CUDA_KERNEL_LAUNCH_CHECK();
-    }
-
-    return handles.size() == 1 ? std::move(handles[0])
-                               : nanovdb::cuda::mergeGridHandles(handles, &guide);
+    // grid padded by one positive octant (the Minkowski sum distributes over the point union). One
+    // batched BoxDilate pass over the Coords result covers every member -- no per-member PadGrid
+    // builds, handle merging, or host copy of the jagged offsets (issue #775). Members without
+    // points are empty base grids and stay empty.
+    batched::BatchedTopologyResult padded = batched::runBatchedTopologyPass(
+        batched::sourceFromResult(base, points.device()),
+        batched::TopologyPassSpec::boxDilate(nanovdb::Coord(0), nanovdb::Coord(1)),
+        stream.stream());
+    return nanovdb::GridHandle<TorchDeviceBuffer>(std::move(padded.buffer));
 }
 
 template <>

--- a/src/fvdb/detail/ops/BuildGridFromPoints.cu
+++ b/src/fvdb/detail/ops/BuildGridFromPoints.cu
@@ -1,6 +1,7 @@
 // Copyright Contributors to the OpenVDB Project
 // SPDX-License-Identifier: Apache-2.0
 //
+#include <fvdb/BuilderResource.h>
 #include <fvdb/GridBatchData.h>
 #include <fvdb/detail/GridBatchDataFactory.h>
 #include <fvdb/detail/ops/BuildGridFromIjk.h>
@@ -10,14 +11,18 @@
 #include <fvdb/detail/utils/cuda/ForEachCUDA.cuh>
 #include <fvdb/detail/utils/cuda/ForEachPrivateUse1.cuh>
 #include <fvdb/detail/utils/cuda/RAIIRawDeviceBuffer.h>
+#include <fvdb/detail/utils/nanovdb/CreateEmptyGridHandle.h>
 
 #include <nanovdb/tools/CreateNanoGrid.h>
+#include <nanovdb/tools/cuda/PointsToGrid.cuh>
 
 #include <c10/cuda/CUDACachingAllocator.h>
 #include <c10/cuda/CUDAGuard.h>
 #include <c10/cuda/CUDAMathCompat.h>
 
 #include <thrust/universal_vector.h>
+
+#include <limits>
 
 namespace fvdb {
 namespace detail {
@@ -27,6 +32,132 @@ template <torch::DeviceType>
 nanovdb::GridHandle<TorchDeviceBuffer>
 dispatchBuildGridFromPoints(const JaggedTensor &points,
                             const std::vector<VoxelCoordTransform> &txs);
+
+namespace {
+
+/// @brief Pointer-like adaptor that yields index-space voxel coordinates from world-space points
+///        on demand, so the coordinates never have to be materialized in memory.
+///
+/// `nanovdb::tools::cuda::voxelsToGrid` reads its input through a pointer-like type rather than a
+/// raw pointer (see `nanovdb::tools::cuda::fancy_ptr`, which documents the contract): `operator[]`
+/// is what the kernels actually call, and `operator*` exists only so `pointer_traits` can deduce
+/// `element_type` from its return type. Returning `nanovdb::Coord` by value satisfies both and
+/// selects the `is_same<Vec3T, Coord>` branch of `TileKeyFunctor` -- the same branch a raw
+/// `nanovdb::Coord *` takes -- so the resulting topology is bit-for-bit what a
+/// materialize-then-sort path produces.
+///
+/// Used by the single-member build, which keeps PointsToGrid (see dispatchBuildGridFromPoints):
+/// there the adaptor saves the 12 B per point that the multi-member path materializes.
+///
+/// The class supports both memory layouts of an (N, 3) tensor so that non-contiguous views --
+/// e.g. the xyz columns of an (N, 6) point cloud, `cloud[:, :3]` -- are read in place rather
+/// than copied. `IsContiguous` selects between compile-time strides (3, 1) and runtime strides
+/// taken from the tensor, so the packed fast path pays nothing for the generality.
+///
+/// @tparam ScalarT Scalar type of the input points (floating point or half)
+/// @tparam IsContiguous Whether the points are a packed (N, 3) array; when false, element
+///         strides are supplied at construction
+template <typename ScalarT, bool IsContiguous> class TransformedPointPtr {
+  public:
+    using MathT = typename at::opmath_type<ScalarT>;
+
+    /// @param points Pointer to the first component of the first point
+    /// @param transform World-space to index-space transform for this batch item
+    /// @param rowStride Distance in elements between consecutive points (3 if packed)
+    /// @param colStride Distance in elements between a point's components (1 if packed)
+    __hostdev__
+    TransformedPointPtr(const ScalarT *points,
+                        const VoxelCoordTransform &transform,
+                        int64_t rowStride = 3,
+                        int64_t colStride = 1)
+        : mPoints(points), mTransform(transform), mRowStride(rowStride), mColStride(colStride) {}
+
+    /// @brief Return the index-space voxel coordinate of the i'th point. Required by PointsToGrid.
+    __hostdev__ inline nanovdb::Coord
+    operator[](size_t i) const {
+        MathT x, y, z;
+        if constexpr (IsContiguous) {
+            const ScalarT *point = mPoints + 3 * i;
+            x                    = static_cast<MathT>(point[0]);
+            y                    = static_cast<MathT>(point[1]);
+            z                    = static_cast<MathT>(point[2]);
+        } else {
+            const ScalarT *point = mPoints + static_cast<int64_t>(i) * mRowStride;
+            x                    = static_cast<MathT>(point[0]);
+            y                    = static_cast<MathT>(point[mColStride]);
+            z                    = static_cast<MathT>(point[2 * mColStride]);
+        }
+        return mTransform.apply(x, y, z).round();
+    }
+
+    /// @brief Required by `pointer_traits` to deduce `element_type` -- only the return *type* is
+    ///        used. Deliberately does not read `mPoints`: `pointer_traits` never evaluates this,
+    ///        and returning a default coordinate keeps it well defined for an empty point set if
+    ///        some future code path (or debug instrumentation) ever does evaluate it.
+    __hostdev__ inline nanovdb::Coord
+    operator*() const {
+        return nanovdb::Coord();
+    }
+
+  private:
+    const ScalarT *mPoints;
+    VoxelCoordTransform mTransform;
+    int64_t mRowStride;
+    int64_t mColStride;
+};
+
+/// Single-member from_points: NanoVDB's PointsToGrid over the transformed-point adaptor, reading
+/// the points in place. Kept for B == 1 because the batched path gains almost nothing in time
+/// there while materializing coordinates and holding more scratch per point.
+nanovdb::GridHandle<TorchDeviceBuffer>
+pointsToGridSingle(const JaggedTensor &points, const VoxelCoordTransform &tx) {
+    using GridT = nanovdb::ValueOnIndex;
+
+    // The guide buffer carries the device (with index) into TorchDeviceBuffer::create.
+    TorchDeviceBuffer guide(0, points.device());
+
+    const torch::Tensor pointsData = points.jdata();
+    const int64_t nPoints          = pointsData.size(0);
+    // PointsToGrid casts its element count to int for the segmented radix sort, so anything at or
+    // above 2^31 would silently produce a corrupt grid.
+    TORCH_CHECK(nPoints <= std::numeric_limits<int32_t>::max(),
+                "Cannot build a grid from ",
+                nPoints,
+                " points in a single batch item (limit is ",
+                std::numeric_limits<int32_t>::max(),
+                ")");
+    if (nPoints == 0) {
+        return createEmptyGridHandle(points.device());
+    }
+
+    return AT_DISPATCH_V2(
+        points.scalar_type(),
+        "buildGridFromPoints",
+        AT_WRAP([&]() -> nanovdb::GridHandle<TorchDeviceBuffer> {
+            const scalar_t *pointsPtr = pointsData.data_ptr<scalar_t>();
+            nanovdb::GridHandle<TorchDeviceBuffer> handle;
+            if (pointsData.is_contiguous()) {
+                using PointPtrT = TransformedPointPtr<scalar_t, true>;
+                handle          = nanovdb::tools::cuda::
+                    voxelsToGrid<GridT, PointPtrT, TorchDeviceBuffer, BuilderResource>(
+                        PointPtrT(pointsPtr, tx), nPoints, 1.0, guide);
+            } else {
+                using PointPtrT = TransformedPointPtr<scalar_t, false>;
+                handle          = nanovdb::tools::cuda::
+                    voxelsToGrid<GridT, PointPtrT, TorchDeviceBuffer, BuilderResource>(
+                        PointPtrT(pointsPtr, tx, pointsData.stride(0), pointsData.stride(1)),
+                        nPoints,
+                        1.0,
+                        guide);
+            }
+            C10_CUDA_KERNEL_LAUNCH_CHECK();
+            return handle;
+        }),
+        AT_EXPAND(AT_FLOATING_TYPES),
+        c10::kHalf);
+}
+
+} // namespace
 
 template <typename ScalarT>
 __device__ void
@@ -63,10 +194,14 @@ dispatchBuildGridFromPoints<torch::kCUDA>(const JaggedTensor &points,
 
     c10::cuda::CUDAGuard deviceGuard(points.device());
 
-    // Materialize the rounded index-space coordinate of every point (12 B per point) and build
-    // the whole batch in one batched from_ijk pass (issue #775). This replaces a per-member
-    // PointsToGrid loop over a transformed-point adaptor plus mergeGridHandles: one stream
-    // synchronization for the whole batch instead of several per member.
+    if (points.num_outer_lists() == 1) {
+        return pointsToGridSingle(points, txs[0]);
+    }
+
+    // Multi-member: materialize the rounded index-space coordinate of every point (12 B per
+    // point) and build the whole batch in one batched from_ijk pass (issue #775). This replaces a
+    // per-member PointsToGrid loop over the transformed-point adaptor plus mergeGridHandles: one
+    // stream synchronization for the whole batch instead of several per member.
     const torch::TensorOptions ijkOptions =
         torch::TensorOptions().dtype(torch::kInt32).device(points.device());
     torch::Tensor ijk = torch::empty({points.jdata().size(0), 3}, ijkOptions);

--- a/src/fvdb/detail/ops/BuildGridFromPoints.cu
+++ b/src/fvdb/detail/ops/BuildGridFromPoints.cu
@@ -1,27 +1,23 @@
 // Copyright Contributors to the OpenVDB Project
 // SPDX-License-Identifier: Apache-2.0
 //
-#include <fvdb/BuilderResource.h>
 #include <fvdb/GridBatchData.h>
 #include <fvdb/detail/GridBatchDataFactory.h>
 #include <fvdb/detail/ops/BuildGridFromIjk.h>
 #include <fvdb/detail/ops/BuildGridFromPoints.h>
 #include <fvdb/detail/utils/AccessorHelpers.cuh>
 #include <fvdb/detail/utils/Utils.h>
+#include <fvdb/detail/utils/cuda/ForEachCUDA.cuh>
 #include <fvdb/detail/utils/cuda/ForEachPrivateUse1.cuh>
-#include <fvdb/detail/utils/nanovdb/CreateEmptyGridHandle.h>
+#include <fvdb/detail/utils/cuda/RAIIRawDeviceBuffer.h>
 
-#include <nanovdb/cuda/GridHandle.cuh>
 #include <nanovdb/tools/CreateNanoGrid.h>
-#include <nanovdb/tools/cuda/PointsToGrid.cuh>
 
 #include <c10/cuda/CUDACachingAllocator.h>
 #include <c10/cuda/CUDAGuard.h>
 #include <c10/cuda/CUDAMathCompat.h>
 
 #include <thrust/universal_vector.h>
-
-#include <limits>
 
 namespace fvdb {
 namespace detail {
@@ -31,81 +27,6 @@ template <torch::DeviceType>
 nanovdb::GridHandle<TorchDeviceBuffer>
 dispatchBuildGridFromPoints(const JaggedTensor &points,
                             const std::vector<VoxelCoordTransform> &txs);
-
-namespace {
-
-/// @brief Pointer-like adaptor that yields index-space voxel coordinates from world-space points
-///        on demand, so the coordinates never have to be materialized in memory.
-///
-/// `nanovdb::tools::cuda::voxelsToGrid` reads its input through a pointer-like type rather than a
-/// raw pointer (see `nanovdb::tools::cuda::fancy_ptr`, which documents the contract): `operator[]`
-/// is what the kernels actually call, and `operator*` exists only so `pointer_traits` can deduce
-/// `element_type` from its return type. Returning `nanovdb::Coord` by value satisfies both and
-/// selects the `is_same<Vec3T, Coord>` branch of `TileKeyFunctor` — the same branch a raw
-/// `nanovdb::Coord *` takes — so the resulting topology is bit-for-bit what the previous
-/// materialize-then-sort path produced.
-///
-/// This replaces a `torch::empty({N, 3}, kInt32)` coordinate tensor (12 B per input point) that
-/// was written once and read once.
-///
-/// The class supports both memory layouts of an (N, 3) tensor so that non-contiguous views --
-/// e.g. the xyz columns of an (N, 6) point cloud, `cloud[:, :3]` -- are read in place rather
-/// than copied. `IsContiguous` selects between compile-time strides (3, 1) and runtime strides
-/// taken from the tensor, so the packed fast path pays nothing for the generality.
-///
-/// @tparam ScalarT Scalar type of the input points (floating point or half)
-/// @tparam IsContiguous Whether the points are a packed (N, 3) array; when false, element
-///         strides are supplied at construction
-template <typename ScalarT, bool IsContiguous> class TransformedPointPtr {
-  public:
-    using MathT = typename at::opmath_type<ScalarT>;
-
-    /// @param points Pointer to the first component of the first point
-    /// @param transform World-space to index-space transform for this batch item
-    /// @param rowStride Distance in elements between consecutive points (3 if packed)
-    /// @param colStride Distance in elements between a point's components (1 if packed)
-    __hostdev__
-    TransformedPointPtr(const ScalarT *points,
-                        const VoxelCoordTransform &transform,
-                        int64_t rowStride = 3,
-                        int64_t colStride = 1)
-        : mPoints(points), mTransform(transform), mRowStride(rowStride), mColStride(colStride) {}
-
-    /// @brief Return the index-space voxel coordinate of the i'th point. Required by PointsToGrid.
-    __hostdev__ inline nanovdb::Coord
-    operator[](size_t i) const {
-        MathT x, y, z;
-        if constexpr (IsContiguous) {
-            const ScalarT *point = mPoints + 3 * i;
-            x                    = static_cast<MathT>(point[0]);
-            y                    = static_cast<MathT>(point[1]);
-            z                    = static_cast<MathT>(point[2]);
-        } else {
-            const ScalarT *point = mPoints + static_cast<int64_t>(i) * mRowStride;
-            x                    = static_cast<MathT>(point[0]);
-            y                    = static_cast<MathT>(point[mColStride]);
-            z                    = static_cast<MathT>(point[2 * mColStride]);
-        }
-        return mTransform.apply(x, y, z).round();
-    }
-
-    /// @brief Required by `pointer_traits` to deduce `element_type` -- only the return *type* is
-    ///        used. Deliberately does not read `mPoints`: `pointer_traits` never evaluates this,
-    ///        and returning a default coordinate keeps it well defined for an empty point set if
-    ///        some future code path (or debug instrumentation) ever does evaluate it.
-    __hostdev__ inline nanovdb::Coord
-    operator*() const {
-        return nanovdb::Coord();
-    }
-
-  private:
-    const ScalarT *mPoints;
-    VoxelCoordTransform mTransform;
-    int64_t mRowStride;
-    int64_t mColStride;
-};
-
-} // namespace
 
 template <typename ScalarT>
 __device__ void
@@ -131,100 +52,47 @@ template <>
 nanovdb::GridHandle<TorchDeviceBuffer>
 dispatchBuildGridFromPoints<torch::kCUDA>(const JaggedTensor &points,
                                           const std::vector<VoxelCoordTransform> &txs) {
-    using GridT = nanovdb::ValueOnIndex;
-
     TORCH_CHECK(points.device().is_cuda(), "points must be on a CUDA device");
     TORCH_CHECK(points.device().has_index(), "points device must have a valid index");
-
-    c10::cuda::CUDAGuard deviceGuard(points.device());
-
-    // This guide buffer is a hack to pass in a device with an index to the grid building
-    // functions. We can't pass in a device directly but we can pass in a buffer which gets
-    // passed to TorchDeviceBuffer::create. The guide buffer holds the device and effectively
-    // passes it to the created buffer.
-    TorchDeviceBuffer guide(0, points.device());
-
-    // FIXME: Same host sync as _createNanoGridFromIJK -- the per-batch-item loop below needs the
-    // offsets on the host in order to slice the point array. Ideally this would be a single
-    // invocation over the whole batch.
-    const torch::Tensor pointsBOffsetTensor = points.joffsets().cpu();
-    const auto pointsBOffset                = pointsBOffsetTensor.accessor<fvdb::JOffsetsType, 1>();
-
-    // The loop below indexes txs by batch item, so make the invariant explicit rather than
-    // relying on the caller. joffsets holds one offset per batch item plus a terminating entry.
-    TORCH_CHECK(pointsBOffset.size(0) >= 1,
-                "Expected joffsets to have at least one entry, got ",
-                pointsBOffset.size(0));
-    TORCH_CHECK(static_cast<int64_t>(txs.size()) == pointsBOffset.size(0) - 1,
+    TORCH_CHECK(static_cast<int64_t>(txs.size()) == points.num_outer_lists(),
                 "Expected one transform per batch item, but got ",
                 txs.size(),
                 " transforms for ",
-                pointsBOffset.size(0) - 1,
+                points.num_outer_lists(),
                 " batch items");
 
-    // TransformedPointPtr reads the points in place for both layouts: compile-time strides for
-    // a packed (N, 3) array, runtime strides otherwise (e.g. the xyz columns of an (N, 6)
-    // tensor). Neither path copies the point data.
-    const torch::Tensor pointsData = points.jdata();
-    const bool pointsAreContiguous = pointsData.is_contiguous();
-    const int64_t rowStride        = pointsData.stride(0);
-    const int64_t colStride        = pointsData.stride(1);
+    c10::cuda::CUDAGuard deviceGuard(points.device());
 
-    return AT_DISPATCH_V2(
+    // Materialize the rounded index-space coordinate of every point (12 B per point) and build
+    // the whole batch in one batched from_ijk pass (issue #775). This replaces a per-member
+    // PointsToGrid loop over a transformed-point adaptor plus mergeGridHandles: one stream
+    // synchronization for the whole batch instead of several per member.
+    const torch::TensorOptions ijkOptions =
+        torch::TensorOptions().dtype(torch::kInt32).device(points.device());
+    torch::Tensor ijk = torch::empty({points.jdata().size(0), 3}, ijkOptions);
+    auto ijkAcc       = ijk.packed_accessor64<int32_t, 2, torch::RestrictPtrTraits>();
+
+    AT_DISPATCH_V2(
         points.scalar_type(),
-        "buildGridFromPoints",
-        AT_WRAP([&]() -> nanovdb::GridHandle<TorchDeviceBuffer> {
-            const scalar_t *pointsPtr = pointsData.data_ptr<scalar_t>();
+        "ijkForPoints",
+        AT_WRAP([&] {
+            RAIIRawDeviceBuffer<VoxelCoordTransform> transformsDVec(txs.size(), points.device());
+            transformsDVec.setData((VoxelCoordTransform *)txs.data(), true /* blocking */);
+            const VoxelCoordTransform *transformsPtr = transformsDVec.devicePtr;
 
-            // Create a grid for each batch item and store the handles
-            std::vector<nanovdb::GridHandle<TorchDeviceBuffer>> handles;
-            handles.reserve(pointsBOffset.size(0) - 1);
-            for (int64_t i = 0; i < (pointsBOffset.size(0) - 1); i += 1) {
-                const int64_t startIdx = pointsBOffset[i];
-                const int64_t nPoints  = pointsBOffset[i + 1] - startIdx;
-
-                // PointsToGrid casts its element count to int for the segmented radix sort, so
-                // anything at or above 2^31 would silently produce a corrupt grid.
-                TORCH_CHECK(nPoints <= std::numeric_limits<int32_t>::max(),
-                            "Cannot build a grid from ",
-                            nPoints,
-                            " points in a single batch item (limit is ",
-                            std::numeric_limits<int32_t>::max(),
-                            ")");
-
-                if (nPoints == 0) {
-                    handles.push_back(createEmptyGridHandle(guide.device()));
-                } else if (pointsAreContiguous) {
-                    using PointPtrT = TransformedPointPtr<scalar_t, true>;
-                    handles.push_back(
-                        nanovdb::tools::cuda::
-                            voxelsToGrid<GridT, PointPtrT, TorchDeviceBuffer, BuilderResource>(
-                                PointPtrT(pointsPtr + 3 * startIdx, txs[i]), nPoints, 1.0, guide));
-                } else {
-                    using PointPtrT = TransformedPointPtr<scalar_t, false>;
-                    handles.push_back(
-                        nanovdb::tools::cuda::
-                            voxelsToGrid<GridT, PointPtrT, TorchDeviceBuffer, BuilderResource>(
-                                PointPtrT(
-                                    pointsPtr + startIdx * rowStride, txs[i], rowStride, colStride),
-                                nPoints,
-                                1.0,
-                                guide));
-                }
-                C10_CUDA_KERNEL_LAUNCH_CHECK();
-            }
-
-            if (handles.size() == 1) {
-                // If there's only one handle, just return it
-                return std::move(handles[0]);
-            } else {
-                // This copies all the handles into a single handle -- only do it if there are
-                // multiple grids
-                return nanovdb::cuda::mergeGridHandles(handles, &guide);
-            }
+            auto cb = [=] __device__(int32_t bidx,
+                                     int32_t eidx,
+                                     int32_t cidx,
+                                     JaggedRAcc64<scalar_t, 2> pacc) {
+                ijkForPointsCallback(bidx, eidx, pacc, transformsPtr, ijkAcc);
+            };
+            forEachJaggedElementChannelCUDA<scalar_t, 2, 1024>(1, points, cb);
         }),
         AT_EXPAND(AT_FLOATING_TYPES),
         c10::kHalf);
+
+    JaggedTensor coords = points.jagged_like(ijk);
+    return ops::_createNanoGridFromIJK(coords);
 }
 
 template <>

--- a/src/fvdb/detail/utils/nanovdb/BatchedTopologyBuilder.cuh
+++ b/src/fvdb/detail/utils/nanovdb/BatchedTopologyBuilder.cuh
@@ -944,6 +944,36 @@ finalizeGrids(BuildDeviceArrays a, const uint64_t *__restrict__ voxelScan, int32
 // Host driver
 // ---------------------------------------------------------------------------------------------
 
+/// Wraps an already-built contiguous device handle as a pass result so further batched passes can
+/// be chained onto it through `sourceFromResult` (used by the single-member PointsToGrid fallback
+/// of from_ijk). Grid byte sizes are host-known from the handle metadata; the per-grid leaf counts
+/// are read back from the device tree headers (one stream synchronization).
+inline BatchedTopologyResult
+resultFromGridHandle(nanovdb::GridHandle<TorchDeviceBuffer> &&handle, cudaStream_t stream) {
+    const uint32_t numGrids = handle.gridCount();
+    TORCH_CHECK(numGrids > 0 && handle.buffer().deviceData() != nullptr,
+                "resultFromGridHandle requires a non-empty device handle");
+    BatchedTopologyResult result;
+    result.gridByteOffsets.resize(numGrids + 1);
+    result.leafCounts.resize(numGrids);
+    std::vector<nanovdb::TreeData> trees(numGrids);
+    uint64_t offset = 0;
+    for (uint32_t g = 0; g < numGrids; ++g) {
+        result.gridByteOffsets[g] = offset;
+        const uint8_t *tree       = handle.buffer().deviceData() + offset + GridT::memUsage();
+        C10_CUDA_CHECK(cudaMemcpyAsync(
+            &trees[g], tree, sizeof(nanovdb::TreeData), cudaMemcpyDeviceToHost, stream));
+        offset += handle.gridSize(g);
+    }
+    result.gridByteOffsets[numGrids] = offset;
+    C10_CUDA_CHECK(cudaStreamSynchronize(stream));
+    for (uint32_t g = 0; g < numGrids; ++g) {
+        result.leafCounts[g] = trees[g].mNodeCount[0];
+    }
+    result.buffer = std::move(handle.buffer());
+    return result;
+}
+
 inline BatchedTopologySource
 sourceFromGridBatch(const GridBatchData &batch) {
     BatchedTopologySource src;

--- a/src/fvdb/detail/utils/nanovdb/BatchedTopologyBuilder.cuh
+++ b/src/fvdb/detail/utils/nanovdb/BatchedTopologyBuilder.cuh
@@ -11,19 +11,22 @@
 // workloads that rebuild grids every training iteration (issue #755), that per-member fixed
 // overhead -- not the topology size -- dominates wall clock and serializes the GPU.
 //
-// This header rebuilds the factor-2 refine (subdivision) and coarsen passes so one invocation
-// covers the whole batch:
+// This header rebuilds the factor-2 refine (subdivision) and coarsen passes, box dilation, and
+// coordinate-list construction (from_ijk) so one invocation covers the whole batch:
 //
-//   emit    one kernel over all source leaves of all members emits candidate output leaves as
-//           (root-tile sort key, in-tile node key, leaf origin, 512-bit activity mask) slots,
-//           segmented per grid;
-//   sort    two stable segmented radix sorts put each grid's slots in canonical NanoVDB node
-//           order (root tiles by the PointsToGrid offset-shifted key, then upper/lower child
-//           offsets); invalid slots sort to the segment tails;
-//   dedup   head-flag + scan passes derive the unique leaf/lower/upper nodes, their per-grid
-//           counts, and parent linkage (coarsen additionally OR-combines duplicate leaf masks);
+//   emit    one kernel over all emission slots of all members (source leaves, or coordinates for
+//           the Coords pass) emits candidate output leaves as (root-tile sort key, in-tile node
+//           key, leaf origin, 512-bit activity mask) slots, segmented per grid;
+//   sort    stable global radix sorts (node key, then tile key, then grid index) put each grid's
+//           slots in canonical NanoVDB node order (root tiles by the PointsToGrid offset-shifted
+//           key, then upper/lower child offsets); invalid slots sort to the segment tails;
+//   dedup   head-flag + scan passes derive the unique leaf/lower/upper nodes and their per-grid
+//           counts;
 //   size    ONE host synchronization reads back the per-grid node counts; per-grid byte offsets
-//           are computed on the host and a single output buffer is allocated;
+//           are computed on the host and a single output buffer is allocated, together with the
+//           unique-node-sized tables (head slot, parent linkage, per-leaf 512-bit masks) into
+//           which every slot's mask contribution is reduced (non-injective passes -- coarsen,
+//           dilate, coords -- OR-combine duplicate producers here);
 //   build   batched kernels write every grid's GridData/TreeData/RootData (mGridIndex = g,
 //           mGridCount = B), root tiles, upper/lower/leaf nodes, leaf mOffset/mPrefixSum, and
 //           bounding boxes. Empty members become valid empty grids inline (no host proxy grids).
@@ -33,8 +36,10 @@
 // tools::cuda::TopologyBuilder's functors with (gridIndex, localIndex) indexing. Checksums are
 // disabled on the output, matching ops::contiguousGridHandle and mergeGridHandles behavior.
 //
-// Scratch is allocated through torch (the caching allocator) on the caller's current stream. The
-// only stream synchronization per pass is the node-count readback that sizes the output buffer.
+// Scratch is allocated through torch (the caching allocator) on the caller's current stream and
+// released stage by stage so the torch-visible peak stays near one sort's working set per slot
+// (from_ijk on millions of coordinates emits one slot per coordinate). The only stream
+// synchronization per pass is the node-count readback that sizes the output buffer.
 
 #ifndef FVDB_DETAIL_UTILS_NANOVDB_BATCHEDTOPOLOGYBUILDER_CUH
 #define FVDB_DETAIL_UTILS_NANOVDB_BATCHEDTOPOLOGYBUILDER_CUH
@@ -73,11 +78,17 @@ using LeafT  = nanovdb::NanoLeaf<BuildT>;
 /// subdivision / coarsening passes; `BoxDilate` is a Minkowski sum with the axis-aligned box
 /// [boxLo, boxHi] (components in {-1,0,1}), covering NanoVDB's 26-neighbor DilateGrid
 /// (boxLo=-1, boxHi=1) and fvdb's one-sided PadGrid octants ({-1,0}^3 and {0,1}^3). Larger
-/// boxes compose from multiple passes (Minkowski sums by boxes compose).
+/// boxes compose from multiple passes (Minkowski sums by boxes compose). `Coords` builds the
+/// batch from a jagged voxel-coordinate list (from_ijk): it has no source grids, one emission
+/// slot per coordinate, and its per-grid slot counts come from `BatchedTopologySource::slotCounts`.
 struct TopologyPassSpec {
-    enum class Op { Refine, Coarsen, BoxDilate };
+    enum class Op { Refine, Coarsen, BoxDilate, Coords };
     Op op;
     nanovdb::Coord boxLo{0}, boxHi{0}; // BoxDilate only
+    // Coords only: device pointers to the N x 3 contiguous int32 coordinates and to the B+1
+    // int64 jagged offsets (JaggedTensor::joffsets) that delimit each grid's coordinates.
+    const int32_t *ijk     = nullptr;
+    const int64_t *offsets = nullptr;
 
     static TopologyPassSpec
     refine() {
@@ -91,14 +102,45 @@ struct TopologyPassSpec {
     boxDilate(const nanovdb::Coord &lo, const nanovdb::Coord &hi) {
         return {Op::BoxDilate, lo, hi};
     }
+    static TopologyPassSpec
+    coords(const int32_t *ijk, const int64_t *offsets) {
+        TopologyPassSpec spec{Op::Coords};
+        spec.ijk     = ijk;
+        spec.offsets = offsets;
+        return spec;
+    }
 };
+
+/// True for passes in which several emission slots may target the same output leaf, so the
+/// duplicates' mask contributions must be OR-combined into the unique leaf (Refine is injective).
+inline bool
+passHasDuplicateProducers(TopologyPassSpec::Op op) {
+    switch (op) {
+    case TopologyPassSpec::Op::Refine: return false;
+    case TopologyPassSpec::Op::Coarsen:
+    case TopologyPassSpec::Op::BoxDilate:
+    case TopologyPassSpec::Op::Coords: return true;
+    }
+    return true;
+}
 
 /// Device-pointer view of the B source grids of one pass. The grids may live anywhere (a
 /// GridBatchData buffer -- including sliced/non-contiguous views -- or the output buffer of a
 /// previous pass); only per-member device grid pointers and leaf counts are needed.
+///
+/// Emission slot counts: by default a pass emits leafCounts[g] * fanout(op) slots for grid g
+/// (slots are source leaves or source-leaf/neighbor pairs). A pass whose slots are not source
+/// leaves supplies its own host-known per-grid counts in `slotCounts` (the Coords pass: one slot
+/// per coordinate, counts from the jagged offsets). When `slotCounts` is non-empty it replaces the
+/// leaf-based count for every grid and `leafCounts` is not consulted.
+///
+/// Source grids are optional for passes that do not read them (Coords). With `grids` empty the
+/// batch size is `slotCounts.size()` and every output header is initialized to the default
+/// ValueOnIndex header (identity map, IndexGrid class) instead of being copied from a source grid.
 struct BatchedTopologySource {
     std::vector<const GridT *> grids; // per-member device grid pointers (host-side vector)
     std::vector<int64_t> leafCounts;  // per-member leaf counts (host-side)
+    std::vector<int64_t> slotCounts;  // optional per-member emission slot counts (host-side)
     torch::Device device{torch::kCUDA};
 };
 
@@ -227,6 +269,7 @@ struct EmissionArrays {
     uint32_t *nodeKey;            // [N] (upperChildOffset << 12) | lowerChildOffset
     int32_t *origin;              // [N*3] output leaf origin
     uint64_t *mask;               // [N*8] output leaf 512-bit activity-mask contribution
+                                  // (nullptr for Coords: the bit lives in the origin low bits)
     const int32_t *segOffsets;    // [B+1] per-grid slot ranges
     const GridT *const *srcGrids; // [B] device pointers to the source grids
     int32_t numSegments;
@@ -433,6 +476,33 @@ emitBoxDilatedLeaves(EmissionArrays em, nanovdb::Coord boxLo, nanovdb::Coord box
     }
 }
 
+/// Coords: slot = one voxel coordinate of the jagged list. The output leaf is the 8-aligned leaf
+/// containing the coordinate and the mask contribution is that single voxel's bit (Mask<3>
+/// layout via LeafNode::CoordToOffset: word = local x, byte within word = local y, bit within
+/// byte = local z). Instead of a 512-bit mask per slot, the slot stores the full coordinate in the
+/// origin array: the leaf origin is its 8-aligned part and the voxel bit is recovered from the low
+/// 3 bits of each component in reduceLeafMasks (em.mask is null for this pass). Coordinates
+/// sharing a leaf, and duplicate coordinates, are OR-combined there. Slot s of grid g is
+/// coordinate offsets[g] + (s - seg[g]).
+static __global__ void
+emitCoordLeaves(EmissionArrays em,
+                const int32_t *__restrict__ ijk,
+                const int64_t *__restrict__ offsets) {
+    for (int32_t s = blockIdx.x * blockDim.x + threadIdx.x; s < em.numSlots;
+         s += gridDim.x * blockDim.x) {
+        const int32_t g     = findSegment(em.segOffsets, em.numSegments, s);
+        const int64_t index = offsets[g] + int64_t(s - em.segOffsets[g]);
+        const nanovdb::Coord c(ijk[index * 3], ijk[index * 3 + 1], ijk[index * 3 + 2]);
+        const nanovdb::Coord leafOrigin(c[0] & ~7, c[1] & ~7, c[2] & ~7);
+
+        em.tileKey[s]                 = tileSortKey(leafOrigin);
+        em.nodeKey[s]                 = nodeSortKey(leafOrigin);
+        em.origin[originIndex(s)]     = c[0];
+        em.origin[originIndex(s) + 1] = c[1];
+        em.origin[originIndex(s) + 2] = c[2];
+    }
+}
+
 // ---------------------------------------------------------------------------------------------
 // Sort / dedup kernels
 // ---------------------------------------------------------------------------------------------
@@ -454,11 +524,24 @@ gatherKeys64(const uint64_t *__restrict__ keys,
     }
 }
 
+/// Grid index of the slot at each position of the current permutation (key of the final sort).
+static __global__ void
+gatherSegmentKeys(const uint32_t *__restrict__ perm,
+                  const int32_t *__restrict__ segOffsets,
+                  int32_t numSegments,
+                  uint32_t *__restrict__ out,
+                  int32_t n) {
+    for (int32_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n; i += gridDim.x * blockDim.x) {
+        out[i] = uint32_t(findSegment(segOffsets, numSegments, int32_t(perm[i])));
+    }
+}
+
+/// Slot payload in canonical order (masks are not permuted: reduceLeafMasks reads the emission
+/// masks through the permutation once, directly into the per-leaf mask table).
 struct SortedArrays {
     const uint64_t *tileKey; // [N] canonical order, invalid slots at segment tails
     uint32_t *nodeKey;       // [N]
-    int32_t *origin;         // [N*3]
-    uint64_t *mask;          // [N*8]
+    int32_t *origin;         // [N*3] leaf origin (Coords: full coordinate; origin = & ~7)
 };
 
 static __global__ void
@@ -473,9 +556,6 @@ gatherSorted(EmissionArrays em, const uint32_t *__restrict__ perm, SortedArrays 
         out.origin[originIndex(j)]     = em.origin[originIndex(s)];
         out.origin[originIndex(j) + 1] = em.origin[originIndex(s) + 1];
         out.origin[originIndex(j) + 2] = em.origin[originIndex(s) + 2];
-        for (int i = 0; i < 8; ++i) {
-            out.mask[maskIndex(j) + i] = em.mask[maskIndex(s) + i];
-        }
     }
 }
 
@@ -558,24 +638,46 @@ scatterNodeTables(const uint32_t *__restrict__ leafFlag,
     }
 }
 
-/// Coarsen and BoxDilate: OR every duplicate slot's mask contribution into its unique leaf's head
-/// slot. Refine is excluded because its source-to-output leaf mapping is injective.
+/// Reduces every valid slot's mask contribution into its unique leaf's 512-bit mask, in the
+/// per-leaf table indexed by global leaf rank (zero-initialized, allocated after the sizing
+/// readback). Contributions are read from the unsorted emission masks through the canonical
+/// permutation; Coords slots (emMask == nullptr) instead contribute the single voxel bit encoded
+/// in the low 3 bits of their origin components. Injective passes (Refine) have exactly one slot
+/// per leaf and store directly; Coarsen, BoxDilate and Coords (passHasDuplicateProducers)
+/// OR-combine atomically.
 static __global__ void
-combineDuplicateMasks(const uint64_t *__restrict__ tileKey,
-                      const uint32_t *__restrict__ leafFlag,
-                      const uint32_t *__restrict__ leafRank,
-                      const uint32_t *__restrict__ leafHeadSlot,
-                      int32_t n,
-                      uint64_t *__restrict__ mask) {
+reduceLeafMasks(const uint64_t *__restrict__ sortedTileKey,
+                const int32_t *__restrict__ sortedOrigin,
+                const uint32_t *__restrict__ leafRank,
+                const uint32_t *__restrict__ perm,
+                const uint64_t *__restrict__ emMask,
+                int32_t n,
+                bool injective,
+                uint64_t *__restrict__ leafMask) {
     for (int32_t j = blockIdx.x * blockDim.x + threadIdx.x; j < n; j += gridDim.x * blockDim.x) {
-        if (tileKey[j] == kInvalidTileKey || leafFlag[j]) {
+        if (sortedTileKey[j] == kInvalidTileKey) {
             continue;
         }
-        const uint32_t head = leafHeadSlot[leafRank[j] - 1];
-        for (int i = 0; i < 8; ++i) {
-            const uint64_t w = mask[maskIndex(j) + i];
-            if (w) {
-                nanovdb::util::atomicOr(&mask[maskIndex(head) + i], w);
+        uint64_t *dst = leafMask + maskIndex(leafRank[j] - 1);
+        if (emMask == nullptr) { // Coords: one voxel bit per slot
+            const nanovdb::Coord c(sortedOrigin[originIndex(j)],
+                                   sortedOrigin[originIndex(j) + 1],
+                                   sortedOrigin[originIndex(j) + 2]);
+            const uint32_t bit = LeafT::CoordToOffset(c); // ((x&7)<<6) | ((y&7)<<3) | (z&7)
+            nanovdb::util::atomicOr(&dst[bit >> 6], uint64_t(1) << (bit & 63));
+            continue;
+        }
+        const uint64_t *src = emMask + maskIndex(perm[j]);
+        if (injective) {
+            for (int i = 0; i < 8; ++i) {
+                dst[i] = src[i];
+            }
+        } else {
+            for (int i = 0; i < 8; ++i) {
+                const uint64_t w = src[i];
+                if (w) {
+                    nanovdb::util::atomicOr(&dst[i], w);
+                }
             }
         }
     }
@@ -599,6 +701,26 @@ copyGridData(const GridT *const *__restrict__ srcGrids, BuildDeviceArrays a, int
         uint64_t *dst       = reinterpret_cast<uint64_t *>(a.dstBase + a.gridByteOffsets[g]);
         dst[w]              = src[w];
     }
+}
+
+/// Header seed for passes without source grids (Coords): the default ValueOnIndex GridData that
+/// PointsToGrid's BuildGridTreeRootFunctor writes (GridData::init with the identity map, OnIndex
+/// type, IndexGrid class, empty name; the map is what a from_ijk build with voxel size 1 at the
+/// origin carries, and fvdb keeps per-grid transforms in GridBatchData metadata instead). The
+/// fields reset by initGridTreeRoot are rewritten afterwards.
+static __global__ void
+initDefaultGridData(BuildDeviceArrays a, int32_t numGrids) {
+    const int32_t g = blockIdx.x * blockDim.x + threadIdx.x;
+    if (g >= numGrids) {
+        return;
+    }
+    nanovdb::GridData *grid =
+        reinterpret_cast<nanovdb::GridData *>(a.dstBase + a.gridByteOffsets[g]);
+    grid->init({nanovdb::GridFlags::IsBreadthFirst},
+               a.gridByteOffsets[g + 1] - a.gridByteOffsets[g],
+               nanovdb::Map(),
+               nanovdb::toGridType<BuildT>(),
+               nanovdb::GridClass::IndexGrid);
 }
 
 /// Per-grid transcription of tools::cuda::topology::detail::BuildGridTreeRootFunctor with
@@ -702,9 +824,10 @@ buildLeafNodes(BuildDeviceArrays a,
                SortedArrays sorted,
                const uint32_t *__restrict__ leafHeadSlot,
                const uint32_t *__restrict__ leafParent,
+               const uint64_t *__restrict__ leafMask, // [totalLeaf*8] reduced activity masks
                int32_t numGrids,
                int32_t totalLeaf,
-               uint64_t *__restrict__ voxelCounts) { // [totalLeaf+1]; element 0 stays 0
+               uint64_t *__restrict__ voxelCounts) {  // [totalLeaf+1]; element 0 stays 0
     for (int32_t t = blockIdx.x * blockDim.x + threadIdx.x; t < totalLeaf;
          t += gridDim.x * blockDim.x) {
         const int32_t g         = findSegment(a.leafStart, numGrids, uint32_t(t));
@@ -716,14 +839,14 @@ buildLeafNodes(BuildDeviceArrays a,
         LeafT &leaf             = n.leaf[local];
         lower.mChildMask.setOnAtomic(lowerOff);
         lower.setChild(lowerOff, &leaf);
-        leaf.mBBoxMin = nanovdb::Coord(sorted.origin[originIndex(slot)],
-                                       sorted.origin[originIndex(slot) + 1],
-                                       sorted.origin[originIndex(slot) + 2]);
+        leaf.mBBoxMin = nanovdb::Coord(sorted.origin[originIndex(slot)] & ~7,
+                                       sorted.origin[originIndex(slot) + 1] & ~7,
+                                       sorted.origin[originIndex(slot) + 2] & ~7);
         leaf.mFlags   = uint8_t(nanovdb::GridFlags::HasBBox);
 
         uint64_t *dstWords = leaf.mValueMask.words();
         for (int i = 0; i < 8; ++i) {
-            dstWords[i] = sorted.mask[maskIndex(slot) + i];
+            dstWords[i] = leafMask[maskIndex(t) + i];
         }
 
         // Per-leaf voxel count and the 9-bit encoded intra-leaf prefix sums (transcribed from
@@ -849,6 +972,16 @@ sourceFromResult(const BatchedTopologyResult &result, const torch::Device &devic
     return src;
 }
 
+/// Source for a Coords pass: no source grids, one emission slot per coordinate of each member
+/// (`coordCounts[g]` = joffsets[g+1] - joffsets[g], host-known).
+inline BatchedTopologySource
+sourceFromCoordCounts(const std::vector<int64_t> &coordCounts, const torch::Device &device) {
+    BatchedTopologySource src;
+    src.device     = device;
+    src.slotCounts = coordCounts;
+    return src;
+}
+
 /// Runs one batched topology pass over all grids of `src`.
 /// One cudaStreamSynchronize total (the node-count readback that sizes the output allocation).
 inline BatchedTopologyResult
@@ -856,8 +989,13 @@ runBatchedTopologyPass(const BatchedTopologySource &src,
                        const TopologyPassSpec &pass,
                        cudaStream_t stream) {
     TORCH_CHECK(src.device.is_cuda(), "batched topology passes require a CUDA device");
-    const int32_t numGrids = int32_t(src.grids.size());
+    const bool hasSourceGrids = !src.grids.empty();
+    const int32_t numGrids    = int32_t(hasSourceGrids ? src.grids.size() : src.slotCounts.size());
     TORCH_CHECK(numGrids > 0, "batched topology pass requires at least one grid");
+    TORCH_CHECK(src.slotCounts.empty() || int32_t(src.slotCounts.size()) == numGrids,
+                "batched topology pass: slotCounts must have one entry per grid");
+    TORCH_CHECK(hasSourceGrids || pass.op == TopologyPassSpec::Op::Coords,
+                "batched topology pass: only the Coords pass may run without source grids");
     int32_t fanout = 1;
     switch (pass.op) {
     case TopologyPassSpec::Op::Refine: fanout = 8; break;
@@ -870,14 +1008,20 @@ runBatchedTopologyPass(const BatchedTopologySource &src,
             fanout *= (pass.boxHi[a] > 0 ? 1 : 0) - (pass.boxLo[a] < 0 ? -1 : 0) + 1;
         }
         break;
+    case TopologyPassSpec::Op::Coords:
+        TORCH_CHECK(pass.offsets != nullptr, "Coords pass requires the jagged offsets pointer");
+        TORCH_CHECK(!src.slotCounts.empty(),
+                    "Coords pass requires per-grid slot counts (coordinates per grid)");
+        break;
     }
 
-    // Per-grid emission slot ranges (host-known: leaf counts x fanout; no sync needed).
+    // Per-grid emission slot ranges (host-known: caller-supplied slot counts, or leaf counts x
+    // fanout; no sync needed).
     std::vector<int32_t> segOffsetsHost(numGrids + 1, 0);
     int64_t total = 0;
     for (int32_t g = 0; g < numGrids; ++g) {
         segOffsetsHost[g] = int32_t(total);
-        total += src.leafCounts[g] * fanout;
+        total += src.slotCounts.empty() ? src.leafCounts[g] * fanout : src.slotCounts[g];
     }
     TORCH_CHECK(total <= std::numeric_limits<int32_t>::max(),
                 "batched topology pass: emission slot count ",
@@ -885,6 +1029,10 @@ runBatchedTopologyPass(const BatchedTopologySource &src,
                 " exceeds int32 range");
     segOffsetsHost[numGrids] = int32_t(total);
     const int32_t numSlots   = int32_t(total);
+    // A zero-size torch tensor has a null data_ptr, so an all-empty coordinate batch legitimately
+    // carries ijk == nullptr; the pointer is only dereferenced when there are slots to emit.
+    TORCH_CHECK(pass.op != TopologyPassSpec::Op::Coords || numSlots == 0 || pass.ijk != nullptr,
+                "Coords pass requires the coordinate device pointer");
     const int64_t allocSlots = std::max(numSlots, 1); // torch::empty({0}) yields a null data_ptr
 
     const auto byteOpts = torch::TensorOptions().dtype(torch::kUInt8).device(src.device);
@@ -912,32 +1060,39 @@ runBatchedTopologyPass(const BatchedTopologySource &src,
     // Small host-side staging uploaded once per pass: segment offsets + source grid pointers.
     // (Pageable H2D copies are synchronous with the host but do not synchronize the stream.)
     torch::Tensor segOffsetsDev = torch::empty({numGrids + 1}, i32Opts);
-    torch::Tensor srcGridsDev   = torch::empty({numGrids}, i64Opts);
+    torch::Tensor srcGridsDev   = torch::empty({hasSourceGrids ? numGrids : 0}, i64Opts);
     C10_CUDA_CHECK(cudaMemcpyAsync(segOffsetsDev.data_ptr<int32_t>(),
                                    segOffsetsHost.data(),
                                    sizeof(int32_t) * (numGrids + 1),
                                    cudaMemcpyHostToDevice,
                                    stream));
     static_assert(sizeof(const GridT *) == sizeof(int64_t));
-    C10_CUDA_CHECK(cudaMemcpyAsync(srcGridsDev.data_ptr<int64_t>(),
-                                   src.grids.data(),
-                                   sizeof(const GridT *) * numGrids,
-                                   cudaMemcpyHostToDevice,
-                                   stream));
+    if (hasSourceGrids) {
+        C10_CUDA_CHECK(cudaMemcpyAsync(srcGridsDev.data_ptr<int64_t>(),
+                                       src.grids.data(),
+                                       sizeof(const GridT *) * numGrids,
+                                       cudaMemcpyHostToDevice,
+                                       stream));
+    }
 
-    // --- Emit candidate output leaves. ---
+    // --- Emit candidate output leaves. Scratch tensors are released (reassigned to an empty
+    // tensor) as soon as the last consumer has been enqueued; the caching allocator only reuses
+    // freed blocks on this stream, so no host/device ordering issue arises. ---
+    const bool isCoords     = pass.op == TopologyPassSpec::Op::Coords;
     torch::Tensor emTileKey = torch::empty({allocSlots}, i64Opts);
     torch::Tensor emNodeKey = torch::empty({allocSlots}, i32Opts);
     torch::Tensor emOrigin  = torch::empty({allocSlots * 3}, i32Opts);
-    torch::Tensor emMask    = torch::empty({allocSlots * 8}, i64Opts);
+    torch::Tensor emMask    = torch::empty({isCoords ? 0 : allocSlots * 8}, i64Opts);
 
     EmissionArrays em;
     em.tileKey     = u64(emTileKey);
     em.nodeKey     = u32(emNodeKey);
     em.origin      = emOrigin.data_ptr<int32_t>();
-    em.mask        = u64(emMask);
+    em.mask        = isCoords ? nullptr : u64(emMask);
     em.segOffsets  = segOffsetsDev.data_ptr<int32_t>();
-    em.srcGrids    = reinterpret_cast<const GridT *const *>(srcGridsDev.data_ptr<int64_t>());
+    em.srcGrids    = hasSourceGrids
+                         ? reinterpret_cast<const GridT *const *>(srcGridsDev.data_ptr<int64_t>())
+                         : nullptr;
     em.numSegments = numGrids;
     em.numSlots    = numSlots;
 
@@ -953,36 +1108,43 @@ runBatchedTopologyPass(const BatchedTopologySource &src,
             emitBoxDilatedLeaves<<<numBlocks(numSlots), kThreads, 0, stream>>>(
                 em, pass.boxLo, pass.boxHi);
             break;
+        case TopologyPassSpec::Op::Coords:
+            emitCoordLeaves<<<numBlocks(numSlots), kThreads, 0, stream>>>(
+                em, pass.ijk, pass.offsets);
+            break;
         }
         C10_CUDA_KERNEL_LAUNCH_CHECK();
     }
 
-    // --- Canonical-order segmented sort: stable by node key, then stable by tile key. ---
+    // --- Canonical-order sort: stable global radix sorts by node key, then tile key, then grid
+    // index compose (LSD) to (grid, tile, node) order within every segment. Global rather than
+    // segmented sorts: cub::DeviceSegmentedRadixSort assigns one thread block per segment, which
+    // serializes a large member (a single 1M-coordinate grid sorted on one SM took 16 ms). The
+    // grid-index sort is skipped for a single grid. ---
     torch::Tensor permA   = torch::empty({allocSlots}, i32Opts);
     torch::Tensor permB   = torch::empty({allocSlots}, i32Opts);
     torch::Tensor keysTmp = torch::empty({allocSlots}, i32Opts);
     torch::Tensor keys64A = torch::empty({allocSlots}, i64Opts);
     torch::Tensor keys64B = torch::empty({allocSlots}, i64Opts);
+    uint32_t *perm        = u32(permA);   // canonical-order permutation once the sorts are done
+    uint64_t *sortedTile  = u64(keys64B); // tile keys in canonical order
 
     if (numSlots > 0) {
         iotaKernel<<<numBlocks(numSlots), kThreads, 0, stream>>>(u32(permA), numSlots);
         C10_CUDA_KERNEL_LAUNCH_CHECK();
 
-        // Pass 1: sort by the 27-bit in-tile node key.
+        // Pass 1: sort by the 27-bit in-tile node key (sorted keys themselves are not needed).
         callCub([&](void *temp, size_t &bytes) {
-            C10_CUDA_CHECK(cub::DeviceSegmentedRadixSort::SortPairs(temp,
-                                                                    bytes,
-                                                                    em.nodeKey,
-                                                                    u32(keysTmp),
-                                                                    u32(permA),
-                                                                    u32(permB),
-                                                                    numSlots,
-                                                                    numGrids,
-                                                                    em.segOffsets,
-                                                                    em.segOffsets + 1,
-                                                                    0,
-                                                                    27,
-                                                                    stream));
+            C10_CUDA_CHECK(cub::DeviceRadixSort::SortPairs(temp,
+                                                           bytes,
+                                                           em.nodeKey,
+                                                           u32(keysTmp),
+                                                           u32(permA),
+                                                           u32(permB),
+                                                           numSlots,
+                                                           0,
+                                                           27,
+                                                           stream));
         });
 
         // Pass 2: stable sort by the 64-bit tile key (invalid slots carry ~0 and sort last).
@@ -991,34 +1153,64 @@ runBatchedTopologyPass(const BatchedTopologySource &src,
         C10_CUDA_KERNEL_LAUNCH_CHECK();
 
         callCub([&](void *temp, size_t &bytes) {
-            C10_CUDA_CHECK(cub::DeviceSegmentedRadixSort::SortPairs(temp,
-                                                                    bytes,
-                                                                    u64(keys64A),
-                                                                    u64(keys64B),
-                                                                    u32(permB),
-                                                                    u32(permA),
-                                                                    numSlots,
-                                                                    numGrids,
-                                                                    em.segOffsets,
-                                                                    em.segOffsets + 1,
-                                                                    0,
-                                                                    64,
-                                                                    stream));
+            C10_CUDA_CHECK(cub::DeviceRadixSort::SortPairs(temp,
+                                                           bytes,
+                                                           u64(keys64A),
+                                                           u64(keys64B),
+                                                           u32(permB),
+                                                           u32(permA),
+                                                           numSlots,
+                                                           0,
+                                                           64,
+                                                           stream));
         });
+
+        if (numGrids > 1) {
+            // Pass 3: stable sort by grid index (ceil(log2 B) bits) restores the segmentation.
+            gatherSegmentKeys<<<numBlocks(numSlots), kThreads, 0, stream>>>(
+                u32(permA), em.segOffsets, numGrids, u32(keysTmp), numSlots);
+            C10_CUDA_KERNEL_LAUNCH_CHECK();
+            int gridBits = 1;
+            while ((int64_t(1) << gridBits) < numGrids) {
+                ++gridBits;
+            }
+            callCub([&](void *temp, size_t &bytes) {
+                C10_CUDA_CHECK(cub::DeviceRadixSort::SortPairs(
+                    temp,
+                    bytes,
+                    u32(keysTmp),
+                    reinterpret_cast<uint32_t *>(u64(keys64A)), // scratch for the sorted keys
+                    u32(permA),
+                    u32(permB),
+                    numSlots,
+                    0,
+                    gridBits,
+                    stream));
+            });
+            perm = u32(permB);
+            gatherKeys64<<<numBlocks(numSlots), kThreads, 0, stream>>>(
+                em.tileKey, perm, u64(keys64B), numSlots);
+            C10_CUDA_KERNEL_LAUNCH_CHECK();
+        }
     }
-    // From here on: permA = canonical-order permutation, keys64B = sorted tile keys.
+    if (perm == u32(permB)) {
+        permA = torch::Tensor();
+    } else {
+        permB = torch::Tensor();
+    }
+    keysTmp = torch::Tensor();
+    keys64A = torch::Tensor();
+    // From here on: perm = canonical-order permutation, sortedTile = sorted tile keys.
 
     torch::Tensor sortedNodeKey = torch::empty({allocSlots}, i32Opts);
     torch::Tensor sortedOrigin  = torch::empty({allocSlots * 3}, i32Opts);
-    torch::Tensor sortedMask    = torch::empty({allocSlots * 8}, i64Opts);
 
     SortedArrays sorted;
-    sorted.tileKey = u64(keys64B);
+    sorted.tileKey = sortedTile;
     sorted.nodeKey = u32(sortedNodeKey);
     sorted.origin  = sortedOrigin.data_ptr<int32_t>();
-    sorted.mask    = u64(sortedMask);
 
-    // --- Dedup: head flags, global node ranks, per-grid offsets, parent linkage. ---
+    // --- Dedup: head flags, global node ranks, per-grid offsets. ---
     torch::Tensor leafFlag  = torch::empty({allocSlots}, i32Opts);
     torch::Tensor lowerFlag = torch::empty({allocSlots}, i32Opts);
     torch::Tensor upperFlag = torch::empty({allocSlots}, i32Opts);
@@ -1026,15 +1218,16 @@ runBatchedTopologyPass(const BatchedTopologySource &src,
     torch::Tensor lowerRank = torch::empty({allocSlots}, i32Opts);
     torch::Tensor upperRank = torch::empty({allocSlots}, i32Opts);
 
-    torch::Tensor leafHeadSlot  = torch::empty({allocSlots}, i32Opts);
-    torch::Tensor leafParent    = torch::empty({allocSlots}, i32Opts);
-    torch::Tensor lowerHeadSlot = torch::empty({allocSlots}, i32Opts);
-    torch::Tensor lowerParent   = torch::empty({allocSlots}, i32Opts);
-    torch::Tensor upperHeadSlot = torch::empty({allocSlots}, i32Opts);
-
     if (numSlots > 0) {
-        gatherSorted<<<numBlocks(numSlots), kThreads, 0, stream>>>(em, u32(permA), sorted);
+        gatherSorted<<<numBlocks(numSlots), kThreads, 0, stream>>>(em, perm, sorted);
         C10_CUDA_KERNEL_LAUNCH_CHECK();
+        // The unsorted emission masks stay alive (read through perm by reduceLeafMasks).
+        emTileKey  = torch::Tensor();
+        emNodeKey  = torch::Tensor();
+        emOrigin   = torch::Tensor();
+        em.tileKey = nullptr;
+        em.nodeKey = nullptr;
+        em.origin  = nullptr;
 
         computeHeadFlags<<<numBlocks(numSlots), kThreads, 0, stream>>>(sorted.tileKey,
                                                                        sorted.nodeKey,
@@ -1053,30 +1246,6 @@ runBatchedTopologyPass(const BatchedTopologySource &src,
                 C10_CUDA_CHECK(cub::DeviceScan::InclusiveSum(
                     temp, bytes, u32(*flags), u32(*ranks), numSlots, stream));
             });
-        }
-
-        scatterNodeTables<<<numBlocks(numSlots), kThreads, 0, stream>>>(u32(leafFlag),
-                                                                        u32(lowerFlag),
-                                                                        u32(upperFlag),
-                                                                        u32(leafRank),
-                                                                        u32(lowerRank),
-                                                                        u32(upperRank),
-                                                                        numSlots,
-                                                                        u32(leafHeadSlot),
-                                                                        u32(leafParent),
-                                                                        u32(lowerHeadSlot),
-                                                                        u32(lowerParent),
-                                                                        u32(upperHeadSlot));
-        C10_CUDA_KERNEL_LAUNCH_CHECK();
-
-        if (pass.op != TopologyPassSpec::Op::Refine) { // coarsen/dilate have duplicate producers
-            combineDuplicateMasks<<<numBlocks(numSlots), kThreads, 0, stream>>>(sorted.tileKey,
-                                                                                u32(leafFlag),
-                                                                                u32(leafRank),
-                                                                                u32(leafHeadSlot),
-                                                                                numSlots,
-                                                                                sorted.mask);
-            C10_CUDA_KERNEL_LAUNCH_CHECK();
         }
     }
 
@@ -1149,10 +1318,63 @@ runBatchedTopologyPass(const BatchedTopologySource &src,
     build.lowerStart      = u32(lowerStart);
     build.leafStart       = u32(leafStart);
 
-    // --- Build all grids. ---
-    constexpr int32_t kGridDataWords = int32_t(sizeof(nanovdb::GridData) / sizeof(uint64_t));
-    copyGridData<<<numBlocks(numGrids * kGridDataWords), kThreads, 0, stream>>>(
-        em.srcGrids, build, numGrids);
+    // --- Unique-node tables (sized by the readback, not by slot count): head slot and parent
+    // linkage per node, and the reduced 512-bit activity mask per leaf. ---
+    torch::Tensor leafHeadSlot  = torch::empty({std::max(totalLeaf, 1)}, i32Opts);
+    torch::Tensor leafParent    = torch::empty({std::max(totalLeaf, 1)}, i32Opts);
+    torch::Tensor lowerHeadSlot = torch::empty({std::max(totalLower, 1)}, i32Opts);
+    torch::Tensor lowerParent   = torch::empty({std::max(totalLower, 1)}, i32Opts);
+    torch::Tensor upperHeadSlot = torch::empty({std::max(totalUpper, 1)}, i32Opts);
+    torch::Tensor leafMask      = torch::zeros({int64_t(std::max(totalLeaf, 1)) * 8}, i64Opts);
+
+    if (numSlots > 0) {
+        scatterNodeTables<<<numBlocks(numSlots), kThreads, 0, stream>>>(u32(leafFlag),
+                                                                        u32(lowerFlag),
+                                                                        u32(upperFlag),
+                                                                        u32(leafRank),
+                                                                        u32(lowerRank),
+                                                                        u32(upperRank),
+                                                                        numSlots,
+                                                                        u32(leafHeadSlot),
+                                                                        u32(leafParent),
+                                                                        u32(lowerHeadSlot),
+                                                                        u32(lowerParent),
+                                                                        u32(upperHeadSlot));
+        C10_CUDA_KERNEL_LAUNCH_CHECK();
+
+        reduceLeafMasks<<<numBlocks(numSlots), kThreads, 0, stream>>>(
+            sorted.tileKey,
+            sorted.origin,
+            u32(leafRank),
+            perm,
+            em.mask,
+            numSlots,
+            !passHasDuplicateProducers(pass.op),
+            u64(leafMask));
+        C10_CUDA_KERNEL_LAUNCH_CHECK();
+    }
+    // Per-slot scratch no longer needed by the build kernels (they index the unique-node tables
+    // and read only the head slots' node keys / origins).
+    leafFlag  = torch::Tensor();
+    lowerFlag = torch::Tensor();
+    upperFlag = torch::Tensor();
+    leafRank  = torch::Tensor();
+    lowerRank = torch::Tensor();
+    upperRank = torch::Tensor();
+    permA     = torch::Tensor();
+    permB     = torch::Tensor();
+    emMask    = torch::Tensor();
+    em.mask   = nullptr;
+
+    // --- Build all grids. Headers are seeded from the source grids when the pass has them, else
+    // from the default ValueOnIndex header. ---
+    if (hasSourceGrids) {
+        constexpr int32_t kGridDataWords = int32_t(sizeof(nanovdb::GridData) / sizeof(uint64_t));
+        copyGridData<<<numBlocks(numGrids * kGridDataWords), kThreads, 0, stream>>>(
+            em.srcGrids, build, numGrids);
+    } else {
+        initDefaultGridData<<<numBlocks(numGrids), kThreads, 0, stream>>>(build, numGrids);
+    }
     C10_CUDA_KERNEL_LAUNCH_CHECK();
 
     initGridTreeRoot<<<numBlocks(numGrids), kThreads, 0, stream>>>(build, numGrids);
@@ -1173,6 +1395,7 @@ runBatchedTopologyPass(const BatchedTopologySource &src,
                                                                       sorted,
                                                                       u32(leafHeadSlot),
                                                                       u32(leafParent),
+                                                                      u64(leafMask),
                                                                       numGrids,
                                                                       totalLeaf,
                                                                       u64(voxelCounts));

--- a/tests/unit/test_batched_topology_builder.py
+++ b/tests/unit/test_batched_topology_builder.py
@@ -165,6 +165,84 @@ def _from_ijk_batches():
     return batches
 
 
+# Point batches for from_nearest_voxels_to_points. World coordinates are chosen so that, with the
+# voxel size / origin below, the index-space coordinates cover the same tricky regimes as
+# _tricky_batches(): mixed member sizes, empty members (first/middle/last/all), coordinates
+# straddling the +-4096 root-tile boundaries with negative components (points exactly on voxel
+# boundaries included, where floor and the +1 pad land in different root tiles), single members
+# (non-empty, one point, empty), and a 16-member batch.
+_NEAREST_VOXEL_SIZE = 0.5  # power of two: p * (1 / voxel_size) is exact in float32
+_NEAREST_ORIGIN = 0.25  # origin / voxel_size = 0.5 is exact in float32
+
+
+def _nearest_voxel_point_batches():
+    torch.manual_seed(11)
+    vs = _NEAREST_VOXEL_SIZE
+    # World position of index-space value `i` (voxel boundary), so floor lands exactly on `i`.
+    world = lambda i: i * vs + _NEAREST_ORIGIN  # noqa: E731
+    return {
+        "mixed_sizes": [
+            torch.rand(2000, 3) * 8 - 4,
+            torch.tensor([[0.3, -0.7, 1.1]]),
+            torch.rand(50, 3) * 0.1 + 5.0,
+            torch.rand(3000, 3) * 40 - 20,
+        ],
+        "empty_members": [
+            torch.empty(0, 3),
+            torch.rand(500, 3) * 6 - 3,
+            torch.empty(0, 3),
+            torch.tensor([[world(5), world(5), world(5)], [world(5), world(5), world(6)]]),
+            torch.empty(0, 3),
+        ],
+        "all_empty": [torch.empty(0, 3), torch.empty(0, 3)],
+        "tile_boundaries": [
+            torch.tensor(
+                [
+                    [world(-4097), world(-4097), world(-4097)],
+                    [world(-4096), world(-4096), world(-4096)],
+                    [world(-4097) + 0.1, world(-4097) + 0.2, world(-4097) + 0.3],
+                    [world(-2049), 0.0, 0.0],
+                    [world(-1), world(-1), world(-1)],
+                    [world(-1) + 0.49, world(-1) + 0.49, world(-1) + 0.49],
+                    [0.0, 0.0, 0.0],
+                    [world(4095), world(4095), world(4095)],
+                    [world(4095) + 0.3, world(4095) + 0.3, world(4095) + 0.3],
+                    [world(4096), world(4096), world(4096)],
+                    [world(4096), world(-4097), world(0)],
+                    [world(-8193), world(0), world(-4097)],
+                ]
+            ),
+            torch.rand(600, 3) * (world(-3900) - world(-4200)) + world(-4200),
+            torch.rand(600, 3) * (world(4200) - world(3900)) + world(3900),
+            torch.cat(
+                [
+                    torch.rand(300, 3) * 20 - world(4110),
+                    torch.rand(300, 3) * 20 + world(4080),
+                ]
+            ),
+        ],
+        # Single-member batches take the PointsToGrid path of batchedCoordsPassFromIJK (wrapped by
+        # resultFromGridHandle); the pad pass then chains onto that wrapped result.
+        "single_grid": [torch.rand(1500, 3) * 16 - 8],
+        "single_point": [torch.tensor([[world(-4097) + 0.1, world(4095) + 0.4, world(-1) + 0.3]])],
+        "single_empty": [torch.empty(0, 3)],
+        "larger_batch": [torch.rand(50 + 137 * i, 3) * 32 - 16 for i in range(16)],
+    }
+
+
+def _expected_nearest_voxels_ijk(points: torch.Tensor, voxel_size: float, origin: float) -> torch.Tensor:
+    """Unique floor(transform(p)) + {0,1}^3 -- the 8 voxels nearest to each point -- computed like
+    the op's VoxelCoordTransform (p * (1 / voxel_size) + (-origin / voxel_size), then floor)."""
+    if points.numel() == 0:
+        return torch.empty((0, 3), dtype=torch.int32)
+    scale = torch.tensor(1.0 / voxel_size, dtype=torch.float32)
+    translate = torch.tensor(-origin / voxel_size, dtype=torch.float32)
+    ijk0 = torch.floor(points.to(torch.float32) * scale + translate).to(torch.int64)
+    offsets = torch.stack(torch.meshgrid(*[torch.arange(2)] * 3, indexing="ij"), dim=-1).reshape(-1, 3)
+    ijk = (ijk0[:, None, :] + offsets[None, :, :]).reshape(-1, 3)
+    return torch.unique(ijk, dim=0).to(torch.int32)
+
+
 # Canonical NanoVDB voxel enumeration order (root tiles by offset-shifted sort key, then x-major
 # upper/lower child offsets, then leaf-local offset) of the hand-written members above, as produced
 # by the per-member PointsToGrid path from_ijk used before the batched Coords pass. Pins the
@@ -392,6 +470,45 @@ class TestBatchedTopologyBuilder(unittest.TestCase):
         self._check_multi_member_equals_per_member(nearest, nearest_singles, "from_nearest_voxels_to_points")
         nearest_cpu = GridBatch.from_nearest_voxels_to_points(JaggedTensor(pts), voxel_sizes=0.1, origins=0.0)
         self._check_against_cpu(nearest, nearest_cpu, "from_nearest_voxels_to_points vs CPU")
+
+    @parameterized.expand([(name,) for name in _nearest_voxel_point_batches()])
+    def test_from_nearest_voxels_to_points_matches_expected_and_cpu(self, name):
+        # CUDA: batched Coords pass (floor(p) per point) chained with one batched BoxDilate(0, +1)
+        # pass (the {0,1}^3 pad) -- no per-member PadGrid / mergeGridHandles.
+        pts = _nearest_voxel_point_batches()[name]
+        vs, og = _NEAREST_VOXEL_SIZE, _NEAREST_ORIGIN
+        result = GridBatch.from_nearest_voxels_to_points(
+            JaggedTensor([p.cuda() for p in pts]), voxel_sizes=vs, origins=og
+        )
+        expected = [_expected_nearest_voxels_ijk(p, vs, og) for p in pts]
+        for p, e in zip(pts, expected):
+            # Every point contributes exactly 8 candidates; the union has at least 8 unless empty.
+            self.assertEqual(e.shape[0] >= 8, p.shape[0] > 0, f"{name}: expected-set sanity")
+        self._check_against_expected(result, expected, f"from_nearest_voxels_to_points[{name}]")
+        singles = [
+            GridBatch.from_nearest_voxels_to_points(JaggedTensor([p.cuda()]), voxel_sizes=vs, origins=og) for p in pts
+        ]
+        self._check_multi_member_equals_per_member(result, singles, f"from_nearest_voxels_to_points[{name}]")
+        cpu = GridBatch.from_nearest_voxels_to_points(JaggedTensor(pts), voxel_sizes=vs, origins=og)
+        self._check_against_cpu(result, cpu, f"from_nearest_voxels_to_points[{name}] vs CPU")
+
+    def test_from_nearest_voxels_to_points_per_member_transforms(self):
+        # Per-member voxel sizes / origins: each member's pad must use its own transform.
+        torch.manual_seed(5)
+        pts = [torch.rand(700, 3) * 10 - 5, torch.empty(0, 3), torch.rand(300, 3) * 3]
+        sizes = [0.5, 1.0, 0.25]
+        origins = [0.0, 0.25, -0.125]
+        result = GridBatch.from_nearest_voxels_to_points(
+            JaggedTensor([p.cuda() for p in pts]),
+            voxel_sizes=[[v] * 3 for v in sizes],
+            origins=[[o] * 3 for o in origins],
+        )
+        expected = [_expected_nearest_voxels_ijk(p, v, o) for p, v, o in zip(pts, sizes, origins)]
+        self._check_against_expected(result, expected, "from_nearest_voxels_to_points per-member transforms")
+        cpu = GridBatch.from_nearest_voxels_to_points(
+            JaggedTensor(pts), voxel_sizes=[[v] * 3 for v in sizes], origins=[[o] * 3 for o in origins]
+        )
+        self._check_against_cpu(result, cpu, "from_nearest_voxels_to_points per-member transforms vs CPU")
 
     def test_from_mesh_multi_member_matches_per_member_and_cpu(self):
         try:

--- a/tests/unit/test_batched_topology_builder.py
+++ b/tests/unit/test_batched_topology_builder.py
@@ -316,6 +316,51 @@ class TestBatchedTopologyBuilder(unittest.TestCase):
         self.assertTrue(torch.equal(rebuilt.ijk.jdata, result.ijk.jdata), f"{name} from_ijk idempotence")
         self.assertTrue(torch.equal(rebuilt.num_voxels, result.num_voxels), f"{name} from_ijk idempotence counts")
 
+    def test_from_ijk_single_member_fallback_and_pairs(self):
+        # B == 1 keeps NanoVDB's PointsToGrid (lower peak memory); B >= 2 runs the batched Coords
+        # pass. Every single-member build must equal the corresponding member of a two-member
+        # build elementwise, and both must reproduce the canonical order captured from the old
+        # per-member PointsToGrid path.
+        for name in ("tile_boundaries", "neg_tile_straddle", "heavy_duplicates", "empty_members"):
+            coords = _from_ijk_batches()[name]
+            singles = [_build([c], "cuda") for c in coords]
+            for b in range(len(coords) - 1):
+                pair = _build(coords[b : b + 2], "cuda")
+                self.assertEqual(pair.grid_count, 2)
+                for k in range(2):
+                    single = singles[b + k]
+                    msg = f"{name} pair ({b},{b + 1}) member {k}"
+                    self.assertTrue(torch.equal(pair.ijk.unbind()[k], single.ijk.jdata), msg)
+                    self.assertTrue(torch.equal(pair.num_voxels[k : k + 1], single.num_voxels), msg)
+                    self.assertTrue(torch.equal(pair.bbox_at(k), single.bbox_at(0)), f"{msg} bbox")
+            for b, single in enumerate(singles):
+                pinned = _FROM_IJK_CANONICAL_ORDER.get((name, b))
+                if pinned is not None:
+                    self.assertEqual(single.ijk.jdata.cpu().tolist(), pinned, f"{name} B=1 member {b} order")
+                    pair = _build(coords[b : b + 2] if b + 1 < len(coords) else coords[b - 1 : b + 1], "cuda")
+                    k = 0 if b + 1 < len(coords) else 1
+                    self.assertEqual(pair.ijk.unbind()[k].cpu().tolist(), pinned, f"{name} B=2 member {b} order")
+
+    def test_from_points_single_member_fallback_and_pairs(self):
+        torch.manual_seed(5)
+        pts = [torch.rand(3000, 3) * 40 - 20, torch.empty(0, 3), torch.rand(2000, 3) * 4 - 2]
+        for layout in ("packed", "strided"):
+
+            def prep(p):
+                p = p.cuda()
+                if layout == "strided":
+                    p = torch.cat([p, torch.zeros_like(p)], dim=1)[:, :3]
+                return p
+
+            singles = [GridBatch.from_points(JaggedTensor([prep(p)]), voxel_sizes=0.1, origins=0.0) for p in pts]
+            for b in range(len(pts) - 1):
+                pair = GridBatch.from_points(
+                    JaggedTensor([prep(p) for p in pts[b : b + 2]]), voxel_sizes=0.1, origins=0.0
+                )
+                self._check_multi_member_equals_per_member(pair, singles[b : b + 2], f"from_points {layout} pair {b}")
+            cpu = GridBatch.from_points(JaggedTensor([pts[0]]), voxel_sizes=0.1, origins=0.0)
+            self._check_against_cpu(singles[0], cpu, f"from_points {layout} B=1 vs CPU")
+
     def _check_multi_member_equals_per_member(self, multi: GridBatch, singles, msg: str):
         self.assertEqual(multi.grid_count, len(singles), msg)
         for b, single in enumerate(singles):

--- a/tests/unit/test_batched_topology_builder.py
+++ b/tests/unit/test_batched_topology_builder.py
@@ -4,8 +4,10 @@
 """Equivalence tests for the batched leaf-mask topology builder (issue #755).
 
 On CUDA, ``refined_grid`` / ``coarsened_grid`` (and through them ``conv_grid`` /
-``conv_transpose_grid`` for K == S) build all batch members in a single batched pass instead of
-one NanoVDB build + merge per member. These tests pin the batched results against:
+``conv_transpose_grid`` for K == S), and ``from_ijk`` (and through it ``from_points``,
+``from_mesh``, ``from_nearest_voxels_to_points`` and the non-power-of-two ``conv_grid`` fallback)
+build all batch members in a single batched pass instead of one NanoVDB build + merge per member.
+These tests pin the batched results against:
 
 - ``from_ijk`` (PointsToGrid) grids built from independently computed expected coordinates,
   compared **elementwise** (``torch.equal`` on ``ijk.jdata``), which pins the canonical NanoVDB
@@ -101,6 +103,97 @@ def _tricky_batches():
         ],
         "larger_batch": [torch.randint(-32, 32, (50 + 37 * i, 3), dtype=torch.int32) for i in range(16)],
     }
+
+
+# Additional coordinate batches for the from_ijk (Coords) pass, whose slots are coordinates rather
+# than leaves: heavy duplication (many coordinates per output leaf, repeated coordinates) and
+# coordinates straddling the +-4096 root-tile boundaries with negative components.
+def _from_ijk_batches():
+    batches = _tricky_batches()
+    torch.manual_seed(7)
+    batches.update(
+        {
+            "heavy_duplicates": [
+                torch.randint(-4, 4, (5000, 3), dtype=torch.int32),
+                torch.tensor([[3, -5, 7]], dtype=torch.int32).repeat(1000, 1),
+                torch.tensor(
+                    [[7, 7, 7], [8, 8, 8], [7, 7, 7], [8, 7, 8], [-1, 0, 0], [-1, 0, 0]], dtype=torch.int32
+                ).repeat(50, 1),
+                torch.randint(-4100, -4090, (3000, 3), dtype=torch.int32),
+            ],
+            "neg_tile_straddle": [
+                torch.tensor(
+                    [
+                        [-4096, -4097, -4095],
+                        [-4097, -4096, -4096],
+                        [-1, -4096, 4096],
+                        [-8193, 0, -4097],
+                        [-8192, -8192, -8192],
+                        [-8193, -8193, -8193],
+                        [4096, -1, -4097],
+                        [-4096, -4097, -4095],
+                        [-4097, -4096, -4096],
+                        [0, -1, 0],
+                        [-1, 0, -1],
+                        [-4095, 4095, -4096],
+                    ],
+                    dtype=torch.int32,
+                ),
+                torch.randint(-4110, -4080, (400, 3), dtype=torch.int32),
+                torch.cat(
+                    [
+                        torch.randint(-4110, -4080, (200, 3), dtype=torch.int32),
+                        torch.randint(4080, 4110, (200, 3), dtype=torch.int32),
+                        torch.randint(-20, 20, (200, 3), dtype=torch.int32),
+                    ]
+                ),
+                torch.stack(
+                    [
+                        torch.randint(-8200, -8180, (300,), dtype=torch.int32),
+                        torch.randint(4090, 4100, (300,), dtype=torch.int32),
+                        torch.randint(-5, 5, (300,), dtype=torch.int32),
+                    ],
+                    dim=-1,
+                ),
+            ],
+            "int64_input": [
+                torch.randint(-100, 100, (700, 3), dtype=torch.int64),
+                torch.randint(-5000, 5000, (300, 3), dtype=torch.int64),
+            ],
+        }
+    )
+    return batches
+
+
+# Canonical NanoVDB voxel enumeration order (root tiles by offset-shifted sort key, then x-major
+# upper/lower child offsets, then leaf-local offset) of the hand-written members above, as produced
+# by the per-member PointsToGrid path from_ijk used before the batched Coords pass. Pins the
+# elementwise ``ijk.jdata`` order of the batched pass to that reference.
+_FROM_IJK_CANONICAL_ORDER = {
+    ("tile_boundaries", 0): [
+        [-4097, -4097, -4097],
+        [-4096, -4096, -4096],
+        [-1, -1, -1],
+        [-2049, 0, 0],
+        [0, 0, 0],
+        [4095, 4095, 4095],
+        [4096, -4097, 0],
+        [4096, 4096, 4096],
+    ],
+    ("neg_tile_straddle", 0): [
+        [-8193, -8193, -8193],
+        [-8193, 0, -4097],
+        [-8192, -8192, -8192],
+        [-4097, -4096, -4096],
+        [-4096, -4097, -4095],
+        [-1, -4096, 4096],
+        [-4095, 4095, -4096],
+        [-1, 0, -1],
+        [0, -1, 0],
+        [4096, -1, -4097],
+    ],
+    ("heavy_duplicates", 2): [[-1, 0, 0], [7, 7, 7], [8, 7, 8], [8, 8, 8]],
+}
 
 
 @unittest.skipIf(not torch.cuda.is_available(), "CUDA is required for the batched builder")
@@ -200,6 +293,96 @@ class TestBatchedTopologyBuilder(unittest.TestCase):
         cpu_mask = JaggedTensor([m.cpu() for m in mask.unbind()])
         cpu_result = cpu_grid.refined_grid(2, mask=cpu_mask)
         self._check_against_cpu(result, cpu_result, "masked refine x2 vs CPU")
+
+    @parameterized.expand([(name,) for name in _from_ijk_batches().keys()])
+    def test_from_ijk_matches_cpu_per_member_and_canonical_order(self, name):
+        coords = _from_ijk_batches()[name]
+        result = _build(coords, "cuda")
+        cpu_result = _build(coords, "cpu")
+        self._check_against_cpu(result, cpu_result, f"{name} from_ijk vs CPU")
+        for b, c in enumerate(coords):
+            self.assertTrue(torch.equal(result.bbox_at(b).cpu(), cpu_result.bbox_at(b)), f"{name} bbox {b}")
+            expected_count = 0 if c.numel() == 0 else torch.unique(c, dim=0).shape[0]
+            self.assertEqual(int(result.num_voxels[b]), expected_count, f"{name} unique count {b}")
+            # Multi-member build equals the single-member build elementwise (same canonical order).
+            single = _build([c], "cuda")
+            self.assertTrue(torch.equal(result.ijk.unbind()[b], single.ijk.jdata), f"{name} member {b} vs B=1")
+            self.assertTrue(torch.equal(result.bbox_at(b), single.bbox_at(0)), f"{name} member {b} bbox vs B=1")
+            pinned = _FROM_IJK_CANONICAL_ORDER.get((name, b))
+            if pinned is not None:
+                self.assertEqual(result.ijk.unbind()[b].cpu().tolist(), pinned, f"{name} member {b} canonical order")
+        # Idempotence: rebuilding from the enumerated voxels reproduces the enumeration.
+        rebuilt = GridBatch.from_ijk(result.ijk, voxel_sizes=1.0, origins=0.0)
+        self.assertTrue(torch.equal(rebuilt.ijk.jdata, result.ijk.jdata), f"{name} from_ijk idempotence")
+        self.assertTrue(torch.equal(rebuilt.num_voxels, result.num_voxels), f"{name} from_ijk idempotence counts")
+
+    def _check_multi_member_equals_per_member(self, multi: GridBatch, singles, msg: str):
+        self.assertEqual(multi.grid_count, len(singles), msg)
+        for b, single in enumerate(singles):
+            self.assertEqual(single.grid_count, 1, msg)
+            self.assertTrue(torch.equal(multi.num_voxels[b : b + 1], single.num_voxels), f"{msg} member {b} count")
+            self.assertTrue(torch.equal(multi.ijk.unbind()[b], single.ijk.jdata), f"{msg} member {b} ijk")
+            self.assertTrue(torch.equal(multi.bbox_at(b), single.bbox_at(0)), f"{msg} member {b} bbox")
+
+    def test_from_points_multi_member_matches_per_member_and_cpu(self):
+        torch.manual_seed(3)
+        pts = [
+            torch.rand(2000, 3) * 4 - 2,
+            torch.empty(0, 3),
+            torch.rand(50, 3) * 0.1 + 5.0,
+            torch.rand(3000, 3) * 40 - 20,
+        ]
+        multi = GridBatch.from_points(JaggedTensor([p.cuda() for p in pts]), voxel_sizes=0.1, origins=0.0)
+        singles = [GridBatch.from_points(JaggedTensor([p.cuda()]), voxel_sizes=0.1, origins=0.0) for p in pts]
+        self._check_multi_member_equals_per_member(multi, singles, "from_points")
+        cpu = GridBatch.from_points(JaggedTensor(pts), voxel_sizes=0.1, origins=0.0)
+        self._check_against_cpu(multi, cpu, "from_points vs CPU")
+
+        nearest = GridBatch.from_nearest_voxels_to_points(
+            JaggedTensor([p.cuda() for p in pts]), voxel_sizes=0.1, origins=0.0
+        )
+        nearest_singles = [
+            GridBatch.from_nearest_voxels_to_points(JaggedTensor([p.cuda()]), voxel_sizes=0.1, origins=0.0) for p in pts
+        ]
+        self._check_multi_member_equals_per_member(nearest, nearest_singles, "from_nearest_voxels_to_points")
+        nearest_cpu = GridBatch.from_nearest_voxels_to_points(JaggedTensor(pts), voxel_sizes=0.1, origins=0.0)
+        self._check_against_cpu(nearest, nearest_cpu, "from_nearest_voxels_to_points vs CPU")
+
+    def test_from_mesh_multi_member_matches_per_member_and_cpu(self):
+        try:
+            from fvdb.utils.examples import load_bunny_mesh
+
+            vertices, faces = load_bunny_mesh(device="cpu")
+        except Exception as e:  # example data not available offline
+            self.skipTest(f"bunny mesh example data unavailable: {e}")
+        vertices = vertices.to(torch.float32)
+        faces = faces.to(torch.int64)
+        verts = [vertices * s + o for s, o in ((1.0, 0.0), (2.5, -3.0), (0.4, 7.0))]
+        multi = GridBatch.from_mesh(
+            JaggedTensor([v.cuda() for v in verts]),
+            JaggedTensor([faces.cuda() for _ in verts]),
+            voxel_sizes=0.02,
+            origins=0.0,
+        )
+        singles = [
+            GridBatch.from_mesh(JaggedTensor([v.cuda()]), JaggedTensor([faces.cuda()]), voxel_sizes=0.02, origins=0.0)
+            for v in verts
+        ]
+        self._check_multi_member_equals_per_member(multi, singles, "from_mesh")
+        cpu = GridBatch.from_mesh(
+            JaggedTensor(verts), JaggedTensor([faces for _ in verts]), voxel_sizes=0.02, origins=0.0
+        )
+        self._check_against_cpu(multi, cpu, "from_mesh vs CPU")
+
+    def test_conv_grid_k3s3_multi_member_matches_per_member_and_cpu(self):
+        # Non-power-of-two stride: coordinate-list fallback through from_ijk.
+        coords = _tricky_batches()["mixed_sizes"] + _from_ijk_batches()["neg_tile_straddle"][:2]
+        full = _build(coords, "cuda")
+        conv = full.conv_grid(kernel_size=3, stride=3)
+        singles = [_build([c], "cuda").conv_grid(kernel_size=3, stride=3) for c in coords]
+        self._check_multi_member_equals_per_member(conv, singles, "conv_grid k3s3")
+        cpu = _build(coords, "cpu").conv_grid(kernel_size=3, stride=3)
+        self._check_against_cpu(conv, cpu, "conv_grid k3s3 vs CPU")
 
     def test_refine_coarsen_roundtrip_grid_count(self):
         # Serialization-visible metadata: grid_count/address arithmetic must be consistent for a


### PR DESCRIPTION
Stacked on PR 780 (`batched/from-ijk` at edc1e5a0, item 2); only the last commit is new.

## Summary

`GridBatch.from_nearest_voxels_to_points` on CUDA built the floored-ijk base grid batch (one voxel per point) and then padded it by the positive octant {0,1}^3 -- the 8 voxels nearest to each point -- with a per-member loop: copy `points.joffsets()` to the host, run `morphology::PadGrid` once per member (several stream syncs per `getHandle`), create an empty grid handle for members without points, then `nanovdb::cuda::mergeGridHandles` (another sync per grid). With PR 780 the base grid is already a batched Coords pass result; this PR replaces the pad loop with one batched `BoxDilate(lo=0, hi=+1)` pass chained directly onto that result, so the whole op is two batched passes with one sizing synchronization each and no per-member work. The host copy of the jagged offsets in this file is gone (the Coords pass keeps its own single host copy for the int32 guard and slot counts).

## Approach

- `BuildGridFromNearestVoxelsToPoints.cu` (CUDA dispatch): `flooredIjkForPoints` -> `ops::batchedCoordsPassFromIJK` (PR 780: the batched Coords pass for B >= 2, or the single-member PointsToGrid handle wrapped by `batched::resultFromGridHandle` for B = 1) -> `runBatchedTopologyPass(sourceFromResult(base), TopologyPassSpec::boxDilate(Coord(0), Coord(1)))` -> `GridHandle`. Semantics match the CPU implementation in the same file (floor(transform(p)) + {0,1}^3 per point; the Minkowski sum distributes over the union, and `PadGrid(positiveOctant=true)` was exactly the {0,1}^3 pad). Members without points are empty base grids and stay empty through the dilate pass (zero emission slots). CPU and PrivateUse1 paths untouched; `PadGrid.cuh`, `CreateEmptyGridHandle.h`, `PointsToGrid.cuh` and `BuilderResource.h` are no longer included here.
- No builder or from_ijk changes in this PR; `batchedCoordsPassFromIJK` and `resultFromGridHandle` come from PR 780. This PR is the first runtime exercise of that B = 1 wrapping branch (nothing on PR 780 chains a pass onto a single-member result); the single-member batches below (1500 points, one point, no points) cover it.

## Benchmark

RTX PRO 6000 Blackwell, 100k random float32 points per member, `voxel_sizes=0.1`, 20 iterations after one warmup, `torch.cuda.synchronize()` around the loop, GPU lock held. "main" is the installed env (per-member PointsToGrid + per-member PadGrid); "PR 780" is this branch's base commit alone (batched from_ijk, per-member PadGrid); "this PR" adds the batched pad.

Points in a 40^3 world box (sparse: ~800k voxels per member spread over ~69k base leaves / ~86k output leaves, so the dilate pass emits ~550k slots per member and at large B the time is real per-leaf work, ~0.45 ms per member):

| B | main (ms) | PR 780 (ms) | this PR (ms) |
|---|---|---|---|
| 1 | 2.16 | 2.05 | 1.89 |
| 4 | 7.47 | 5.31 | 1.92 |
| 16 | 28.79 | 18.39 | 7.22 |
| 64 | 115.85 | 71.01 | 27.78 |

Points in an 8^3 world box (~410k voxels per member in 1000 base leaves / ~1.3k output leaves, the regime where the per-member fixed cost dominated):

| B | main (ms) | PR 780 (ms) | this PR (ms) |
|---|---|---|---|
| 1 | 2.60 | 1.88 | 1.81 |
| 4 | 7.83 | 4.62 | 1.27 |
| 16 | 27.31 | 15.49 | 1.43 |
| 64 | 106.31 | 62.11 | 3.26 |

At B = 1 the base grid comes from PR 780's PointsToGrid branch (its B = 1 time is unchanged by design); this PR removes the PadGrid's own syncs there (2.05 -> 1.89 ms). Before PR 780's single-member fallback, the same code measured 1.26 ms at B = 1 through the Coords pass, at a higher peak.

`test_nearest_voxels_to_points_peak_memory` (2M points, B = 1): torch-visible peak 104.2 MiB (main: 158.9 MiB; PR 780 alone: 170.8 MiB before its single-member fallback), well under the 200 MiB bound. The batched pad's scratch is per leaf, not per point, so it is a few MiB here, and PointsToGrid's B = 1 scratch is smaller than the old PadGrid TopologyBuilder scratch it replaces in the peak.

## Tests

`tests/unit/test_batched_topology_builder.py` (44 passed):
- New `test_from_nearest_voxels_to_points_matches_expected_and_cpu`, parameterized over point batches covering mixed member sizes, empty members (first/middle/last), an all-empty batch, points whose floored / padded coordinates straddle the +-4096 and -8192 root-tile boundaries with negative components (including points exactly on voxel boundaries), single members (1500 points, one point, no points -- the B = 1 PointsToGrid + `resultFromGridHandle` path) and a 16-member batch. Each result is pinned elementwise (`_check_against_expected`: `ijk.jdata`, `num_voxels`, per-member bbox) against a `from_ijk` build of expected coordinates computed in torch the way the op's `VoxelCoordTransform` does (`p * (1/voxel_size) + (-origin/voxel_size)`, floor, Minkowski sum with {0,1}^3, `unique`; power-of-two voxel size so the float32 arithmetic is exact on both sides), checked multi-member == per-member builds, and compared against the CPU implementation (`_check_against_cpu`).
- New `test_from_nearest_voxels_to_points_per_member_transforms`: per-member voxel sizes and origins (including an empty member), vs expected and vs CPU.
- All PR 780 tests unchanged and passing.

Existing suites on the new build: `test_basic_ops.py`, `test_basic_ops_single.py`, `test_empty_grids.py`, `test_sliced_batch.py`, `test_batching.py`: 524 passed, 1 skipped (includes `test_nearest_voxels_to_points_peak_memory`, `test_build_from_pointcloud_nearest_voxels` on every device/dtype combination, and the `from_nearest_voxels_to_points` empty-grid and >2^31-candidate guard tests).

Part of #775 (item 6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

